### PR TITLE
[#32222] Actually maintain the heap invariant for timers.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -81,6 +81,7 @@
 ## Bugfixes
 
 * Fixed X (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
+* Fixed EventTimeTimer ordering in Prism. ([#32222](https://github.com/apache/beam/issues/32222)).
 
 ## Security Fixes
 * Fixed (CVE-YYYY-NNNN)[https://www.cve.org/CVERecord?id=CVE-YYYY-NNNN] (Java/Python/Go) ([#X](https://github.com/apache/beam/issues/X)).

--- a/runners/prism/java/build.gradle
+++ b/runners/prism/java/build.gradle
@@ -178,10 +178,7 @@ def sickbayTests = [
     'org.apache.beam.sdk.transforms.ParDoTest$StateTests.testTwoRequiresTimeSortedInputWithLateData',
     'org.apache.beam.sdk.transforms.ParDoTest$StateTests.testRequiresTimeSortedInputWithLateData',
 
-    // Timer race condition/ordering issue in Prism.
-    'org.apache.beam.sdk.transforms.ParDoTest$TimerTests.testTwoTimersSettingEachOtherWithCreateAsInputUnbounded',
-
-    // Missing output due to timer skew.
+    // Missing output due to processing time timer skew.
     'org.apache.beam.sdk.transforms.ParDoTest$TimestampTests.testProcessElementSkew',
 
     // TestStream + BundleFinalization.
@@ -241,10 +238,6 @@ def createPrismValidatesRunnerTask = { name, environmentType ->
        excludeCategories 'org.apache.beam.sdk.testing.UsesMultimapState'
     }
     filter {
-      // Hangs forever with prism. Put here instead of sickbay to allow sickbay runs to terminate.
-      // https://github.com/apache/beam/issues/32222
-      excludeTestsMatching 'org.apache.beam.sdk.transforms.ParDoTest$TimerTests.testEventTimeTimerOrderingWithCreate'
-
       for (String test : sickbayTests) {
           excludeTestsMatching test
       }

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
@@ -1579,7 +1579,7 @@ func (ss *stageState) updateWatermarks(em *ElementManager) set[string] {
 				// TODO(#https://github.com/apache/beam/issues/31438):
 				// Adjust with AllowedLateness
 				// Clear out anything we've already used.
-				if win.MaxTimestamp()+1 < newOut {
+				if win.MaxTimestamp() < newOut {
 					delete(wins, win)
 				}
 			}
@@ -1588,7 +1588,7 @@ func (ss *stageState) updateWatermarks(em *ElementManager) set[string] {
 			for win := range wins {
 				// TODO(#https://github.com/apache/beam/issues/31438):
 				// Adjust with AllowedLateness
-				if win.MaxTimestamp()+1 < newOut {
+				if win.MaxTimestamp() < newOut {
 					delete(wins, win)
 				}
 			}

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
@@ -1576,16 +1576,19 @@ func (ss *stageState) updateWatermarks(em *ElementManager) set[string] {
 		// They'll never be read in again.
 		for _, wins := range ss.sideInputs {
 			for win := range wins {
+				// TODO(#https://github.com/apache/beam/issues/31438):
+				// Adjust with AllowedLateness
 				// Clear out anything we've already used.
-				if win.MaxTimestamp() < newOut {
+				if win.MaxTimestamp()+1 < newOut {
 					delete(wins, win)
 				}
 			}
 		}
 		for _, wins := range ss.state {
 			for win := range wins {
-				// Clear out anything we've already used.
-				if win.MaxTimestamp() < newOut {
+				// TODO(#https://github.com/apache/beam/issues/31438):
+				// Adjust with AllowedLateness
+				if win.MaxTimestamp()+1 < newOut {
 					delete(wins, win)
 				}
 			}

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
@@ -1159,7 +1159,7 @@ func (ss *stageState) AddPending(newPending []element) int {
 				}
 				ss.pendingByKeys[string(e.keyBytes)] = dnt
 			}
-			dnt.elements.Push(e)
+			heap.Push(&dnt.elements, e)
 
 			if e.IsTimer() {
 				if lastSet, ok := dnt.timers[timerKey{family: e.family, tag: e.tag, window: e.window}]; ok {

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
@@ -791,8 +791,10 @@ class FnApiRunnerTest(unittest.TestCase):
       # Acutal should be a grouping of the inputs into batches of size
       # at most buffer_size, but the actual batching is nondeterministic
       # based on ordering and trigger firing timing.
-      self.assertEqual(sorted(sum((list(b) for b in actual), [])), elements, actual)
-      self.assertEqual(max(len(list(buffer)) for buffer in actual), buffer_size, actual)
+      self.assertEqual(
+          sorted(sum((list(b) for b in actual), [])), elements, actual)
+      self.assertEqual(
+          max(len(list(buffer)) for buffer in actual), buffer_size, actual)
       if windowed:
         # Elements were assigned to windows based on their parity.
         # Assert that each grouping consists of elements belonging to the

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
@@ -790,8 +790,8 @@ class FnApiRunnerTest(unittest.TestCase):
       # Acutal should be a grouping of the inputs into batches of size
       # at most buffer_size, but the actual batching is nondeterministic
       # based on ordering and trigger firing timing.
-      self.assertEqual(sorted(sum((list(b) for b in actual), [])), elements)
-      self.assertEqual(max(len(list(buffer)) for buffer in actual), buffer_size)
+      self.assertEqual(sorted(sum((list(b) for b in actual), [])), elements, actual)
+      self.assertEqual(max(len(list(buffer)) for buffer in actual), buffer_size, actual)
       if windowed:
         # Elements were assigned to windows based on their parity.
         # Assert that each grouping consists of elements belonging to the

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
@@ -776,7 +776,8 @@ class FnApiRunnerTest(unittest.TestCase):
           state.clear()
           yield buffer
         else:
-          timer.set(ts + 1)
+          # Set the timer to fire within it's window.
+          timer.set(ts + (1 - timestamp.Duration(micros=1000)))
 
       @userstate.on_timer(timer_spec)
       def process_timer(self, state=beam.DoFn.StateParam(state_spec)):


### PR DESCRIPTION
testEventTimeTimerOrderingWithCreate was hanging due to timers being fired in incorrect order. The issue was that the heap variant wasn't being maintained on inserting timers for a key. This would cause timers to fire out of event time ordering. In particular, the "GC" timer would fire first (because it was set first), instead of the earlier firing "append" timer.

This incorrect ordering was also what caused testTwoTimersSettingEachOtherWithCreateAsInputUnbounded to fail.

Fixes #32222.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
