### PR TITLE
Synchronize JdbcSchemaIO provider and Python transform configuration field order

### DIFF
--- a/.github/trigger_files/beam_PostCommit_Python.json
+++ b/.github/trigger_files/beam_PostCommit_Python.json
@@ -1,5 +1,5 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run.",
-  "modification": 5
+  "modification": 6
 }
 

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcSchemaIOProvider.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcSchemaIOProvider.java
@@ -68,13 +68,13 @@ public class JdbcSchemaIOProvider implements SchemaIOProvider {
         .addNullableField("disableAutoCommit", FieldType.BOOLEAN)
         .addNullableField("outputParallelization", FieldType.BOOLEAN)
         .addNullableField("autosharding", FieldType.BOOLEAN)
-        .addNullableField("writeBatchSize", FieldType.INT64)
         // Partitioning support. If you specify a partition column we will use that instead of
         // readQuery
         .addNullableField("partitionColumn", FieldType.STRING)
         .addNullableField("partitions", FieldType.INT16)
         .addNullableField("maxConnections", FieldType.INT16)
         .addNullableField("driverJars", FieldType.STRING)
+        .addNullableField("writeBatchSize", FieldType.INT64)
         .build();
   }
 

--- a/sdks/python/apache_beam/io/jdbc.py
+++ b/sdks/python/apache_beam/io/jdbc.py
@@ -119,8 +119,11 @@ JdbcConfigSchema = typing.NamedTuple(
 
 Config = typing.NamedTuple(
     'Config',
-    [('driver_class_name', str), ('jdbc_url', str), ('username', str),
-     ('password', str), ('connection_properties', typing.Optional[str]),
+    [('driver_class_name', str),
+     ('jdbc_url', str),
+     ('username', str),
+     ('password', str),
+     ('connection_properties', typing.Optional[str]),
      ('connection_init_sqls', typing.Optional[typing.List[str]]),
      ('read_query', typing.Optional[str]),
      ('write_statement', typing.Optional[str]),
@@ -128,11 +131,11 @@ Config = typing.NamedTuple(
      ('disable_autocommit', typing.Optional[bool]),
      ('output_parallelization', typing.Optional[bool]),
      ('autosharding', typing.Optional[bool]),
-     ('write_batch_size', typing.Optional[np.int64]),
      ('partition_column', typing.Optional[str]),
      ('partitions', typing.Optional[np.int16]),
      ('max_connections', typing.Optional[np.int16]),
-     ('driver_jars', typing.Optional[str])],
+     ('driver_jars', typing.Optional[str]),
+     ('write_batch_size', typing.Optional[np.int64])],
 )
 
 DEFAULT_JDBC_CLASSPATH = ['org.postgresql:postgresql:42.2.16']

--- a/sdks/python/apache_beam/io/jdbc.py
+++ b/sdks/python/apache_beam/io/jdbc.py
@@ -128,11 +128,11 @@ Config = typing.NamedTuple(
      ('disable_autocommit', typing.Optional[bool]),
      ('output_parallelization', typing.Optional[bool]),
      ('autosharding', typing.Optional[bool]),
+     ('write_batch_size', typing.Optional[np.int64]),
      ('partition_column', typing.Optional[str]),
      ('partitions', typing.Optional[np.int16]),
      ('max_connections', typing.Optional[np.int16]),
-     ('driver_jars', typing.Optional[str]),
-     ('write_batch_size', typing.Optional[np.int64])],
+     ('driver_jars', typing.Optional[str])],
 )
 
 DEFAULT_JDBC_CLASSPATH = ['org.postgresql:postgresql:42.2.16']

--- a/sdks/python/apache_beam/io/jdbc.py
+++ b/sdks/python/apache_beam/io/jdbc.py
@@ -119,11 +119,8 @@ JdbcConfigSchema = typing.NamedTuple(
 
 Config = typing.NamedTuple(
     'Config',
-    [('driver_class_name', str),
-     ('jdbc_url', str),
-     ('username', str),
-     ('password', str),
-     ('connection_properties', typing.Optional[str]),
+    [('driver_class_name', str), ('jdbc_url', str), ('username', str),
+     ('password', str), ('connection_properties', typing.Optional[str]),
      ('connection_init_sqls', typing.Optional[typing.List[str]]),
      ('read_query', typing.Optional[str]),
      ('write_statement', typing.Optional[str]),


### PR DESCRIPTION
This PR fixes #33286 due to changes introduced by #33205. Changing the order of the Python WriteToJdbc configuration to match the order of the fields in the corresponding JdbcSchemaIOProvider schema is what fixed the failing tests.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
