### PR TITLE
[#32211] Fail job on SDK worker disconnect, instead of hanging forever.

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/worker/worker.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/worker.go
@@ -68,6 +68,7 @@ type W struct {
 	// These are the ID sources
 	inst               uint64
 	connected, stopped atomic.Bool
+	StoppedChan        chan struct{} // Channel to Broadcast stopped state.
 
 	InstReqs chan *fnpb.InstructionRequest
 	DataReqs chan *fnpb.Elements
@@ -96,8 +97,9 @@ func New(id, env string) *W {
 		lis:    lis,
 		server: grpc.NewServer(opts...),
 
-		InstReqs: make(chan *fnpb.InstructionRequest, 10),
-		DataReqs: make(chan *fnpb.Elements, 10),
+		InstReqs:    make(chan *fnpb.InstructionRequest, 10),
+		DataReqs:    make(chan *fnpb.Elements, 10),
+		StoppedChan: make(chan struct{}),
 
 		activeInstructions: make(map[string]controlResponder),
 		Descriptors:        make(map[string]*fnpb.ProcessBundleDescriptor),
@@ -132,12 +134,26 @@ func (wk *W) LogValue() slog.Value {
 	)
 }
 
+// shutdown safely closes channels, and can be called in the event of SDK crashes.
+//
+// Splitting this logic from the GRPC server Stop is necessary, since a worker
+// crash would be handled in a streaming RPC context, which will block GRPC
+// stop calls.
+func (wk *W) shutdown() {
+	// If this is the first call to "stop" this worker, also close the channels.
+	if wk.stopped.CompareAndSwap(false, true) {
+		slog.Debug("shutdown", "worker", wk, "firstTime", true)
+		close(wk.StoppedChan)
+		close(wk.InstReqs)
+		close(wk.DataReqs)
+	} else {
+		slog.Debug("shutdown", "worker", wk, "firstTime", false)
+	}
+}
+
 // Stop the GRPC server.
 func (wk *W) Stop() {
-	slog.Debug("stopping", "worker", wk)
-	wk.stopped.Store(true)
-	close(wk.InstReqs)
-	close(wk.DataReqs)
+	wk.shutdown()
 
 	// Give the SDK side 5 seconds to gracefully stop, before
 	// hard stopping all RPCs.
@@ -331,17 +347,21 @@ func (wk *W) Control(ctrl fnpb.BeamFnControl_ControlServer) error {
 		case <-ctrl.Context().Done():
 			wk.mu.Lock()
 			// Fail extant instructions
-			slog.Debug("SDK Disconnected", "worker", wk, "ctx_error", ctrl.Context().Err(), "outstanding_instructions", len(wk.activeInstructions))
+			err := context.Cause(ctrl.Context())
+			slog.Debug("SDK Disconnected", "worker", wk, "ctx_error", err, "outstanding_instructions", len(wk.activeInstructions))
 
-			msg := fmt.Sprintf("SDK worker disconnected: %v, %v active instructions", wk.String(), len(wk.activeInstructions))
+			msg := fmt.Sprintf("SDK worker disconnected: %v, %v active instructions, error: %v", wk.String(), len(wk.activeInstructions), err)
 			for instID, b := range wk.activeInstructions {
 				b.Respond(&fnpb.InstructionResponse{
 					InstructionId: instID,
 					Error:         msg,
 				})
 			}
+			// Soft shutdown to prevent GRPC shutdown from being blocked by this
+			// streaming call.
+			wk.shutdown()
 			wk.mu.Unlock()
-			return context.Cause(ctrl.Context())
+			return err
 		case err := <-done:
 			if err != nil {
 				slog.Warn("Control done", "error", err, "worker", wk)
@@ -639,9 +659,22 @@ func (wk *W) sendInstruction(ctx context.Context, req *fnpb.InstructionRequest) 
 	if wk.Stopped() {
 		return nil
 	}
-	wk.InstReqs <- req
+	select {
+	case <-wk.StoppedChan:
+		return &fnpb.InstructionResponse{
+			InstructionId: progInst,
+			Error:         "worker stopped before send",
+		}
+	case wk.InstReqs <- req:
+		// desired outcome
+	}
 
 	select {
+	case <-wk.StoppedChan:
+		return &fnpb.InstructionResponse{
+			InstructionId: progInst,
+			Error:         "worker stopped before receive",
+		}
 	case <-ctx.Done():
 		return &fnpb.InstructionResponse{
 			InstructionId: progInst,


### PR DESCRIPTION
In working on OnWindowExpiry, it shows SDK side disconnects would cause the job to hang indefinitely if there were outstanding ProcessBundleRequests. 

Instead, the job should fail (as SDK disconnects are not WAI behavior), and terminate execution instead.

Not testable as a closed form Go side without a more involved set up, but obvious in certain Python and Java side test failures. Clean job termination leads to better iteration than hangs do.

Part of #32211 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
