### PR TITLE
Force portable TestStream to use the Nested Coder context throughout.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/TestStreamTranslation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/TestStreamTranslation.java
@@ -123,7 +123,7 @@ public class TestStreamTranslation {
                   .setTimestamp(element.getTimestamp().getMillis())
                   .setEncodedElement(
                       ByteString.copyFrom(
-                          CoderUtils.encodeToByteArray(coder, element.getValue()))));
+                          CoderUtils.encodeToByteArray(coder, element.getValue(), Coder.Context.NESTED))));
         }
         return RunnerApi.TestStreamPayload.Event.newBuilder().setElementEvent(builder).build();
       default:
@@ -149,7 +149,7 @@ public class TestStreamTranslation {
             protoEvent.getElementEvent().getElementsList()) {
           decodedElements.add(
               TimestampedValue.of(
-                  CoderUtils.decodeFromByteArray(coder, element.getEncodedElement().toByteArray()),
+                  CoderUtils.decodeFromByteArray(coder, element.getEncodedElement().toByteArray(), Coder.Context.NESTED),
                   new Instant(element.getTimestamp())));
         }
         return TestStream.ElementEvent.add(decodedElements);


### PR DESCRIPTION
Coder Contexts are largely deprecated as a notion in Beam, and aren't used, with the default being the "nested" coder context instead of the Outer context. There are a few places though that still set "outer coder context" by default, notably in the CoderUtils helper methods.

Where this manifests for TestStream is that CoderUtils is used to take elements and convert them into byte buffers when moved portably. While *most* coders now ignore the difference, for various legacy reasons, the KVCoder still pipes the context to the *value* coder, and some coders still understand and use the difference. In this case, the StringUTF8 coder, when given the Outer context, doesn't length prefix the string. 

This leads to TestStream values being encoded in weird ways, that don't translate portably. eg. If the values are KV<String, String> the Key will be length prefixed, but the value will not be. This will ultimately cause a break at test run time, because the CoderUtils path isn't used in decoding over Beam Portability, but the normal decoder path, which wouldn't provide the Outer context.

This is likely what's caused difficulty in using TestStream in non-Java SDKs, such as Go on Flink.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
