### PR TITLE
[#32211] Support OnWindowExpiration in Prism.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,8 @@
 ## New Features / Improvements
 
 * X feature added (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
+* Support OnWindowExpiration in Prism ([#32211](https://github.com/apache/beam/issues/32211)).
+  * This enables initial Java GroupIntoBatches support.
 
 ## Breaking Changes
 

--- a/runners/prism/java/build.gradle
+++ b/runners/prism/java/build.gradle
@@ -228,8 +228,6 @@ def createPrismValidatesRunnerTask = { name, environmentType ->
       excludeCategories 'org.apache.beam.sdk.testing.UsesSdkHarnessEnvironment'
 
       // Not yet implemented in Prism
-      // https://github.com/apache/beam/issues/32211
-      excludeCategories 'org.apache.beam.sdk.testing.UsesOnWindowExpiration'
       // https://github.com/apache/beam/issues/32929
       excludeCategories 'org.apache.beam.sdk.testing.UsesOrderedListState'
 

--- a/runners/prism/java/build.gradle
+++ b/runners/prism/java/build.gradle
@@ -106,6 +106,12 @@ def sickbayTests = [
     'org.apache.beam.sdk.testing.TestStreamTest.testMultipleStreams',
     'org.apache.beam.sdk.testing.TestStreamTest.testProcessingTimeTrigger',
 
+    // GroupIntoBatchesTest tests that fail:
+    // Teststream has bad KV encodings due to using an outer context.
+    'org.apache.beam.sdk.transforms.GroupIntoBatchesTest.testInStreamingMode',
+    // ShardedKey not yet implemented.
+    'org.apache.beam.sdk.transforms.GroupIntoBatchesTest.testWithShardedKeyInGlobalWindow',
+
     // Coding error somehow: short write: reached end of stream after reading 5 bytes; 98 bytes expected
     'org.apache.beam.sdk.testing.TestStreamTest.testMultiStage',
 
@@ -231,9 +237,13 @@ def createPrismValidatesRunnerTask = { name, environmentType ->
       // https://github.com/apache/beam/issues/32929
       excludeCategories 'org.apache.beam.sdk.testing.UsesOrderedListState'
 
-       // Not supported in Portable Java SDK yet.
-       // https://github.com/apache/beam/issues?q=is%3Aissue+is%3Aopen+MultimapState
-       excludeCategories 'org.apache.beam.sdk.testing.UsesMultimapState'
+      // Not supported in Portable Java SDK yet.
+      // https://github.com/apache/beam/issues?q=is%3Aissue+is%3Aopen+MultimapState
+      excludeCategories 'org.apache.beam.sdk.testing.UsesMultimapState'
+
+      // Processing time with TestStream is unreliable without being able to control
+      // SDK side time portably. Ignore these tests.
+      excludeCategories 'org.apache.beam.sdk.testing.UsesTestStreamWithProcessingTime'
     }
     filter {
       for (String test : sickbayTests) {

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
@@ -656,7 +656,8 @@ type Block struct {
 	Transform, Family string
 }
 
-// StaticTimerID represents the static user identifiers for a timer.
+// StaticTimerID represents the static user identifiers for a timer,
+// in particular, the ID of the Transform, and the family for the timer.
 type StaticTimerID struct {
 	Transform, TimerFamily string
 }

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
@@ -659,7 +659,7 @@ type Block struct {
 // StaticTimerID represents the static user identifiers for a timer,
 // in particular, the ID of the Transform, and the family for the timer.
 type StaticTimerID struct {
-	Transform, TimerFamily string
+	TransformID, TimerFamily string
 }
 
 // StateForBundle retreives relevant state for the given bundle, WRT the data in the bundle.
@@ -1719,7 +1719,7 @@ func (ss *stageState) createOnWindowExpirationBundles(newOut mtime.Time, em *Ele
 				timestamp:     wm,
 				pane:          typex.NoFiringPane(),
 				holdTimestamp: wm,
-				transform:     ss.onWindowExpiration.Transform,
+				transform:     ss.onWindowExpiration.TransformID,
 				family:        ss.onWindowExpiration.TimerFamily,
 				sequence:      1,
 				keyBytes:      []byte(k),

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
@@ -1118,7 +1118,7 @@ type stageState struct {
 	// onWindowExpiration management
 	onWindowExpiration       StaticTimerID                // The static ID of the OnWindowExpiration callback.
 	keysToExpireByWindow     map[typex.Window]set[string] // Tracks all keys ever used with a window, so they may be expired.
-	inProgressExpiredWindows map[typex.Window]int         // Tracks the number of bundles currently expiring these windows, so we don't prematurely collect them.
+	inProgressExpiredWindows map[typex.Window]int         // Tracks the number of bundles currently expiring these windows, so we don't prematurely garbage collect them.
 	expiryWindowsByBundles   map[string]typex.Window      // Tracks which bundle is handling which window, so the above map can be cleared.
 
 	mu                 sync.Mutex

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sync/atomic"
 	"testing"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/coder"
@@ -522,5 +523,164 @@ func TestElementManager(t *testing.T) {
 		if got, want := i, 2; got != want {
 			t.Errorf("got %v bundles, want %v", got, want)
 		}
+	})
+}
+
+func TestElementManager_OnWindowExpiration(t *testing.T) {
+	t.Run("createOnWindowExpirationBundles", func(t *testing.T) {
+		// Unlike the other tests above, we synthesize the input configuration,
+		em := NewElementManager(Config{})
+		var instID uint64
+		em.nextBundID = func() string {
+			return fmt.Sprintf("inst%03d", atomic.AddUint64(&instID, 1))
+		}
+		em.AddStage("impulse", nil, []string{"input"}, nil)
+		em.AddStage("dofn", []string{"input"}, nil, nil)
+		onWE := StaticTimerID{
+			Transform:   "dofn1",
+			TimerFamily: "onWinExp",
+		}
+		em.StageOnWindowExpiration("dofn", onWE)
+		em.Impulse("impulse")
+
+		stage := em.stages["dofn"]
+		stage.pendingByKeys = map[string]*dataAndTimers{}
+		stage.inprogressKeys = set[string]{}
+
+		validateInProgressExpiredWindows := func(t *testing.T, win typex.Window, want int) {
+			t.Helper()
+			if got := stage.inProgressExpiredWindows[win]; got != want {
+				t.Errorf("stage.inProgressExpiredWindows[%v] = %v, want %v", win, got, want)
+			}
+		}
+		validateSideBundles := func(t *testing.T, keys set[string]) {
+			t.Helper()
+			if len(em.sideChannelBundles) == 0 {
+				t.Errorf("no sideChannelBundles exist when checking keys: %v", keys)
+			}
+			// Check that all keys are marked as in progress
+			for k := range keys {
+				if !stage.inprogressKeys.present(k) {
+					t.Errorf("key %q not marked as in progress", k)
+				}
+			}
+
+			bundleID := ""
+		sideBundles:
+			for _, rb := range em.sideChannelBundles {
+				// find that a side channel bundle exists with these keys.
+				bkeys := stage.inprogressKeysByBundle[rb.BundleID]
+				if len(bkeys) != len(keys) {
+					continue sideBundles
+				}
+				for k := range keys {
+					if !bkeys.present(k) {
+						continue sideBundles
+					}
+				}
+				bundleID = rb.BundleID
+				break
+			}
+			if bundleID == "" {
+				t.Errorf("no bundle found with all the given keys: %v: bundles: %v keysByBundle: %v", keys, em.sideChannelBundles, stage.inprogressKeysByBundle)
+			}
+		}
+
+		newOut := mtime.EndOfGlobalWindowTime
+		// No windows exist, so no side channel bundles should be set.
+		if got, want := stage.createOnWindowExpirationBundles(newOut, em), false; got != want {
+			t.Errorf("createOnWindowExpirationBundles(%v) = %v, want %v", newOut, got, want)
+		}
+		// Validate that no side channel bundles were created.
+		if got, want := len(stage.inProgressExpiredWindows), 0; got != want {
+			t.Errorf("len(stage.inProgressExpiredWindows) = %v, want %v", got, want)
+		}
+		if got, want := len(em.sideChannelBundles), 0; got != want {
+			t.Errorf("len(em.sideChannelBundles) = %v, want %v", got, want)
+		}
+
+		// Configure a few conditions to validate in the call.
+		// Each window is in it's own bundle, all are in the same bundle.
+		// Bundle 1
+		expiredWindow1 := window.IntervalWindow{Start: 0, End: newOut - 1}
+
+		akey := "\u0004key1"
+		keys1 := singleSet(akey)
+		stage.keysToExpireByWindow[expiredWindow1] = keys1
+		// Bundle 2
+		expiredWindow2 := window.IntervalWindow{Start: 1, End: newOut - 1}
+		keys2 := singleSet("\u0004key2")
+		keys2.insert("\u0004key3")
+		keys2.insert("\u0004key4")
+		stage.keysToExpireByWindow[expiredWindow2] = keys2
+
+		// We should never see this key and window combination, as the window is
+		// not yet expired.
+		liveWindow := window.IntervalWindow{Start: 2, End: newOut + 1}
+		stage.keysToExpireByWindow[liveWindow] = singleSet("\u0010keyNotSeen")
+
+		if got, want := stage.createOnWindowExpirationBundles(newOut, em), true; got != want {
+			t.Errorf("createOnWindowExpirationBundles(%v) = %v, want %v", newOut, got, want)
+		}
+
+		// We should only see 2 sideChannelBundles at this point.
+		if got, want := len(em.sideChannelBundles), 2; got != want {
+			t.Errorf("len(em.sideChannelBundles) = %v, want %v", got, want)
+		}
+
+		validateInProgressExpiredWindows(t, expiredWindow1, 1)
+		validateInProgressExpiredWindows(t, expiredWindow2, 1)
+		validateSideBundles(t, keys1)
+		validateSideBundles(t, keys2)
+
+		// Bundle 3
+		expiredWindow3 := window.IntervalWindow{Start: 3, End: newOut - 1}
+		keys3 := singleSet(akey)   // We shouldn't see this key, since it's in progress.
+		keys3.insert("\u0004key5") // We should see this key since it isn't.
+		stage.keysToExpireByWindow[expiredWindow3] = keys3
+
+		if got, want := stage.createOnWindowExpirationBundles(newOut, em), true; got != want {
+			t.Errorf("createOnWindowExpirationBundles(%v) = %v, want %v", newOut, got, want)
+		}
+
+		// We should see 3 sideChannelBundles at this point.
+		if got, want := len(em.sideChannelBundles), 3; got != want {
+			t.Errorf("len(em.sideChannelBundles) = %v, want %v", got, want)
+		}
+
+		validateInProgressExpiredWindows(t, expiredWindow1, 1)
+		validateInProgressExpiredWindows(t, expiredWindow2, 1)
+		validateInProgressExpiredWindows(t, expiredWindow3, 1)
+		validateSideBundles(t, keys1)
+		validateSideBundles(t, keys2)
+		validateSideBundles(t, singleSet("\u0004key5"))
+
+		// remove key1 from "inprogress keys", and the associated bundle.
+		stage.inprogressKeys.remove(akey)
+		delete(stage.inProgressExpiredWindows, expiredWindow1)
+		for bundID, bkeys := range stage.inprogressKeysByBundle {
+			if bkeys.present(akey) {
+				t.Logf("bundID: %v, bkeys: %v, keyByBundle: %v", bundID, bkeys, stage.inprogressKeysByBundle)
+				delete(stage.inprogressKeysByBundle, bundID)
+				win := stage.expiryWindowsByBundles[bundID]
+				delete(stage.expiryWindowsByBundles, bundID)
+				if win != expiredWindow1 {
+					t.Fatalf("Unexpected window: got %v, want %v", win, expiredWindow1)
+				}
+				break
+			}
+		}
+
+		// Now we should get another bundle for expiredWindow3, and have none for expiredWindow1
+		if got, want := stage.createOnWindowExpirationBundles(newOut, em), true; got != want {
+			t.Errorf("createOnWindowExpirationBundles(%v) = %v, want %v", newOut, got, want)
+		}
+
+		validateInProgressExpiredWindows(t, expiredWindow1, 0)
+		validateInProgressExpiredWindows(t, expiredWindow2, 1)
+		validateInProgressExpiredWindows(t, expiredWindow3, 2)
+		validateSideBundles(t, keys1) // Should still have this key present, but with a different bundle.
+		validateSideBundles(t, keys2)
+		validateSideBundles(t, singleSet("\u0004key5")) // still exist..
 	})
 }

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager_test.go
@@ -555,8 +555,8 @@ func TestElementManager_OnWindowExpiration(t *testing.T) {
 		}
 		validateSideBundles := func(t *testing.T, keys set[string]) {
 			t.Helper()
-			if len(em.sideChannelBundles) == 0 {
-				t.Errorf("no sideChannelBundles exist when checking keys: %v", keys)
+			if len(em.injectedBundles) == 0 {
+				t.Errorf("no injectedBundles exist when checking keys: %v", keys)
 			}
 			// Check that all keys are marked as in progress
 			for k := range keys {
@@ -567,7 +567,7 @@ func TestElementManager_OnWindowExpiration(t *testing.T) {
 
 			bundleID := ""
 		sideBundles:
-			for _, rb := range em.sideChannelBundles {
+			for _, rb := range em.injectedBundles {
 				// find that a side channel bundle exists with these keys.
 				bkeys := stage.inprogressKeysByBundle[rb.BundleID]
 				if len(bkeys) != len(keys) {
@@ -582,7 +582,7 @@ func TestElementManager_OnWindowExpiration(t *testing.T) {
 				break
 			}
 			if bundleID == "" {
-				t.Errorf("no bundle found with all the given keys: %v: bundles: %v keysByBundle: %v", keys, em.sideChannelBundles, stage.inprogressKeysByBundle)
+				t.Errorf("no bundle found with all the given keys: %v: bundles: %v keysByBundle: %v", keys, em.injectedBundles, stage.inprogressKeysByBundle)
 			}
 		}
 
@@ -595,8 +595,8 @@ func TestElementManager_OnWindowExpiration(t *testing.T) {
 		if got, want := len(stage.inProgressExpiredWindows), 0; got != want {
 			t.Errorf("len(stage.inProgressExpiredWindows) = %v, want %v", got, want)
 		}
-		if got, want := len(em.sideChannelBundles), 0; got != want {
-			t.Errorf("len(em.sideChannelBundles) = %v, want %v", got, want)
+		if got, want := len(em.injectedBundles), 0; got != want {
+			t.Errorf("len(em.injectedBundles) = %v, want %v", got, want)
 		}
 
 		// Configure a few conditions to validate in the call.
@@ -623,9 +623,9 @@ func TestElementManager_OnWindowExpiration(t *testing.T) {
 			t.Errorf("createOnWindowExpirationBundles(%v) = %v, want %v", newOut, got, want)
 		}
 
-		// We should only see 2 sideChannelBundles at this point.
-		if got, want := len(em.sideChannelBundles), 2; got != want {
-			t.Errorf("len(em.sideChannelBundles) = %v, want %v", got, want)
+		// We should only see 2 injectedBundles at this point.
+		if got, want := len(em.injectedBundles), 2; got != want {
+			t.Errorf("len(em.injectedBundles) = %v, want %v", got, want)
 		}
 
 		validateInProgressExpiredWindows(t, expiredWindow1, 1)
@@ -643,9 +643,9 @@ func TestElementManager_OnWindowExpiration(t *testing.T) {
 			t.Errorf("createOnWindowExpirationBundles(%v) = %v, want %v", newOut, got, want)
 		}
 
-		// We should see 3 sideChannelBundles at this point.
-		if got, want := len(em.sideChannelBundles), 3; got != want {
-			t.Errorf("len(em.sideChannelBundles) = %v, want %v", got, want)
+		// We should see 3 injectedBundles at this point.
+		if got, want := len(em.injectedBundles), 3; got != want {
+			t.Errorf("len(em.injectedBundles) = %v, want %v", got, want)
 		}
 
 		validateInProgressExpiredWindows(t, expiredWindow1, 1)

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager_test.go
@@ -537,7 +537,7 @@ func TestElementManager_OnWindowExpiration(t *testing.T) {
 		em.AddStage("impulse", nil, []string{"input"}, nil)
 		em.AddStage("dofn", []string{"input"}, nil, nil)
 		onWE := StaticTimerID{
-			Transform:   "dofn1",
+			TransformID: "dofn1",
 			TimerFamily: "onWinExp",
 		}
 		em.StageOnWindowExpiration("dofn", onWE)

--- a/sdks/go/pkg/beam/runners/prism/internal/execute.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/execute.go
@@ -318,6 +318,10 @@ func executePipeline(ctx context.Context, wks map[string]*worker.W, j *jobservic
 			if stage.stateful {
 				em.StageStateful(stage.ID)
 			}
+			if stage.onWindowExpiration.TimerFamily != "" {
+				slog.Debug("OnWindowExpiration", slog.String("stage", stage.ID), slog.Any("values", stage.onWindowExpiration))
+				em.StageOnWindowExpiration(stage.ID, stage.onWindowExpiration)
+			}
 			if len(stage.processingTimeTimers) > 0 {
 				em.StageProcessingTimeTimers(stage.ID, stage.processingTimeTimers)
 			}

--- a/sdks/go/pkg/beam/runners/prism/internal/jobservices/job.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/jobservices/job.go
@@ -45,6 +45,7 @@ var supportedRequirements = map[string]struct{}{
 	urns.RequirementSplittableDoFn:     {},
 	urns.RequirementStatefulProcessing: {},
 	urns.RequirementBundleFinalization: {},
+	urns.RequirementOnWindowExpiration: {},
 }
 
 // TODO, move back to main package, and key off of executor handlers?

--- a/sdks/go/pkg/beam/runners/prism/internal/jobservices/management.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/jobservices/management.go
@@ -182,8 +182,6 @@ func (s *Server) Prepare(ctx context.Context, req *jobpb.PrepareJobRequest) (_ *
 				check("TimerFamilySpecs.TimeDomain.Urn", spec.GetTimeDomain(), pipepb.TimeDomain_EVENT_TIME, pipepb.TimeDomain_PROCESSING_TIME)
 			}
 
-			check("OnWindowExpirationTimerFamily", pardo.GetOnWindowExpirationTimerFamilySpec(), "") // Unsupported for now.
-
 			// Check for a stateful SDF and direct user to https://github.com/apache/beam/issues/32139
 			if pardo.GetRestrictionCoderId() != "" && isStateful {
 				check("Splittable+Stateful DoFn", "See https://github.com/apache/beam/issues/32139 for information.", "")

--- a/sdks/go/pkg/beam/runners/prism/internal/preprocess.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/preprocess.go
@@ -449,6 +449,12 @@ func finalizeStage(stg *stage, comps *pipepb.Components, pipelineFacts *fusionFa
 				if len(pardo.GetTimerFamilySpecs())+len(pardo.GetStateSpecs())+len(pardo.GetOnWindowExpirationTimerFamilySpec()) > 0 {
 					stg.stateful = true
 				}
+				if pardo.GetOnWindowExpirationTimerFamilySpec() != "" {
+					stg.onWindowExpiration = struct {
+						Transform   string
+						TimerFamily string
+					}{Transform: link.Transform, TimerFamily: pardo.GetOnWindowExpirationTimerFamilySpec()}
+				}
 				sis = pardo.GetSideInputs()
 			}
 			if _, ok := sis[link.Local]; ok {

--- a/sdks/go/pkg/beam/runners/prism/internal/preprocess.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/preprocess.go
@@ -450,10 +450,7 @@ func finalizeStage(stg *stage, comps *pipepb.Components, pipelineFacts *fusionFa
 					stg.stateful = true
 				}
 				if pardo.GetOnWindowExpirationTimerFamilySpec() != "" {
-					stg.onWindowExpiration = struct {
-						Transform   string
-						TimerFamily string
-					}{Transform: link.Transform, TimerFamily: pardo.GetOnWindowExpirationTimerFamilySpec()}
+					stg.onWindowExpiration = engine.StaticTimerID{TransformID: link.Transform, TimerFamily: pardo.GetOnWindowExpirationTimerFamilySpec()}
 				}
 				sis = pardo.GetSideInputs()
 			}

--- a/sdks/go/pkg/beam/runners/prism/internal/stage.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/stage.go
@@ -57,18 +57,20 @@ type link struct {
 // account, but all serialization boundaries remain since the pcollections
 // would continue to get serialized.
 type stage struct {
-	ID           string
-	transforms   []string
-	primaryInput string          // PCollection used as the parallel input.
-	outputs      []link          // PCollections that must escape this stage.
-	sideInputs   []engine.LinkID // Non-parallel input PCollections and their consumers
-	internalCols []string        // PCollections that escape. Used for precise coder sending.
-	envID        string
-	finalize     bool
-	stateful     bool
+	ID                 string
+	transforms         []string
+	primaryInput       string          // PCollection used as the parallel input.
+	outputs            []link          // PCollections that must escape this stage.
+	sideInputs         []engine.LinkID // Non-parallel input PCollections and their consumers
+	internalCols       []string        // PCollections that escape. Used for precise coder sending.
+	envID              string
+	finalize           bool
+	stateful           bool
+	onWindowExpiration engine.StaticTimerID
+
 	// hasTimers indicates the transform+timerfamily pairs that need to be waited on for
 	// the stage to be considered complete.
-	hasTimers            []struct{ Transform, TimerFamily string }
+	hasTimers            []engine.StaticTimerID
 	processingTimeTimers map[string]bool
 
 	exe              transformExecuter

--- a/sdks/go/pkg/beam/runners/prism/internal/stage.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/stage.go
@@ -454,7 +454,7 @@ func buildDescriptor(stg *stage, comps *pipepb.Components, wk *worker.W, em *eng
 			}
 		}
 		for timerID, v := range pardo.GetTimerFamilySpecs() {
-			stg.hasTimers = append(stg.hasTimers, struct{ Transform, TimerFamily string }{Transform: tid, TimerFamily: timerID})
+			stg.hasTimers = append(stg.hasTimers, engine.StaticTimerID{TransformID: tid, TimerFamily: timerID})
 			if v.TimeDomain == pipepb.TimeDomain_PROCESSING_TIME {
 				if stg.processingTimeTimers == nil {
 					stg.processingTimeTimers = map[string]bool{}

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/bundle.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/bundle.go
@@ -190,7 +190,7 @@ func (b *B) ProcessOn(ctx context.Context, wk *W) <-chan struct{} {
 	for _, tid := range b.HasTimers {
 		timers = append(timers, &fnpb.Elements_Timers{
 			InstructionId: b.InstID,
-			TransformId:   tid.Transform,
+			TransformId:   tid.TransformID,
 			TimerFamilyId: tid.TimerFamily,
 			IsLast:        true,
 		})

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/bundle.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/bundle.go
@@ -42,7 +42,7 @@ type B struct {
 	InputTransformID       string
 	Input                  []*engine.Block // Data and Timers for this bundle.
 	EstimatedInputElements int
-	HasTimers              []struct{ Transform, TimerFamily string } // Timer streams to terminate.
+	HasTimers              []engine.StaticTimerID // Timer streams to terminate.
 
 	// IterableSideInputData is a map from transformID + inputID, to window, to data.
 	IterableSideInputData map[SideInputKey]map[typex.Window][][]byte


### PR DESCRIPTION
* Adds tracking for keys used within a window, so the OnWindowExpiration callback can be invoked.
* Restricts the output watermark from advancing until a window's been garbage collected and all keys have been expired.
* Added a "side channel" mechanism to insert bundles for execution outside of normal execution flow.
  * This may ultimately be used for ProcessingTime timers, as well as for Triggers/
* Supports OnWindowExpiration, enabling initial GroupIntoBatches support. 

Fixes #32211

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
