### PR TITLE
Add hadoop-auth

### DIFF
--- a/.github/trigger_files/beam_PostCommit_Python_Xlang_IO_Direct.json
+++ b/.github/trigger_files/beam_PostCommit_Python_Xlang_IO_Direct.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run",
-  "modification": 3
+  "modification": 2
 }

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -795,6 +795,7 @@ class BeamModulePlugin implements Plugin<Project> {
         grpc_xds                                    : "io.grpc:grpc-xds", // google_cloud_platform_libraries_bom sets version
         guava                                       : "com.google.guava:guava:$guava_version",
         guava_testlib                               : "com.google.guava:guava-testlib:$guava_version",
+        hadoop_auth                                 : "org.apache.hadoop:hadoop-auth:$hadoop_version",
         hadoop_client                               : "org.apache.hadoop:hadoop-client:$hadoop_version",
         hadoop_common                               : "org.apache.hadoop:hadoop-common:$hadoop_version",
         hadoop_mapreduce_client_core                : "org.apache.hadoop:hadoop-mapreduce-client-core:$hadoop_version",

--- a/sdks/java/io/expansion-service/build.gradle
+++ b/sdks/java/io/expansion-service/build.gradle
@@ -54,6 +54,7 @@ dependencies {
   permitUnusedDeclared project(":sdks:java:io:kafka:upgrade") // BEAM-11761
 
   // **** IcebergIO runtime dependencies ****
+  runtimeOnly library.java.hadoop_auth
   runtimeOnly library.java.hadoop_client
   // Needed when using GCS as the warehouse location.
   runtimeOnly library.java.bigdataoss_gcs_connector

--- a/sdks/java/io/iceberg/build.gradle
+++ b/sdks/java/io/iceberg/build.gradle
@@ -53,15 +53,15 @@ dependencies {
     implementation "org.apache.iceberg:iceberg-api:$iceberg_version"
     implementation "org.apache.iceberg:iceberg-parquet:$iceberg_version"
     implementation "org.apache.iceberg:iceberg-orc:$iceberg_version"
-    runtimeOnly "org.apache.iceberg:iceberg-gcp:$iceberg_version"
     implementation library.java.hadoop_common
+    runtimeOnly "org.apache.iceberg:iceberg-gcp:$iceberg_version"
+    runtimeOnly library.java.hadoop_auth
 
     testImplementation project(":sdks:java:managed")
     testImplementation library.java.hadoop_client
     testImplementation library.java.bigdataoss_gcsio
     testImplementation library.java.bigdataoss_gcs_connector
     testImplementation library.java.bigdataoss_util_hadoop
-    testImplementation "org.apache.iceberg:iceberg-gcp:$iceberg_version"
     testImplementation "org.apache.iceberg:iceberg-data:$iceberg_version"
     testImplementation project(path: ":sdks:java:core", configuration: "shadowTest")
     testImplementation project(":sdks:java:extensions:google-cloud-platform-core")

--- a/sdks/java/io/iceberg/build.gradle
+++ b/sdks/java/io/iceberg/build.gradle
@@ -55,7 +55,6 @@ dependencies {
     implementation "org.apache.iceberg:iceberg-orc:$iceberg_version"
     implementation library.java.hadoop_common
     runtimeOnly "org.apache.iceberg:iceberg-gcp:$iceberg_version"
-    runtimeOnly library.java.hadoop_auth
 
     testImplementation project(":sdks:java:managed")
     testImplementation library.java.hadoop_client


### PR DESCRIPTION
Fixes the failing [beam_PostCommit_Python_Xlang_IO_Direct](https://github.com/apache/beam/actions/workflows/beam_PostCommit_Python_Xlang_IO_Direct.yml) and [beam_PostCommit_Python_Xlang_IO_Dataflow](https://github.com/apache/beam/actions/workflows/beam_PostCommit_Python_Xlang_IO_Dataflow.yml) tests, which are running into the following error after the [recent hadoop bump](https://github.com/apache/beam/pull/33312) from 2.10.2 --> 3.4.1:

<details>
<summary> Error stacktrace: </summary>

```
E       RuntimeError: org.apache.beam.sdk.util.UserCodeException: java.lang.NoSuchMethodError: org.apache.hadoop.security.HadoopKerberosName.setRuleMechanism(Ljava/lang/String;)V
E               at org.apache.beam.sdk.util.UserCodeException.wrap(UserCodeException.java:39)
E               at org.apache.beam.sdk.io.iceberg.WriteUngroupedRowsToFiles$WriteUngroupedRowsToFilesDoFn$DoFnInvoker.invokeStartBundle(Unknown Source)
E               at org.apache.beam.fn.harness.FnApiDoFnRunner.startBundle(FnApiDoFnRunner.java:804)
E               at org.apache.beam.fn.harness.data.PTransformFunctionRegistry.lambda$register$0(PTransformFunctionRegistry.java:116)
E               at org.apache.beam.fn.harness.control.ProcessBundleHandler.processBundle(ProcessBundleHandler.java:532)
E               at org.apache.beam.fn.harness.control.BeamFnControlClient.delegateOnInstructionRequestType(BeamFnControlClient.java:150)
E               at org.apache.beam.fn.harness.control.BeamFnControlClient$InboundObserver.lambda$onNext$0(BeamFnControlClient.java:115)
E               at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
E               at java.util.concurrent.FutureTask.run(FutureTask.java:266)
E               at org.apache.beam.sdk.util.UnboundedScheduledExecutorService$ScheduledFutureTask.run(UnboundedScheduledExecutorService.java:163)
E               at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
E               at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
E               at java.lang.Thread.run(Thread.java:750)
E       Caused by: java.lang.NoSuchMethodError: org.apache.hadoop.security.HadoopKerberosName.setRuleMechanism(Ljava/lang/String;)V
E               at org.apache.hadoop.security.HadoopKerberosName.setConfiguration(HadoopKerberosName.java:84)
E               at org.apache.hadoop.security.UserGroupInformation.initialize(UserGroupInformation.java:314)
E               at org.apache.hadoop.security.UserGroupInformation.ensureInitialized(UserGroupInformation.java:299)
E               at org.apache.hadoop.security.UserGroupInformation.getCurrentUser(UserGroupInformation.java:586)
E               at org.apache.hadoop.fs.FileSystem$Cache$Key.<init>(FileSystem.java:3888)
E               at org.apache.hadoop.fs.FileSystem$Cache$Key.<init>(FileSystem.java:3878)
E               at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:3666)
E               at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:557)
E               at org.apache.hadoop.fs.Path.getFileSystem(Path.java:366)
E               at org.apache.iceberg.hadoop.Util.getFs(Util.java:56)
E               at org.apache.iceberg.hadoop.HadoopCatalog.initialize(HadoopCatalog.java:112)
E               at org.apache.iceberg.CatalogUtil.loadCatalog(CatalogUtil.java:239)
E               at org.apache.iceberg.CatalogUtil.buildIcebergCatalog(CatalogUtil.java:284)
E               at org.apache.beam.sdk.io.iceberg.IcebergCatalogConfig.catalog(IcebergCatalogConfig.java:66)
E               at org.apache.beam.sdk.io.iceberg.WriteUngroupedRowsToFiles$WriteUngroupedRowsToFilesDoFn.getCatalog(WriteUngroupedRowsToFiles.java:213)
E               at org.apache.beam.sdk.io.iceberg.WriteUngroupedRowsToFiles$WriteUngroupedRowsToFilesDoFn.startBundle(WriteUngroupedRowsToFiles.java:221)
```

</details>