### PR TITLE
[#32929] Add OrderedListState support to Prism.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,6 +71,7 @@
 * X feature added (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
 * Support OnWindowExpiration in Prism ([#32211](https://github.com/apache/beam/issues/32211)).
   * This enables initial Java GroupIntoBatches support.
+* Support OrderedListState in Prism ([#32929](https://github.com/apache/beam/issues/32929)).
 
 ## Breaking Changes
 

--- a/runners/prism/java/build.gradle
+++ b/runners/prism/java/build.gradle
@@ -233,10 +233,6 @@ def createPrismValidatesRunnerTask = { name, environmentType ->
       excludeCategories 'org.apache.beam.sdk.testing.UsesExternalService'
       excludeCategories 'org.apache.beam.sdk.testing.UsesSdkHarnessEnvironment'
 
-      // Not yet implemented in Prism
-      // https://github.com/apache/beam/issues/32929
-      excludeCategories 'org.apache.beam.sdk.testing.UsesOrderedListState'
-
       // Not supported in Portable Java SDK yet.
       // https://github.com/apache/beam/issues?q=is%3Aissue+is%3Aopen+MultimapState
       excludeCategories 'org.apache.beam.sdk.testing.UsesMultimapState'

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/data.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/data.go
@@ -49,46 +49,12 @@ type TentativeData struct {
 	// stateTypeLen is a map from LinkID to valueLen function for parsing data.
 	// Only used by OrderedListState, since Prism must manipulate these datavalues,
 	// which isn't expected, or a requirement of other state values.
-	stateTypeLen map[LinkID]valueLen
+	stateTypeLen map[LinkID]func([]byte) int
 	// state is a map from transformID + UserStateID, to window, to userKey, to datavalues.
 	state map[LinkID]map[typex.Window]map[string]StateData
 	// timers is a map from the Timer transform+family to the encoded timer.
 	timers map[TimerKey][][]byte
 }
-
-// valueLen is a function that extracts the length of a value in bytes from a
-// byte buffer. The expectation is that it will provide an exact count of bytes
-// that are required to consume the value from the buffer.
-type valueLen func([]byte) int
-
-var (
-	// varIntLen returns the number of bytes representing the varint.
-	varIntLen valueLen = func(b []byte) int {
-		_, n := protowire.ConsumeVarint(b)
-		return int(n)
-	}
-	// lenPrefiedLen returns the total length of the length prefixed
-	// value and the bytes of the length prefix.
-	// This applies to arbitrary custom coders, bytes, and string values.
-	lenPrefiedLen = func(b []byte) int {
-		l, n := protowire.ConsumeVarint(b)
-		return int(l) + n
-	}
-	// oneByteLen returns the number of bytes in a boolean, which is 1.
-	oneByteLen = func(_ []byte) int {
-		return 1
-	}
-	// fourByteLen returns the number of bytes in a single float, float32, or int32
-	// which is 4.
-	fourByteLen = func(_ []byte) int {
-		return 4
-	}
-	// eightByteLen returns the number of bytes in a double, float64, or int64
-	// which is 8.
-	eightByteLen = func(_ []byte) int {
-		return 8
-	}
-)
 
 // WriteData adds data to a given global collectionID.
 func (d *TentativeData) WriteData(colID string, data []byte) {
@@ -287,7 +253,7 @@ func (d *TentativeData) AppendOrderedListState(stateID LinkID, wKey, uKey []byte
 	// We need to parse out all values individually for later sorting.
 	for i := 0; i < len(data); {
 		// Get the length of the VarInt for the timestamp.
-		tn := varIntLen(data[i:])
+		_, tn := protowire.ConsumeVarint(data[i:])
 
 		// Get the length of the encoded value.
 		vn := typeLen(data[i+tn:])

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/data_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/data_test.go
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+func TestCompareTimestampSuffixes(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		loI := int64(math.MinInt64)
+		hiI := int64(math.MaxInt64)
+
+		loB := binary.BigEndian.AppendUint64(nil, uint64(loI))
+		hiB := binary.BigEndian.AppendUint64(nil, uint64(hiI))
+
+		if compareTimestampSuffixes(loB, hiB) != (loI < hiI) {
+			t.Errorf("lo vs Hi%v < %v: bytes %v vs %v, %v %v", loI, hiI, loB, hiB, loI < hiI, compareTimestampSuffixes(loB, hiB))
+		}
+	})
+}

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/data_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/data_test.go
@@ -16,9 +16,13 @@
 package engine
 
 import (
+	"bytes"
 	"encoding/binary"
 	"math"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/encoding/protowire"
 )
 
 func TestCompareTimestampSuffixes(t *testing.T) {
@@ -31,6 +35,200 @@ func TestCompareTimestampSuffixes(t *testing.T) {
 
 		if compareTimestampSuffixes(loB, hiB) != (loI < hiI) {
 			t.Errorf("lo vs Hi%v < %v: bytes %v vs %v, %v %v", loI, hiI, loB, hiB, loI < hiI, compareTimestampSuffixes(loB, hiB))
+		}
+	})
+}
+
+func TestOrderedListState(t *testing.T) {
+	time1 := protowire.AppendVarint(nil, 11)
+	time2 := protowire.AppendVarint(nil, 22)
+	time3 := protowire.AppendVarint(nil, 33)
+	time4 := protowire.AppendVarint(nil, 44)
+	time5 := protowire.AppendVarint(nil, 55)
+
+	wKey := []byte{} // global window.
+	uKey := []byte("\u0007userkey")
+	linkID := LinkID{
+		Transform: "dofn",
+		Local:     "localStateName",
+	}
+	cc := func(a []byte, b ...byte) []byte {
+		return bytes.Join([][]byte{a, b}, []byte{})
+	}
+
+	t.Run("bool", func(t *testing.T) {
+		d := TentativeData{
+			stateTypeLen: map[LinkID]valueLen{
+				linkID: oneByteLen,
+			},
+		}
+
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time3, 1))
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time2, 0))
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time5, 1))
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time1, 1))
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time4, 0))
+
+		got := d.GetOrderedListState(linkID, wKey, uKey, 0, 60)
+		want := [][]byte{
+			cc(time1, 1),
+			cc(time2, 0),
+			cc(time3, 1),
+			cc(time4, 0),
+			cc(time5, 1),
+		}
+		if d := cmp.Diff(want, got); d != "" {
+			t.Errorf("OrderedList booleans \n%v", d)
+		}
+
+		d.ClearOrderedListState(linkID, wKey, uKey, 12, 54)
+		got = d.GetOrderedListState(linkID, wKey, uKey, 0, 60)
+		want = [][]byte{
+			cc(time1, 1),
+			cc(time5, 1),
+		}
+		if d := cmp.Diff(want, got); d != "" {
+			t.Errorf("OrderedList booleans, after clear\n%v", d)
+		}
+	})
+	t.Run("int32", func(t *testing.T) {
+		d := TentativeData{
+			stateTypeLen: map[LinkID]valueLen{
+				linkID: fourByteLen,
+			},
+		}
+
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time5, 0, 0, 0, 1))
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time4, 0, 0, 1, 0))
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time3, 0, 1, 0, 0))
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time2, 1, 0, 0, 0))
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time1, 1, 0, 0, 1))
+
+		got := d.GetOrderedListState(linkID, wKey, uKey, 0, 60)
+		want := [][]byte{
+			cc(time1, 1, 0, 0, 1),
+			cc(time2, 1, 0, 0, 0),
+			cc(time3, 0, 1, 0, 0),
+			cc(time4, 0, 0, 1, 0),
+			cc(time5, 0, 0, 0, 1),
+		}
+		if d := cmp.Diff(want, got); d != "" {
+			t.Errorf("OrderedList int32 \n%v", d)
+		}
+	})
+	t.Run("float64", func(t *testing.T) {
+		d := TentativeData{
+			stateTypeLen: map[LinkID]valueLen{
+				linkID: eightByteLen,
+			},
+		}
+
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time5, 0, 0, 0, 0, 0, 0, 0, 1))
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time1, 0, 0, 0, 0, 0, 0, 1, 0))
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time3, 0, 0, 0, 0, 0, 1, 0, 0))
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time2, 0, 0, 0, 0, 1, 0, 0, 0))
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time4, 0, 0, 0, 1, 0, 0, 0, 0))
+
+		got := d.GetOrderedListState(linkID, wKey, uKey, 0, 60)
+		want := [][]byte{
+			cc(time1, 0, 0, 0, 0, 0, 0, 1, 0),
+			cc(time2, 0, 0, 0, 0, 1, 0, 0, 0),
+			cc(time3, 0, 0, 0, 0, 0, 1, 0, 0),
+			cc(time4, 0, 0, 0, 1, 0, 0, 0, 0),
+			cc(time5, 0, 0, 0, 0, 0, 0, 0, 1),
+		}
+		if d := cmp.Diff(want, got); d != "" {
+			t.Errorf("OrderedList float64s \n%v", d)
+		}
+
+		d.ClearOrderedListState(linkID, wKey, uKey, 11, 12)
+		d.ClearOrderedListState(linkID, wKey, uKey, 33, 34)
+		d.ClearOrderedListState(linkID, wKey, uKey, 55, 56)
+
+		got = d.GetOrderedListState(linkID, wKey, uKey, 0, 60)
+		want = [][]byte{
+			cc(time2, 0, 0, 0, 0, 1, 0, 0, 0),
+			cc(time4, 0, 0, 0, 1, 0, 0, 0, 0),
+		}
+		if d := cmp.Diff(want, got); d != "" {
+			t.Errorf("OrderedList float64s, after clear \n%v", d)
+		}
+	})
+
+	t.Run("varint", func(t *testing.T) {
+		d := TentativeData{
+			stateTypeLen: map[LinkID]valueLen{
+				linkID: varIntLen,
+			},
+		}
+
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time2, protowire.AppendVarint(nil, 56)...))
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time4, protowire.AppendVarint(nil, 20067)...))
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time3, protowire.AppendVarint(nil, 7777777)...))
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time1, protowire.AppendVarint(nil, 424242)...))
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time5, protowire.AppendVarint(nil, 0)...))
+
+		got := d.GetOrderedListState(linkID, wKey, uKey, 0, 60)
+		want := [][]byte{
+			cc(time1, protowire.AppendVarint(nil, 424242)...),
+			cc(time2, protowire.AppendVarint(nil, 56)...),
+			cc(time3, protowire.AppendVarint(nil, 7777777)...),
+			cc(time4, protowire.AppendVarint(nil, 20067)...),
+			cc(time5, protowire.AppendVarint(nil, 0)...),
+		}
+		if d := cmp.Diff(want, got); d != "" {
+			t.Errorf("OrderedList int32 \n%v", d)
+		}
+	})
+	t.Run("lp", func(t *testing.T) {
+		d := TentativeData{
+			stateTypeLen: map[LinkID]valueLen{
+				linkID: lenPrefiedLen,
+			},
+		}
+
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time1, []byte("\u0003one")...))
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time2, []byte("\u0003two")...))
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time3, []byte("\u0005three")...))
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time4, []byte("\u0004four")...))
+		d.AppendOrderedListState(linkID, wKey, uKey, cc(time5, []byte("\u0019FourHundredAndEleventyTwo")...))
+
+		got := d.GetOrderedListState(linkID, wKey, uKey, 0, 60)
+		want := [][]byte{
+			cc(time1, []byte("\u0003one")...),
+			cc(time2, []byte("\u0003two")...),
+			cc(time3, []byte("\u0005three")...),
+			cc(time4, []byte("\u0004four")...),
+			cc(time5, []byte("\u0019FourHundredAndEleventyTwo")...),
+		}
+		if d := cmp.Diff(want, got); d != "" {
+			t.Errorf("OrderedList int32 \n%v", d)
+		}
+	})
+	t.Run("lp_onecall", func(t *testing.T) {
+		d := TentativeData{
+			stateTypeLen: map[LinkID]valueLen{
+				linkID: lenPrefiedLen,
+			},
+		}
+		d.AppendOrderedListState(linkID, wKey, uKey, bytes.Join([][]byte{
+			time5, []byte("\u0019FourHundredAndEleventyTwo"),
+			time3, []byte("\u0005three"),
+			time2, []byte("\u0003two"),
+			time1, []byte("\u0003one"),
+			time4, []byte("\u0004four"),
+		}, nil))
+
+		got := d.GetOrderedListState(linkID, wKey, uKey, 0, 60)
+		want := [][]byte{
+			cc(time1, []byte("\u0003one")...),
+			cc(time2, []byte("\u0003two")...),
+			cc(time3, []byte("\u0005three")...),
+			cc(time4, []byte("\u0004four")...),
+			cc(time5, []byte("\u0019FourHundredAndEleventyTwo")...),
+		}
+		if d := cmp.Diff(want, got); d != "" {
+			t.Errorf("OrderedList int32 \n%v", d)
 		}
 	})
 }

--- a/sdks/go/pkg/beam/runners/prism/internal/execute.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/execute.go
@@ -316,7 +316,7 @@ func executePipeline(ctx context.Context, wks map[string]*worker.W, j *jobservic
 			sort.Strings(outputs)
 			em.AddStage(stage.ID, []string{stage.primaryInput}, outputs, stage.sideInputs)
 			if stage.stateful {
-				em.StageStateful(stage.ID)
+				em.StageStateful(stage.ID, stage.stateTypeLen)
 			}
 			if stage.onWindowExpiration.TimerFamily != "" {
 				slog.Debug("OnWindowExpiration", slog.String("stage", stage.ID), slog.Any("values", stage.onWindowExpiration))

--- a/sdks/go/pkg/beam/runners/prism/internal/jobservices/management.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/jobservices/management.go
@@ -174,7 +174,8 @@ func (s *Server) Prepare(ctx context.Context, req *jobpb.PrepareJobRequest) (_ *
 			// Validate all the state features
 			for _, spec := range pardo.GetStateSpecs() {
 				isStateful = true
-				check("StateSpec.Protocol.Urn", spec.GetProtocol().GetUrn(), urns.UserStateBag, urns.UserStateMultiMap)
+				check("StateSpec.Protocol.Urn", spec.GetProtocol().GetUrn(),
+					urns.UserStateBag, urns.UserStateMultiMap, urns.UserStateOrderedList)
 			}
 			// Validate all the timer features
 			for _, spec := range pardo.GetTimerFamilySpecs() {

--- a/sdks/go/pkg/beam/runners/prism/internal/urns/urns.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/urns/urns.go
@@ -95,8 +95,9 @@ var (
 	SideInputMultiMap = siUrn(pipepb.StandardSideInputTypes_MULTIMAP)
 
 	// UserState kinds
-	UserStateBag      = usUrn(pipepb.StandardUserStateTypes_BAG)
-	UserStateMultiMap = usUrn(pipepb.StandardUserStateTypes_MULTIMAP)
+	UserStateBag         = usUrn(pipepb.StandardUserStateTypes_BAG)
+	UserStateMultiMap    = usUrn(pipepb.StandardUserStateTypes_MULTIMAP)
+	UserStateOrderedList = usUrn(pipepb.StandardUserStateTypes_ORDERED_LIST)
 
 	// WindowsFns
 	WindowFnGlobal  = quickUrn(pipepb.GlobalWindowsPayload_PROPERTIES)

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/worker.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/worker.go
@@ -554,6 +554,11 @@ func (wk *W) State(state fnpb.BeamFnState_StateServer) error {
 				case *fnpb.StateKey_MultimapKeysUserState_:
 					mmkey := key.GetMultimapKeysUserState()
 					data = b.OutputData.GetMultimapKeysState(engine.LinkID{Transform: mmkey.GetTransformId(), Local: mmkey.GetUserStateId()}, mmkey.GetWindow(), mmkey.GetKey())
+				case *fnpb.StateKey_OrderedListUserState_:
+					olkey := key.GetOrderedListUserState()
+					data = b.OutputData.GetOrderedListState(
+						engine.LinkID{Transform: olkey.GetTransformId(), Local: olkey.GetUserStateId()},
+						olkey.GetWindow(), olkey.GetKey(), olkey.GetRange().GetStart(), olkey.GetRange().GetEnd())
 				default:
 					panic(fmt.Sprintf("unsupported StateKey Get type: %T: %v", key.GetType(), prototext.Format(key)))
 				}
@@ -578,6 +583,11 @@ func (wk *W) State(state fnpb.BeamFnState_StateServer) error {
 				case *fnpb.StateKey_MultimapUserState_:
 					mmkey := key.GetMultimapUserState()
 					b.OutputData.AppendMultimapState(engine.LinkID{Transform: mmkey.GetTransformId(), Local: mmkey.GetUserStateId()}, mmkey.GetWindow(), mmkey.GetKey(), mmkey.GetMapKey(), req.GetAppend().GetData())
+				case *fnpb.StateKey_OrderedListUserState_:
+					olkey := key.GetOrderedListUserState()
+					b.OutputData.AppendOrderedListState(
+						engine.LinkID{Transform: olkey.GetTransformId(), Local: olkey.GetUserStateId()},
+						olkey.GetWindow(), olkey.GetKey(), req.GetAppend().GetData())
 				default:
 					panic(fmt.Sprintf("unsupported StateKey Append type: %T: %v", key.GetType(), prototext.Format(key)))
 				}
@@ -601,6 +611,10 @@ func (wk *W) State(state fnpb.BeamFnState_StateServer) error {
 				case *fnpb.StateKey_MultimapKeysUserState_:
 					mmkey := key.GetMultimapUserState()
 					b.OutputData.ClearMultimapKeysState(engine.LinkID{Transform: mmkey.GetTransformId(), Local: mmkey.GetUserStateId()}, mmkey.GetWindow(), mmkey.GetKey())
+				case *fnpb.StateKey_OrderedListUserState_:
+					olkey := key.GetOrderedListUserState()
+					b.OutputData.ClearOrderedListState(engine.LinkID{Transform: olkey.GetTransformId(), Local: olkey.GetUserStateId()},
+						olkey.GetWindow(), olkey.GetKey(), olkey.GetRange().GetStart(), olkey.GetRange().GetEnd())
 				default:
 					panic(fmt.Sprintf("unsupported StateKey Clear type: %T: %v", key.GetType(), prototext.Format(key)))
 				}


### PR DESCRIPTION
Adds support for the OrderedListState to Prism.

* Sorts values by VarInt Millis timestamp order on append.
* Lookup values by range requests from SDK.
* Handles known fixed leaf types as values (bools, doubles), varints,  and length prefixed types.
  * If the type can be length prefixed, then Prism will do that for that coder.
  * Otherwise fails for unknown coders that can't be handled.
  * Runner side, Only OrderedListState needs to parse the individual values, so they can be manipulated, so the length function plumbing isn't otherwise necessary. It would not be difficult to extend this for all state types in the future, should it be required.

Note, must be submitted after #33337 because OrderedListState tests require OnWindowExpiration.

Fixes #32929. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
