### PR TITLE
Improve existing Python multi-lang SchemaTransform examples

### DIFF
--- a/examples/multi-language/src/main/java/org/apache/beam/examples/multilanguage/schematransforms/ExtractWordsProvider.java
+++ b/examples/multi-language/src/main/java/org/apache/beam/examples/multilanguage/schematransforms/ExtractWordsProvider.java
@@ -21,9 +21,12 @@ import static org.apache.beam.examples.multilanguage.schematransforms.ExtractWor
 
 import com.google.auto.service.AutoService;
 import com.google.auto.value.AutoValue;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.beam.sdk.schemas.AutoValueSchema;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
+import org.apache.beam.sdk.schemas.annotations.SchemaFieldDescription;
 import org.apache.beam.sdk.schemas.transforms.SchemaTransform;
 import org.apache.beam.sdk.schemas.transforms.SchemaTransformProvider;
 import org.apache.beam.sdk.schemas.transforms.TypedSchemaTransformProvider;
@@ -36,7 +39,6 @@ import org.apache.beam.sdk.values.Row;
 /** Splits a line into separate words and returns each word. */
 @AutoService(SchemaTransformProvider.class)
 public class ExtractWordsProvider extends TypedSchemaTransformProvider<Configuration> {
-  public static final Schema OUTPUT_SCHEMA = Schema.builder().addStringField("word").build();
 
   @Override
   public String identifier() {
@@ -45,32 +47,60 @@ public class ExtractWordsProvider extends TypedSchemaTransformProvider<Configura
 
   @Override
   protected SchemaTransform from(Configuration configuration) {
-    return new SchemaTransform() {
-      @Override
-      public PCollectionRowTuple expand(PCollectionRowTuple input) {
-        return PCollectionRowTuple.of(
-            "output",
-            input.get("input").apply(ParDo.of(new ExtractWordsFn())).setRowSchema(OUTPUT_SCHEMA));
-      }
-    };
+    return new ExtractWordsTransform(configuration);
   }
 
-  static class ExtractWordsFn extends DoFn<Row, Row> {
-    @ProcessElement
-    public void processElement(@Element Row element, OutputReceiver<Row> receiver) {
-      // Split the line into words.
-      String line = Preconditions.checkStateNotNull(element.getString("line"));
-      String[] words = line.split("[^\\p{L}]+", -1);
+  static class ExtractWordsTransform extends SchemaTransform {
+    private static final Schema OUTPUT_SCHEMA = Schema.builder().addStringField("word").build();
+    private final List<String> filter;
 
-      for (String word : words) {
-        if (!word.isEmpty()) {
-          receiver.output(Row.withSchema(OUTPUT_SCHEMA).withFieldValue("word", word).build());
-        }
-      }
+    ExtractWordsTransform(Configuration configuration) {
+      this.filter = configuration.getFilter();
+    }
+
+    @Override
+    public PCollectionRowTuple expand(PCollectionRowTuple input) {
+      return PCollectionRowTuple.of(
+          "output",
+          input
+              .getSinglePCollection()
+              .apply(
+                  ParDo.of(
+                      new DoFn<Row, Row>() {
+                        @ProcessElement
+                        public void process(@Element Row element, OutputReceiver<Row> receiver) {
+                          // Split the line into words.
+                          String line = Preconditions.checkStateNotNull(element.getString("line"));
+                          String[] words = line.split("[^\\p{L}]+", -1);
+                          Arrays.stream(words)
+                              .filter(filter::contains)
+                              .forEach(
+                                  word ->
+                                      receiver.output(
+                                          Row.withSchema(OUTPUT_SCHEMA)
+                                              .withFieldValue("word", word)
+                                              .build()));
+                        }
+                      }))
+              .setRowSchema(OUTPUT_SCHEMA));
     }
   }
 
   @DefaultSchema(AutoValueSchema.class)
   @AutoValue
-  protected abstract static class Configuration {}
+  public abstract static class Configuration {
+    public static Builder builder() {
+      return new AutoValue_ExtractWordsProvider_Configuration.Builder();
+    }
+
+    @SchemaFieldDescription("List of words to filter out.")
+    public abstract List<String> getFilter();
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+      public abstract Builder setFilter(List<String> foo);
+
+      public abstract Configuration build();
+    }
+  }
 }

--- a/examples/multi-language/src/main/java/org/apache/beam/examples/multilanguage/schematransforms/ExtractWordsProvider.java
+++ b/examples/multi-language/src/main/java/org/apache/beam/examples/multilanguage/schematransforms/ExtractWordsProvider.java
@@ -52,10 +52,10 @@ public class ExtractWordsProvider extends TypedSchemaTransformProvider<Configura
 
   static class ExtractWordsTransform extends SchemaTransform {
     private static final Schema OUTPUT_SCHEMA = Schema.builder().addStringField("word").build();
-    private final List<String> filter;
+    private final List<String> drop;
 
     ExtractWordsTransform(Configuration configuration) {
-      this.filter = configuration.getFilter();
+      this.drop = configuration.getDrop();
     }
 
     @Override
@@ -73,7 +73,7 @@ public class ExtractWordsProvider extends TypedSchemaTransformProvider<Configura
                           String line = Preconditions.checkStateNotNull(element.getString("line"));
                           String[] words = line.split("[^\\p{L}]+", -1);
                           Arrays.stream(words)
-                              .filter(filter::contains)
+                              .filter(w -> !drop.contains(w))
                               .forEach(
                                   word ->
                                       receiver.output(
@@ -93,12 +93,12 @@ public class ExtractWordsProvider extends TypedSchemaTransformProvider<Configura
       return new AutoValue_ExtractWordsProvider_Configuration.Builder();
     }
 
-    @SchemaFieldDescription("List of words to filter out.")
-    public abstract List<String> getFilter();
+    @SchemaFieldDescription("List of words to drop.")
+    public abstract List<String> getDrop();
 
     @AutoValue.Builder
     public abstract static class Builder {
-      public abstract Builder setFilter(List<String> foo);
+      public abstract Builder setDrop(List<String> foo);
 
       public abstract Configuration build();
     }

--- a/examples/multi-language/src/main/java/org/apache/beam/examples/multilanguage/schematransforms/JavaCountProvider.java
+++ b/examples/multi-language/src/main/java/org/apache/beam/examples/multilanguage/schematransforms/JavaCountProvider.java
@@ -44,35 +44,37 @@ public class JavaCountProvider extends TypedSchemaTransformProvider<Configuratio
 
   @Override
   protected SchemaTransform from(Configuration configuration) {
-    return new SchemaTransform() {
-      @Override
-      public PCollectionRowTuple expand(PCollectionRowTuple input) {
-        Schema outputSchema =
-            Schema.builder().addStringField("word").addInt64Field("count").build();
+    return new JavaCountTransform();
+  }
 
-        PCollection<Row> wordCounts =
-            input
-                .get("input")
-                .apply(Count.perElement())
-                .apply(
-                    MapElements.into(TypeDescriptors.rows())
-                        .via(
-                            kv ->
-                                Row.withSchema(outputSchema)
-                                    .withFieldValue(
-                                        "word",
-                                        Preconditions.checkStateNotNull(
-                                            kv.getKey().getString("word")))
-                                    .withFieldValue("count", kv.getValue())
-                                    .build()))
-                .setRowSchema(outputSchema);
+  static class JavaCountTransform extends SchemaTransform {
+    static final Schema OUTPUT_SCHEMA =
+        Schema.builder().addStringField("word").addInt64Field("count").build();
 
-        return PCollectionRowTuple.of("output", wordCounts);
-      }
-    };
+    @Override
+    public PCollectionRowTuple expand(PCollectionRowTuple input) {
+      PCollection<Row> wordCounts =
+          input
+              .get("input")
+              .apply(Count.perElement())
+              .apply(
+                  MapElements.into(TypeDescriptors.rows())
+                      .via(
+                          kv ->
+                              Row.withSchema(OUTPUT_SCHEMA)
+                                  .withFieldValue(
+                                      "word",
+                                      Preconditions.checkStateNotNull(
+                                          kv.getKey().getString("word")))
+                                  .withFieldValue("count", kv.getValue())
+                                  .build()))
+              .setRowSchema(OUTPUT_SCHEMA);
+
+      return PCollectionRowTuple.of("output", wordCounts);
+    }
   }
 
   @DefaultSchema(AutoValueSchema.class)
   @AutoValue
-  protected abstract static class Configuration {}
+  public abstract static class Configuration {}
 }

--- a/examples/multi-language/src/main/java/org/apache/beam/examples/multilanguage/schematransforms/WriteWordsProvider.java
+++ b/examples/multi-language/src/main/java/org/apache/beam/examples/multilanguage/schematransforms/WriteWordsProvider.java
@@ -42,24 +42,32 @@ public class WriteWordsProvider extends TypedSchemaTransformProvider<Configurati
 
   @Override
   protected SchemaTransform from(Configuration configuration) {
-    return new SchemaTransform() {
-      @Override
-      public PCollectionRowTuple expand(PCollectionRowTuple input) {
-        input
-            .get("input")
-            .apply(
-                MapElements.into(TypeDescriptors.strings())
-                    .via(row -> Preconditions.checkStateNotNull(row.getString("line"))))
-            .apply(TextIO.write().to(configuration.getFilePathPrefix()));
+    return new WriteWordsTransform(configuration);
+  }
 
-        return PCollectionRowTuple.empty(input.getPipeline());
-      }
-    };
+  static class WriteWordsTransform extends SchemaTransform {
+    private final String filePathPrefix;
+
+    WriteWordsTransform(Configuration configuration) {
+      this.filePathPrefix = configuration.getFilePathPrefix();
+    }
+
+    @Override
+    public PCollectionRowTuple expand(PCollectionRowTuple input) {
+      input
+          .get("input")
+          .apply(
+              MapElements.into(TypeDescriptors.strings())
+                  .via(row -> Preconditions.checkStateNotNull(row.getString("line"))))
+          .apply(TextIO.write().to(filePathPrefix));
+
+      return PCollectionRowTuple.empty(input.getPipeline());
+    }
   }
 
   @DefaultSchema(AutoValueSchema.class)
   @AutoValue
-  protected abstract static class Configuration {
+  public abstract static class Configuration {
     public static Builder builder() {
       return new AutoValue_WriteWordsProvider_Configuration.Builder();
     }

--- a/sdks/python/apache_beam/transforms/external.py
+++ b/sdks/python/apache_beam/transforms/external.py
@@ -239,7 +239,8 @@ class ExplicitSchemaTransformPayloadBuilder(SchemaTransformPayloadBuilder):
         extra = set(py_value.keys()) - set(row_type._fields)
         if extra:
           raise ValueError(
-              f"Unknown fields: {extra}. Valid fields: {row_type._fields}")
+              f"Transform '{self.identifier()}' was configured with unknown "
+              f"fields: {extra}. Valid fields: {set(row_type._fields)}")
         return row_type(
             *[
                 dict_to_row_recursive(


### PR DESCRIPTION
Part of #33358

Simplify the Python example, and refactor the Java SchemaTransforms to be consistent