### PR TITLE
Fix Apache snapshot repo usage

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/Repositories.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/Repositories.groovy
@@ -39,6 +39,12 @@ class Repositories {
       mavenCentral()
       mavenLocal()
 
+      // For Confluent Kafka dependencies
+      maven {
+        url "https://packages.confluent.io/maven/"
+        content { includeGroup "io.confluent" }
+      }
+
       // Release staging repository
       maven { url "https://oss.sonatype.org/content/repositories/staging/" }
 
@@ -52,12 +58,6 @@ class Repositories {
 
       // Apache release snapshots
       maven { url "https://repository.apache.org/content/repositories/releases" }
-
-      // For Confluent Kafka dependencies
-      maven {
-        url "https://packages.confluent.io/maven/"
-        content { includeGroup "io.confluent" }
-      }
     }
 
     // Apply a plugin which provides the 'updateOfflineRepository' task that creates an offline

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/Repositories.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/Repositories.groovy
@@ -43,7 +43,12 @@ class Repositories {
       maven { url "https://oss.sonatype.org/content/repositories/staging/" }
 
       // Apache nightly snapshots
-      maven { url "https://repository.apache.org/snapshots" }
+      maven {
+        url "https://repository.apache.org/snapshots"
+        mavenContent {
+          snapshotsOnly()
+        }
+      }
 
       // Apache release snapshots
       maven { url "https://repository.apache.org/content/repositories/releases" }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Problem: Beam build searches `repository.apache.org` for artifacts not to be found there.  (See also #33333.)

Repro:

```
$ rm -fr ~/.gradle/caches
$ ./gradlew --info sdks:java:io:kafka:compileJava
...
Resource missing. [HTTP GET: https://repository.apache.org/snapshots/io/confluent/kafka-avro-serializer/7.5.5/kafka-avro-serializer-7.5.5.pom]
Resource missing. [HTTP GET: https://repository.apache.org/snapshots/io/confluent/kafka-schema-registry-client/7.5.5/kafka-schema-registry-client-7.5.5.pom]
Resource missing. [HTTP GET: https://repository.apache.org/content/repositories/releases/io/confluent/kafka-schema-registry-client/7.5.5/kafka-schema-registry-client-7.5.5.pom]
Resource missing. [HTTP GET: https://repository.apache.org/content/repositories/releases/io/confluent/kafka-avro-serializer/7.5.5/kafka-avro-serializer-7.5.5.pom]
...
```

Fix:

1. Limit `repository.apache.org/snapshots` to snapshot artifacts.
2. Move Confluent repo definition before the Apache repos.

## How was this patch tested?

```
$ rm -fr ~/.gradle/caches
$ ./gradlew --info sdks:java:io:kafka:compileJava | tee gradle.log 2>&1

$ grep -c 'HTTP GET.*repository.apache.org' gradle.log
0

$ grep 'packages.confluent' gradle.log
Downloading https://packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/7.5.5/kafka-schema-registry-client-7.5.5.pom to ...
Downloading https://packages.confluent.io/maven/io/confluent/kafka-avro-serializer/7.5.5/kafka-avro-serializer-7.5.5.pom to ...
...
```