### PR TITLE
Remove flaky Go DataMGR tests that terminate before read.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/harness/datamgr_test.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/datamgr_test.go
@@ -262,22 +262,6 @@ func TestElementChan(t *testing.T) {
 			},
 			wantSum: 6, wantCount: 3,
 		}, {
-			name: "FillBufferThenAbortThenRead",
-			sequenceFn: func(ctx context.Context, t *testing.T, client *fakeChanClient, c *DataChannel) <-chan exec.Elements {
-				for i := 0; i < bufElements+2; i++ {
-					client.Send(&fnpb.Elements{Data: []*fnpb.Elements_Data{dataElm(1, false)}})
-				}
-				elms := openChan(ctx, t, c, timerID)
-				c.removeInstruction(instID)
-
-				// These will be ignored
-				client.Send(&fnpb.Elements{Data: []*fnpb.Elements_Data{dataElm(1, false)}})
-				client.Send(&fnpb.Elements{Data: []*fnpb.Elements_Data{dataElm(2, false)}})
-				client.Send(&fnpb.Elements{Data: []*fnpb.Elements_Data{dataElm(3, true)}})
-				return elms
-			},
-			wantSum: bufElements, wantCount: bufElements,
-		}, {
 			name: "DataThenReaderThenLast",
 			sequenceFn: func(ctx context.Context, t *testing.T, client *fakeChanClient, c *DataChannel) <-chan exec.Elements {
 				client.Send(&fnpb.Elements{
@@ -389,18 +373,6 @@ func TestElementChan(t *testing.T) {
 				return elms
 			},
 			wantSum: 0, wantCount: 0,
-		}, {
-			name: "SomeTimersAndADataThenReaderThenCleanup",
-			sequenceFn: func(ctx context.Context, t *testing.T, client *fakeChanClient, c *DataChannel) <-chan exec.Elements {
-				client.Send(&fnpb.Elements{
-					Timers: []*fnpb.Elements_Timers{timerElm(1, false), timerElm(2, true)},
-					Data:   []*fnpb.Elements_Data{dataElm(3, true)},
-				})
-				elms := openChan(ctx, t, c, timerID)
-				c.removeInstruction(instID)
-				return elms
-			},
-			wantSum: 6, wantCount: 3,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
* The two flaky tests both followed the pattern of "remove the instruction prior to a bundle reading it". And tried to assert a specific amount of elements would be read.
* This isn't generally useful behavior.
* There was no guarantee that the element channel would have ingested any data before the removal, short of a read being attempted.
* Their case is better covered in other tests anyway, with deterministic results (eg PartialReadThenEndInstruction, which should always return 0s).

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
