### PR TITLE
chore: Upgrade google cloud bigdataoss version

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -606,7 +606,7 @@ class BeamModulePlugin implements Plugin<Project> {
     def gax_version = "2.52.0"
     def google_ads_version = "33.0.0"
     def google_clients_version = "2.0.0"
-    def google_cloud_bigdataoss_version = "2.2.16"
+    def google_cloud_bigdataoss_version = "2.2.26"
     // [bomupgrader] determined by: com.google.cloud:google-cloud-spanner, consistent with: google_cloud_platform_libraries_bom
     def google_cloud_spanner_version = "6.74.0"
     def google_code_gson_version = "2.10.1"

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/GrpcVendoring_1_60_1.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/GrpcVendoring_1_60_1.groovy
@@ -37,7 +37,7 @@ class GrpcVendoring_1_60_1 {
   // See https://github.com/grpc/grpc-java/blob/v1.60.1/gradle/libs.versions.toml
   // or https://search.maven.org/search?q=io.grpc%201.60.1
   static def guava_version = "32.0.1-jre"
-  static def protobuf_version = "3.24.0"
+  static def protobuf_version = "4.28.1"
   static def gson_version = "2.10.1"
   static def google_auth_version = "1.4.0"
   static def opencensus_version = "0.31.1"


### PR DESCRIPTION
google cloud bigdataoss released a version 2.2.26 that is protobuf 3 and 4 compatible (previously it was only 3 compatible).  Would like to include it in Apache beam to alleviate customer issues with protobuf 4 compatibility specifically with gscio.