### PR TITLE
chore: Upgrade google cloud bigdataoss version

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -606,7 +606,7 @@ class BeamModulePlugin implements Plugin<Project> {
     def gax_version = "2.52.0"
     def google_ads_version = "33.0.0"
     def google_clients_version = "2.0.0"
-    def google_cloud_bigdataoss_version = "2.2.16"
+    def google_cloud_bigdataoss_version = "2.2.26"
     // [bomupgrader] determined by: com.google.cloud:google-cloud-spanner, consistent with: google_cloud_platform_libraries_bom
     def google_cloud_spanner_version = "6.74.0"
     def google_code_gson_version = "2.10.1"


### PR DESCRIPTION
google cloud bigdataoss released a version 2.2.26 that is protobuf 3 and 4 compatible (previously it was only 3 compatible). Would like to include it in Apache beam to alleviate customer issues with protobuf 4 compatibility specifically with gscio.