### PR TITLE
Add missing to_type_hint to WindowedValueCoder

### DIFF
--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -1446,6 +1446,9 @@ class WindowedValueCoder(FastCoder):
     # pickle coders.
     return cls(registry.get_coder(typehint.inner_type))
 
+  def to_type_hint(self):
+    return typehints.WindowedValue[self.wrapped_value_coder.to_type_hint()]
+
 
 Coder.register_structured_urn(
     common_urns.coders.WINDOWED_VALUE.urn, WindowedValueCoder)

--- a/sdks/python/apache_beam/coders/coders_test.py
+++ b/sdks/python/apache_beam/coders/coders_test.py
@@ -258,6 +258,12 @@ class NumpyIntAsKeyTest(unittest.TestCase):
         _ = indata | "CombinePerKey" >> beam.CombinePerKey(sum)
 
 
+class WindowedValueCoderTest(unittest.TestCase):
+  def test_to_type_hint(self):
+    coder = coders.WindowedValueCoder(coders.VarIntCoder())
+    self.assertEqual(coder.to_type_hint(), typehints.WindowedValue[int])
+
+
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)
   unittest.main()

--- a/sdks/python/apache_beam/coders/coders_test.py
+++ b/sdks/python/apache_beam/coders/coders_test.py
@@ -261,7 +261,7 @@ class NumpyIntAsKeyTest(unittest.TestCase):
 class WindowedValueCoderTest(unittest.TestCase):
   def test_to_type_hint(self):
     coder = coders.WindowedValueCoder(coders.VarIntCoder())
-    self.assertEqual(coder.to_type_hint(), typehints.WindowedValue[int])
+    self.assertEqual(coder.to_type_hint(), typehints.WindowedValue[int])  # type: ignore[misc]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is to fix some internal test failure caused by #33363.
