### PR TITLE
Revert three commits related to supporting custom coder in reshuffle

### DIFF
--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -1438,17 +1438,6 @@ class WindowedValueCoder(FastCoder):
     return hash(
         (self.wrapped_value_coder, self.timestamp_coder, self.window_coder))
 
-  @classmethod
-  def from_type_hint(cls, typehint, registry):
-    # type: (Any, CoderRegistry) -> WindowedValueCoder
-    # Ideally this'd take two parameters so that one could hint at
-    # the window type as well instead of falling back to the
-    # pickle coders.
-    return cls(registry.get_coder(typehint.inner_type))
-
-  def to_type_hint(self):
-    return typehints.WindowedValue[self.wrapped_value_coder.to_type_hint()]
-
 
 Coder.register_structured_urn(
     common_urns.coders.WINDOWED_VALUE.urn, WindowedValueCoder)

--- a/sdks/python/apache_beam/coders/coders_test.py
+++ b/sdks/python/apache_beam/coders/coders_test.py
@@ -258,12 +258,6 @@ class NumpyIntAsKeyTest(unittest.TestCase):
         _ = indata | "CombinePerKey" >> beam.CombinePerKey(sum)
 
 
-class WindowedValueCoderTest(unittest.TestCase):
-  def test_to_type_hint(self):
-    coder = coders.WindowedValueCoder(coders.VarIntCoder())
-    self.assertEqual(coder.to_type_hint(), typehints.WindowedValue[int])  # type: ignore[misc]
-
-
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)
   unittest.main()

--- a/sdks/python/apache_beam/coders/typecoders.py
+++ b/sdks/python/apache_beam/coders/typecoders.py
@@ -94,8 +94,6 @@ class CoderRegistry(object):
     self._register_coder_internal(str, coders.StrUtf8Coder)
     self._register_coder_internal(typehints.TupleConstraint, coders.TupleCoder)
     self._register_coder_internal(typehints.DictConstraint, coders.MapCoder)
-    self._register_coder_internal(
-        typehints.WindowedTypeConstraint, coders.WindowedValueCoder)
     # Default fallback coders applied in that order until the first matching
     # coder found.
     default_fallback_coders = [

--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -24,12 +24,8 @@ import logging
 import sys
 import types
 import typing
-from typing import Generic
-from typing import TypeVar
 
 from apache_beam.typehints import typehints
-
-T = TypeVar('T')
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -220,18 +216,6 @@ def convert_collections_to_typing(typ):
   return typ
 
 
-# During type inference of WindowedValue, we need to pass in the inner value
-# type. This cannot be achieved immediately with WindowedValue class because it
-# is not parameterized. Changing it to a generic class (e.g. WindowedValue[T])
-# could work in theory. However, the class is cythonized and it seems that
-# cython does not handle generic classes well.
-# The workaround here is to create a separate class solely for the type
-# inference purpose. This class should never be used for creating instances.
-class TypedWindowedValue(Generic[T]):
-  def __init__(self, *args, **kwargs):
-    raise NotImplementedError("This class is solely for type inference")
-
-
 def convert_to_beam_type(typ):
   """Convert a given typing type to a Beam type.
 
@@ -283,12 +267,6 @@ def convert_to_beam_type(typ):
     # TODO(https://github.com/apache/beam/issues/20076): Currently unhandled.
     _LOGGER.info('Converting NewType type hint to Any: "%s"', typ)
     return typehints.Any
-  elif typ_module == 'apache_beam.typehints.native_type_compatibility' and \
-      getattr(typ, "__name__", typ.__origin__.__name__) == 'TypedWindowedValue':
-    # Need to pass through WindowedValue class so that it can be converted
-    # to the correct type constraint in Beam
-    # This is needed to fix https://github.com/apache/beam/issues/33356
-    pass
   elif (typ_module != 'typing') and (typ_module != 'collections.abc'):
     # Only translate types from the typing and collections.abc modules.
     return typ
@@ -346,10 +324,6 @@ def convert_to_beam_type(typ):
           match=_match_is_exactly_collection,
           arity=1,
           beam_type=typehints.Collection),
-      _TypeMapEntry(
-          match=_match_issubclass(TypedWindowedValue),
-          arity=1,
-          beam_type=typehints.WindowedValue),
   ]
 
   # Find the first matching entry.

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -1213,15 +1213,6 @@ class WindowedTypeConstraint(TypeConstraint, metaclass=GetitemConstructor):
               repr(self.inner_type),
               instance.value.__class__.__name__))
 
-  def bind_type_variables(self, bindings):
-    bound_inner_type = bind_type_variables(self.inner_type, bindings)
-    if bound_inner_type == self.inner_type:
-      return self
-    return WindowedValue[bound_inner_type]
-
-  def __repr__(self):
-    return 'WindowedValue[%s]' % repr(self.inner_type)
-
 
 class GeneratorHint(IteratorHint):
   """A Generator type hint.


### PR DESCRIPTION
- Fix custom coder not being used in Reshuffle (global window) (#33339)
- Fix custom coders not being used in Reshuffle (non global window) #33363
- Add missing to_type_hint to WindowedValueCoder #33403

It is causing some internal test failure so we revert it for now.