### PR TITLE
Eliminate benign race condition in DirectStreamObserver and make first and subsequent iterations consistent

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/fn/stream/DirectStreamObserver.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/fn/stream/DirectStreamObserver.java
@@ -53,7 +53,7 @@ public final class DirectStreamObserver<T> implements StreamObserver<T> {
   private final int maxMessagesBeforeCheck;
 
   private final Object lock = new Object();
-  private int numMessages = -1;
+  private int numMessages;
 
   public DirectStreamObserver(Phaser phaser, CallStreamObserver<T> outboundObserver) {
     this(phaser, outboundObserver, DEFAULT_MAX_MESSAGES_BEFORE_CHECK);
@@ -69,7 +69,7 @@ public final class DirectStreamObserver<T> implements StreamObserver<T> {
   @Override
   public void onNext(T value) {
     synchronized (lock) {
-      if (++numMessages >= maxMessagesBeforeCheck) {
+      if (numMessages >= maxMessagesBeforeCheck) {
         numMessages = 0;
         int waitSeconds = 1;
         int totalSecondsWaited = 0;
@@ -114,6 +114,7 @@ public final class DirectStreamObserver<T> implements StreamObserver<T> {
         }
       }
       outboundObserver.onNext(value);
+      numMessages += 1;
     }
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/fn/stream/DirectStreamObserverTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/fn/stream/DirectStreamObserverTest.java
@@ -36,6 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.beam.sdk.fn.test.TestExecutors;
 import org.apache.beam.sdk.fn.test.TestExecutors.TestExecutorService;
 import org.apache.beam.sdk.fn.test.TestStreams;
+import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.stub.CallStreamObserver;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ArrayListMultimap;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.Uninterruptibles;
@@ -224,17 +225,19 @@ public class DirectStreamObserverTest {
   public void testMessageCheckInterval() throws Exception {
     final AtomicInteger index = new AtomicInteger();
     ArrayListMultimap<Integer, String> values = ArrayListMultimap.create();
+
+    // An observer that is always ready but puts items into a new bucket each time it is queried
+    CallStreamObserver<String> bucketingObserver =
+        TestStreams.withOnNext((String t) -> assertTrue(values.put(index.get(), t)))
+            .withIsReady(
+                () -> {
+                  index.incrementAndGet();
+                  return true;
+                })
+            .build();
+
     final DirectStreamObserver<String> streamObserver =
-        new DirectStreamObserver<>(
-            new AdvancingPhaser(1),
-            TestStreams.withOnNext((String t) -> assertTrue(values.put(index.get(), t)))
-                .withIsReady(
-                    () -> {
-                      index.incrementAndGet();
-                      return true;
-                    })
-                .build(),
-            10);
+        new DirectStreamObserver<>(new AdvancingPhaser(1), bucketingObserver, 10);
 
     List<String> prefixes = ImmutableList.of("0", "1", "2", "3", "4");
     List<Future<String>> results = new ArrayList<>();


### PR DESCRIPTION
A dynamic race condition detector correct identifies an unsynchronized read-after-write between the field initializer and the first call of onNext.

Additionally, this fixes a benign inconsistency in which it would wait one extra message the first time around.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
