### PR TITLE
Use other fallback coders for protobuf message base class

### DIFF
--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -1039,10 +1039,12 @@ class ProtoCoder(FastCoder):
 
   @classmethod
   def from_type_hint(cls, typehint, unused_registry):
-    # The typehint must be a subclass of google.protobuf.message.Message.
-    # ProtoCoder cannot work with message.Message itself, as required APIs are
-    # not implemented in the base class. If this occurs, an error is raised
-    # and the system defaults to other fallback coders.
+    # The typehint must be a strict subclass of google.protobuf.message.Message.
+    # ProtoCoder cannot work with message.Message itself, as deserialization of
+    # a serialized proto requires knowledge of the desired concrete proto
+    # subclass which is not stored in the encoded bytes themselves. If this
+    # occurs, an error is raised and the system defaults to other fallback
+    # coders.
     if (issubclass(typehint, proto_utils.message_types) and
         typehint != message.Message):
       return cls(typehint)

--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -1040,8 +1040,8 @@ class ProtoCoder(FastCoder):
   @classmethod
   def from_type_hint(cls, typehint, unused_registry):
     # The typehint must be a subclass of google.protobuf.message.Message.
-    # Using message.Message itself prevents ProtoCoder usage, as required APIs
-    # are not implemented in the base class. If this occurs, an error is raised
+    # ProtoCoder cannot work with message.Message itself, as required APIs are
+    # not implemented in the base class. If this occurs, an error is raised
     # and the system defaults to other fallback coders.
     if (issubclass(typehint, proto_utils.message_types) and
         typehint != message.Message):

--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -53,9 +53,9 @@ from typing import Type
 from typing import TypeVar
 from typing import overload
 
-from google.protobuf import message
 import google.protobuf.wrappers_pb2
 import proto
+from google.protobuf import message
 
 from apache_beam.coders import coder_impl
 from apache_beam.coders.avro_record import AvroRecord

--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -53,6 +53,7 @@ from typing import Type
 from typing import TypeVar
 from typing import overload
 
+from google.protobuf import message
 import google.protobuf.wrappers_pb2
 import proto
 
@@ -65,7 +66,6 @@ from apache_beam.typehints import typehints
 from apache_beam.utils import proto_utils
 
 if TYPE_CHECKING:
-  from google.protobuf import message  # pylint: disable=ungrouped-imports
   from apache_beam.coders.typecoders import CoderRegistry
   from apache_beam.runners.pipeline_context import PipelineContext
 

--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -1039,11 +1039,16 @@ class ProtoCoder(FastCoder):
 
   @classmethod
   def from_type_hint(cls, typehint, unused_registry):
-    if issubclass(typehint, proto_utils.message_types):
+    # The typehint must be a subclass of google.protobuf.message.Message.
+    # Using message.Message itself prevents ProtoCoder usage, as required APIs
+    # are not implemented in the base class. If this occurs, an error is raised
+    # and the system defaults to other fallback coders.
+    if (issubclass(typehint, proto_utils.message_types) and
+        typehint != message.Message):
       return cls(typehint)
     else:
       raise ValueError((
-          'Expected a subclass of google.protobuf.message.Message'
+          'Expected a strict subclass of google.protobuf.message.Message'
           ', but got a %s' % typehint))
 
   def to_type_hint(self):

--- a/sdks/python/apache_beam/coders/coders_test.py
+++ b/sdks/python/apache_beam/coders/coders_test.py
@@ -20,6 +20,7 @@ import base64
 import logging
 import unittest
 
+from google.protobuf import message
 import proto
 import pytest
 
@@ -85,6 +86,23 @@ class ProtoCoderTest(unittest.TestCase):
     self.assertEqual(real_coder.encode(ma), expected_coder.encode(ma))
     self.assertEqual(ma, real_coder.decode(real_coder.encode(ma)))
     self.assertEqual(ma.__class__, real_coder.to_type_hint())
+
+  def test_proto_coder_on_protobuf_message_subclasses(self):
+    # This replicates a scenario where users provide message.Message as the
+    # output typehint for a Map function, even though the actual output messages
+    # are subclasses of message.Message.
+    ma = test_message.MessageA()
+    mb = ma.field2.add()
+    mb.field1 = True
+    ma.field1 = 'hello world'
+
+    coder = coders_registry.get_coder(message.Message)
+    # For messages of google.protobuf.message.Message, the fallback coder will
+    # be FastPrimitiveCoder other than ProtoCoder.
+    # See the comment on ProtoCoder.from_type_hint() for further details.
+    self.assertEqual(coder, coders.FastPrimitivesCoder())
+
+    self.assertEqual(ma, coder.decode(coder.encode(ma)))
 
 
 class DeterministicProtoCoderTest(unittest.TestCase):

--- a/sdks/python/apache_beam/coders/coders_test.py
+++ b/sdks/python/apache_beam/coders/coders_test.py
@@ -98,7 +98,7 @@ class ProtoCoderTest(unittest.TestCase):
 
     coder = coders_registry.get_coder(message.Message)
     # For messages of google.protobuf.message.Message, the fallback coder will
-    # be FastPrimitiveCoder other than ProtoCoder.
+    # be FastPrimitivesCoder rather than ProtoCoder.
     # See the comment on ProtoCoder.from_type_hint() for further details.
     self.assertEqual(coder, coders.FastPrimitivesCoder())
 

--- a/sdks/python/apache_beam/coders/coders_test.py
+++ b/sdks/python/apache_beam/coders/coders_test.py
@@ -20,9 +20,9 @@ import base64
 import logging
 import unittest
 
-from google.protobuf import message
 import proto
 import pytest
+from google.protobuf import message
 
 import apache_beam as beam
 from apache_beam import typehints


### PR DESCRIPTION
This PR addresses internal test failures (internal bug ID: 385108730) introduced by recent Reshuffle code changes. It does not impact existing Reshuffle functionality, but is a necessary prerequisite for upcoming Reshuffle modifications.
