### PR TITLE
Implement "stage_file_with_retry" for robust file staging

### DIFF
--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
@@ -707,8 +707,8 @@ class DataflowApplicationClient(object):
             gcs_or_local_path, file_name, stream, mime_type, total_size)
     elif isinstance(stream_or_path, io.BufferedIOBase):
       stream = stream_or_path
-      assert stream.seekable(), "stream must be seekable"
       if stream.tell() > 0:
+        assert stream.seekable(), "stream must be seekable"
         stream.seek(0)
       self.stage_file(
           gcs_or_local_path, file_name, stream, mime_type, total_size)

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
@@ -713,6 +713,7 @@ class DataflowApplicationClient(object):
             gcs_or_local_path, file_name, stream, mime_type, total_size)
       except Exception as exn:
         if stream.seekable():
+          # reset cursor for possible retrying
           stream.seek(0)
           raise exn
         else:
@@ -722,7 +723,8 @@ class DataflowApplicationClient(object):
               ', but the stream is not seekable.')
     else:
       raise retry.PermanentException(
-          f"Unsupported type {type(stream_or_path)} in stream_or_path")
+          "Skip retrying because type " + str(type(stream_or_path)) +
+          "stream_or_path is unsupported.")
 
   @retry.no_retries  # Using no_retries marks this as an integration point.
   def create_job(self, job):

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
@@ -706,7 +706,7 @@ class DataflowApplicationClient(object):
       with open(path, 'rb') as stream:
         self.stage_file(
             gcs_or_local_path, file_name, stream, mime_type, total_size)
-    elif isinstance(stream_or_path, io.BufferedIOBase):
+    elif isinstance(stream_or_path, io.IOBase):
       stream = stream_or_path
       try:
         self.stage_file(
@@ -717,9 +717,12 @@ class DataflowApplicationClient(object):
           raise exn
         else:
           raise retry.PermanentException(
-              "Skip retrying because we caught exception:",
-              ''.join(traceback.format_exception_only(exn.__class__, exn)),
-              ', but the stream is not seekable')
+              "Skip retrying because we caught exception:" +
+              ''.join(traceback.format_exception_only(exn.__class__, exn)) +
+              ', but the stream is not seekable.')
+    else:
+      raise retry.PermanentException(
+          f"Unsupported type {type(stream_or_path)} in stream_or_path")
 
   @retry.no_retries  # Using no_retries marks this as an integration point.
   def create_job(self, job):

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
@@ -557,13 +557,11 @@ class DataflowApplicationClient(object):
         source_file_names=[cached_path], destination_file_names=[to_path])
     _LOGGER.info('Copied cached artifact from %s to %s', from_path, to_path)
 
-  @retry.with_exponential_backoff(
-      retry_filter=retry.retry_on_server_errors_and_timeout_filter)
   def _uncached_gcs_file_copy(self, from_path, to_path):
     to_folder, to_name = os.path.split(to_path)
     total_size = os.path.getsize(from_path)
-    with open(from_path, 'rb') as f:
-      self.stage_file(to_folder, to_name, f, total_size=total_size)
+    self.stage_file_with_retry(
+        to_folder, to_name, from_path, total_size=total_size)
 
   def _stage_resources(self, pipeline, options):
     google_cloud_options = options.view_as(GoogleCloudOptions)
@@ -692,6 +690,29 @@ class DataflowApplicationClient(object):
                       (gcs_or_local_path, e))
       raise
 
+  @retry.with_exponential_backoff(
+      retry_filter=retry.retry_on_server_errors_and_timeout_filter)
+  def stage_file_with_retry(
+      self,
+      gcs_or_local_path,
+      file_name,
+      stream_or_path,
+      mime_type='application/octet-stream',
+      total_size=None):
+
+    if isinstance(stream_or_path, str):
+      path = stream_or_path
+      with open(path, 'rb') as stream:
+        self.stage_file(
+            gcs_or_local_path, file_name, stream, mime_type, total_size)
+    elif isinstance(stream_or_path, io.BufferedIOBase):
+      stream = stream_or_path
+      assert stream.seekable(), "stream must be seekable"
+      if stream.tell() > 0:
+        stream.seek(0)
+      self.stage_file(
+          gcs_or_local_path, file_name, stream, mime_type, total_size)
+
   @retry.no_retries  # Using no_retries marks this as an integration point.
   def create_job(self, job):
     """Creates job description. May stage and/or submit for remote execution."""
@@ -703,7 +724,7 @@ class DataflowApplicationClient(object):
         job.options.view_as(GoogleCloudOptions).template_location)
 
     if job.options.view_as(DebugOptions).lookup_experiment('upload_graph'):
-      self.stage_file(
+      self.stage_file_with_retry(
           job.options.view_as(GoogleCloudOptions).staging_location,
           "dataflow_graph.json",
           io.BytesIO(job.json().encode('utf-8')))
@@ -718,7 +739,7 @@ class DataflowApplicationClient(object):
     if job_location:
       gcs_or_local_path = os.path.dirname(job_location)
       file_name = os.path.basename(job_location)
-      self.stage_file(
+      self.stage_file_with_retry(
           gcs_or_local_path, file_name, io.BytesIO(job.json().encode('utf-8')))
 
     if not template_location:
@@ -790,7 +811,7 @@ class DataflowApplicationClient(object):
     resources = self._stage_resources(job.proto_pipeline, job.options)
 
     # Stage proto pipeline.
-    self.stage_file(
+    self.stage_file_with_retry(
         job.google_cloud_options.staging_location,
         shared_names.STAGED_PIPELINE_FILENAME,
         io.BytesIO(job.proto_pipeline.SerializeToString()))

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
@@ -717,8 +717,9 @@ class DataflowApplicationClient(object):
           raise exn
         else:
           raise retry.PermanentException(
-              "Failed to tell or seek in stream because we caught exception:",
-              ''.join(traceback.format_exception_only(exn.__class__, exn)))
+              "Skip retrying because we caught exception:",
+              ''.join(traceback.format_exception_only(exn.__class__, exn)),
+              ', but the stream is not seekable')
 
   @retry.no_retries  # Using no_retries marks this as an integration point.
   def create_job(self, job):

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
@@ -1678,7 +1678,7 @@ class UtilTest(unittest.TestCase):
       if count <= 2:
         raise Exception("This exception is raised for testing purpose.")
 
-    class Unseekable(io.BufferedIOBase):
+    class Unseekable(io.IOBase):
       def seekable(self):
         return False
 

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
@@ -1733,8 +1733,27 @@ class UtilTest(unittest.TestCase):
               "new_name",
               Unseekable(),
               total_size=4)
-          # Unseekable is only staged once. There won't be any retry if it fails
+          # Unseekable streams are staged once. If staging fails, no retries are
+          # attempted.
           self.assertEqual(mock_stage_file.call_count, 1)
+          mock_sleep.assert_not_called()
+          mock_file_open.assert_not_called()
+
+          count = 0
+          mock_sleep.reset_mock()
+          mock_file_open.reset_mock()
+          mock_stage_file.reset_mock()
+
+          # calling with something else
+          self.assertRaises(
+              retry.PermanentException,
+              client.stage_file_with_retry,
+              "/to",
+              "new_name",
+              object(),
+              total_size=4)
+          # No staging will be called for wrong arg type
+          mock_stage_file.assert_not_called()
           mock_sleep.assert_not_called()
           mock_file_open.assert_not_called()
 


### PR DESCRIPTION
Job creation involves staging multiple files (artifacts, pipeline proto, job file, template). While artifact staging has retry logic, these other types do not, leading to potential job failures due to transient service issues.

This commit introduces `stage_file_with_retry`, a new function with built-in retry logic.  Several `stage_file` calls in `apiclient.py` have been replaced with this new function.

Internal bug id: 384579652.