### PR TITLE
[yaml] propogate error_handling to windowing composite config

### DIFF
--- a/sdks/python/apache_beam/yaml/yaml_transform.py
+++ b/sdks/python/apache_beam/yaml/yaml_transform.py
@@ -717,6 +717,9 @@ def preprocess_windowing(spec):
         'transforms': [modified_spec] + windowing_transforms,
         'input': spec['input'],
         'output': modified_spec['__uuid__'],
+        'config': {
+            'error_handling': spec.get('config').get('error_handling', None)
+        } or {},
         '__line__': spec['__line__'],
         '__uuid__': spec['__uuid__'],
     }
@@ -751,6 +754,9 @@ def preprocess_windowing(spec):
         'name': spec.get('name', None) or spec['type'],
         'transforms': [modified_spec] + windowing_transforms,
         'output': windowed_outputs,
+        'config': {
+            'error_handling': spec.get('config').get('error_handling', None)
+        } or {},
         '__line__': spec['__line__'],
         '__uuid__': spec['__uuid__'],
     }

--- a/sdks/python/apache_beam/yaml/yaml_transform.py
+++ b/sdks/python/apache_beam/yaml/yaml_transform.py
@@ -718,8 +718,8 @@ def preprocess_windowing(spec):
         'input': spec['input'],
         'output': modified_spec['__uuid__'],
         'config': {
-            'error_handling': spec.get('config').get('error_handling', None)
-        } or {},
+            'error_handling': spec.get('config', {}).get('error_handling', {})
+        },
         '__line__': spec['__line__'],
         '__uuid__': spec['__uuid__'],
     }
@@ -755,8 +755,8 @@ def preprocess_windowing(spec):
         'transforms': [modified_spec] + windowing_transforms,
         'output': windowed_outputs,
         'config': {
-            'error_handling': spec.get('config').get('error_handling', None)
-        } or {},
+            'error_handling': spec.get('config', {}).get('error_handling', {})
+        },
         '__line__': spec['__line__'],
         '__uuid__': spec['__uuid__'],
     }

--- a/sdks/python/apache_beam/yaml/yaml_transform_unit_test.py
+++ b/sdks/python/apache_beam/yaml/yaml_transform_unit_test.py
@@ -626,6 +626,8 @@ class MainTest(unittest.TestCase):
             size: 4
           input: {{input: input}}
       output: {result['transforms'][0]['__uuid__']}
+      config: 
+        error_handling: {{}}
     '''
     self.assertYaml(expected, result)
 
@@ -747,6 +749,8 @@ class MainTest(unittest.TestCase):
             type: fixed
             size: 4
       output: {result['transforms'][1]["__uuid__"]}
+      config: 
+        error_handling: {{}}
     '''
     self.maxDiff = 1e9
 


### PR DESCRIPTION
There was a bug with pipeline-level windowing with transforms that define `error_handling` in which pipelines would fail with error:
```
Ambiguous output at line 16: Stream has outputs [None, 'errors']
```

This was due to a check to ensure a transform only outputs a "good" collection and optionally a collection defined by the named output in the `error_handling` config. Since the `error_handling` was not propagated to the top-level composite constructed as part of pipeline-level windowing, the check would fail.

Example affected pipeline:
```
pipeline:
  transforms:
    - type: ReadFromPubSub
      name: Stream
      config:
        topic: projects/pubsub-public-data/topics/taxirides-realtime
        format: json
        schema:
          type: object
          properties:
            ride_id: {type: string}
        error_handling:
          output: errors
    - type: LogForTesting
      name: Log messages
      input: Stream
    - type: LogForTesting
      name: Log errors
      config:
        level: INFO
      input: Stream.errors
  windowing:
    type: fixed
    size: 60
options:
  streaming: true
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
