### PR TITLE
Add support for bounded trie metric in legacy worker

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/BoundedTrieCell.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/BoundedTrieCell.java
@@ -74,6 +74,17 @@ public class BoundedTrieCell implements BoundedTrie, MetricCell<BoundedTrieData>
     return value.getCumulative();
   }
 
+  // Used by Streaming metric container to extract deltas since streaming metrics are
+  // reported as deltas rather than cumulative as in batch.
+  // For delta we take the current value then reset the cell to empty so the next call only see
+  // delta/updates from last call.
+  public synchronized BoundedTrieData getAndReset() {
+    // since we are resetting no need to deep a copy just change the reference
+    BoundedTrieData shallowCopy = this.value;
+    this.value = new BoundedTrieData(); // create now object should not call reset on existing
+    return shallowCopy;
+  }
+
   @Override
   public MetricName getName() {
     return name;

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/BoundedTrieCell.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/BoundedTrieCell.java
@@ -79,9 +79,9 @@ public class BoundedTrieCell implements BoundedTrie, MetricCell<BoundedTrieData>
   // For delta we take the current value then reset the cell to empty so the next call only see
   // delta/updates from last call.
   public synchronized BoundedTrieData getAndReset() {
-    // since we are resetting no need to deep a copy just change the reference
+    // since we are resetting no need to do a deep copy, just change the reference
     BoundedTrieData shallowCopy = this.value;
-    this.value = new BoundedTrieData(); // create now object should not call reset on existing
+    this.value = new BoundedTrieData(); // create new object, should not call reset on existing
     return shallowCopy;
   }
 

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/BoundedTrieData.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/BoundedTrieData.java
@@ -180,14 +180,16 @@ public class BoundedTrieData implements Serializable {
    */
   public synchronized void add(Iterable<String> segments) {
     List<String> segmentsParts = ImmutableList.copyOf(segments);
-    if (this.root == null) {
-      if (this.singleton == null || !this.singleton.equals(segmentsParts)) {
+    if (this.singleton == null && this.root == null) {
+      // empty case
+      this.singleton = segmentsParts;
+    } else if (this.singleton != null && this.singleton.equals(segmentsParts)) {
+      // skip
+    } else {
+      if (this.root == null) {
         this.root = this.asTrie();
         this.singleton = null;
       }
-    }
-
-    if (this.root != null) {
       this.root.add(segmentsParts);
       if (this.root.getSize() > this.bound) {
         this.root.trim();

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/BoundedTrieData.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/BoundedTrieData.java
@@ -180,6 +180,9 @@ public class BoundedTrieData implements Serializable {
    */
   public synchronized void add(Iterable<String> segments) {
     List<String> segmentsParts = ImmutableList.copyOf(segments);
+    if (segmentsParts.isEmpty()) {
+      return;
+    }
     if (this.singleton == null && this.root == null) {
       // empty case
       this.singleton = segmentsParts;
@@ -342,7 +345,7 @@ public class BoundedTrieData implements Serializable {
      * @param truncated Whether this node is truncated.
      * @param size The size of the subtree rooted at this node.
      */
-    BoundedTrieNode(Map<String, BoundedTrieNode> children, boolean truncated, int size) {
+    BoundedTrieNode(@Nonnull Map<String, BoundedTrieNode> children, boolean truncated, int size) {
       this.children = children;
       this.size = size;
       this.truncated = truncated;

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/BoundedTrieData.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/BoundedTrieData.java
@@ -273,6 +273,11 @@ public class BoundedTrieData implements Serializable {
     }
   }
 
+  /** @return true if this {@link BoundedTrieData} is empty else false. */
+  public boolean isEmpty() {
+    return (root == null || root.children.isEmpty()) && (singleton == null || singleton.isEmpty());
+  }
+
   @Override
   public final boolean equals(@Nullable Object other) {
     if (this == other) {

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/BoundedTrieNodeTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/BoundedTrieNodeTest.java
@@ -883,11 +883,30 @@ public class BoundedTrieNodeTest {
   }
 
   @Test
+  public void testIsEmpty() {
+    BoundedTrieData trie = new BoundedTrieData();
+    assertTrue(trie.isEmpty());
+
+    trie.add(Collections.emptyList());
+    assertTrue(trie.isEmpty());
+
+    trie.add(ImmutableList.of("a", "b"));
+    assertFalse(trie.isEmpty());
+
+    trie.add(ImmutableList.of("c", "d"));
+    assertFalse(trie.isEmpty());
+
+    trie.clear();
+    assertTrue(trie.isEmpty());
+  }
+
+  @Test
   public void testBoundedTrieDataContains() {
     BoundedTrieData trie = new BoundedTrieData();
     trie.add(ImmutableList.of("a", "b"));
     assertTrue(trie.contains(ImmutableList.of("a", "b")));
-    assertTrue(trie.contains(ImmutableList.of("a")));
+    // path ab is not same as path a
+    assertFalse(trie.contains(ImmutableList.of("a")));
     assertFalse(trie.contains(ImmutableList.of("a", "c")));
   }
 
@@ -1001,17 +1020,10 @@ public class BoundedTrieNodeTest {
   }
 
   @Test
-  public void testAddEmptyPath() {
-    BoundedTrieData trie = new BoundedTrieData();
-    trie.add(Collections.emptyList());
-    assertEquals(1, trie.size());
-    assertTrue(trie.extractResult().getResult().contains(ImmutableList.of("false")));
-  }
-
-  @Test
   public void testContainsEmptyPath() {
     BoundedTrieData trie = new BoundedTrieData();
     trie.add(Collections.emptyList());
-    assertTrue(trie.contains(Collections.emptyList()));
+    assertFalse(trie.contains(Collections.emptyList()));
+    assertTrue(trie.isEmpty());
   }
 }

--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -94,6 +94,7 @@ dependencies {
   // io-kafka is only used in PTransform override so it is optional
   provided project(":sdks:java:io:kafka")
   implementation project(":sdks:java:io:google-cloud-platform")
+  implementation project(":runners:core-java")
   implementation library.java.avro
   implementation library.java.bigdataoss_util
   implementation library.java.commons_codec

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowMetrics.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowMetrics.java
@@ -59,9 +59,6 @@ import org.slf4j.LoggerFactory;
 class DataflowMetrics extends MetricResults {
 
   private static final Logger LOG = LoggerFactory.getLogger(DataflowMetrics.class);
-  // TODO (rosinha): Remove this once bounded_trie is available in metrics proto Dataflow
-  //  java client.
-  public static final String BOUNDED_TRIE = "bounded_trie";
   /**
    * Client for the Dataflow service. This can be used to query the service for information about
    * the job.
@@ -177,9 +174,7 @@ class DataflowMetrics extends MetricResults {
         // stringset metric
         StringSetResult value = getStringSetValue(committed);
         stringSetResults.add(MetricResult.create(metricKey, !isStreamingJob, value));
-      } else if (committed.get(BOUNDED_TRIE) != null && attempted.get(BOUNDED_TRIE) != null) {
-        // TODO (rosinha): This is dummy code. Once Dataflow MetricUpdate
-        //  google client api is updated. Update this.
+      } else if (committed.getTrie() != null && attempted.getTrie() != null) {
         BoundedTrieResult value = getBoundedTrieValue(committed);
         boundedTrieResults.add(MetricResult.create(metricKey, !isStreamingJob, value));
       } else {
@@ -210,10 +205,10 @@ class DataflowMetrics extends MetricResults {
     }
 
     private BoundedTrieResult getBoundedTrieValue(MetricUpdate metricUpdate) {
-      if (metricUpdate.get(BOUNDED_TRIE) == null) {
+      if (metricUpdate.getTrie() == null) {
         return BoundedTrieResult.empty();
       }
-      BoundedTrie bTrie = (BoundedTrie) metricUpdate.get(BOUNDED_TRIE);
+      BoundedTrie bTrie = (BoundedTrie) metricUpdate.getTrie();
       BoundedTrieData trieData = BoundedTrieData.fromProto(bTrie);
       return BoundedTrieResult.create(trieData.extractResult().getResult());
     }

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowMetricsTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowMetricsTest.java
@@ -41,11 +41,13 @@ import com.google.api.services.dataflow.model.MetricUpdate;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Set;
+import org.apache.beam.runners.core.metrics.BoundedTrieData;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
 import org.apache.beam.runners.dataflow.util.DataflowTemplateJob;
 import org.apache.beam.sdk.PipelineResult.State;
 import org.apache.beam.sdk.extensions.gcp.auth.TestCredential;
 import org.apache.beam.sdk.extensions.gcp.storage.NoopPathValidator;
+import org.apache.beam.sdk.metrics.BoundedTrieResult;
 import org.apache.beam.sdk.metrics.DistributionResult;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
 import org.apache.beam.sdk.metrics.MetricsFilter;
@@ -196,6 +198,13 @@ public class DataflowMetricsTest {
     return setStructuredName(update, name, namespace, step, tentative);
   }
 
+  private MetricUpdate makeBoundedTrieMetricUpdate(
+      String name, String namespace, String step, BoundedTrieData data, boolean tentative) {
+    MetricUpdate update = new MetricUpdate();
+    update.set(DataflowMetrics.BOUNDED_TRIE, data.toProto());
+    return setStructuredName(update, name, namespace, step, tentative);
+  }
+
   @Test
   public void testSingleCounterUpdates() throws IOException {
     AppliedPTransform<?, ?, ?> myStep = mock(AppliedPTransform.class);
@@ -284,6 +293,64 @@ public class DataflowMetricsTest {
                 "counterName",
                 "myStepName",
                 StringSetResult.create(ImmutableSet.of("ab", "cd")))));
+  }
+
+  @Test
+  public void testSingleBoundedTrieUpdates() throws IOException {
+    AppliedPTransform<?, ?, ?> myStep = mock(AppliedPTransform.class);
+    when(myStep.getFullName()).thenReturn("myStepName");
+    BiMap<AppliedPTransform<?, ?, ?>, String> transformStepNames = HashBiMap.create();
+    transformStepNames.put(myStep, "s2");
+
+    JobMetrics jobMetrics = new JobMetrics();
+    DataflowPipelineJob job = mock(DataflowPipelineJob.class);
+    DataflowPipelineOptions options = mock(DataflowPipelineOptions.class);
+    when(options.isStreaming()).thenReturn(false);
+    when(job.getDataflowOptions()).thenReturn(options);
+    when(job.getState()).thenReturn(State.RUNNING);
+    when(job.getJobId()).thenReturn(JOB_ID);
+    when(job.getTransformStepNames()).thenReturn(transformStepNames);
+
+    // The parser relies on the fact that one tentative and one committed metric update exist in
+    // the job metrics results.
+    MetricUpdate mu1 =
+        makeBoundedTrieMetricUpdate(
+            "counterName",
+            "counterNamespace",
+            "s2",
+            new BoundedTrieData(ImmutableList.of("ab", "cd")),
+            false);
+    MetricUpdate mu1Tentative =
+        makeBoundedTrieMetricUpdate(
+            "counterName",
+            "counterNamespace",
+            "s2",
+            new BoundedTrieData(ImmutableList.of("ab", "cd")),
+            true);
+    jobMetrics.setMetrics(ImmutableList.of(mu1, mu1Tentative));
+    DataflowClient dataflowClient = mock(DataflowClient.class);
+    when(dataflowClient.getJobMetrics(JOB_ID)).thenReturn(jobMetrics);
+
+    DataflowMetrics dataflowMetrics = new DataflowMetrics(job, dataflowClient);
+    MetricQueryResults result = dataflowMetrics.allMetrics();
+    assertThat(
+        result.getBoundedTries(),
+        containsInAnyOrder(
+            attemptedMetricsResult(
+                "counterNamespace",
+                "counterName",
+                "myStepName",
+                BoundedTrieResult.create(
+                    ImmutableSet.of(ImmutableList.of("ab", "cd", String.valueOf(false)))))));
+    assertThat(
+        result.getBoundedTries(),
+        containsInAnyOrder(
+            committedMetricsResult(
+                "counterNamespace",
+                "counterName",
+                "myStepName",
+                BoundedTrieResult.create(
+                    ImmutableSet.of(ImmutableList.of("ab", "cd", String.valueOf(false)))))));
   }
 
   @Test

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowMetricsTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowMetricsTest.java
@@ -41,6 +41,7 @@ import com.google.api.services.dataflow.model.MetricUpdate;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Set;
+import org.apache.beam.model.pipeline.v1.MetricsApi.BoundedTrie;
 import org.apache.beam.runners.core.metrics.BoundedTrieData;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
 import org.apache.beam.runners.dataflow.util.DataflowTemplateJob;
@@ -199,9 +200,9 @@ public class DataflowMetricsTest {
   }
 
   private MetricUpdate makeBoundedTrieMetricUpdate(
-      String name, String namespace, String step, BoundedTrieData data, boolean tentative) {
+      String name, String namespace, String step, BoundedTrie data, boolean tentative) {
     MetricUpdate update = new MetricUpdate();
-    update.set(DataflowMetrics.BOUNDED_TRIE, data.toProto());
+    update.setTrie(data);
     return setStructuredName(update, name, namespace, step, tentative);
   }
 
@@ -318,14 +319,14 @@ public class DataflowMetricsTest {
             "counterName",
             "counterNamespace",
             "s2",
-            new BoundedTrieData(ImmutableList.of("ab", "cd")),
+            new BoundedTrieData(ImmutableList.of("ab", "cd")).toProto(),
             false);
     MetricUpdate mu1Tentative =
         makeBoundedTrieMetricUpdate(
             "counterName",
             "counterNamespace",
             "s2",
-            new BoundedTrieData(ImmutableList.of("ab", "cd")),
+            new BoundedTrieData(ImmutableList.of("ab", "cd")).toProto(),
             true);
     jobMetrics.setMetrics(ImmutableList.of(mu1, mu1Tentative));
     DataflowClient dataflowClient = mock(DataflowClient.class);

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/BatchModeExecutionContext.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/BatchModeExecutionContext.java
@@ -519,7 +519,12 @@ public class BatchModeExecutionContext
                       .transform(
                           update ->
                               MetricsToCounterUpdateConverter.fromStringSet(
-                                  update.getKey(), true, update.getUpdate())));
+                                  update.getKey(), true, update.getUpdate())),
+                  FluentIterable.from(updates.boundedTrieUpdates())
+                      .transform(
+                          update ->
+                              MetricsToCounterUpdateConverter.fromBoundedTrie(
+                                  update.getKey(), update.getUpdate())));
             });
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/BatchModeExecutionContext.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/BatchModeExecutionContext.java
@@ -524,7 +524,7 @@ public class BatchModeExecutionContext
                       .transform(
                           update ->
                               MetricsToCounterUpdateConverter.fromBoundedTrie(
-                                  update.getKey(), update.getUpdate())));
+                                  update.getKey(), true, update.getUpdate())));
             });
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/MetricsToCounterUpdateConverter.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/MetricsToCounterUpdateConverter.java
@@ -28,7 +28,6 @@ import com.google.api.services.dataflow.model.CounterUpdate;
 import com.google.api.services.dataflow.model.DistributionUpdate;
 import com.google.api.services.dataflow.model.IntegerGauge;
 import com.google.api.services.dataflow.model.StringList;
-import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -38,6 +37,7 @@ import org.apache.beam.runners.core.metrics.DistributionData;
 import org.apache.beam.runners.core.metrics.StringSetData;
 import org.apache.beam.sdk.metrics.MetricKey;
 import org.apache.beam.sdk.metrics.MetricName;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
 
 /** Convertor from Metrics to {@link CounterUpdate} protos. */
 @SuppressWarnings({

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/MetricsToCounterUpdateConverter.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/MetricsToCounterUpdateConverter.java
@@ -118,14 +118,15 @@ public class MetricsToCounterUpdateConverter {
         .setStringList(stringList);
   }
 
-  public static CounterUpdate fromBoundedTrie(MetricKey key, BoundedTrieData boundedTrieData) {
+  public static CounterUpdate fromBoundedTrie(
+      MetricKey key, boolean isCumulative, BoundedTrieData boundedTrieData) {
     // BoundedTrie uses SET kind metric aggregation which tracks unique strings as a trie.
     CounterStructuredNameAndMetadata name = structuredNameAndMetadata(key, Kind.SET);
     BoundedTrie counterUpdateTrie = getBoundedTrie(boundedTrieData);
 
     return new CounterUpdate()
         .setStructuredNameAndMetadata(name)
-        .setCumulative(false)
+        .setCumulative(isCumulative)
         .setBoundedTrie(counterUpdateTrie);
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/MetricsToCounterUpdateConverter.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/MetricsToCounterUpdateConverter.java
@@ -27,6 +27,7 @@ import com.google.api.services.dataflow.model.DistributionUpdate;
 import com.google.api.services.dataflow.model.IntegerGauge;
 import com.google.api.services.dataflow.model.StringList;
 import java.util.ArrayList;
+import org.apache.beam.runners.core.metrics.BoundedTrieData;
 import org.apache.beam.runners.core.metrics.DistributionData;
 import org.apache.beam.runners.core.metrics.StringSetData;
 import org.apache.beam.sdk.metrics.MetricKey;
@@ -109,6 +110,16 @@ public class MetricsToCounterUpdateConverter {
         .setStructuredNameAndMetadata(name)
         .setCumulative(isCumulative)
         .setStringList(stringList);
+  }
+
+  public static CounterUpdate fromBoundedTrie(MetricKey key, BoundedTrieData boundedTrieData) {
+    // BoundedTrie uses SET kind metric aggregation which tracks unique strings.
+    CounterStructuredNameAndMetadata name = structuredNameAndMetadata(key, Kind.SET);
+    // TODO (rosinha): Once the CounterUpdate API is updated in dataflow client update this.
+    return new CounterUpdate()
+        .setStructuredNameAndMetadata(name)
+        .setCumulative(false)
+        .set("bounded_trie", boundedTrieData.toProto());
   }
 
   public static CounterUpdate fromDistribution(

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingStepMetricsContainer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingStepMetricsContainer.java
@@ -217,7 +217,8 @@ public class StreamingStepMetricsContainer implements MetricsContainer {
     return counterUpdates()
         .append(distributionUpdates())
         .append(gaugeUpdates())
-        .append(stringSetUpdates());
+        .append(stringSetUpdates())
+        .append(boundedTrieUpdates());
   }
 
   private FluentIterable<CounterUpdate> counterUpdates() {
@@ -272,6 +273,20 @@ public class StreamingStepMetricsContainer implements MetricsContainer {
                 }
                 return MetricsToCounterUpdateConverter.fromStringSet(
                     MetricKey.create(stepName, entry.getKey()), false, value);
+              }
+            })
+        .filter(Predicates.notNull());
+  }
+
+  private FluentIterable<CounterUpdate> boundedTrieUpdates() {
+    return FluentIterable.from(boundedTries.entries())
+        .transform(
+            new Function<Entry<MetricName, BoundedTrieCell>, CounterUpdate>() {
+              @Override
+              public @Nullable CounterUpdate apply(
+                  @Nonnull Map.Entry<MetricName, BoundedTrieCell> entry) {
+                return MetricsToCounterUpdateConverter.fromBoundedTrie(
+                    MetricKey.create(stepName, entry.getKey()), entry.getValue().getCumulative());
               }
             })
         .filter(Predicates.notNull());

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/BatchModeExecutionContextTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/BatchModeExecutionContextTest.java
@@ -32,6 +32,8 @@ import com.google.api.services.dataflow.model.CounterUpdate;
 import com.google.api.services.dataflow.model.DistributionUpdate;
 import com.google.api.services.dataflow.model.StringList;
 import java.util.Arrays;
+import org.apache.beam.model.pipeline.v1.MetricsApi;
+import org.apache.beam.runners.core.metrics.BoundedTrieData;
 import org.apache.beam.runners.core.metrics.ExecutionStateSampler;
 import org.apache.beam.runners.core.metrics.ExecutionStateTracker;
 import org.apache.beam.runners.core.metrics.ExecutionStateTracker.ExecutionState;
@@ -40,6 +42,7 @@ import org.apache.beam.runners.dataflow.worker.MetricsToCounterUpdateConverter.K
 import org.apache.beam.runners.dataflow.worker.counters.NameContext;
 import org.apache.beam.runners.dataflow.worker.profiler.ScopedProfiler.NoopProfileScope;
 import org.apache.beam.runners.dataflow.worker.profiler.ScopedProfiler.ProfileScope;
+import org.apache.beam.sdk.metrics.BoundedTrie;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Distribution;
 import org.apache.beam.sdk.metrics.MetricName;
@@ -47,6 +50,7 @@ import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.metrics.MetricsContainer;
 import org.apache.beam.sdk.metrics.StringSet;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -189,6 +193,42 @@ public class BatchModeExecutionContextTest {
                     .setMetadata(new CounterMetadata().setKind(Kind.SET.toString())))
             .setCumulative(true)
             .setStringList(new StringList().setElements(Arrays.asList("ab", "cd")));
+
+    assertThat(executionContext.extractMetricUpdates(false), containsInAnyOrder(expected));
+  }
+
+  @Test
+  public void extractMetricUpdatesBoundedTrie() {
+    BatchModeExecutionContext executionContext =
+        BatchModeExecutionContext.forTesting(PipelineOptionsFactory.create(), "testStage");
+    DataflowOperationContext operationContext =
+        executionContext.createOperationContext(NameContextsForTests.nameContextForTest());
+
+    BoundedTrie boundedTrie =
+        operationContext
+            .metricsContainer()
+            .getBoundedTrie(MetricName.named("namespace", "some-bounded-trie"));
+    boundedTrie.add("ab");
+    boundedTrie.add("cd");
+
+    BoundedTrieData trieData = new BoundedTrieData();
+    trieData.add(ImmutableList.of("ab"));
+    trieData.add(ImmutableList.of("cd"));
+    MetricsApi.BoundedTrie expectedTrie = trieData.toProto();
+
+    final CounterUpdate expected =
+        new CounterUpdate()
+            .setStructuredNameAndMetadata(
+                new CounterStructuredNameAndMetadata()
+                    .setName(
+                        new CounterStructuredName()
+                            .setOrigin("USER")
+                            .setOriginNamespace("namespace")
+                            .setName("some-bounded-trie")
+                            .setOriginalStepName("originalName"))
+                    .setMetadata(new CounterMetadata().setKind(Kind.SET.toString())))
+            .setCumulative(false)
+            .set("bounded_trie", expectedTrie);
 
     assertThat(executionContext.extractMetricUpdates(false), containsInAnyOrder(expected));
   }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/BatchModeExecutionContextTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/BatchModeExecutionContextTest.java
@@ -32,7 +32,6 @@ import com.google.api.services.dataflow.model.CounterUpdate;
 import com.google.api.services.dataflow.model.DistributionUpdate;
 import com.google.api.services.dataflow.model.StringList;
 import java.util.Arrays;
-import org.apache.beam.model.pipeline.v1.MetricsApi;
 import org.apache.beam.runners.core.metrics.BoundedTrieData;
 import org.apache.beam.runners.core.metrics.ExecutionStateSampler;
 import org.apache.beam.runners.core.metrics.ExecutionStateTracker;
@@ -214,7 +213,6 @@ public class BatchModeExecutionContextTest {
     BoundedTrieData trieData = new BoundedTrieData();
     trieData.add(ImmutableList.of("ab"));
     trieData.add(ImmutableList.of("cd"));
-    MetricsApi.BoundedTrie expectedTrie = trieData.toProto();
 
     final CounterUpdate expected =
         new CounterUpdate()
@@ -228,7 +226,7 @@ public class BatchModeExecutionContextTest {
                             .setOriginalStepName("originalName"))
                     .setMetadata(new CounterMetadata().setKind(Kind.SET.toString())))
             .setCumulative(false)
-            .set("bounded_trie", expectedTrie);
+            .setBoundedTrie(MetricsToCounterUpdateConverter.getBoundedTrie(trieData));
 
     assertThat(executionContext.extractMetricUpdates(false), containsInAnyOrder(expected));
   }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/BatchModeExecutionContextTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/BatchModeExecutionContextTest.java
@@ -226,7 +226,7 @@ public class BatchModeExecutionContextTest {
                             .setOriginalStepName("originalName"))
                     .setMetadata(new CounterMetadata().setKind(Kind.SET.toString())))
             .setCumulative(false)
-            .setBoundedTrie(MetricsToCounterUpdateConverter.getBoundedTrie(trieData));
+            .setBoundedTrie(MetricsToCounterUpdateConverter.getBoundedTrie(trieData.toProto()));
 
     assertThat(executionContext.extractMetricUpdates(false), containsInAnyOrder(expected));
   }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/BatchModeExecutionContextTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/BatchModeExecutionContextTest.java
@@ -225,7 +225,7 @@ public class BatchModeExecutionContextTest {
                             .setName("some-bounded-trie")
                             .setOriginalStepName("originalName"))
                     .setMetadata(new CounterMetadata().setKind(Kind.SET.toString())))
-            .setCumulative(false)
+            .setCumulative(true) // batch counters are cumulative
             .setBoundedTrie(MetricsToCounterUpdateConverter.getBoundedTrie(trieData.toProto()));
 
     assertThat(executionContext.extractMetricUpdates(false), containsInAnyOrder(expected));

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/MetricsToCounterUpdateConverterTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/MetricsToCounterUpdateConverterTest.java
@@ -96,7 +96,8 @@ public class MetricsToCounterUpdateConverterTest {
     boundedTrieData.add(ImmutableList.of("ef", "gh"));
     boundedTrieData.add(ImmutableList.of("ef", "xy"));
 
-    BoundedTrie actualTrie = MetricsToCounterUpdateConverter.getBoundedTrie(boundedTrieData);
+    BoundedTrie actualTrie =
+        MetricsToCounterUpdateConverter.getBoundedTrie(boundedTrieData.toProto());
 
     BoundedTrie expectedTrie = new BoundedTrie();
     expectedTrie.setBound(100);
@@ -116,12 +117,13 @@ public class MetricsToCounterUpdateConverterTest {
   public void testGetBoundedTrieNodeSingleton() {
     BoundedTrieData boundedTrieData = new BoundedTrieData();
     boundedTrieData.add(ImmutableList.of("ab"));
-    BoundedTrie actualTrie = MetricsToCounterUpdateConverter.getBoundedTrie(boundedTrieData);
+    BoundedTrie actualTrie =
+        MetricsToCounterUpdateConverter.getBoundedTrie(boundedTrieData.toProto());
 
     BoundedTrie expectedTrie = new BoundedTrie();
     expectedTrie.setBound(100);
     expectedTrie.setSingleton(ImmutableList.of("ab"));
-    expectedTrie.setRoot(getEmptyNode());
+    expectedTrie.setRoot(null);
 
     assertEquals(expectedTrie, actualTrie);
   }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/MetricsToCounterUpdateConverterTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/MetricsToCounterUpdateConverterTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import com.google.api.services.dataflow.model.BoundedTrie;
+import com.google.api.services.dataflow.model.BoundedTrieNode;
+import com.google.api.services.dataflow.model.CounterUpdate;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import org.apache.beam.runners.core.metrics.BoundedTrieData;
+import org.apache.beam.runners.core.metrics.StringSetData;
+import org.apache.beam.runners.dataflow.worker.MetricsToCounterUpdateConverter.Kind;
+import org.apache.beam.sdk.metrics.MetricKey;
+import org.apache.beam.sdk.metrics.MetricName;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class MetricsToCounterUpdateConverterTest {
+
+  private static final String STEP_NAME = "testStep";
+  private static final String METRIC_NAME = "testMetric";
+  private static final String NAMESPACE = "testNamespace";
+
+  private MetricKey createMetricKey() {
+    return MetricKey.create(STEP_NAME, MetricName.named(NAMESPACE, METRIC_NAME));
+  }
+
+  @Test
+  public void testFromStringSet() {
+    MetricKey key = createMetricKey();
+    boolean isCumulative = false;
+    StringSetData stringSetData = StringSetData.create(ImmutableSet.of("a", "b", "c"));
+
+    CounterUpdate counterUpdate =
+        MetricsToCounterUpdateConverter.fromStringSet(key, isCumulative, stringSetData);
+
+    assertEquals(
+        Kind.SET.toString(), counterUpdate.getStructuredNameAndMetadata().getMetadata().getKind());
+    assertFalse(counterUpdate.getCumulative());
+    assertEquals(
+        stringSetData.stringSet(), new HashSet<>(counterUpdate.getStringList().getElements()));
+  }
+
+  @Test
+  public void testFromBoundedTrie() {
+    MetricKey key = createMetricKey();
+    BoundedTrieData boundedTrieData = new BoundedTrieData();
+    boundedTrieData.add(ImmutableList.of("ab"));
+    boundedTrieData.add(ImmutableList.of("cd"));
+
+    CounterUpdate counterUpdate =
+        MetricsToCounterUpdateConverter.fromBoundedTrie(key, boundedTrieData);
+
+    assertEquals(
+        Kind.SET.toString(), counterUpdate.getStructuredNameAndMetadata().getMetadata().getKind());
+    assertFalse(counterUpdate.getCumulative());
+    BoundedTrie trie = counterUpdate.getBoundedTrie();
+    assertEquals(100, (int) trie.getBound());
+    assertEquals(Collections.emptyList(), trie.getSingleton());
+
+    BoundedTrieNode root = getMiddleNode(ImmutableList.of("ab", "cd"));
+    assertEquals(root, trie.getRoot());
+  }
+
+  @Test
+  public void testGetBoundedTrieNodeLevels() {
+    BoundedTrieData boundedTrieData = new BoundedTrieData();
+    boundedTrieData.add(ImmutableList.of("ab"));
+    boundedTrieData.add(ImmutableList.of("cd"));
+    boundedTrieData.add(ImmutableList.of("ef", "gh"));
+    boundedTrieData.add(ImmutableList.of("ef", "xy"));
+
+    BoundedTrie actualTrie = MetricsToCounterUpdateConverter.getBoundedTrie(boundedTrieData);
+
+    BoundedTrie expectedTrie = new BoundedTrie();
+    expectedTrie.setBound(100);
+    BoundedTrieNode root = new BoundedTrieNode();
+    Map<String, BoundedTrieNode> rootChildren = new HashMap<>();
+    rootChildren.put("ab", getEmptyNode());
+    rootChildren.put("cd", getEmptyNode());
+    rootChildren.put("ef", getMiddleNode(ImmutableList.of("gh", "xy")));
+    root.setChildren(rootChildren);
+    root.setTruncated(false);
+    expectedTrie.setRoot(root);
+    expectedTrie.setSingleton(null);
+    assertEquals(expectedTrie, actualTrie);
+  }
+
+  @Test
+  public void testGetBoundedTrieNodeSingleton() {
+    BoundedTrieData boundedTrieData = new BoundedTrieData();
+    boundedTrieData.add(ImmutableList.of("ab"));
+    BoundedTrie actualTrie = MetricsToCounterUpdateConverter.getBoundedTrie(boundedTrieData);
+
+    BoundedTrie expectedTrie = new BoundedTrie();
+    expectedTrie.setBound(100);
+    expectedTrie.setSingleton(ImmutableList.of("ab"));
+    expectedTrie.setRoot(getEmptyNode());
+
+    assertEquals(expectedTrie, actualTrie);
+  }
+
+  private static BoundedTrieNode getMiddleNode(ImmutableList<String> elements) {
+    BoundedTrieNode middleNode = new BoundedTrieNode();
+    Map<String, BoundedTrieNode> children = new HashMap<>();
+    elements.forEach(val -> children.put(val, getEmptyNode()));
+    middleNode.setChildren(children);
+    middleNode.setTruncated(false);
+    return middleNode;
+  }
+
+  private static BoundedTrieNode getEmptyNode() {
+    BoundedTrieNode leafNode = new BoundedTrieNode();
+    leafNode.setChildren(Collections.emptyMap());
+    leafNode.setTruncated(false);
+    return leafNode;
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/MetricsToCounterUpdateConverterTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/MetricsToCounterUpdateConverterTest.java
@@ -19,6 +19,8 @@ package org.apache.beam.runners.dataflow.worker;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import com.google.api.services.dataflow.model.BoundedTrie;
 import com.google.api.services.dataflow.model.BoundedTrieNode;
@@ -73,14 +75,14 @@ public class MetricsToCounterUpdateConverterTest {
     boundedTrieData.add(ImmutableList.of("cd"));
 
     CounterUpdate counterUpdate =
-        MetricsToCounterUpdateConverter.fromBoundedTrie(key, boundedTrieData);
+        MetricsToCounterUpdateConverter.fromBoundedTrie(key, true, boundedTrieData);
 
     assertEquals(
         Kind.SET.toString(), counterUpdate.getStructuredNameAndMetadata().getMetadata().getKind());
-    assertFalse(counterUpdate.getCumulative());
+    assertTrue(counterUpdate.getCumulative());
     BoundedTrie trie = counterUpdate.getBoundedTrie();
     assertEquals(100, (int) trie.getBound());
-    assertEquals(Collections.emptyList(), trie.getSingleton());
+    assertNull(trie.getSingleton());
 
     BoundedTrieNode root = getMiddleNode(ImmutableList.of("ab", "cd"));
     assertEquals(root, trie.getRoot());

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingStepMetricsContainerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingStepMetricsContainerTest.java
@@ -354,7 +354,7 @@ public class StreamingStepMetricsContainerTest {
                             .setOriginalStepName("s1"))
                     .setMetadata(new CounterMetadata().setKind(Kind.SET.toString())))
             .setCumulative(false)
-            .set("bounded_trie", expectedName1.toProto());
+            .setBoundedTrie(MetricsToCounterUpdateConverter.getBoundedTrie(expectedName1));
 
     Iterable<CounterUpdate> updates = StreamingStepMetricsContainer.extractMetricUpdates(registry);
     assertThat(updates, containsInAnyOrder(name1Update));
@@ -381,14 +381,15 @@ public class StreamingStepMetricsContainerTest {
                             .setOriginalStepName("s2"))
                     .setMetadata(new CounterMetadata().setKind(Kind.SET.toString())))
             .setCumulative(false)
-            .set("bounded_trie", expectedName2.toProto());
+            .setBoundedTrie(MetricsToCounterUpdateConverter.getBoundedTrie(expectedName2));
 
     updates = StreamingStepMetricsContainer.extractMetricUpdates(registry);
     assertThat(updates, containsInAnyOrder(name1Update, name2Update));
 
     c1.getBoundedTrie(name1).add("op");
+
     expectedName1.add(ImmutableList.of("op"));
-    name1Update.set("bounded_trie", expectedName1.toProto());
+    name1Update.setBoundedTrie(MetricsToCounterUpdateConverter.getBoundedTrie(expectedName1));
 
     updates = StreamingStepMetricsContainer.extractMetricUpdates(registry);
     assertThat(updates, containsInAnyOrder(name1Update, name2Update));

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingStepMetricsContainerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingStepMetricsContainerTest.java
@@ -50,8 +50,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import org.apache.beam.runners.core.metrics.BoundedTrieData;
 import org.apache.beam.runners.dataflow.worker.MetricsToCounterUpdateConverter.Kind;
 import org.apache.beam.runners.dataflow.worker.MetricsToCounterUpdateConverter.Origin;
+import org.apache.beam.sdk.metrics.BoundedTrie;
 import org.apache.beam.sdk.metrics.Distribution;
 import org.apache.beam.sdk.metrics.Gauge;
 import org.apache.beam.sdk.metrics.LabeledMetricNameUtils;
@@ -61,6 +63,7 @@ import org.apache.beam.sdk.metrics.NoOpCounter;
 import org.apache.beam.sdk.metrics.NoOpHistogram;
 import org.apache.beam.sdk.metrics.StringSet;
 import org.apache.beam.sdk.util.HistogramData;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
 import org.hamcrest.collection.IsEmptyIterable;
 import org.hamcrest.collection.IsMapContaining;
@@ -323,6 +326,72 @@ public class StreamingStepMetricsContainerTest {
 
     updates = StreamingStepMetricsContainer.extractMetricUpdates(registry);
     assertThat(updates, containsInAnyOrder(name1Update));
+  }
+
+  @Test
+  public void testBoundedTrieUpdateExtraction() {
+    BoundedTrie boundedTrie = c1.getBoundedTrie(name1);
+    boundedTrie.add("ab");
+    boundedTrie.add("cd", "ef");
+    boundedTrie.add("gh");
+    boundedTrie.add("gh");
+
+    BoundedTrieData expectedName1 = new BoundedTrieData();
+    expectedName1.add(ImmutableList.of("ab"));
+    expectedName1.add(ImmutableList.of("cd", "ef"));
+    expectedName1.add(ImmutableList.of("gh"));
+    expectedName1.add(ImmutableList.of("gh"));
+
+    CounterUpdate name1Update =
+        new CounterUpdate()
+            .setStructuredNameAndMetadata(
+                new CounterStructuredNameAndMetadata()
+                    .setName(
+                        new CounterStructuredName()
+                            .setOrigin(Origin.USER.toString())
+                            .setOriginNamespace("ns")
+                            .setName("name1")
+                            .setOriginalStepName("s1"))
+                    .setMetadata(new CounterMetadata().setKind(Kind.SET.toString())))
+            .setCumulative(false)
+            .set("bounded_trie", expectedName1.toProto());
+
+    Iterable<CounterUpdate> updates = StreamingStepMetricsContainer.extractMetricUpdates(registry);
+    assertThat(updates, containsInAnyOrder(name1Update));
+
+    boundedTrie = c2.getBoundedTrie(name2);
+    boundedTrie.add("ij");
+    boundedTrie.add("kl", "mn");
+    boundedTrie.add("mn");
+
+    BoundedTrieData expectedName2 = new BoundedTrieData();
+    expectedName2.add(ImmutableList.of("ij"));
+    expectedName2.add(ImmutableList.of("kl", "mn"));
+    expectedName2.add(ImmutableList.of("mn"));
+
+    CounterUpdate name2Update =
+        new CounterUpdate()
+            .setStructuredNameAndMetadata(
+                new CounterStructuredNameAndMetadata()
+                    .setName(
+                        new CounterStructuredName()
+                            .setOrigin(Origin.USER.toString())
+                            .setOriginNamespace("ns")
+                            .setName("name2")
+                            .setOriginalStepName("s2"))
+                    .setMetadata(new CounterMetadata().setKind(Kind.SET.toString())))
+            .setCumulative(false)
+            .set("bounded_trie", expectedName2.toProto());
+
+    updates = StreamingStepMetricsContainer.extractMetricUpdates(registry);
+    assertThat(updates, containsInAnyOrder(name1Update, name2Update));
+
+    c1.getBoundedTrie(name1).add("op");
+    expectedName1.add(ImmutableList.of("op"));
+    name1Update.set("bounded_trie", expectedName1.toProto());
+
+    updates = StreamingStepMetricsContainer.extractMetricUpdates(registry);
+    assertThat(updates, containsInAnyOrder(name1Update, name2Update));
   }
 
   @Test

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingStepMetricsContainerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingStepMetricsContainerTest.java
@@ -354,7 +354,8 @@ public class StreamingStepMetricsContainerTest {
                             .setOriginalStepName("s1"))
                     .setMetadata(new CounterMetadata().setKind(Kind.SET.toString())))
             .setCumulative(false)
-            .setBoundedTrie(MetricsToCounterUpdateConverter.getBoundedTrie(expectedName1));
+            .setBoundedTrie(
+                MetricsToCounterUpdateConverter.getBoundedTrie(expectedName1.toProto()));
 
     Iterable<CounterUpdate> updates = StreamingStepMetricsContainer.extractMetricUpdates(registry);
     assertThat(updates, containsInAnyOrder(name1Update));
@@ -381,7 +382,8 @@ public class StreamingStepMetricsContainerTest {
                             .setOriginalStepName("s2"))
                     .setMetadata(new CounterMetadata().setKind(Kind.SET.toString())))
             .setCumulative(false)
-            .setBoundedTrie(MetricsToCounterUpdateConverter.getBoundedTrie(expectedName2));
+            .setBoundedTrie(
+                MetricsToCounterUpdateConverter.getBoundedTrie(expectedName2.toProto()));
 
     updates = StreamingStepMetricsContainer.extractMetricUpdates(registry);
     assertThat(updates, containsInAnyOrder(name2Update));
@@ -391,7 +393,8 @@ public class StreamingStepMetricsContainerTest {
 
     expectedName1.clear();
     expectedName1.add(ImmutableList.of("op"));
-    name1Update.setBoundedTrie(MetricsToCounterUpdateConverter.getBoundedTrie(expectedName1));
+    name1Update.setBoundedTrie(
+        MetricsToCounterUpdateConverter.getBoundedTrie(expectedName1.toProto()));
 
     updates = StreamingStepMetricsContainer.extractMetricUpdates(registry);
     assertThat(updates, containsInAnyOrder(name1Update));

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingStepMetricsContainerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingStepMetricsContainerTest.java
@@ -384,15 +384,17 @@ public class StreamingStepMetricsContainerTest {
             .setBoundedTrie(MetricsToCounterUpdateConverter.getBoundedTrie(expectedName2));
 
     updates = StreamingStepMetricsContainer.extractMetricUpdates(registry);
-    assertThat(updates, containsInAnyOrder(name1Update, name2Update));
+    assertThat(updates, containsInAnyOrder(name2Update));
 
+    // test delta
     c1.getBoundedTrie(name1).add("op");
 
+    expectedName1.clear();
     expectedName1.add(ImmutableList.of("op"));
     name1Update.setBoundedTrie(MetricsToCounterUpdateConverter.getBoundedTrie(expectedName1));
 
     updates = StreamingStepMetricsContainer.extractMetricUpdates(registry);
-    assertThat(updates, containsInAnyOrder(name1Update, name2Update));
+    assertThat(updates, containsInAnyOrder(name1Update));
   }
 
   @Test

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/StateBackedIterable.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/StateBackedIterable.java
@@ -30,7 +30,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 import org.apache.beam.fn.harness.Cache;


### PR DESCRIPTION
- Adds support for bounded trie in Dataflow legacy workers.
- Streaming reports delta counters. This is essential because without it streaming will end up remaining same counters as cumulative through it's entire lifespan. This will be bad even with bounded trie which is self-limiting in size because in backend the level db monitoring writer keeps taking snapshot of counters on publish and writing to level db and for a long running job even with self-limiting data store the file sizes will keep growing.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
