### PR TITLE
Revert "Update Java expansion service to use distroless"

### DIFF
--- a/sdks/java/expansion-service/container/Dockerfile
+++ b/sdks/java/expansion-service/container/Dockerfile
@@ -16,7 +16,7 @@
 # limitations under the License.
 ###############################################################################
 
-FROM gcr.io/distroless/java:11
+FROM eclipse-temurin:11
 LABEL Author "Apache Beam <dev@beam.apache.org>"
 ARG TARGETOS
 ARG TARGETARCH
@@ -39,8 +39,7 @@ COPY target/launcher/${TARGETOS}_${TARGETARCH}/boot /opt/apache/beam/
 # Copy the config file
 COPY target/expansion_service_config.yml ./
 
-# Add golang licenses. These commands require having a shell to work with
-COPY --from=busybox:1.35.0-uclibc /bin/sh /bin/sh
+# Add golang licenses.
 COPY target/go-licenses/* /opt/apache/beam/third_party_licenses/golang/
 RUN if [ "${pull_licenses}" = "false" ] ; then \
     # Remove above license dir if pull licenses false


### PR DESCRIPTION
Reverts apache/beam#33464

Per conversation in https://github.com/apache/beam/pull/33464#issuecomment-2567963274 this did not actually drive down vulnerability counts