### PR TITLE
[#31912] Fix bug in finalization for Prism & fix the Java bundle finalizing tests.

### DIFF
--- a/runners/prism/java/build.gradle
+++ b/runners/prism/java/build.gradle
@@ -187,14 +187,6 @@ def sickbayTests = [
     // Missing output due to processing time timer skew.
     'org.apache.beam.sdk.transforms.ParDoTest$TimestampTests.testProcessElementSkew',
 
-    // TestStream + BundleFinalization.
-    // Tests seem to assume individual element bundles from test stream, but prism will aggregate them, preventing
-    // a subsequent firing. Tests ultimately hang until timeout.
-    // Either a test problem, or a misunderstanding of how test stream must work problem in prism.
-    // Biased to test problem, due to how they are constructed.
-    'org.apache.beam.sdk.transforms.ParDoTest$BundleFinalizationTests.testBundleFinalization',
-    'org.apache.beam.sdk.transforms.ParDoTest$BundleFinalizationTests.testBundleFinalizationWithSideInputs',
-
     // Filtered by PortableRunner tests.
     // Teardown not called in exceptions
     // https://github.com/apache/beam/issues/20372

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/teststream.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/teststream.go
@@ -142,10 +142,8 @@ func (ts *testStreamHandler) UpdateHold(em *ElementManager, newHold mtime.Time) 
 	ts.currentHold = newHold
 	ss.watermarkHolds.Add(ts.currentHold, 1)
 
-	// kick the TestStream and Impulse stages too.
+	// kick the TestStream stage to ensure downstream watermark propagation.
 	kick := singleSet(ts.ID)
-	kick.merge(em.impulses)
-
 	// This executes under the refreshCond lock, so we can't call em.addRefreshes.
 	em.changedStages.merge(kick)
 	em.refreshCond.Broadcast()

--- a/sdks/go/pkg/beam/runners/prism/internal/execute.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/execute.go
@@ -285,7 +285,6 @@ func executePipeline(ctx context.Context, wks map[string]*worker.W, j *jobservic
 							elms = append(elms, engine.TestStreamElement{Encoded: mayLP(e.GetEncodedElement()), EventTime: mtime.Time(e.GetTimestamp())})
 						}
 						tsb.AddElementEvent(ev.ElementEvent.GetTag(), elms)
-						ev.ElementEvent.GetTag()
 					case *pipepb.TestStreamPayload_Event_WatermarkEvent:
 						tsb.AddWatermarkEvent(ev.WatermarkEvent.GetTag(), mtime.Time(ev.WatermarkEvent.GetNewWatermark()))
 					case *pipepb.TestStreamPayload_Event_ProcessingTimeEvent:

--- a/sdks/go/pkg/beam/runners/prism/internal/preprocess.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/preprocess.go
@@ -445,7 +445,12 @@ func finalizeStage(stg *stage, comps *pipepb.Components, pipelineFacts *fusionFa
 				if err := (proto.UnmarshalOptions{}).Unmarshal(t.GetSpec().GetPayload(), pardo); err != nil {
 					return fmt.Errorf("unable to decode ParDoPayload for %v", link.Transform)
 				}
-				stg.finalize = pardo.RequestsFinalization
+				if pardo.GetRequestsFinalization() {
+					stg.finalize = true
+					// Key based execution encourages smaller bundles which
+					// have better finalization behavior.
+					stg.stateful = true
+				}
 				if len(pardo.GetTimerFamilySpecs())+len(pardo.GetStateSpecs())+len(pardo.GetOnWindowExpirationTimerFamilySpec()) > 0 {
 					stg.stateful = true
 				}

--- a/sdks/go/pkg/beam/runners/prism/internal/preprocess.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/preprocess.go
@@ -447,9 +447,6 @@ func finalizeStage(stg *stage, comps *pipepb.Components, pipelineFacts *fusionFa
 				}
 				if pardo.GetRequestsFinalization() {
 					stg.finalize = true
-					// Key based execution encourages smaller bundles which
-					// have better finalization behavior.
-					stg.stateful = true
 				}
 				if len(pardo.GetTimerFamilySpecs())+len(pardo.GetStateSpecs())+len(pardo.GetOnWindowExpirationTimerFamilySpec()) > 0 {
 					stg.stateful = true

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -1593,7 +1593,7 @@ public class ParDoTest implements Serializable {
   @RunWith(JUnit4.class)
   public static class BundleFinalizationTests extends SharedTestBase implements Serializable {
     private abstract static class BundleFinalizingDoFn extends DoFn<KV<String, Long>, String> {
-      private static final long MAX_ATTEMPTS = 3000;
+      private static final long MAX_ATTEMPTS = 100;
       // We use the UUID to uniquely identify this DoFn in case this test is run with
       // other tests in the same JVM.
       private static final Map<UUID, AtomicBoolean> WAS_FINALIZED = new HashMap();
@@ -1637,9 +1637,15 @@ public class ParDoTest implements Serializable {
     public void testBundleFinalization() {
       TestStream.Builder<KV<String, Long>> stream =
           TestStream.create(KvCoder.of(StringUtf8Coder.of(), VarLongCoder.of()));
-      for (long i = 0; i < BundleFinalizingDoFn.MAX_ATTEMPTS; ++i) {
+      long attemptCap = BundleFinalizingDoFn.MAX_ATTEMPTS - 1;
+      for (long i = 0; i < attemptCap; ++i) {
         stream = stream.addElements(KV.of("key" + (i % 10), i));
       }
+      // Advance the time, and add the final element. This allows Finalization
+      // check mechanism to work without being sensitive to how bundles are
+      // produced by a runner.
+      stream = stream.advanceWatermarkTo(new Instant(10));
+      stream = stream.addElements(KV.of("key" + (attemptCap % 10), attemptCap));
       PCollection<String> output =
           pipeline
               .apply(stream.advanceWatermarkToInfinity())
@@ -1677,6 +1683,8 @@ public class ParDoTest implements Serializable {
       for (long i = 0; i < BundleFinalizingDoFn.MAX_ATTEMPTS; ++i) {
         stream = stream.addElements(KV.of("key" + (i % 10), i));
       }
+      // Stateful execution is already per-key, so it is unnecessary to add a
+      // "final" element to attempt additional bundles to validate finalization.
       PCollection<String> output =
           pipeline
               .apply(stream.advanceWatermarkToInfinity())
@@ -1715,9 +1723,15 @@ public class ParDoTest implements Serializable {
     public void testBundleFinalizationWithSideInputs() {
       TestStream.Builder<KV<String, Long>> stream =
           TestStream.create(KvCoder.of(StringUtf8Coder.of(), VarLongCoder.of()));
-      for (long i = 0; i < BundleFinalizingDoFn.MAX_ATTEMPTS; ++i) {
+      long attemptCap = BundleFinalizingDoFn.MAX_ATTEMPTS - 1;
+      for (long i = 0; i < attemptCap; ++i) {
         stream = stream.addElements(KV.of("key" + (i % 10), i));
       }
+      // Advance the time, and add the final element. This allows Finalization
+      // check mechanism to work without being sensitive to how bundles are
+      // produced by a runner.
+      stream = stream.advanceWatermarkTo(GlobalWindow.INSTANCE.maxTimestamp());
+      stream = stream.addElements(KV.of("key" + (attemptCap % 10), attemptCap));
       PCollectionView<String> sideInput =
           pipeline.apply(Create.of("sideInput value")).apply(View.asSingleton());
       PCollection<String> output =


### PR DESCRIPTION
Unblock two Java Bundle Finalization tests.

* Fix potential for fused transforms to flip finalization state of a stage. If any transform requires finalization, then so does the entire stage.
* Fix the tests themselves: They were making assumptions on bundle production outside of the needs of the tests.
  * Reduce the "attempts" count, since they should now play better with other runners as well.
* Remove unnecessary impulse kick set for TestStream. This plays better with Side input validation.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
