### PR TITLE
Fix: Replace deprecated DataFrame.applymap with map for compatibility

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization.py
@@ -420,7 +420,7 @@ class PCollectionVisualization(object):
     format_window_info_in_dataframe(data)
     # Convert the dataframe into rows, each row looks like
     # [column_1_val, column_2_val, ...].
-    rows = data.applymap(lambda x: str(x)).to_dict('split')['data']
+    rows = data.apply(lambda col: col.map(lambda x: str(x))).to_dict('split')['data']
     # Convert each row into dict where keys are column index in the datatable
     # to be rendered and values are data from the dataframe. Column index 0 is
     # left out to hold the int index (not part of the data) from dataframe.


### PR DESCRIPTION
This pull request replaces the deprecated DataFrame.applymap function with map in the file pcoll_visualization.py. The change ensures compatibility with newer versions of pandas and avoids deprecation warnings during execution.

The modification is minimal and focuses only on updating the function to maintain functionality and improve codebase compatibility.