### PR TITLE
[WIP] [Do not Merge] [Dataflow Streaming] Support for using virtual harness threads

### DIFF
--- a/.github/workflows/beam_PreCommit_Java_Examples_Dataflow_Java21.yml
+++ b/.github/workflows/beam_PreCommit_Java_Examples_Dataflow_Java21.yml
@@ -112,7 +112,7 @@ jobs:
     - name: Build and Test
       uses: ./.github/actions/gradle-command-self-hosted-action
       with:
-        gradle-command: :runners:google-cloud-dataflow-java:examples:preCommit
+        gradle-command: :javaExamplesDataflowPrecommit
         arguments: |
           -PdisableSpotlessCheck=true \
           -PdisableCheckStyle=true \

--- a/runners/google-cloud-dataflow-java/examples-streaming/build.gradle
+++ b/runners/google-cloud-dataflow-java/examples-streaming/build.gradle
@@ -70,7 +70,7 @@ task windmillVirtualThreadPreCommit(type: Test) {
           "--tempRoot=${gcsTempRoot}",
           "--runner=TestDataflowRunner",
           "--dataflowWorkerJar=${dataflowWorkerJar}",
-          "--workerHarnessContainerImage=",
+//          "--workerHarnessContainerImage=",
           "--streaming=true",
           "--enableStreamingEngine",
           "--virtualHarnessThreads=true",
@@ -112,5 +112,7 @@ task preCommit(type: Test) {
   dependsOn appliancePreCommit
   dependsOn windmillPreCommit
   dependsOn windmillVirtualThreadPreCommit
+  if (project.hasProperty("testJavaVersion")) {
+    dependsOn ":sdks:java:testing:test-utils:verifyJavaVersion${project.property("testJavaVersion")}"
+  }
 }
-

--- a/runners/google-cloud-dataflow-java/examples-streaming/build.gradle
+++ b/runners/google-cloud-dataflow-java/examples-streaming/build.gradle
@@ -58,6 +58,31 @@ task windmillPreCommit(type: Test) {
   systemProperty "beamTestPipelineOptions", JsonOutput.toJson(preCommitBeamTestPipelineOptions)
 }
 
+task windmillVirtualThreadPreCommit(type: Test) {
+  dependsOn ":runners:google-cloud-dataflow-java:worker:shadowJar"
+  def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":runners:google-cloud-dataflow-java:worker").shadowJar.archivePath
+
+  // Set workerHarnessContainerImage to empty to make Dataflow pick up the
+  // non-versioned container image, which handles a staged worker jar.
+  def preCommitBeamTestPipelineOptions = [
+          "--project=${gcpProject}",
+          "--region=${gcpRegion}",
+          "--tempRoot=${gcsTempRoot}",
+          "--runner=TestDataflowRunner",
+          "--dataflowWorkerJar=${dataflowWorkerJar}",
+          "--workerHarnessContainerImage=",
+          "--streaming=true",
+          "--enableStreamingEngine",
+          "--virtualHarnessThreads=true",
+  ]
+  enabled = (project.findProperty('testJavaVersion') == '21')
+  testClassesDirs = files(project(":examples:java").sourceSets.test.output.classesDirs)
+  include "**/WordCountIT.class"
+  forkEvery 1
+  maxParallelForks 4
+  systemProperty "beamTestPipelineOptions", JsonOutput.toJson(preCommitBeamTestPipelineOptions)
+}
+
 task appliancePreCommit(type: Test) {
   dependsOn ":runners:google-cloud-dataflow-java:worker:shadowJar"
   def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":runners:google-cloud-dataflow-java:worker").shadowJar.archivePath
@@ -86,5 +111,6 @@ task appliancePreCommit(type: Test) {
 task preCommit(type: Test) {
   dependsOn appliancePreCommit
   dependsOn windmillPreCommit
+  dependsOn windmillVirtualThreadPreCommit
 }
 

--- a/runners/google-cloud-dataflow-java/examples-streaming/build.gradle
+++ b/runners/google-cloud-dataflow-java/examples-streaming/build.gradle
@@ -62,15 +62,12 @@ task windmillVirtualThreadPreCommit(type: Test) {
   dependsOn ":runners:google-cloud-dataflow-java:worker:shadowJar"
   def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":runners:google-cloud-dataflow-java:worker").shadowJar.archivePath
 
-  // Set workerHarnessContainerImage to empty to make Dataflow pick up the
-  // non-versioned container image, which handles a staged worker jar.
   def preCommitBeamTestPipelineOptions = [
           "--project=${gcpProject}",
           "--region=${gcpRegion}",
           "--tempRoot=${gcsTempRoot}",
           "--runner=TestDataflowRunner",
           "--dataflowWorkerJar=${dataflowWorkerJar}",
-//          "--workerHarnessContainerImage=",
           "--streaming=true",
           "--enableStreamingEngine",
           "--virtualHarnessThreads=true",

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -57,6 +57,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -511,6 +512,14 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
         String.format("%s/%s%s", userAgentName, userAgentVersion, agentJavaVer).replace(" ", "_");
     dataflowOptions.setUserAgent(userAgent);
 
+    if (dataflowOptions.getVirtualHarnessThreads()) {
+      try {
+        Executors.class.getMethod("newVirtualThreadPerTaskExecutor");
+      } catch (NoSuchMethodException e) {
+        throw new IllegalArgumentException(
+            "--virtualHarnessThreads is only supported on java 21 and up.");
+      }
+    }
     return new DataflowRunner(dataflowOptions);
   }
 

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowStreamingPipelineOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowStreamingPipelineOptions.java
@@ -226,11 +226,19 @@ public interface DataflowStreamingPipelineOptions extends PipelineOptions {
 
   void setIsWindmillServiceDirectPathEnabled(boolean isWindmillServiceDirectPathEnabled);
 
+  @Description(
+      "Use virtual threads for harness threads, requires Java 21+. This is experimental, "
+          + "user need to make sure no code pins the platform threads for too long")
+  boolean getVirtualHarnessThreads();
+
+  void setVirtualHarnessThreads(boolean value);
+
   /**
    * Factory for creating local Windmill address. Reads from system propery 'windmill.hostport' for
    * backwards compatibility.
    */
   class LocalWindmillHostportFactory implements DefaultValueFactory<String> {
+
     private static final String WINDMILL_HOSTPORT_PROPERTY = "windmill.hostport";
 
     @Override

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -802,6 +802,7 @@ public final class StreamingDataflowWorker {
 
   private static BoundedQueueExecutor createWorkUnitExecutor(DataflowWorkerHarnessOptions options) {
     return new BoundedQueueExecutor(
+        options.getVirtualHarnessThreads(),
         chooseMaxThreads(options),
         THREAD_EXPIRATION_TIME_SEC,
         TimeUnit.SECONDS,

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/BoundedQueueExecutor.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/BoundedQueueExecutor.java
@@ -372,6 +372,7 @@ public class BoundedQueueExecutor {
 
     DataflowPlatformThreadExecutor(
         int maximumPoolSize, long keepAliveTime, TimeUnit unit, ThreadFactory threadFactory) {
+      this.maximumPoolSize = maximumPoolSize;
       executor =
           new ThreadPoolExecutor(
               maximumPoolSize,

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/ResizableSemaphore.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/ResizableSemaphore.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.util.common;
+
+import java.util.concurrent.Semaphore;
+
+public final class ResizableSemaphore extends Semaphore {
+
+  private volatile int totalPermits;
+
+  /**
+   * Constructs a Resizable Semaphore with the given initial number of permits
+   *
+   * @param permits the initial number of permits available. This value may be negative, in which
+   *     case releases must occur before any acquires will be granted.
+   */
+  public ResizableSemaphore(int permits) {
+    super(permits);
+    totalPermits = permits;
+  }
+
+  /**
+   * Sets the new total number of permits. If the new value is larger than the current value, then
+   * current blocking threads may be released. If the new value is smaller than the current value,
+   * then future calls to {@link Semaphore#release()} will not unblock a thread until the total
+   * number of acquired permits is less than the new total number of permits.
+   *
+   * @param permits the new total number of permits (must be non-negative)
+   * @see #getTotalPermits
+   */
+  public void setTotalPermits(int permits) {
+    synchronized (this) {
+      if (totalPermits == permits) {
+        return;
+      }
+
+      if (permits < 0) {
+        throw new IllegalArgumentException("Cannot resize semaphore to a negative size.");
+      }
+
+      int diff = permits - totalPermits;
+
+      if (diff > 0) {
+        // Increase the number of permits
+        this.release(diff);
+      } else {
+        this.reducePermits(-diff);
+      }
+      totalPermits = permits;
+    }
+  }
+
+  /**
+   * Gets the total number of permits. This value is equal to the number of permits that have been
+   * acquired plus the number of permits that could be acquired without blocking.
+   *
+   * @return total number of permits
+   */
+  public int getTotalPermits() {
+    return totalPermits;
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
@@ -2938,6 +2938,7 @@ public class StreamingDataflowWorkerTest {
     // active thread count.
     BoundedQueueExecutor executor =
         new BoundedQueueExecutor(
+            false,
             maxThreads,
             threadExpiration,
             TimeUnit.SECONDS,
@@ -2998,6 +2999,7 @@ public class StreamingDataflowWorkerTest {
     // active thread count.
     BoundedQueueExecutor executor =
         new BoundedQueueExecutor(
+            false,
             maxThreads,
             threadExpirationSec,
             TimeUnit.SECONDS,
@@ -3067,6 +3069,7 @@ public class StreamingDataflowWorkerTest {
     // active thread count.
     BoundedQueueExecutor executor =
         new BoundedQueueExecutor(
+            false,
             maxThreads,
             threadExpirationSec,
             TimeUnit.SECONDS,
@@ -3140,6 +3143,7 @@ public class StreamingDataflowWorkerTest {
     // active thread count.
     BoundedQueueExecutor executor =
         new BoundedQueueExecutor(
+            false,
             maxThreads,
             threadExpirationSec,
             TimeUnit.SECONDS,

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/util/BoundedQueueExecutorTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/util/BoundedQueueExecutorTest.java
@@ -91,6 +91,7 @@ public class BoundedQueueExecutorTest {
   public void setUp() {
     this.executor =
         new BoundedQueueExecutor(
+            false,
             DEFAULT_MAX_THREADS,
             DEFAULT_THREAD_EXPIRATION_SEC,
             TimeUnit.SECONDS,

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/util/common/ResizableSemaphoreTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/util/common/ResizableSemaphoreTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.util.common;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ResizableSemaphoreTest {
+
+  @Test
+  public void testSetTotalPermits() throws InterruptedException {
+    ResizableSemaphore semaphore = new ResizableSemaphore(0);
+    assertFalse(semaphore.tryAcquire());
+    semaphore.setTotalPermits(1);
+    assertEquals(1, semaphore.getTotalPermits());
+
+    assertTrue(semaphore.tryAcquire());
+    assertFalse(semaphore.tryAcquire());
+
+    semaphore.release();
+    semaphore.setTotalPermits(0);
+    assertFalse(semaphore.tryAcquire());
+    assertEquals(0, semaphore.getTotalPermits());
+
+    semaphore.setTotalPermits(5);
+    assertEquals(5, semaphore.getTotalPermits());
+
+    semaphore.acquire(4);
+    assertEquals(1, semaphore.availablePermits());
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/failures/WorkFailureProcessorTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/failures/WorkFailureProcessorTest.java
@@ -54,6 +54,7 @@ public class WorkFailureProcessorTest {
       FailureTracker failureTracker, Supplier<Instant> clock) {
     BoundedQueueExecutor workExecutor =
         new BoundedQueueExecutor(
+            false,
             1,
             60,
             TimeUnit.SECONDS,

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/work/refresh/ActiveWorkRefresherTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/work/refresh/ActiveWorkRefresherTest.java
@@ -72,6 +72,7 @@ public class ActiveWorkRefresherTest {
 
   private static BoundedQueueExecutor workExecutor() {
     return new BoundedQueueExecutor(
+        false,
         1,
         60,
         TimeUnit.SECONDS,


### PR DESCRIPTION
This is an experimental feature that can be used on Java 21+ by passing pipeline option `--virtualHarnessThreads=true`.

In Java 21, virtual threads pin the underlying platform thread when inside synchronized blocks or in native code. When enabling this, care should be taken by user code to not block and pin the harness threads for long.

Tested the feature on sample jobs. Will send separate changes to optimize blocking synchronize blocks, if any, in runner code.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
