### PR TITLE
Temporarily skip deleting beam-performancetests-singlestoreio-12661373176

### DIFF
--- a/.test-infra/tools/stale_k8s_workload_cleaner.sh
+++ b/.test-infra/tools/stale_k8s_workload_cleaner.sh
@@ -44,6 +44,8 @@ gcloud container clusters get-credentials io-datastores --zone us-central1-a --p
 
 while read NAME STATUS AGE; do
   # Regex has temporary workaround to avoid trying to delete already deleted beam-performancetests-singlestoreio-12661373176
+  # See https://github.com/apache/beam/pull/33545 for context.
+  # This may be safe to remove if the system has healed, just try it before checking in :)
   if [[ $NAME =~ ^beam-.+(test|-it)(?!s-singlestoreio-12661373176) ]] && should_teardown $AGE; then
     kubectl delete namespace $NAME
   fi

--- a/.test-infra/tools/stale_k8s_workload_cleaner.sh
+++ b/.test-infra/tools/stale_k8s_workload_cleaner.sh
@@ -18,7 +18,7 @@
 #    Deletes stale and old BQ datasets that are left after tests.
 #
 
-set -euo pipefail
+set -exuo pipefail
 
 # Clean up the stale kubernetes workload of given cluster
 

--- a/.test-infra/tools/stale_k8s_workload_cleaner.sh
+++ b/.test-infra/tools/stale_k8s_workload_cleaner.sh
@@ -18,7 +18,7 @@
 #    Deletes stale and old BQ datasets that are left after tests.
 #
 
-set -exuo pipefail
+set -euo pipefail
 
 # Clean up the stale kubernetes workload of given cluster
 
@@ -43,6 +43,7 @@ function should_teardown() {
 gcloud container clusters get-credentials io-datastores --zone us-central1-a --project apache-beam-testing
 
 while read NAME STATUS AGE; do
+  # Regex has temporary workaround to avoid trying to delete already deleted beam-performancetests-singlestoreio-12661373176
   if [[ $NAME =~ ^beam-.+(test|-it)(?!s-singlestoreio-12661373176) ]] && should_teardown $AGE; then
     kubectl delete namespace $NAME
   fi

--- a/.test-infra/tools/stale_k8s_workload_cleaner.sh
+++ b/.test-infra/tools/stale_k8s_workload_cleaner.sh
@@ -43,10 +43,10 @@ function should_teardown() {
 gcloud container clusters get-credentials io-datastores --zone us-central1-a --project apache-beam-testing
 
 while read NAME STATUS AGE; do
-  # Regex has temporary workaround to avoid trying to delete already deleted beam-performancetests-singlestoreio-12661373176
+  # Regex has temporary workaround to avoid trying to delete beam-performancetests-singlestoreio-* to avoid getting stuck in a terminal state
   # See https://github.com/apache/beam/pull/33545 for context.
-  # This may be safe to remove if the system has healed, just try it before checking in :)
-  if [[ $NAME =~ ^beam-.+(test|-it)(?!s-singlestoreio-12661373176) ]] && should_teardown $AGE; then
+  # This may be safe to remove if https://cloud.google.com/knowledge/kb/deleted-namespace-remains-in-terminating-status-000004867 has been resolved, just try it before checking in :)
+  if [[ $NAME =~ ^beam-.+(test|-it)(?!s-singlestoreio) ]] && should_teardown $AGE; then
     kubectl delete namespace $NAME
   fi
 done < <( kubectl get namespaces --context=gke_${PROJECT}_${LOCATION}_${CLUSTER} )

--- a/.test-infra/tools/stale_k8s_workload_cleaner.sh
+++ b/.test-infra/tools/stale_k8s_workload_cleaner.sh
@@ -43,7 +43,7 @@ function should_teardown() {
 gcloud container clusters get-credentials io-datastores --zone us-central1-a --project apache-beam-testing
 
 while read NAME STATUS AGE; do
-  if [[ $NAME =~ ^beam-.+(test|-it) ]] && should_teardown $AGE; then
+  if [[ $NAME =~ ^beam-.+(test|-it)(?!s-singlestoreio-12661373176) ]] && should_teardown $AGE; then
     kubectl delete namespace $NAME
   fi
 done < <( kubectl get namespaces --context=gke_${PROJECT}_${LOCATION}_${CLUSTER} )


### PR DESCRIPTION
Right now, the clean gcp resources actions runs are failing on deleting beam-performancetests-singlestoreio-12661373176 -  they just hang because the resource doesn't exist. This looks like maybe a gke bug.

To work around this, I'm removing this resource from the delete command. Hopefully this is just temporary and things heal over time.

Example failure without my change - https://github.com/apache/beam/actions/runs/12689615728/job/35368720669

Example success with my change - https://github.com/apache/beam/actions/runs/12693438231/job/35381012473

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
