### PR TITLE
Revert "Bump yapf from 0.29.0 to 0.43.0 in /sdks/python"

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -34,7 +34,7 @@ requires = [
     'pyyaml>=3.12,<7.0.0',
     # also update Jinja2 bounds in test-suites/xlang/build.gradle (look for xlangWrapperValidation task)
     "jinja2>=2.7.1,<4.0.0",
-    'yapf==0.43.0'
+    'yapf==0.29.0'
 ]
 
 


### PR DESCRIPTION
Reverts apache/beam#33112