### PR TITLE
feat: caches watermark for Spanner change streams

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/ChangeStreamsConstants.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/ChangeStreamsConstants.java
@@ -20,9 +20,11 @@ package org.apache.beam.sdk.io.gcp.spanner.changestreams;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Options.RpcPriority;
 import java.util.Collections;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.dofn.DetectNewPartitionsDoFn;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.PartitionMetadata;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.PartitionMetadata.State;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Sets;
+import org.joda.time.Duration;
 
 /**
  * Single place for defining the constants used in the {@code Spanner.readChangeStreams()}
@@ -75,4 +77,10 @@ public class ChangeStreamsConstants {
           .setWatermark(Timestamp.now())
           .setCreatedAt(Timestamp.now())
           .build();
+
+  /**
+   * The default period for which we will re-compute the watermark of the {@link
+   * DetectNewPartitionsDoFn} stage.
+   */
+  public static final Duration DEFAULT_WATERMARK_REFRESH_RATE = Duration.standardSeconds(1);
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/action/ActionFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/action/ActionFactory.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.io.gcp.spanner.changestreams.action;
 
 import java.io.Serializable;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.ChangeStreamMetrics;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.cache.WatermarkCache;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.dao.ChangeStreamDao;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.dao.PartitionMetadataDao;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.estimator.ThroughputEstimator;
@@ -151,12 +152,17 @@ public class ActionFactory implements Serializable {
   public synchronized DetectNewPartitionsAction detectNewPartitionsAction(
       PartitionMetadataDao partitionMetadataDao,
       PartitionMetadataMapper partitionMetadataMapper,
+      WatermarkCache watermarkCache,
       ChangeStreamMetrics metrics,
       Duration resumeDuration) {
     if (detectNewPartitionsActionInstance == null) {
       detectNewPartitionsActionInstance =
           new DetectNewPartitionsAction(
-              partitionMetadataDao, partitionMetadataMapper, metrics, resumeDuration);
+              partitionMetadataDao,
+              partitionMetadataMapper,
+              watermarkCache,
+              metrics,
+              resumeDuration);
     }
     return detectNewPartitionsActionInstance;
   }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/cache/AsyncWatermarkCache.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/cache/AsyncWatermarkCache.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.spanner.changestreams.cache;
+
+import com.google.cloud.Timestamp;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.dao.PartitionMetadataDao;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.cache.CacheBuilder;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.cache.CacheLoader;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.cache.LoadingCache;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.joda.time.Duration;
+
+/**
+ * Asynchronously compute the earliest partition watermark and stores it in memory. The value will
+ * be recomputed periodically, as configured by the refresh rate.
+ *
+ * <p>On every period, we will call {@link PartitionMetadataDao#getUnfinishedMinWatermark()} to
+ * refresh the value.
+ */
+public class AsyncWatermarkCache implements WatermarkCache {
+
+  private static final String THREAD_NAME_FORMAT = "watermark_loading_thread_%d";
+  private static final Object MIN_WATERMARK_KEY = new Object();
+  private final LoadingCache<Object, Optional<Timestamp>> cache;
+
+  public AsyncWatermarkCache(PartitionMetadataDao dao, Duration refreshRate) {
+    this.cache =
+        CacheBuilder.newBuilder()
+            .refreshAfterWrite(java.time.Duration.ofMillis(refreshRate.getMillis()))
+            .build(
+                CacheLoader.asyncReloading(
+                    CacheLoader.from(key -> Optional.ofNullable(dao.getUnfinishedMinWatermark())),
+                    Executors.newSingleThreadExecutor(
+                        new ThreadFactoryBuilder().setNameFormat(THREAD_NAME_FORMAT).build())));
+  }
+
+  @Override
+  public @Nullable Timestamp getUnfinishedMinWatermark() {
+    try {
+      return cache.get(MIN_WATERMARK_KEY).orElse(null);
+    } catch (ExecutionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/cache/CacheFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/cache/CacheFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.spanner.changestreams.cache;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.dao.DaoFactory;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
+import org.joda.time.Duration;
+
+public class CacheFactory implements Serializable {
+
+  private static final long serialVersionUID = -8722905670370252723L;
+  private static final Map<Long, WatermarkCache> WATERMARK_CACHE = new ConcurrentHashMap<>();
+  private static final AtomicLong CACHE_ID = new AtomicLong();
+
+  // The unique id for the cache of this CacheFactory. This guarantees that if the CacheFactory is
+  // serialized / deserialized it will get the same instance of the factory.
+  private final long cacheId = CACHE_ID.getAndIncrement();
+  private final DaoFactory daoFactory;
+  private final Duration refreshRate;
+
+  public CacheFactory(DaoFactory daoFactory, Duration watermarkRefreshRate) {
+    this.daoFactory = daoFactory;
+    this.refreshRate = watermarkRefreshRate;
+  }
+
+  public WatermarkCache getWatermarkCache() {
+    return WATERMARK_CACHE.computeIfAbsent(
+        cacheId,
+        key ->
+            refreshRate.getMillis() == 0
+                ? new NoOpWatermarkCache(daoFactory.getPartitionMetadataDao())
+                : new AsyncWatermarkCache(daoFactory.getPartitionMetadataDao(), refreshRate));
+  }
+
+  @VisibleForTesting
+  long getCacheId() {
+    return cacheId;
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/cache/NoOpWatermarkCache.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/cache/NoOpWatermarkCache.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.spanner.changestreams.cache;
+
+import com.google.cloud.Timestamp;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.dao.PartitionMetadataDao;
+
+/**
+ * Synchronously compute the earliest partition watermark, by delegating the call to {@link
+ * PartitionMetadataDao#getUnfinishedMinWatermark()}.
+ */
+public class NoOpWatermarkCache implements WatermarkCache {
+
+  private final PartitionMetadataDao dao;
+
+  public NoOpWatermarkCache(PartitionMetadataDao dao) {
+    this.dao = dao;
+  }
+
+  @Override
+  public @Nullable Timestamp getUnfinishedMinWatermark() {
+    return dao.getUnfinishedMinWatermark();
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/cache/WatermarkCache.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/cache/WatermarkCache.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.spanner.changestreams.cache;
+
+import com.google.cloud.Timestamp;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.PartitionMetadata.State;
+
+@FunctionalInterface
+public interface WatermarkCache {
+
+  /**
+   * Fetches the earliest partition watermark from the partition metadata table that is not in a
+   * {@link State#FINISHED} state.
+   *
+   * @return the earliest partition watermark which is not in a {@link State#FINISHED} state.
+   */
+  @Nullable
+  Timestamp getUnfinishedMinWatermark();
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/cache/package-info.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/cache/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Caching strategy for watermark. */
+package org.apache.beam.sdk.io.gcp.spanner.changestreams.cache;

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/cache/CacheFactoryTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/cache/CacheFactoryTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.spanner.changestreams.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.dao.DaoFactory;
+import org.joda.time.Duration;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CacheFactoryTest {
+
+  private DaoFactory daoFactory;
+
+  @Before
+  public void setUp() throws Exception {
+    daoFactory = mock(DaoFactory.class, withSettings().serializable());
+  }
+
+  @Test
+  public void testReturnsNoOpWatermarkCacheWhenDurationIsZero() {
+    CacheFactory cacheFactory = new CacheFactory(daoFactory, Duration.ZERO);
+
+    assertEquals(NoOpWatermarkCache.class, cacheFactory.getWatermarkCache().getClass());
+  }
+
+  @Test
+  public void testReturnsAsyncWatermarkCacheWhenDurationIsNonZero() {
+    CacheFactory cacheFactory = new CacheFactory(daoFactory, Duration.standardSeconds(1));
+
+    assertEquals(AsyncWatermarkCache.class, cacheFactory.getWatermarkCache().getClass());
+  }
+
+  @Test
+  public void testSerializeDeserialize() throws Exception {
+    CacheFactory cacheFactory = new CacheFactory(daoFactory, Duration.standardSeconds(5));
+    long cacheId = cacheFactory.getCacheId();
+    WatermarkCache watermarkCache = cacheFactory.getWatermarkCache();
+
+    CacheFactory deserializedCacheFactory = deserialize(serialize(cacheFactory));
+
+    assertEquals(cacheId, deserializedCacheFactory.getCacheId());
+    assertEquals(watermarkCache, deserializedCacheFactory.getWatermarkCache());
+  }
+
+  @Test
+  public void testMultipleDeserializations() throws Exception {
+    CacheFactory cacheFactory = new CacheFactory(daoFactory, Duration.standardSeconds(5));
+    long cacheId = cacheFactory.getCacheId();
+    WatermarkCache watermarkCache = cacheFactory.getWatermarkCache();
+    byte[] serializedCacheFactory = serialize(cacheFactory);
+
+    for (int i = 0; i < 10; i++) {
+      CacheFactory deserializedCacheFactory = deserialize(serializedCacheFactory);
+
+      assertEquals(cacheId, deserializedCacheFactory.getCacheId());
+      assertEquals(watermarkCache, deserializedCacheFactory.getWatermarkCache());
+    }
+  }
+
+  @Test
+  public void testMultipleInstancesHaveDifferentCacheIds() throws Exception {
+    CacheFactory cacheFactory1 = new CacheFactory(daoFactory, Duration.standardSeconds(5));
+    long cacheId1 = cacheFactory1.getCacheId();
+    CacheFactory cacheFactory2 = new CacheFactory(daoFactory, Duration.standardSeconds(5));
+    long cacheId2 = cacheFactory2.getCacheId();
+
+    CacheFactory deserializedCacheFactory1 = deserialize(serialize(cacheFactory1));
+    CacheFactory deserializedCacheFactory2 = deserialize(serialize(cacheFactory2));
+
+    assertNotEquals(cacheId1, cacheId2);
+    assertEquals(cacheId1, deserializedCacheFactory1.getCacheId());
+    assertEquals(cacheId2, deserializedCacheFactory2.getCacheId());
+  }
+
+  private byte[] serialize(CacheFactory cacheFactory) throws IOException {
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(cacheFactory);
+      return baos.toByteArray();
+    }
+  }
+
+  private CacheFactory deserialize(byte[] bytes) throws IOException, ClassNotFoundException {
+    try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(bais)) {
+      return (CacheFactory) ois.readObject();
+    }
+  }
+}


### PR DESCRIPTION
Asynchronously compute the minimum watermark from Spanner change stream partitions and cache them for DoFn access.

This PR addresses the issue that if computing the minimum watermark from the metadata partition table takes over 5s (max time to issue a split for a DoFn), the pipeline will not be able to progress. Here, we initialize a static guava cache that executes the watermark query asynchronously, thus not being limited by the 5s compute time.