### PR TITLE
[Go SDK] Container Worker pool functionality.

### DIFF
--- a/sdks/go/container/boot.go
+++ b/sdks/go/container/boot.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/apache/beam/sdks/v2/go/container/pool"
 	"github.com/apache/beam/sdks/v2/go/container/tools"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/artifact"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime"
@@ -44,6 +45,7 @@ import (
 var (
 	// Contract: https://s.apache.org/beam-fn-api-container-contract.
 
+	workerPool        = flag.Bool("worker_pool", false, "Run as worker pool (optional).")
 	id                = flag.String("id", "", "Local identifier (required).")
 	loggingEndpoint   = flag.String("logging_endpoint", "", "Local logging endpoint for FnHarness (required).")
 	artifactEndpoint  = flag.String("artifact_endpoint", "", "Local artifact endpoint for FnHarness (required).")
@@ -56,6 +58,7 @@ const (
 	cloudProfilingJobName           = "CLOUD_PROF_JOB_NAME"
 	cloudProfilingJobID             = "CLOUD_PROF_JOB_ID"
 	enableGoogleCloudProfilerOption = "enable_google_cloud_profiler"
+	workerPoolIdEnv                 = "BEAM_GO_WORKER_POOL_ID"
 )
 
 func configureGoogleCloudProfilerEnvVars(ctx context.Context, logger *tools.Logger, metadata map[string]string) error {
@@ -78,6 +81,24 @@ func configureGoogleCloudProfilerEnvVars(ctx context.Context, logger *tools.Logg
 
 func main() {
 	flag.Parse()
+
+	if *workerPool {
+		workerPoolId := fmt.Sprintf("%d", os.Getpid())
+		ctx := context.Background()
+		os.Setenv(workerPoolIdEnv, workerPoolId)
+		log.Printf("Starting worker pool %v: Go %v", workerPoolId, "localhost:50000")
+		server, err := pool.New(ctx, 50000, "/opt/apache/beam/boot")
+		if err != nil {
+			log.Fatalf("Error starting worker pool: %v", err)
+		}
+		defer server.Stop(ctx)
+		if err := server.ServeAndWait(); err != nil {
+			log.Fatalf("Error with worker pool: %v", err)
+		}
+		log.Print("Go SDK worker pool exited.")
+		os.Exit(0)
+	}
+
 	if *id == "" {
 		log.Fatal("No id provided.")
 	}

--- a/sdks/go/container/pool/workerpool.go
+++ b/sdks/go/container/pool/workerpool.go
@@ -1,0 +1,156 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pool facilitates a external worker service, as an alternate mode for
+// the standard Beam container.
+//
+// This is predeominantly to serve as a process spawner within a given container
+// VM for an arbitrary number of jobs, instead of for a single worker instance.
+//
+// Workers will be spawned as executed OS processes.
+package pool
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"os/exec"
+	"sync"
+
+	fnpb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/fnexecution_v1"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/util/grpcx"
+	"google.golang.org/grpc"
+)
+
+// StartProcess initializes a process based ExternalWorkerService, at the given
+// port.
+func StartProcess(ctx context.Context, port int, containerExecutable string) (*Process, error) {
+	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
+	if err != nil {
+		return nil, err
+	}
+	slog.Info("starting Process server", "addr", lis.Addr())
+	grpcServer := grpc.NewServer()
+	root, cancel := context.WithCancel(ctx)
+	s := &Process{lis: lis, root: root, rootCancel: cancel, workers: map[string]context.CancelFunc{},
+		grpcServer: grpcServer, containerExecutable: containerExecutable}
+	fnpb.RegisterBeamFnExternalWorkerPoolServer(grpcServer, s)
+	go grpcServer.Serve(lis)
+	return s, nil
+}
+
+// Process implements fnpb.BeamFnExternalWorkerPoolServer, by starting external
+// processes.
+type Process struct {
+	fnpb.UnimplementedBeamFnExternalWorkerPoolServer
+
+	containerExecutable string // The host for the container executable.
+
+	lis        net.Listener
+	root       context.Context
+	rootCancel context.CancelFunc
+
+	mu      sync.Mutex
+	workers map[string]context.CancelFunc
+
+	grpcServer *grpc.Server
+}
+
+// StartWorker initializes a new worker harness, implementing BeamFnExternalWorkerPoolServer.StartWorker.
+func (s *Process) StartWorker(_ context.Context, req *fnpb.StartWorkerRequest) (*fnpb.StartWorkerResponse, error) {
+	slog.Debug("starting worker", "id", req.GetWorkerId())
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.workers == nil {
+		return &fnpb.StartWorkerResponse{
+			Error: "worker pool shutting down",
+		}, nil
+	}
+
+	if _, ok := s.workers[req.GetWorkerId()]; ok {
+		return &fnpb.StartWorkerResponse{
+			Error: fmt.Sprintf("worker with ID %q already exists", req.GetWorkerId()),
+		}, nil
+	}
+	if req.GetLoggingEndpoint() == nil {
+		return &fnpb.StartWorkerResponse{Error: fmt.Sprintf("Missing logging endpoint for worker %v", req.GetWorkerId())}, nil
+	}
+	if req.GetControlEndpoint() == nil {
+		return &fnpb.StartWorkerResponse{Error: fmt.Sprintf("Missing control endpoint for worker %v", req.GetWorkerId())}, nil
+	}
+	if req.GetLoggingEndpoint().Authentication != nil || req.GetControlEndpoint().Authentication != nil {
+		return &fnpb.StartWorkerResponse{Error: "[BEAM-10610] Secure endpoints not supported."}, nil
+	}
+
+	ctx := grpcx.WriteWorkerID(s.root, req.GetWorkerId())
+	ctx, s.workers[req.GetWorkerId()] = context.WithCancel(ctx)
+
+	args := []string{
+		"--id=" + req.GetWorkerId(),
+		"--control_endpoint=" + req.GetControlEndpoint().GetUrl(),
+		"--artifact_endpoint" + req.GetArtifactEndpoint().GetUrl(),
+		"--provision_endpoint" + req.GetProvisionEndpoint().GetUrl(),
+		"--logging_endpoint=" + req.GetLoggingEndpoint().GetUrl(),
+	}
+
+	cmd := exec.CommandContext(ctx, s.containerExecutable, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = nil // Use the current environment.
+
+	if err := cmd.Start(); err != nil {
+		return &fnpb.StartWorkerResponse{Error: fmt.Sprintf("Unable to start boot for worker %v: %v", req.GetWorkerId(), err)}, nil
+	}
+	return &fnpb.StartWorkerResponse{}, nil
+}
+
+// StopWorker terminates a worker harness, implementing BeamFnExternalWorkerPoolServer.StopWorker.
+func (s *Process) StopWorker(_ context.Context, req *fnpb.StopWorkerRequest) (*fnpb.StopWorkerResponse, error) {
+	slog.Info("stopping worker", "id", req.GetWorkerId())
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.workers == nil {
+		// Worker pool is already shutting down, so no action is needed.
+		return &fnpb.StopWorkerResponse{}, nil
+	}
+	if cancelfn, ok := s.workers[req.GetWorkerId()]; ok {
+		cancelfn()
+		delete(s.workers, req.GetWorkerId())
+		return &fnpb.StopWorkerResponse{}, nil
+	}
+	return &fnpb.StopWorkerResponse{
+		Error: fmt.Sprintf("no worker with id %q running", req.GetWorkerId()),
+	}, nil
+
+}
+
+// Stop terminates the service and stops all workers.
+func (s *Process) Stop(ctx context.Context) error {
+	s.mu.Lock()
+
+	slog.Debug("stopping Process", "worker_count", len(s.workers))
+	s.workers = nil
+	s.rootCancel()
+
+	// There can be a deadlock between the StopWorker RPC and GracefulStop
+	// which waits for all RPCs to finish, so it must be outside the critical section.
+	s.mu.Unlock()
+
+	s.grpcServer.GracefulStop()
+	return nil
+}

--- a/sdks/go/container/pool/workerpool.go
+++ b/sdks/go/container/pool/workerpool.go
@@ -39,7 +39,7 @@ import (
 // New initializes a process based ExternalWorkerService, at the given
 // port.
 func New(ctx context.Context, port int, containerExecutable string) (*Process, error) {
-	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ type Process struct {
 
 // StartWorker initializes a new worker harness, implementing BeamFnExternalWorkerPoolServer.StartWorker.
 func (s *Process) StartWorker(_ context.Context, req *fnpb.StartWorkerRequest) (*fnpb.StartWorkerResponse, error) {
-	slog.Debug("starting worker", "id", req.GetWorkerId())
+	slog.Info("starting worker", "id", req.GetWorkerId())
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.workers == nil {
@@ -106,8 +106,8 @@ func (s *Process) StartWorker(_ context.Context, req *fnpb.StartWorkerRequest) (
 	args := []string{
 		"--id=" + req.GetWorkerId(),
 		"--control_endpoint=" + req.GetControlEndpoint().GetUrl(),
-		"--artifact_endpoint" + req.GetArtifactEndpoint().GetUrl(),
-		"--provision_endpoint" + req.GetProvisionEndpoint().GetUrl(),
+		"--artifact_endpoint=" + req.GetArtifactEndpoint().GetUrl(),
+		"--provision_endpoint=" + req.GetProvisionEndpoint().GetUrl(),
 		"--logging_endpoint=" + req.GetLoggingEndpoint().GetUrl(),
 	}
 

--- a/sdks/go/container/pool/workerpool_test.go
+++ b/sdks/go/container/pool/workerpool_test.go
@@ -41,11 +41,13 @@ func TestProcess(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
-	server, err := StartProcess(ctx, 0, dummyExec)
+	ctx, cancelFn := context.WithCancel(context.Background())
+	t.Cleanup(cancelFn)
+	server, err := New(ctx, 0, dummyExec)
 	if err != nil {
-		t.Fatalf("Unable to start server: %v", err)
+		t.Fatalf("Unable to create server: %v", err)
 	}
+	go server.ServeAndWait()
 
 	startTests := []struct {
 		req         *fnpb.StartWorkerRequest

--- a/sdks/go/container/pool/workerpool_test.go
+++ b/sdks/go/container/pool/workerpool_test.go
@@ -1,0 +1,148 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pool
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	fnpb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/fnexecution_v1"
+	pipepb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/pipeline_v1"
+)
+
+func TestProcess(t *testing.T) {
+	// Use the no-op true binary, if available, skip this test otherwise.
+	dummyExec, err := exec.LookPath("true")
+	if err != nil {
+		t.Skip("Binary `true` doesn't exist, skipping tests.")
+	}
+
+	endpoint := &pipepb.ApiServiceDescriptor{
+		Url: "localhost:0",
+	}
+	secureEndpoint := &pipepb.ApiServiceDescriptor{
+		Url: "localhost:0",
+		Authentication: &pipepb.AuthenticationSpec{
+			Urn: "beam:authentication:oauth2_client_credentials_grant:v1",
+		},
+	}
+
+	ctx := context.Background()
+	server, err := StartProcess(ctx, 0, dummyExec)
+	if err != nil {
+		t.Fatalf("Unable to start server: %v", err)
+	}
+
+	startTests := []struct {
+		req         *fnpb.StartWorkerRequest
+		errExpected bool
+	}{
+		{
+			req: &fnpb.StartWorkerRequest{
+				WorkerId:        "Worker1",
+				ControlEndpoint: endpoint,
+				LoggingEndpoint: endpoint,
+			},
+		}, {
+			req: &fnpb.StartWorkerRequest{
+				WorkerId:        "Worker2",
+				ControlEndpoint: endpoint,
+				LoggingEndpoint: endpoint,
+			},
+		}, {
+			req: &fnpb.StartWorkerRequest{
+				WorkerId:        "Worker1",
+				ControlEndpoint: endpoint,
+				LoggingEndpoint: endpoint,
+			},
+			errExpected: true, // Repeated start
+		}, {
+			req: &fnpb.StartWorkerRequest{
+				WorkerId:        "missingControl",
+				LoggingEndpoint: endpoint,
+			},
+			errExpected: true,
+		}, {
+			req: &fnpb.StartWorkerRequest{
+				WorkerId:        "missingLogging",
+				ControlEndpoint: endpoint,
+			},
+			errExpected: true,
+		}, {
+			req: &fnpb.StartWorkerRequest{
+				WorkerId:        "secureLogging",
+				LoggingEndpoint: secureEndpoint,
+				ControlEndpoint: endpoint,
+			},
+			errExpected: true,
+		}, {
+			req: &fnpb.StartWorkerRequest{
+				WorkerId:        "secureControl",
+				LoggingEndpoint: endpoint,
+				ControlEndpoint: secureEndpoint,
+			},
+			errExpected: true,
+		},
+	}
+	for _, test := range startTests {
+		resp, err := server.StartWorker(ctx, test.req)
+		if test.errExpected {
+			if err != nil || resp.Error == "" {
+				t.Errorf("Expected error starting %v: err: %v, resp: %v", test.req.GetWorkerId(), err, resp)
+			}
+		} else {
+			if err != nil || resp.Error != "" {
+				t.Errorf("Unexpected error starting %v: err: %v, resp: %v", test.req.GetWorkerId(), err, resp)
+			}
+		}
+	}
+	stopTests := []struct {
+		req         *fnpb.StopWorkerRequest
+		errExpected bool
+	}{
+		{
+			req: &fnpb.StopWorkerRequest{
+				WorkerId: "Worker1",
+			},
+		}, {
+			req: &fnpb.StopWorkerRequest{
+				WorkerId: "Worker1",
+			},
+			errExpected: true,
+		}, {
+			req: &fnpb.StopWorkerRequest{
+				WorkerId: "NonExistent",
+			},
+			errExpected: true,
+		},
+	}
+	for _, test := range stopTests {
+		resp, err := server.StopWorker(ctx, test.req)
+		if test.errExpected {
+			if err != nil || resp.Error == "" {
+				t.Errorf("Expected error starting %v: err: %v, resp: %v", test.req.GetWorkerId(), err, resp)
+			}
+		} else {
+			if err != nil || resp.Error != "" {
+				t.Errorf("Unexpected error starting %v: err: %v, resp: %v", test.req.GetWorkerId(), err, resp)
+			}
+		}
+	}
+	if err := server.Stop(ctx); err != nil {
+		t.Fatalf("error stopping server: err: %v", err)
+	}
+}

--- a/sdks/go/pkg/beam/options/jobopts/options.go
+++ b/sdks/go/pkg/beam/options/jobopts/options.go
@@ -61,8 +61,8 @@ var (
 	JobName = flag.String("job_name", "", "Job name (optional).")
 
 	// EnvironmentType is the environment type to run the user code.
-	EnvironmentType = flag.String("environment_type", "DOCKER",
-		"Environment Type. Possible options are DOCKER, and LOOPBACK.")
+	EnvironmentType = flag.String("environment_type", "",
+		"Environment Type. Possible options are DOCKER, EXTERNAL, and LOOPBACK.")
 
 	// EnvironmentConfig is the environment configuration for running the user code.
 	EnvironmentConfig = flag.String("environment_config",

--- a/sdks/go/pkg/beam/runners/prism/internal/environments.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/environments.go
@@ -83,7 +83,11 @@ func externalEnvironment(ctx context.Context, ep *pipepb.ExternalPayload, wk *wo
 		Url: wk.Endpoint(),
 	}
 
-	resp, err := pool.StartWorker(ctx, &fnpb.StartWorkerRequest{
+	// Use a background context for these workers to avoid pre-mature
+	// cancelation issues when starting them.
+	bgContext := context.Background()
+
+	resp, err := pool.StartWorker(bgContext, &fnpb.StartWorkerRequest{
 		WorkerId:          wk.ID,
 		ControlEndpoint:   endpoint,
 		LoggingEndpoint:   endpoint,
@@ -103,7 +107,7 @@ func externalEnvironment(ctx context.Context, ep *pipepb.ExternalPayload, wk *wo
 
 	// Previous context cancelled so we need a new one
 	// for this request.
-	pool.StopWorker(context.Background(), &fnpb.StopWorkerRequest{
+	pool.StopWorker(bgContext, &fnpb.StopWorkerRequest{
 		WorkerId: wk.ID,
 	})
 	wk.Stop()

--- a/sdks/go/pkg/beam/runners/prism/internal/environments.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/environments.go
@@ -30,6 +30,7 @@ import (
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/runners/prism/internal/worker"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/docker/docker/api/types/container"
@@ -73,7 +74,7 @@ func runEnvironment(ctx context.Context, j *jobservices.Job, env string, wk *wor
 func externalEnvironment(ctx context.Context, ep *pipepb.ExternalPayload, wk *worker.W) {
 	conn, err := grpc.Dial(ep.GetEndpoint().GetUrl(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		panic(fmt.Sprintf("unable to dial sdk worker %v: %v", ep.GetEndpoint().GetUrl(), err))
+		panic(fmt.Sprintf("unable to dial sdk worker pool %v: %v", ep.GetEndpoint().GetUrl(), err))
 	}
 	defer conn.Close()
 	pool := fnpb.NewBeamFnExternalWorkerPoolClient(conn)
@@ -81,7 +82,8 @@ func externalEnvironment(ctx context.Context, ep *pipepb.ExternalPayload, wk *wo
 	endpoint := &pipepb.ApiServiceDescriptor{
 		Url: wk.Endpoint(),
 	}
-	pool.StartWorker(ctx, &fnpb.StartWorkerRequest{
+
+	resp, err := pool.StartWorker(ctx, &fnpb.StartWorkerRequest{
 		WorkerId:          wk.ID,
 		ControlEndpoint:   endpoint,
 		LoggingEndpoint:   endpoint,
@@ -89,6 +91,11 @@ func externalEnvironment(ctx context.Context, ep *pipepb.ExternalPayload, wk *wo
 		ProvisionEndpoint: endpoint,
 		Params:            ep.GetParams(),
 	})
+
+	if str := resp.GetError(); err != nil || str != "" {
+		panic(fmt.Sprintf("unable to start sdk worker %v error: %v, resp: %v", ep.GetEndpoint().GetUrl(), err, prototext.Format(resp)))
+	}
+
 	// Job processing happens here, but orchestrated by other goroutines
 	// This goroutine blocks until the context is cancelled, signalling
 	// that the pool runner should stop the worker.

--- a/sdks/go/pkg/beam/runners/prism/internal/jobservices/server.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/jobservices/server.go
@@ -99,7 +99,7 @@ func (s *Server) getJob(id string) *Job {
 
 func (s *Server) Endpoint() string {
 	_, port, _ := net.SplitHostPort(s.lis.Addr().String())
-	return fmt.Sprintf("localhost:%v", port)
+	return fmt.Sprintf(":%v", port)
 }
 
 // Serve serves on the started listener. Blocks.

--- a/sdks/go/pkg/beam/runners/prism/internal/jobservices/server.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/jobservices/server.go
@@ -99,7 +99,7 @@ func (s *Server) getJob(id string) *Job {
 
 func (s *Server) Endpoint() string {
 	_, port, _ := net.SplitHostPort(s.lis.Addr().String())
-	return fmt.Sprintf(":%v", port)
+	return fmt.Sprintf("localhost:%v", port)
 }
 
 // Serve serves on the started listener. Blocks.

--- a/sdks/go/pkg/beam/runners/prism/prism.go
+++ b/sdks/go/pkg/beam/runners/prism/prism.go
@@ -49,8 +49,8 @@ func Execute(ctx context.Context, p *beam.Pipeline) (beam.PipelineResult, error)
 		s := jobservices.NewServer(0, internal.RunPipeline)
 		*jobopts.Endpoint = s.Endpoint()
 		go s.Serve()
-		//
-		if !jobopts.IsLoopback() && *jobopts.EnvironmentType == "" {
+		// If the environmentType isn't set, use loopback instead.
+		if *jobopts.EnvironmentType == "" {
 			*jobopts.EnvironmentType = "loopback"
 		}
 	}

--- a/sdks/go/pkg/beam/runners/prism/prism.go
+++ b/sdks/go/pkg/beam/runners/prism/prism.go
@@ -40,8 +40,7 @@ func init() {
 // Execute runs the given pipeline on prism. If no endpoint is set, then an in process instance
 // is started, and the job run against that.
 //
-// At present, loopback mode is forced, though this will change once prism is able to
-// use SDK containers.
+// If an environment type isn't set, then loopback mode is forced and started up.
 func Execute(ctx context.Context, p *beam.Pipeline) (beam.PipelineResult, error) {
 	if *jobopts.Endpoint == "" {
 		// One hasn't been selected, so lets start one up and set the address.
@@ -50,7 +49,8 @@ func Execute(ctx context.Context, p *beam.Pipeline) (beam.PipelineResult, error)
 		s := jobservices.NewServer(0, internal.RunPipeline)
 		*jobopts.Endpoint = s.Endpoint()
 		go s.Serve()
-		if !jobopts.IsLoopback() {
+		//
+		if !jobopts.IsLoopback() && *jobopts.EnvironmentType == "" {
 			*jobopts.EnvironmentType = "loopback"
 		}
 	}


### PR DESCRIPTION
* Allows the Go SDK Container to execute as a SideCar worker pool from the default Beam Go container, with the default port of 50000.
* Enables use as a containered local worker pool as described here for the External configuration: https://beam.apache.org/documentation/runtime/sdk-harness-config/
  * All execution is *pooled* locally as per normal.
* Code can be shared to other SDK container boot loaders, since it largely just re-executes the current bootloader process in the container.  

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
