### PR TITLE
[Dataflow Streaming] Avoid calling WorkItem::getSerializedSize

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -254,7 +254,11 @@ public final class StreamingDataflowWorker {
                   .setBytes(MAX_GET_WORK_FETCH_BYTES)
                   .build(),
               windmillStreamFactory,
-              (workItem, watermarks, processingContext, getWorkStreamLatencies) ->
+              (workItem,
+                  serializedWorkItemSize,
+                  watermarks,
+                  processingContext,
+                  getWorkStreamLatencies) ->
                   computationStateCache
                       .get(processingContext.computationId())
                       .ifPresent(
@@ -263,6 +267,7 @@ public final class StreamingDataflowWorker {
                             streamingWorkScheduler.scheduleWork(
                                 computationState,
                                 workItem,
+                                serializedWorkItemSize,
                                 watermarks,
                                 processingContext,
                                 getWorkStreamLatencies);

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/ActiveWorkState.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/ActiveWorkState.java
@@ -221,12 +221,12 @@ public final class ActiveWorkState {
 
   private void incrementActiveWorkBudget(Work work) {
     activeGetWorkBudget.updateAndGet(
-        getWorkBudget -> getWorkBudget.apply(1, work.getWorkItem().getSerializedSize()));
+        getWorkBudget -> getWorkBudget.apply(1, work.getSerializedWorkItemSize()));
   }
 
   private void decrementActiveWorkBudget(Work work) {
     activeGetWorkBudget.updateAndGet(
-        getWorkBudget -> getWorkBudget.subtract(1, work.getWorkItem().getSerializedSize()));
+        getWorkBudget -> getWorkBudget.subtract(1, work.getSerializedWorkItemSize()));
   }
 
   /**

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/ComputationState.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/ComputationState.java
@@ -139,11 +139,11 @@ public class ComputationState {
   }
 
   private void execute(ExecutableWork executableWork) {
-    executor.execute(executableWork, executableWork.work().getWorkItem().getSerializedSize());
+    executor.execute(executableWork, executableWork.work().getSerializedWorkItemSize());
   }
 
   private void forceExecute(ExecutableWork executableWork) {
-    executor.forceExecute(executableWork, executableWork.work().getWorkItem().getSerializedSize());
+    executor.forceExecute(executableWork, executableWork.work().getSerializedWorkItemSize());
   }
 
   public ImmutableListMultimap<ShardedKey, RefreshableWork> currentActiveWorkReadOnly() {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/Work.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/Work.java
@@ -70,17 +70,20 @@ public final class Work implements RefreshableWork {
   private final Map<LatencyAttribution.State, Duration> totalDurationPerState;
   private final WorkId id;
   private final String latencyTrackingId;
+  private final long serializedWorkItemSize;
   private volatile TimedState currentState;
   private volatile boolean isFailed;
   private volatile String processingThreadName = "";
 
   private Work(
       WorkItem workItem,
+      long serializedWorkItemSize,
       Watermarks watermarks,
       ProcessingContext processingContext,
       Supplier<Instant> clock) {
     this.shardedKey = ShardedKey.create(workItem.getKey(), workItem.getShardingKey());
     this.workItem = workItem;
+    this.serializedWorkItemSize = serializedWorkItemSize;
     this.processingContext = processingContext;
     this.watermarks = watermarks;
     this.clock = clock;
@@ -97,11 +100,12 @@ public final class Work implements RefreshableWork {
 
   public static Work create(
       WorkItem workItem,
+      long serializedWorkItemSize,
       Watermarks watermarks,
       ProcessingContext processingContext,
       Supplier<Instant> clock,
       Collection<LatencyAttribution> getWorkStreamLatencies) {
-    Work work = new Work(workItem, watermarks, processingContext, clock);
+    Work work = new Work(workItem, serializedWorkItemSize, watermarks, processingContext, clock);
     work.recordGetWorkStreamLatencies(getWorkStreamLatencies);
     return work;
   }
@@ -164,6 +168,10 @@ public final class Work implements RefreshableWork {
 
   public WorkItem getWorkItem() {
     return workItem;
+  }
+
+  public long getSerializedWorkItemSize() {
+    return serializedWorkItemSize;
   }
 
   @Override

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/SingleSourceWorkerHarness.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/SingleSourceWorkerHarness.java
@@ -162,6 +162,7 @@ public final class SingleSourceWorkerHarness implements StreamingWorkerHarness {
                   inputDataWatermark,
                   synchronizedProcessingTime,
                   workItem,
+                  serializedWorkItemSize,
                   getWorkStreamLatencies) ->
                   computationStateFetcher
                       .apply(computationId)
@@ -171,6 +172,7 @@ public final class SingleSourceWorkerHarness implements StreamingWorkerHarness {
                             streamingWorkScheduler.scheduleWork(
                                 computationState,
                                 workItem,
+                                serializedWorkItemSize,
                                 Watermarks.builder()
                                     .setInputDataWatermark(
                                         Preconditions.checkNotNull(inputDataWatermark))
@@ -237,6 +239,7 @@ public final class SingleSourceWorkerHarness implements StreamingWorkerHarness {
           streamingWorkScheduler.scheduleWork(
               computationState,
               workItem,
+              workItem.getSerializedSize(),
               watermarks.setOutputDataWatermark(workItem.getOutputDataWatermark()).build(),
               Work.createProcessingContext(
                   computationId, getDataClient, workCommitter::commit, heartbeatSender),

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDirectGetWorkStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDirectGetWorkStream.java
@@ -260,6 +260,7 @@ final class GrpcDirectGetWorkStream
         assembledWorkItem.computationMetadata();
     workItemScheduler.scheduleWork(
         workItem,
+        assembledWorkItem.bufferedSize(),
         createWatermarks(workItem, metadata),
         createProcessingContext(metadata.computationId()),
         assembledWorkItem.latencyAttributions());

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetWorkStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetWorkStream.java
@@ -185,6 +185,7 @@ final class GrpcGetWorkStream
         assembledWorkItem.computationMetadata().inputDataWatermark(),
         assembledWorkItem.computationMetadata().synchronizedProcessingTime(),
         assembledWorkItem.workItem(),
+        assembledWorkItem.bufferedSize(),
         assembledWorkItem.latencyAttributions());
 
     // Record the fact that there are now fewer outstanding messages and bytes on the stream.

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/WorkItemReceiver.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/WorkItemReceiver.java
@@ -30,5 +30,6 @@ public interface WorkItemReceiver {
       @Nullable Instant inputDataWatermark,
       @Nullable Instant synchronizedProcessingTime,
       Windmill.WorkItem workItem,
+      long serializedWorkItemSize,
       Collection<Windmill.LatencyAttribution> getWorkStreamLatencies);
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/WorkItemScheduler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/WorkItemScheduler.java
@@ -40,6 +40,7 @@ public interface WorkItemScheduler {
    */
   void scheduleWork(
       WorkItem workItem,
+      long serializedWorkItemSize,
       Watermarks watermarks,
       Work.ProcessingContext processingContext,
       Collection<LatencyAttribution> getWorkStreamLatencies);

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/StreamingWorkScheduler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/StreamingWorkScheduler.java
@@ -205,12 +205,19 @@ public class StreamingWorkScheduler {
   public void scheduleWork(
       ComputationState computationState,
       Windmill.WorkItem workItem,
+      long serializedWorkItemSize,
       Watermarks watermarks,
       Work.ProcessingContext processingContext,
       Collection<Windmill.LatencyAttribution> getWorkStreamLatencies) {
     computationState.activateWork(
         ExecutableWork.create(
-            Work.create(workItem, watermarks, processingContext, clock, getWorkStreamLatencies),
+            Work.create(
+                workItem,
+                serializedWorkItemSize,
+                watermarks,
+                processingContext,
+                clock,
+                getWorkStreamLatencies),
             work -> processWork(computationState, work)));
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/failures/WorkFailureProcessor.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/failures/WorkFailureProcessor.java
@@ -126,7 +126,8 @@ public final class WorkFailureProcessor {
 
   private void executeWithDelay(long delayMs, ExecutableWork executableWork) {
     Uninterruptibles.sleepUninterruptibly(delayMs, TimeUnit.MILLISECONDS);
-    workUnitExecutor.forceExecute(executableWork, executableWork.getWorkItem().getSerializedSize());
+    workUnitExecutor.forceExecute(
+        executableWork, executableWork.work().getSerializedWorkItemSize());
   }
 
   private boolean shouldRetryLocally(String computationId, Work work, Throwable t) {

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/FakeWindmillServer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/FakeWindmillServer.java
@@ -275,6 +275,7 @@ public final class FakeWindmillServer extends WindmillServerStub {
                   inputDataWatermark,
                   Instant.now(),
                   workItem,
+                  workItem.getSerializedSize(),
                   Collections.singletonList(
                       LatencyAttribution.newBuilder()
                           .setState(State.GET_WORK_IN_TRANSIT_TO_USER_WORKER)

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
@@ -345,13 +345,16 @@ public class StreamingDataflowWorkerTest {
 
   private static ExecutableWork createMockWork(
       ShardedKey shardedKey, long workToken, String computationId, Consumer<Work> processWorkFn) {
+    Windmill.WorkItem workItem =
+        Windmill.WorkItem.newBuilder()
+            .setKey(shardedKey.key())
+            .setShardingKey(shardedKey.shardingKey())
+            .setWorkToken(workToken)
+            .build();
     return ExecutableWork.create(
         Work.create(
-            Windmill.WorkItem.newBuilder()
-                .setKey(shardedKey.key())
-                .setShardingKey(shardedKey.shardingKey())
-                .setWorkToken(workToken)
-                .build(),
+            workItem,
+            workItem.getSerializedSize(),
             Watermarks.builder().setInputDataWatermark(Instant.EPOCH).build(),
             Work.createProcessingContext(
                 computationId, new FakeGetDataClient(), ignored -> {}, mock(HeartbeatSender.class)),
@@ -3508,9 +3511,12 @@ public class StreamingDataflowWorkerTest {
   @Test
   public void testLatencyAttributionProtobufsPopulated() {
     FakeClock clock = new FakeClock();
+    Windmill.WorkItem workItem =
+        Windmill.WorkItem.newBuilder().setKey(ByteString.EMPTY).setWorkToken(1L).build();
     Work work =
         Work.create(
-            Windmill.WorkItem.newBuilder().setKey(ByteString.EMPTY).setWorkToken(1L).build(),
+            workItem,
+            workItem.getSerializedSize(),
             Watermarks.builder().setInputDataWatermark(Instant.EPOCH).build(),
             Work.createProcessingContext(
                 "computationId",

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingModeExecutionContextTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingModeExecutionContextTest.java
@@ -140,6 +140,7 @@ public class StreamingModeExecutionContextTest {
   private static Work createMockWork(Windmill.WorkItem workItem, Watermarks watermarks) {
     return Work.create(
         workItem,
+        workItem.getSerializedSize(),
         watermarks,
         Work.createProcessingContext(
             COMPUTATION_ID, new FakeGetDataClient(), ignored -> {}, mock(HeartbeatSender.class)),

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
@@ -200,6 +200,7 @@ public class WorkerCustomSourcesTest {
   private static Work createMockWork(Windmill.WorkItem workItem, Watermarks watermarks) {
     return Work.create(
         workItem,
+        workItem.getSerializedSize(),
         watermarks,
         Work.createProcessingContext(
             COMPUTATION_ID, new FakeGetDataClient(), ignored -> {}, mock(HeartbeatSender.class)),
@@ -1007,6 +1008,7 @@ public class WorkerCustomSourcesTest {
     Work dummyWork =
         Work.create(
             workItem,
+            workItem.getSerializedSize(),
             Watermarks.builder().setInputDataWatermark(new Instant(0)).build(),
             Work.createProcessingContext(
                 COMPUTATION_ID,

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/ActiveWorkStateTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/ActiveWorkStateTest.java
@@ -62,6 +62,7 @@ public class ActiveWorkStateTest {
     return ExecutableWork.create(
         Work.create(
             workItem,
+            workItem.getSerializedSize(),
             Watermarks.builder().setInputDataWatermark(Instant.EPOCH).build(),
             createWorkProcessingContext(),
             Instant::now,
@@ -73,6 +74,7 @@ public class ActiveWorkStateTest {
     return ExecutableWork.create(
         Work.create(
             workItem,
+            workItem.getSerializedSize(),
             Watermarks.builder().setInputDataWatermark(Instant.EPOCH).build(),
             createWorkProcessingContext(),
             () -> Instant.EPOCH,

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/ComputationStateCacheTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/ComputationStateCacheTest.java
@@ -35,7 +35,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.beam.runners.dataflow.worker.streaming.config.ComputationConfig;
 import org.apache.beam.runners.dataflow.worker.util.BoundedQueueExecutor;
-import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill.WorkItem;
 import org.apache.beam.runners.dataflow.worker.windmill.client.getdata.FakeGetDataClient;
 import org.apache.beam.runners.dataflow.worker.windmill.state.WindmillStateCache;
 import org.apache.beam.runners.dataflow.worker.windmill.work.budget.GetWorkBudget;
@@ -59,14 +59,17 @@ public class ComputationStateCacheTest {
   private ComputationStateCache computationStateCache;
 
   private static ExecutableWork createWork(ShardedKey shardedKey, long workToken, long cacheToken) {
+    WorkItem workItem =
+        WorkItem.newBuilder()
+            .setKey(shardedKey.key())
+            .setShardingKey(shardedKey.shardingKey())
+            .setWorkToken(workToken)
+            .setCacheToken(cacheToken)
+            .build();
     return ExecutableWork.create(
         Work.create(
-            Windmill.WorkItem.newBuilder()
-                .setKey(shardedKey.key())
-                .setShardingKey(shardedKey.shardingKey())
-                .setWorkToken(workToken)
-                .setCacheToken(cacheToken)
-                .build(),
+            workItem,
+            workItem.getSerializedSize(),
             Watermarks.builder().setInputDataWatermark(Instant.now()).build(),
             Work.createProcessingContext(
                 "computationId",

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/harness/FanOutStreamingEngineWorkerHarnessTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/harness/FanOutStreamingEngineWorkerHarnessTest.java
@@ -119,7 +119,11 @@ public class FanOutStreamingEngineWorkerHarnessTest {
   private FanOutStreamingEngineWorkerHarness fanOutStreamingEngineWorkProvider;
 
   private static WorkItemScheduler noOpProcessWorkItemFn() {
-    return (workItem, watermarks, processingContext, getWorkStreamLatencies) -> {};
+    return (workItem,
+        serializedWorkItemSize,
+        watermarks,
+        processingContext,
+        getWorkStreamLatencies) -> {};
   }
 
   private static GetWorkRequest getWorkRequest(long items, long bytes) {

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/harness/WindmillStreamSenderTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/harness/WindmillStreamSenderTest.java
@@ -65,7 +65,11 @@ public class WindmillStreamSenderTest {
                       .build())
               .build());
   private final WorkItemScheduler workItemScheduler =
-      (workItem, watermarks, processingContext, getWorkStreamLatencies) -> {};
+      (workItem,
+          serializedWorkItemSize,
+          watermarks,
+          processingContext,
+          getWorkStreamLatencies) -> {};
   @Rule public transient Timeout globalTimeout = Timeout.seconds(600);
   private ManagedChannel inProcessChannel;
   private WindmillConnection connection;

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/util/BoundedQueueExecutorTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/util/BoundedQueueExecutorTest.java
@@ -31,7 +31,7 @@ import java.util.function.Consumer;
 import org.apache.beam.runners.dataflow.worker.streaming.ExecutableWork;
 import org.apache.beam.runners.dataflow.worker.streaming.Watermarks;
 import org.apache.beam.runners.dataflow.worker.streaming.Work;
-import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill.WorkItem;
 import org.apache.beam.runners.dataflow.worker.windmill.client.getdata.FakeGetDataClient;
 import org.apache.beam.runners.dataflow.worker.windmill.work.refresh.HeartbeatSender;
 import org.apache.beam.vendor.grpc.v1p60p1.com.google.protobuf.ByteString;
@@ -57,14 +57,17 @@ public class BoundedQueueExecutorTest {
   private BoundedQueueExecutor executor;
 
   private static ExecutableWork createWork(Consumer<Work> executeWorkFn) {
+    WorkItem workItem =
+        WorkItem.newBuilder()
+            .setKey(ByteString.EMPTY)
+            .setShardingKey(1)
+            .setWorkToken(33)
+            .setCacheToken(1)
+            .build();
     return ExecutableWork.create(
         Work.create(
-            Windmill.WorkItem.newBuilder()
-                .setKey(ByteString.EMPTY)
-                .setShardingKey(1)
-                .setWorkToken(33)
-                .setCacheToken(1)
-                .build(),
+            workItem,
+            workItem.getSerializedSize(),
             Watermarks.builder().setInputDataWatermark(Instant.now()).build(),
             Work.createProcessingContext(
                 "computationId",

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/commits/StreamingApplianceWorkCommitterTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/commits/StreamingApplianceWorkCommitterTest.java
@@ -36,6 +36,7 @@ import org.apache.beam.runners.dataflow.worker.streaming.Watermarks;
 import org.apache.beam.runners.dataflow.worker.streaming.Work;
 import org.apache.beam.runners.dataflow.worker.util.BoundedQueueExecutor;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill.WorkItem;
 import org.apache.beam.runners.dataflow.worker.windmill.client.getdata.FakeGetDataClient;
 import org.apache.beam.runners.dataflow.worker.windmill.work.refresh.HeartbeatSender;
 import org.apache.beam.vendor.grpc.v1p60p1.com.google.protobuf.ByteString;
@@ -56,13 +57,16 @@ public class StreamingApplianceWorkCommitterTest {
   private StreamingApplianceWorkCommitter workCommitter;
 
   private static Work createMockWork(long workToken) {
-    return Work.create(
-        Windmill.WorkItem.newBuilder()
+    WorkItem workItem =
+        WorkItem.newBuilder()
             .setKey(ByteString.EMPTY)
             .setWorkToken(workToken)
             .setCacheToken(1L)
             .setShardingKey(2L)
-            .build(),
+            .build();
+    return Work.create(
+        workItem,
+        workItem.getSerializedSize(),
         Watermarks.builder().setInputDataWatermark(Instant.EPOCH).build(),
         Work.createProcessingContext(
             "computationId",

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/commits/StreamingEngineWorkCommitterTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/commits/StreamingEngineWorkCommitterTest.java
@@ -46,6 +46,7 @@ import org.apache.beam.runners.dataflow.worker.streaming.Work;
 import org.apache.beam.runners.dataflow.worker.streaming.WorkId;
 import org.apache.beam.runners.dataflow.worker.util.BoundedQueueExecutor;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill.WorkItem;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.WorkItemCommitRequest;
 import org.apache.beam.runners.dataflow.worker.windmill.client.CloseableStream;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStream.CommitWorkStream;
@@ -75,13 +76,16 @@ public class StreamingEngineWorkCommitterTest {
   private Supplier<CloseableStream<CommitWorkStream>> commitWorkStreamFactory;
 
   private static Work createMockWork(long workToken) {
-    return Work.create(
-        Windmill.WorkItem.newBuilder()
+    WorkItem workItem =
+        WorkItem.newBuilder()
             .setKey(ByteString.EMPTY)
             .setWorkToken(workToken)
             .setCacheToken(1L)
             .setShardingKey(2L)
-            .build(),
+            .build();
+    return Work.create(
+        workItem,
+        workItem.getSerializedSize(),
         Watermarks.builder().setInputDataWatermark(Instant.EPOCH).build(),
         Work.createProcessingContext(
             "computationId",

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDirectGetWorkStreamTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDirectGetWorkStreamTest.java
@@ -67,7 +67,11 @@ import org.junit.runners.JUnit4;
 public class GrpcDirectGetWorkStreamTest {
 
   private static final WorkItemScheduler NO_OP_WORK_ITEM_SCHEDULER =
-      (workItem, watermarks, processingContext, getWorkStreamLatencies) -> {};
+      (workItem,
+          serializedWorkItemSize,
+          watermarks,
+          processingContext,
+          getWorkStreamLatencies) -> {};
   private static final Windmill.JobHeader TEST_JOB_HEADER =
       Windmill.JobHeader.newBuilder()
           .setClientId(1L)
@@ -282,7 +286,11 @@ public class GrpcDirectGetWorkStreamTest {
             testStub,
             initialBudget,
             new ThrottleTimer(),
-            (work, watermarks, processingContext, getWorkStreamLatencies) -> {
+            (work,
+                serializedWorkItemSize,
+                watermarks,
+                processingContext,
+                getWorkStreamLatencies) -> {
               scheduledWorkItems.add(work);
             });
     Windmill.WorkItem workItem =
@@ -327,7 +335,7 @@ public class GrpcDirectGetWorkStreamTest {
             testStub,
             initialBudget,
             new ThrottleTimer(),
-            (work, watermarks, processingContext, getWorkStreamLatencies) ->
+            (work, serializedWorkItemSize, watermarks, processingContext, getWorkStreamLatencies) ->
                 scheduledWorkItems.add(work));
     Windmill.WorkItem workItem =
         Windmill.WorkItem.newBuilder()
@@ -362,7 +370,11 @@ public class GrpcDirectGetWorkStreamTest {
             testStub,
             initialBudget,
             new ThrottleTimer(),
-            (work, watermarks, processingContext, getWorkStreamLatencies) -> {
+            (work,
+                serializedWorkItemSize,
+                watermarks,
+                processingContext,
+                getWorkStreamLatencies) -> {
               scheduledWorkItems.add(work);
             });
     Windmill.WorkItem workItem1 =
@@ -400,7 +412,11 @@ public class GrpcDirectGetWorkStreamTest {
             testStub,
             initialBudget,
             new ThrottleTimer(),
-            (work, watermarks, processingContext, getWorkStreamLatencies) -> {
+            (work,
+                serializedWorkItemSize,
+                watermarks,
+                processingContext,
+                getWorkStreamLatencies) -> {
               scheduledWorkItems.add(work);
             });
     Windmill.WorkItem workItem1 =

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillServerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillServerTest.java
@@ -337,6 +337,7 @@ public class GrpcWindmillServerTest {
                 @Nullable Instant inputDataWatermark,
                 Instant synchronizedProcessingTime,
                 WorkItem workItem,
+                long serializedWorkItemSize,
                 Collection<LatencyAttribution> getWorkStreamLatencies) -> {
               latch.countDown();
               assertEquals(inputDataWatermark, new Instant(18));
@@ -469,6 +470,7 @@ public class GrpcWindmillServerTest {
                 @Nullable Instant inputDataWatermark,
                 Instant synchronizedProcessingTime,
                 WorkItem workItem,
+                long serializedWorkItemSize,
                 Collection<LatencyAttribution> getWorkStreamLatencies) -> {
               assertEquals(inputDataWatermark, new Instant(18));
               assertEquals(synchronizedProcessingTime, new Instant(17));
@@ -1341,6 +1343,7 @@ public class GrpcWindmillServerTest {
                 @Nullable Instant inputDataWatermark,
                 Instant synchronizedProcessingTime,
                 Windmill.WorkItem workItem,
+                long serializedWorkItemSize,
                 Collection<LatencyAttribution> getWorkStreamLatencies) -> latch.countDown());
     // Wait for 100 items or 30 seconds.
     assertTrue(latch.await(30, TimeUnit.SECONDS));

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/failures/WorkFailureProcessorTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/failures/WorkFailureProcessorTest.java
@@ -35,6 +35,7 @@ import org.apache.beam.runners.dataflow.worker.streaming.Watermarks;
 import org.apache.beam.runners.dataflow.worker.streaming.Work;
 import org.apache.beam.runners.dataflow.worker.util.BoundedQueueExecutor;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill.WorkItem;
 import org.apache.beam.runners.dataflow.worker.windmill.client.getdata.FakeGetDataClient;
 import org.apache.beam.runners.dataflow.worker.windmill.work.refresh.HeartbeatSender;
 import org.apache.beam.vendor.grpc.v1p60p1.com.google.protobuf.ByteString;
@@ -83,9 +84,11 @@ public class WorkFailureProcessorTest {
   }
 
   private static ExecutableWork createWork(Supplier<Instant> clock, Consumer<Work> processWorkFn) {
+    WorkItem workItem = WorkItem.newBuilder().setKey(ByteString.EMPTY).setWorkToken(1L).build();
     return ExecutableWork.create(
         Work.create(
-            Windmill.WorkItem.newBuilder().setKey(ByteString.EMPTY).setWorkToken(1L).build(),
+            workItem,
+            workItem.getSerializedSize(),
             Watermarks.builder().setInputDataWatermark(Instant.EPOCH).build(),
             Work.createProcessingContext(
                 "computationId",


### PR DESCRIPTION
Prior to this change WorkItem::getSerializedSize is called on the GetWorkStream thread for every work item, it shows up like in cpu profiles. Replacing it with the byteSize computed from the response bytes makes the work submit path a bit more efficient

<img width="1669" alt="Screenshot 2025-01-14 at 5 29 17 PM" src="https://github.com/user-attachments/assets/cf776b80-8669-4856-9eaf-3de2834d7f3e" />

https://github.com/apache/beam/issues/33578
