### PR TITLE
Add offset-based deduplication to Unbounded Source and Dataflow Runner.

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/internal/CustomSources.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/internal/CustomSources.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.dataflow.internal;
 
 import static com.google.api.client.util.Base64.encodeBase64String;
+import static org.apache.beam.runners.dataflow.util.Structs.addBoolean;
 import static org.apache.beam.runners.dataflow.util.Structs.addString;
 import static org.apache.beam.runners.dataflow.util.Structs.addStringList;
 import static org.apache.beam.sdk.util.SerializableUtils.serializeToByteArray;
@@ -45,6 +46,10 @@ import org.slf4j.LoggerFactory;
 public class CustomSources {
   private static final String SERIALIZED_SOURCE = "serialized_source";
   @VisibleForTesting static final String SERIALIZED_SOURCE_SPLITS = "serialized_source_splits";
+
+  @VisibleForTesting
+  static final String SERIALIZED_OFFSET_BASED_DEDUPLICATION =
+      "serialized_offset_based_deduplication";
 
   private static final Logger LOG = LoggerFactory.getLogger(CustomSources.class);
 
@@ -93,6 +98,10 @@ public class CustomSources {
       }
       checkArgument(!encodedSplits.isEmpty(), "UnboundedSources must have at least one split");
       addStringList(cloudSource.getSpec(), SERIALIZED_SOURCE_SPLITS, encodedSplits);
+      addBoolean(
+          cloudSource.getSpec(),
+          SERIALIZED_OFFSET_BASED_DEDUPLICATION,
+          unboundedSource.offsetBasedDeduplicationSupported());
     } else {
       throw new IllegalArgumentException("Unexpected source kind: " + source.getClass());
     }

--- a/runners/google-cloud-dataflow-java/worker/windmill/src/main/proto/windmill.proto
+++ b/runners/google-cloud-dataflow-java/worker/windmill/src/main/proto/windmill.proto
@@ -56,6 +56,7 @@ message KeyedMessageBundle {
   optional fixed64 sharding_key = 4;
   repeated Message messages = 2;
   repeated bytes messages_ids = 3;
+  repeated bytes message_offsets = 5;
 }
 
 message LatencyAttribution {
@@ -410,6 +411,7 @@ message SourceState {
   optional bytes state = 1;
   repeated fixed64 finalize_ids = 2;
   optional bool only_finalize = 3;
+  optional bytes offset_limit = 4;
 }
 
 message WatermarkHold {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/UnboundedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/UnboundedSource.java
@@ -94,6 +94,21 @@ public abstract class UnboundedSource<
   }
 
   /**
+   * If offsetBasedDeduplicationSupported returns true, then the UnboundedSource needs to provide
+   * the following:
+   *
+   * <ul>
+   *   <li>UnboundedReader which provides offsets that are unique for each element and
+   *       lexicographically ordered.
+   *   <li>CheckpointMark which provides an offset greater than all elements read and less than or
+   *       equal to the next offset that will be read.
+   * </ul>
+   */
+  public boolean offsetBasedDeduplicationSupported() {
+    return false;
+  }
+
+  /**
    * A marker representing the progress and state of an {@link
    * org.apache.beam.sdk.io.UnboundedSource.UnboundedReader}.
    *
@@ -138,6 +153,12 @@ public abstract class UnboundedSource<
       public void finalizeCheckpoint() throws IOException {
         // nothing to do
       }
+    }
+
+    /* Get offset limit for unbounded source split checkpoint. */
+    default byte[] getOffsetLimit() {
+      throw new RuntimeException(
+          "CheckpointMark must override getOffsetLimit() if offset-based deduplication is enabled for the UnboundedSource.");
     }
   }
 
@@ -201,6 +222,12 @@ public abstract class UnboundedSource<
             "getCurrentRecordId() must be overridden if requiresDeduping returns true()");
       }
       return EMPTY;
+    }
+
+    /* Returns the offset for the current record of this unbounded reader. */
+    public byte[] getCurrentRecordOffset() {
+      throw new RuntimeException(
+          "UnboundedReader must override getCurrentRecordOffset() if offset-based deduplication is enabled for the UnboundedSource.");
     }
 
     /**


### PR DESCRIPTION
Add offset-based deduplication to Unbounded Source and Dataflow Runner.

------------------------

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
