### PR TITLE
DatastoreV1.Write, DeleteEntity and DeleteKey can optionally return PCollection

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
@@ -2122,6 +2122,19 @@ public class DatastoreV1 {
     private transient MovingAverage meanLatencyPerEntityMs;
   }
 
+  /**
+   * {@link DoFn} that writes {@link Mutation}s to Cloud Datastore. Mutations are written in
+   * batches; see {@link DatastoreV1.WriteBatcherImpl}.
+   *
+   * <p>See <a href="https://cloud.google.com/datastore/docs/concepts/entities">Datastore: Entities,
+   * Properties, and Keys</a> for information about entity keys and mutations.
+   *
+   * <p>Commits are non-transactional. If a commit fails because of a conflict over an entity group,
+   * the commit will be retried (up to {@link DatastoreV1.BaseDatastoreWriterFn#MAX_RETRIES} times).
+   * This means that the mutation operation should be idempotent. Thus, the writer should only be
+   * used for {@code upsert} and {@code delete} mutation operations, as these are the only two Cloud
+   * Datastore mutations that are idempotent.
+   */
   static class DatastoreWriterFn extends BaseDatastoreWriterFn<WriteSuccessSummary> {
 
     DatastoreWriterFn(String projectId, @Nullable String localhost) {
@@ -2162,19 +2175,6 @@ public class DatastoreV1 {
     }
   }
 
-  /**
-   * {@link DoFn} that writes {@link Mutation}s to Cloud Datastore. Mutations are written in
-   * batches; see {@link DatastoreV1.WriteBatcherImpl}.
-   *
-   * <p>See <a href="https://cloud.google.com/datastore/docs/concepts/entities">Datastore: Entities,
-   * Properties, and Keys</a> for information about entity keys and mutations.
-   *
-   * <p>Commits are non-transactional. If a commit fails because of a conflict over an entity group,
-   * the commit will be retried (up to {@link DatastoreV1.BaseDatastoreWriterFn#MAX_RETRIES} times).
-   * This means that the mutation operation should be idempotent. Thus, the writer should only be
-   * used for {@code upsert} and {@code delete} mutation operations, as these are the only two Cloud
-   * Datastore mutations that are idempotent.
-   */
   abstract static class BaseDatastoreWriterFn<OutT> extends DoFn<Mutation, OutT> {
 
     private static final Logger LOG = LoggerFactory.getLogger(BaseDatastoreWriterFn.class);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
@@ -1479,6 +1479,9 @@ public class DatastoreV1 {
      * window has been fully written to the first database.
      *
      * <pre>{@code
+     * PCollection<Entity> entities = ... ;
+     * PCollection<DatastoreV1.WriteSuccessSummary> writeSummary =
+     *         entities.apply(DatastoreIO.v1().write().withProjectId(project).withResults());
      * }</pre>
      */
     public WriteWithSummary withResults() {
@@ -1707,6 +1710,9 @@ public class DatastoreV1 {
      * respective window has been fully deleted from the first database.
      *
      * <pre>{@code
+     * PCollection<Entity> entities = ... ;
+     * PCollection<DatastoreV1.WriteSuccessSummary> deleteSummary =
+     *         entities.apply(DatastoreIO.v1().deleteEntity().withProjectId(project).withResults());
      * }</pre>
      */
     public DeleteEntityWithSummary withResults() {
@@ -1923,9 +1929,6 @@ public class DatastoreV1 {
      * <p>Example: delete a {@link PCollection} of {@link Key} from one database and then from
      * another database, making sure that deleting a window of data to the second database starts
      * only after the respective window has been fully deleted from the first database.
-     *
-     * <pre>{@code
-     * }</pre>
      */
     public DeleteKeyWithSummary withResults() {
       return inner;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
@@ -1729,6 +1729,14 @@ public class DatastoreV1 {
       this.inner.populateDisplayData(builder);
     }
 
+    public String getProjectId() {
+      return this.inner.getProjectId();
+    }
+
+    public String getDatabaseId() {
+      return this.inner.getDatabaseId();
+    }
+
     @Override
     public PDone expand(PCollection<Entity> input) {
       inner.expand(input);
@@ -1942,6 +1950,14 @@ public class DatastoreV1 {
     @Override
     public void populateDisplayData(DisplayData.Builder builder) {
       this.inner.populateDisplayData(builder);
+    }
+
+    public String getProjectId() {
+      return this.inner.getProjectId();
+    }
+
+    public String getDatabaseId() {
+      return this.inner.getDatabaseId();
     }
 
     @Override

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1Test.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1Test.java
@@ -608,17 +608,28 @@ public class DatastoreV1Test {
             makeUpsert(Entity.newBuilder().setKey(makeKey("key" + i, i + 1)).build()).build());
       }
 
+      int start = 0;
+      ArgumentCaptor<CommitRequest> requestCaptor = ArgumentCaptor.forClass(CommitRequest.class);
+      CommitResponse response = CommitResponse.getDefaultInstance();
+      while (start < numMutations) {
+        int end = Math.min(numMutations, start + DatastoreV1.DATASTORE_BATCH_UPDATE_ENTITIES_START);
+        when(mockDatastore.commit(requestCaptor.capture())).thenReturn(response);
+        start = end;
+      }
+
       DatastoreWriterFn datastoreWriter =
           new DatastoreWriterFn(
               StaticValueProvider.of(PROJECT_ID),
               null,
               mockDatastoreFactory,
               new FakeWriteBatcher());
-      DoFnTester<Mutation, Void> doFnTester = DoFnTester.of(datastoreWriter);
+      DoFnTester<Mutation, DatastoreV1.WriteSuccessSummary> doFnTester =
+          DoFnTester.of(datastoreWriter);
       doFnTester.setCloningBehavior(CloningBehavior.DO_NOT_CLONE);
       doFnTester.processBundle(mutations);
 
-      int start = 0;
+      start = 0;
+      List<CommitRequest> requests = new ArrayList<>();
       while (start < numMutations) {
         int end = Math.min(numMutations, start + DatastoreV1.DATASTORE_BATCH_UPDATE_ENTITIES_START);
         CommitRequest.Builder commitRequest = CommitRequest.newBuilder();
@@ -627,9 +638,12 @@ public class DatastoreV1Test {
         commitRequest.setMode(CommitRequest.Mode.NON_TRANSACTIONAL);
         commitRequest.addAllMutations(mutations.subList(start, end));
         // Verify all the batch requests were made with the expected mutations.
-        verify(mockDatastore, times(1)).commit(commitRequest.build());
+        CommitRequest expectedRequest = commitRequest.build();
+        verify(mockDatastore, times(1)).commit(expectedRequest);
+        requests.add(expectedRequest);
         start = end;
       }
+      assertTrue(requestCaptor.getAllValues().containsAll(requests));
     }
 
     /**
@@ -651,20 +665,31 @@ public class DatastoreV1Test {
         mutations.add(makeUpsert(entity).build());
       }
 
+      int entitiesPerRpc = DATASTORE_BATCH_UPDATE_BYTES_LIMIT / entitySize;
+      int start = 0;
+      ArgumentCaptor<CommitRequest> requestCaptor = ArgumentCaptor.forClass(CommitRequest.class);
+      CommitResponse response = CommitResponse.getDefaultInstance();
+      while (start < mutations.size()) {
+        int end = Math.min(mutations.size(), start + entitiesPerRpc);
+        when(mockDatastore.commit(requestCaptor.capture())).thenReturn(response);
+        start = end;
+      }
+
       DatastoreWriterFn datastoreWriter =
           new DatastoreWriterFn(
               StaticValueProvider.of(PROJECT_ID),
               null,
               mockDatastoreFactory,
               new FakeWriteBatcher());
-      DoFnTester<Mutation, Void> doFnTester = DoFnTester.of(datastoreWriter);
+      DoFnTester<Mutation, DatastoreV1.WriteSuccessSummary> doFnTester =
+          DoFnTester.of(datastoreWriter);
       doFnTester.setCloningBehavior(CloningBehavior.DO_NOT_CLONE);
       doFnTester.processBundle(mutations);
 
       // This test is over-specific currently; it requires that we split the 12 entity writes into 3
       // requests, but we only need each CommitRequest to be less than 10MB in size.
-      int entitiesPerRpc = DATASTORE_BATCH_UPDATE_BYTES_LIMIT / entitySize;
-      int start = 0;
+      start = 0;
+      List<CommitRequest> requests = new ArrayList<>();
       while (start < mutations.size()) {
         int end = Math.min(mutations.size(), start + entitiesPerRpc);
         CommitRequest.Builder commitRequest = CommitRequest.newBuilder();
@@ -673,9 +698,12 @@ public class DatastoreV1Test {
         commitRequest.setMode(CommitRequest.Mode.NON_TRANSACTIONAL);
         commitRequest.addAllMutations(mutations.subList(start, end));
         // Verify all the batch requests were made with the expected mutations.
-        verify(mockDatastore).commit(commitRequest.build());
+        CommitRequest expectedRequest = commitRequest.build();
+        verify(mockDatastore).commit(expectedRequest);
+        requests.add(expectedRequest);
         start = end;
       }
+      assertTrue(requestCaptor.getAllValues().containsAll(requests));
     }
 
     /** Tests {@link DatastoreWriterFn} correctly flushes batch upon receive same entity keys. */
@@ -693,13 +721,18 @@ public class DatastoreV1Test {
                 .build());
       }
 
+      ArgumentCaptor<CommitRequest> requestCaptor = ArgumentCaptor.forClass(CommitRequest.class);
+      CommitResponse response = CommitResponse.getDefaultInstance();
+      when(mockDatastore.commit(requestCaptor.capture())).thenReturn(response).thenReturn(response);
+
       DatastoreWriterFn datastoreWriter =
           new DatastoreWriterFn(
               StaticValueProvider.of(PROJECT_ID),
               null,
               mockDatastoreFactory,
               new FakeWriteBatcher());
-      DoFnTester<Mutation, Void> doFnTester = DoFnTester.of(datastoreWriter);
+      DoFnTester<Mutation, DatastoreV1.WriteSuccessSummary> doFnTester =
+          DoFnTester.of(datastoreWriter);
       doFnTester.setCloningBehavior(CloningBehavior.DO_NOT_CLONE);
       doFnTester.processBundle(mutations);
 
@@ -709,7 +742,8 @@ public class DatastoreV1Test {
       commitRequest.addAllMutations(mutations.subList(0, 2));
       commitRequest.setProjectId(PROJECT_ID);
       commitRequest.setDatabaseId(DATABASE_ID);
-      verify(mockDatastore, times(1)).commit(commitRequest.build());
+      CommitRequest expectedRequest1 = commitRequest.build();
+      verify(mockDatastore, times(1)).commit(expectedRequest1);
 
       // second invocation has key [0, 2] because the second 0 triggered a flush batch
       commitRequest = CommitRequest.newBuilder();
@@ -717,8 +751,14 @@ public class DatastoreV1Test {
       commitRequest.addAllMutations(mutations.subList(2, 4));
       commitRequest.setProjectId(PROJECT_ID);
       commitRequest.setDatabaseId(DATABASE_ID);
-      verify(mockDatastore, times(1)).commit(commitRequest.build());
+      CommitRequest expectedRequest2 = commitRequest.build();
+      verify(mockDatastore, times(1)).commit(expectedRequest2);
       verifyMetricWasSet("BatchDatastoreWrite", "ok", "", 2);
+
+      assertTrue(
+          requestCaptor
+              .getAllValues()
+              .containsAll(Arrays.asList(expectedRequest1, expectedRequest2)));
     }
 
     /** Tests {@link DatastoreWriterFn} with a failed request which is retried. */
@@ -743,7 +783,8 @@ public class DatastoreV1Test {
               null,
               mockDatastoreFactory,
               new FakeWriteBatcher());
-      DoFnTester<Mutation, Void> doFnTester = DoFnTester.of(datastoreWriter);
+      DoFnTester<Mutation, DatastoreV1.WriteSuccessSummary> doFnTester =
+          DoFnTester.of(datastoreWriter);
       doFnTester.setCloningBehavior(CloningBehavior.DO_NOT_CLONE);
       doFnTester.processBundle(mutations);
       verifyMetricWasSet("BatchDatastoreWrite", "ok", "", 2);

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/datastore/V1WriteIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/datastore/V1WriteIT.java
@@ -22,6 +22,7 @@ import static com.google.datastore.v1.client.DatastoreHelper.makeUpsert;
 import static org.apache.beam.sdk.io.gcp.datastore.V1TestUtil.countEntities;
 import static org.apache.beam.sdk.io.gcp.datastore.V1TestUtil.deleteAllEntities;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import com.google.datastore.v1.Entity;
 import com.google.datastore.v1.Key;
@@ -39,11 +40,13 @@ import org.apache.beam.sdk.metrics.MetricNameFilter;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
 import org.apache.beam.sdk.metrics.MetricsFilter;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.Flatten;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.Wait;
 import org.apache.beam.sdk.values.PCollection;
 import org.junit.After;
 import org.junit.Before;
@@ -194,6 +197,99 @@ public class V1WriteIT {
     long numEntitiesWritten = countEntities(options, project, database, ancestor);
 
     assertEquals(numLargeEntities, numEntitiesWritten);
+  }
+
+  /** Tests {@link DatastoreV1.WriteWithSummary} using {@link DatastoreV1.Write#withResults()}. */
+  @Test
+  public void testE2EV1WriteWithResults() throws Exception {
+    Pipeline p = Pipeline.create(options);
+
+    PCollection<Entity> firstBatch =
+        p.apply("First GenerateSequence", GenerateSequence.from(0).to(numEntities))
+            .apply(
+                "First CreateEntityFn",
+                ParDo.of(
+                    new V1TestUtil.CreateEntityFn(
+                        options.getKind(), options.getNamespace(), ancestor, 0)));
+    PCollection<Entity> secondBatch =
+        p.apply("Second GenerateSequence", GenerateSequence.from(numEntities).to(numEntities * 2))
+            .apply(
+                "Second CreateEntityFn",
+                ParDo.of(
+                    new V1TestUtil.CreateEntityFn(
+                        options.getKind(), options.getNamespace(), ancestor, 0)));
+    PCollection<DatastoreV1.WriteSuccessSummary> firstWriteResults =
+        firstBatch.apply(DatastoreIO.v1().write().withProjectId(project).withResults());
+
+    secondBatch
+        .apply(Wait.on(firstWriteResults))
+        .setCoder(secondBatch.getCoder())
+        .apply(DatastoreIO.v1().write().withProjectId(project));
+
+    PAssert.that(firstWriteResults)
+        .satisfies(
+            results -> {
+              for (DatastoreV1.WriteSuccessSummary result : results) {
+                assertNotNull(result);
+              }
+              return null;
+            });
+
+    p.run();
+
+    long numEntitiesWritten = countEntities(options, project, database, ancestor);
+
+    assertEquals(numEntities * 2, numEntitiesWritten);
+  }
+
+  /**
+   * Tests {@link DatastoreV1.WriteWithSummary} using {@link DatastoreV1.Write#withResults()} and
+   * {@link DatastoreV1.DeleteEntity#withResults()}.
+   */
+  @Test
+  public void testE2EV1WriteWithResultsAndDeleteWithResults() throws Exception {
+    Pipeline p = Pipeline.create(options);
+
+    PCollection<Entity> entities =
+        p.apply("First GenerateSequence", GenerateSequence.from(0).to(numEntities))
+            .apply(
+                "First CreateEntityFn",
+                ParDo.of(
+                    new V1TestUtil.CreateEntityFn(
+                        options.getKind(), options.getNamespace(), ancestor, 0)));
+
+    PCollection<DatastoreV1.WriteSuccessSummary> writeResults =
+        entities.apply(DatastoreIO.v1().write().withProjectId(project).withResults());
+
+    PCollection<DatastoreV1.WriteSuccessSummary> deleteResults =
+        entities
+            .apply(Wait.on(writeResults))
+            .setCoder(entities.getCoder())
+            .apply(DatastoreIO.v1().deleteEntity().withProjectId(project).withResults());
+
+    PAssert.that(writeResults)
+        .satisfies(
+            results -> {
+              for (DatastoreV1.WriteSuccessSummary result : results) {
+                assertNotNull(result);
+              }
+              return null;
+            });
+
+    PAssert.that(deleteResults)
+        .satisfies(
+            results -> {
+              for (DatastoreV1.WriteSuccessSummary result : results) {
+                assertNotNull(result);
+              }
+              return null;
+            });
+
+    p.run();
+
+    long numEntitiesWritten = countEntities(options, project, database, ancestor);
+
+    assertEquals(0, numEntitiesWritten);
   }
 
   @After

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/datastore/V1WriteIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/datastore/V1WriteIT.java
@@ -119,8 +119,8 @@ public class V1WriteIT {
         new DatastoreV1.DatastoreWriterFn(
             TestPipeline.testingPipelineOptions().as(GcpOptions.class).getProject(), null);
 
-    PTransform<PCollection<? extends Mutation>, PCollection<Void>> datastoreWriterTransform =
-        ParDo.of(datastoreWriter);
+    PTransform<PCollection<? extends Mutation>, PCollection<DatastoreV1.WriteSuccessSummary>>
+        datastoreWriterTransform = ParDo.of(datastoreWriter);
 
     /** Following three lines turn the original arrayList into a member of the first PCollection */
     List<Mutation> newArrayList = new ArrayList<>(mutations);


### PR DESCRIPTION
# Addresses #20219 
- Introduces `withResults()` API to `DatastoreV1.Write`, `DatastoreV1.DeleteEntity` and `DatastoreV1.DeleteKey` PTransforms, which returns `PCollection<DatastoreV1.WriteSuccessSummary>` instead of `PDone`.
- Allows Wait.on semantics for DatastoreIO, e.g.
```
    PCollection<Entity> firstBatch = ... ;
    PCollection<Entity> secondBatch = ... ;
    PCollection<DatastoreV1.WriteSuccessSummary> firstWriteResults =
        firstBatch.apply(DatastoreIO.v1().write().withProjectId(project).withResults());

    secondBatch
        .apply(Wait.on(firstWriteResults)) // Allows Wait.on
        .setCoder(secondBatch.getCoder())
        .apply(DatastoreIO.v1().write().withProjectId(project)); // Returns PDone without withResults()
```
- Maintains backward compatibility with existing API structure
- Draws inspiration from JdbcIO and FirestoreIO connectors
- Modifies unit tests to mock datastore stub to return CommitResponses
- Introduces new integration tests to test the `withResults()` API
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
