### PR TITLE
make Coder.getEncodedElementByteSize public to allow performance improvements in higher level coders

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/Coder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/Coder.java
@@ -198,7 +198,7 @@ public abstract class Coder<T> implements Serializable {
     }
   }
 
-  public static <T> long getEncodedElementByteSize(Coder<T> target, T value) throws Exception {
+  public static <T> long getEncodedElementByteSizeUsingCoder(Coder<T> target, T value) throws Exception {
     return target.getEncodedElementByteSize(value);
   }
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/Coder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/Coder.java
@@ -198,6 +198,9 @@ public abstract class Coder<T> implements Serializable {
     }
   }
 
+  public static <T> long getEncodedElementByteSize(Coder<T> target, T value) throws Exception {
+    return target.getEncodedElementByteSize(value);
+  }
   /**
    * Verifies all of the provided coders are deterministic. If any are not, throws a {@link
    * NonDeterministicException} for the {@code target} {@link Coder}.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/LengthPrefixCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/LengthPrefixCoder.java
@@ -103,16 +103,8 @@ public class LengthPrefixCoder<T> extends StructuredCoder<T> {
    */
   @Override
   protected long getEncodedElementByteSize(T value) throws Exception {
-    if (valueCoder instanceof StructuredCoder) {
-      // If valueCoder is a StructuredCoder then we can ask it directly for the encoded size of
-      // the value, adding the number of bytes to represent the length.
-      long valueSize = ((StructuredCoder<T>) valueCoder).getEncodedElementByteSize(value);
-      return VarInt.getLength(valueSize) + valueSize;
-    }
-
-    // If value is not a StructuredCoder then fall back to the default StructuredCoder behavior
-    // of encoding and counting the bytes. The encoding will include the length prefix.
-    return super.getEncodedElementByteSize(value);
+    long valueSize = valueCoder.getEncodedElementByteSize(value);
+    return VarInt.getLength(valueSize) + valueSize;
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/CombineFns.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/CombineFns.java
@@ -675,6 +675,19 @@ public class CombineFns {
     }
 
     @Override
+    public long getEncodedElementByteSize(Object[] values) throws Exception {
+      if (values.length == 0) {
+        return 0;
+      }
+      long size = 0;
+      for (int i = 0; i < values.length; ++i) {
+        Coder<Object> objectCoder = coders.get(i);
+        size += Coder.getEncodedElementByteSize(objectCoder, values[i]);
+      }
+      return size;
+    }
+
+    @Override
     public Object[] decode(InputStream inStream) throws CoderException, IOException {
       return decode(inStream, Context.NESTED);
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/CombineFns.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/CombineFns.java
@@ -682,7 +682,7 @@ public class CombineFns {
       long size = 0;
       for (int i = 0; i < values.length; ++i) {
         Coder<Object> objectCoder = coders.get(i);
-        size += Coder.getEncodedElementByteSize(objectCoder, values[i]);
+        size += Coder.getEncodedElementByteSizeUsingCoder(objectCoder, values[i]);
       }
       return size;
     }


### PR DESCRIPTION
Fixes #33620

Half of the sdk coders have getEncodedElementByteSize  public because they are invoked outside of beam.sdk.coders package. 
Some accumulators like ComposedAccumulatorCoder should have access to optimized methods for calculating size but due to it can be any Coder.
Optimized way of calculating size shouldn't be limited to Coders implemented in beam.sdk.coders only.
This change changes it to public and fixes all the coders in beam sdk.

This will break coders implemented in customer codebase requiring small patch to change visibility. 

