### PR TITLE
[Dataflow Streaming] Increase windmill state cache concurrency level

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/state/WindmillStateCache.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/state/WindmillStateCache.java
@@ -84,7 +84,6 @@ public class WindmillStateCache implements StatusDataProvider {
     this.stateCache =
         CacheBuilder.newBuilder()
             .maximumWeight(workerCacheBytes)
-            .weakValues()
             .recordStats()
             .weigher(Weighers.weightedKeysAndValues())
             .concurrencyLevel(stateCacheConcurrencyLevel)

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/state/WindmillStateCache.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/state/WindmillStateCache.java
@@ -79,15 +79,18 @@ public class WindmillStateCache implements StatusDataProvider {
 
   WindmillStateCache(long sizeMb, boolean supportMapViaMultimap) {
     this.workerCacheBytes = sizeMb * MEGABYTES;
+    int stateCacheConcurrencyLevel =
+        Math.max(STATE_CACHE_CONCURRENCY_LEVEL, Runtime.getRuntime().availableProcessors());
     this.stateCache =
         CacheBuilder.newBuilder()
             .maximumWeight(workerCacheBytes)
+            .weakValues()
             .recordStats()
             .weigher(Weighers.weightedKeysAndValues())
-            .concurrencyLevel(STATE_CACHE_CONCURRENCY_LEVEL)
+            .concurrencyLevel(stateCacheConcurrencyLevel)
             .build();
     this.keyIndex =
-        new MapMaker().weakValues().concurrencyLevel(STATE_CACHE_CONCURRENCY_LEVEL).makeMap();
+        new MapMaker().weakValues().concurrencyLevel(stateCacheConcurrencyLevel).makeMap();
     this.supportMapViaMultimap = supportMapViaMultimap;
   }
 


### PR DESCRIPTION
Increasing the state cache concurrency level to reduce contention on state cache.