### PR TITLE
[Dataflow] Replace AtomicLong with LongAdder in LongSumCounterValue to reduce contention between harness threads

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/counters/CounterFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/counters/CounterFactory.java
@@ -382,7 +382,7 @@ public class CounterFactory {
 
   /** Implements a {@link Counter} for tracking the sum of long values. */
   public static class LongSumCounterValue extends BaseCounterValue<Long, Long> {
-    protected final LongAdder aggregate = new LongAdder();
+    private final LongAdder aggregate = new LongAdder();
 
     @Override
     public Long getAggregate() {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/counters/CounterFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/counters/CounterFactory.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
 import org.apache.beam.runners.dataflow.worker.counters.Counter.AtomicCounterValue;
 import org.apache.beam.runners.dataflow.worker.counters.Counter.CounterUpdateExtractor;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
@@ -380,15 +381,22 @@ public class CounterFactory {
   }
 
   /** Implements a {@link Counter} for tracking the sum of long values. */
-  public static class LongSumCounterValue extends LongCounterValue {
+  public static class LongSumCounterValue extends BaseCounterValue<Long, Long> {
+    protected final LongAdder aggregate = new LongAdder();
+
+    @Override
+    public Long getAggregate() {
+      return aggregate.sum();
+    }
+
     @Override
     public void addValue(Long value) {
-      aggregate.addAndGet(value);
+      aggregate.add(value);
     }
 
     @Override
     public Long getAndReset() {
-      return aggregate.getAndSet(0);
+      return aggregate.sumThenReset();
     }
 
     @Override


### PR DESCRIPTION
This counter shows up on wallz when workers are under load 
<img width="1682" alt="Screenshot 2025-01-22 at 7 57 30 PM" src="https://github.com/user-attachments/assets/20c8a4a6-8e95-46ba-a474-2ebd1edbd92f" />


#33578