### PR TITLE
[Dataflow Streaming] Optimizing work submit loop

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/Work.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/Work.java
@@ -49,6 +49,7 @@ import org.apache.beam.runners.dataflow.worker.windmill.client.getdata.GetDataCl
 import org.apache.beam.runners.dataflow.worker.windmill.state.WindmillStateReader;
 import org.apache.beam.runners.dataflow.worker.windmill.work.refresh.HeartbeatSender;
 import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
@@ -63,7 +64,7 @@ import org.joda.time.Instant;
 public final class Work implements RefreshableWork {
 
   private static final EnumMap<LatencyAttribution.State, Duration> EMPTY_ENUM_MAP =
-      new EnumMap<LatencyAttribution.State, Duration>(LatencyAttribution.State.class);
+      new EnumMap<>(LatencyAttribution.State.class);
   private final ShardedKey shardedKey;
   private final WorkItem workItem;
   private final ProcessingContext processingContext;
@@ -91,6 +92,7 @@ public final class Work implements RefreshableWork {
     this.watermarks = watermarks;
     this.clock = clock;
     this.startTime = clock.get();
+    Preconditions.checkState(EMPTY_ENUM_MAP.isEmpty());
     // Create by passing EMPTY_ENUM_MAP to avoid recreating
     // keyUniverse inside EnumMap every time.
     this.totalDurationPerState = new EnumMap<>(EMPTY_ENUM_MAP);

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/Work.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/Work.java
@@ -21,8 +21,7 @@ import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect
 
 import com.google.auto.value.AutoValue;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.IntSummaryStatistics;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -88,7 +87,7 @@ public final class Work implements RefreshableWork {
     this.watermarks = watermarks;
     this.clock = clock;
     this.startTime = clock.get();
-    this.totalDurationPerState = new EnumMap<>(LatencyAttribution.State.class);
+    this.totalDurationPerState = new HashMap<>();
     this.id = WorkId.of(workItem);
     this.latencyTrackingId =
         Long.toHexString(workItem.getShardingKey())
@@ -103,11 +102,8 @@ public final class Work implements RefreshableWork {
       long serializedWorkItemSize,
       Watermarks watermarks,
       ProcessingContext processingContext,
-      Supplier<Instant> clock,
-      Collection<LatencyAttribution> getWorkStreamLatencies) {
-    Work work = new Work(workItem, serializedWorkItemSize, watermarks, processingContext, clock);
-    work.recordGetWorkStreamLatencies(getWorkStreamLatencies);
-    return work;
+      Supplier<Instant> clock) {
+    return new Work(workItem, serializedWorkItemSize, watermarks, processingContext, clock);
   }
 
   public static ProcessingContext createProcessingContext(
@@ -256,7 +252,8 @@ public final class Work implements RefreshableWork {
     return id;
   }
 
-  private void recordGetWorkStreamLatencies(Collection<LatencyAttribution> getWorkStreamLatencies) {
+  public void recordGetWorkStreamLatencies(
+      ImmutableList<LatencyAttribution> getWorkStreamLatencies) {
     for (LatencyAttribution latency : getWorkStreamLatencies) {
       totalDurationPerState.put(
           latency.getState(), Duration.millis(latency.getTotalDurationMillis()));

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/SingleSourceWorkerHarness.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/SingleSourceWorkerHarness.java
@@ -21,7 +21,6 @@ import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.co
 
 import com.google.auto.value.AutoBuilder;
 import com.google.auto.value.AutoOneOf;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -44,6 +43,7 @@ import org.apache.beam.runners.dataflow.worker.windmill.work.refresh.HeartbeatSe
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Supplier;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.joda.time.Instant;
 import org.slf4j.Logger;
@@ -243,7 +243,7 @@ public final class SingleSourceWorkerHarness implements StreamingWorkerHarness {
               watermarks.setOutputDataWatermark(workItem.getOutputDataWatermark()).build(),
               Work.createProcessingContext(
                   computationId, getDataClient, workCommitter::commit, heartbeatSender),
-              /* getWorkStreamLatencies= */ Collections.emptyList());
+              /* getWorkStreamLatencies= */ ImmutableList.of());
         }
       }
     }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/OutputReceiver.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/OutputReceiver.java
@@ -19,6 +19,7 @@ package org.apache.beam.runners.dataflow.worker.util.common.worker;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 /**
@@ -27,7 +28,7 @@ import java.util.List;
  */
 public class OutputReceiver implements Receiver {
   private final List<Receiver> outputs = new ArrayList<>();
-  private final HashMap<String, ElementCounter> outputCounters = new HashMap<>();
+  private final HashMap<String, ElementCounter> outputCounters = new LinkedHashMap<>();
 
   /** Adds a new receiver that this OutputReceiver forwards to. */
   public void addOutput(Receiver receiver) {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GetWorkResponseChunkAssembler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GetWorkResponseChunkAssembler.java
@@ -26,9 +26,11 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.beam.runners.dataflow.worker.WindmillTimeUtils;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill.LatencyAttribution;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.WorkItem;
 import org.apache.beam.vendor.grpc.v1p60p1.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.joda.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -134,7 +136,7 @@ final class GetWorkResponseChunkAssembler {
     private static AssembledWorkItem create(
         WorkItem workItem,
         ComputationMetadata computationMetadata,
-        List<Windmill.LatencyAttribution> latencyAttributions,
+        ImmutableList<LatencyAttribution> latencyAttributions,
         long size) {
       return new AutoValue_GetWorkResponseChunkAssembler_AssembledWorkItem(
           workItem, computationMetadata, latencyAttributions, size);
@@ -144,7 +146,7 @@ final class GetWorkResponseChunkAssembler {
 
     abstract ComputationMetadata computationMetadata();
 
-    abstract List<Windmill.LatencyAttribution> latencyAttributions();
+    abstract ImmutableList<LatencyAttribution> latencyAttributions();
 
     abstract long bufferedSize();
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GetWorkTimingInfosTracker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GetWorkTimingInfosTracker.java
@@ -17,18 +17,16 @@
  */
 package org.apache.beam.runners.dataflow.worker.windmill.client.grpc;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.GetWorkStreamTimingInfo;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.GetWorkStreamTimingInfo.Event;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.LatencyAttribution;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.LatencyAttribution.State;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.joda.time.DateTimeUtils.MillisProvider;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
@@ -125,12 +123,12 @@ final class GetWorkTimingInfosTracker {
     workItemLastChunkReceivedByWorkerTime = now;
   }
 
-  List<LatencyAttribution> getLatencyAttributions() {
+  ImmutableList<LatencyAttribution> getLatencyAttributions() {
     if (workItemCreationLatency == null && aggregatedGetWorkStreamLatencies.isEmpty()) {
-      return Collections.emptyList();
+      return ImmutableList.of();
     }
-    List<LatencyAttribution> latencyAttributions =
-        new ArrayList<>(aggregatedGetWorkStreamLatencies.size() + 1);
+    ImmutableList.Builder<LatencyAttribution> latencyAttributions =
+        ImmutableList.builderWithExpectedSize(aggregatedGetWorkStreamLatencies.size() + 1);
     if (workItemCreationLatency != null) {
       latencyAttributions.add(workItemCreationLatency);
     }
@@ -167,7 +165,7 @@ final class GetWorkTimingInfosTracker {
                   .setTotalDurationMillis(durationMills)
                   .build());
         });
-    return latencyAttributions;
+    return latencyAttributions.build();
   }
 
   void reset() {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/WorkItemReceiver.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/WorkItemReceiver.java
@@ -17,8 +17,9 @@
  */
 package org.apache.beam.runners.dataflow.worker.windmill.work;
 
-import java.util.Collection;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill.LatencyAttribution;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.Instant;
 
@@ -31,5 +32,5 @@ public interface WorkItemReceiver {
       @Nullable Instant synchronizedProcessingTime,
       Windmill.WorkItem workItem,
       long serializedWorkItemSize,
-      Collection<Windmill.LatencyAttribution> getWorkStreamLatencies);
+      ImmutableList<LatencyAttribution> getWorkStreamLatencies);
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/WorkItemScheduler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/WorkItemScheduler.java
@@ -17,13 +17,13 @@
  */
 package org.apache.beam.runners.dataflow.worker.windmill.work;
 
-import java.util.Collection;
 import javax.annotation.CheckReturnValue;
 import org.apache.beam.runners.dataflow.worker.streaming.Watermarks;
 import org.apache.beam.runners.dataflow.worker.streaming.Work;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.LatencyAttribution;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.WorkItem;
 import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 
 @FunctionalInterface
 @CheckReturnValue
@@ -43,5 +43,5 @@ public interface WorkItemScheduler {
       long serializedWorkItemSize,
       Watermarks watermarks,
       Work.ProcessingContext processingContext,
-      Collection<LatencyAttribution> getWorkStreamLatencies);
+      ImmutableList<LatencyAttribution> getWorkStreamLatencies);
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/StreamingWorkScheduler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/StreamingWorkScheduler.java
@@ -229,7 +229,10 @@ public class StreamingWorkScheduler {
       Work work,
       ImmutableList<LatencyAttribution> getWorkStreamLatencies) {
     work.recordGetWorkStreamLatencies(getWorkStreamLatencies);
+    processWork(computationState, work);
+  }
 
+  private void processWork(ComputationState computationState, Work work) {
     Windmill.WorkItem workItem = work.getWorkItem();
     String computationId = computationState.getComputationId();
     ByteString key = workItem.getKey();
@@ -299,10 +302,6 @@ public class StreamingWorkScheduler {
       resetWorkLoggingContext(work.getLatencyTrackingId());
       work.setProcessingThreadName("");
     }
-  }
-
-  private void processWork(ComputationState computationState, Work work) {
-    processWork(computationState, work, ImmutableList.of());
   }
 
   private Windmill.WorkItemCommitRequest validateCommitRequestSize(

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/StreamingWorkScheduler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/StreamingWorkScheduler.java
@@ -21,7 +21,6 @@ import static org.apache.beam.sdk.options.ExperimentalOptions.hasExperiment;
 
 import com.google.api.services.dataflow.model.MapTask;
 import com.google.auto.value.AutoValue;
-import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -48,6 +47,7 @@ import org.apache.beam.runners.dataflow.worker.streaming.sideinput.SideInputStat
 import org.apache.beam.runners.dataflow.worker.streaming.sideinput.SideInputStateFetcherFactory;
 import org.apache.beam.runners.dataflow.worker.util.BoundedQueueExecutor;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill.LatencyAttribution;
 import org.apache.beam.runners.dataflow.worker.windmill.client.commits.Commit;
 import org.apache.beam.runners.dataflow.worker.windmill.state.WindmillStateCache;
 import org.apache.beam.runners.dataflow.worker.windmill.state.WindmillStateReader;
@@ -57,6 +57,7 @@ import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.fn.IdGenerator;
 import org.apache.beam.vendor.grpc.v1p60p1.com.google.protobuf.ByteString;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
@@ -71,6 +72,7 @@ import org.slf4j.LoggerFactory;
 @Internal
 @ThreadSafe
 public class StreamingWorkScheduler {
+
   private static final Logger LOG = LoggerFactory.getLogger(StreamingWorkScheduler.class);
 
   private final DataflowWorkerHarnessOptions options;
@@ -208,17 +210,11 @@ public class StreamingWorkScheduler {
       long serializedWorkItemSize,
       Watermarks watermarks,
       Work.ProcessingContext processingContext,
-      Collection<Windmill.LatencyAttribution> getWorkStreamLatencies) {
+      ImmutableList<LatencyAttribution> getWorkStreamLatencies) {
     computationState.activateWork(
         ExecutableWork.create(
-            Work.create(
-                workItem,
-                serializedWorkItemSize,
-                watermarks,
-                processingContext,
-                clock,
-                getWorkStreamLatencies),
-            work -> processWork(computationState, work)));
+            Work.create(workItem, serializedWorkItemSize, watermarks, processingContext, clock),
+            work -> processWork(computationState, work, getWorkStreamLatencies)));
   }
 
   /**
@@ -228,7 +224,12 @@ public class StreamingWorkScheduler {
    *
    * @implNote This will block the calling thread during execution of user DoFns.
    */
-  private void processWork(ComputationState computationState, Work work) {
+  private void processWork(
+      ComputationState computationState,
+      Work work,
+      ImmutableList<LatencyAttribution> getWorkStreamLatencies) {
+    work.recordGetWorkStreamLatencies(getWorkStreamLatencies);
+
     Windmill.WorkItem workItem = work.getWorkItem();
     String computationId = computationState.getComputationId();
     ByteString key = workItem.getKey();
@@ -298,6 +299,10 @@ public class StreamingWorkScheduler {
       resetWorkLoggingContext(work.getLatencyTrackingId());
       work.setProcessingThreadName("");
     }
+  }
+
+  private void processWork(ComputationState computationState, Work work) {
+    processWork(computationState, work, ImmutableList.of());
   }
 
   private Windmill.WorkItemCommitRequest validateCommitRequestSize(
@@ -429,6 +434,7 @@ public class StreamingWorkScheduler {
 
   @AutoValue
   abstract static class ExecuteWorkResult {
+
     private static ExecuteWorkResult create(
         Windmill.WorkItemCommitRequest.Builder commitWorkRequest, long stateBytesRead) {
       return new AutoValue_StreamingWorkScheduler_ExecuteWorkResult(

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/FakeWindmillServer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/FakeWindmillServer.java
@@ -29,7 +29,6 @@ import static org.junit.Assert.assertFalse;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,6 +66,7 @@ import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStream.Ge
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStream.GetWorkStream;
 import org.apache.beam.runners.dataflow.worker.windmill.work.WorkItemReceiver;
 import org.apache.beam.runners.dataflow.worker.windmill.work.budget.GetWorkBudget;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableSet;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.net.HostAndPort;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.Uninterruptibles;
@@ -276,7 +276,7 @@ public final class FakeWindmillServer extends WindmillServerStub {
                   Instant.now(),
                   workItem,
                   workItem.getSerializedSize(),
-                  Collections.singletonList(
+                  ImmutableList.of(
                       LatencyAttribution.newBuilder()
                           .setState(State.GET_WORK_IN_TRANSIT_TO_USER_WORKER)
                           .setTotalDurationMillis(1000)

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
@@ -358,8 +358,7 @@ public class StreamingDataflowWorkerTest {
             Watermarks.builder().setInputDataWatermark(Instant.EPOCH).build(),
             Work.createProcessingContext(
                 computationId, new FakeGetDataClient(), ignored -> {}, mock(HeartbeatSender.class)),
-            Instant::now,
-            Collections.emptyList()),
+            Instant::now),
         processWorkFn);
   }
 
@@ -3523,8 +3522,7 @@ public class StreamingDataflowWorkerTest {
                 new FakeGetDataClient(),
                 ignored -> {},
                 mock(HeartbeatSender.class)),
-            clock,
-            Collections.emptyList());
+            clock);
 
     clock.sleep(Duration.millis(10));
     work.setState(Work.State.PROCESSING);

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingModeExecutionContextTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingModeExecutionContextTest.java
@@ -31,7 +31,6 @@ import com.google.api.services.dataflow.model.CounterStructuredName;
 import com.google.api.services.dataflow.model.CounterStructuredNameAndMetadata;
 import com.google.api.services.dataflow.model.CounterUpdate;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
@@ -144,8 +143,7 @@ public class StreamingModeExecutionContextTest {
         watermarks,
         Work.createProcessingContext(
             COMPUTATION_ID, new FakeGetDataClient(), ignored -> {}, mock(HeartbeatSender.class)),
-        Instant::now,
-        Collections.emptyList());
+        Instant::now);
   }
 
   @Test

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
@@ -204,8 +204,7 @@ public class WorkerCustomSourcesTest {
         watermarks,
         Work.createProcessingContext(
             COMPUTATION_ID, new FakeGetDataClient(), ignored -> {}, mock(HeartbeatSender.class)),
-        Instant::now,
-        Collections.emptyList());
+        Instant::now);
   }
 
   private static class SourceProducingSubSourcesInSplit extends MockSource {
@@ -1015,8 +1014,7 @@ public class WorkerCustomSourcesTest {
                 new FakeGetDataClient(),
                 ignored -> {},
                 mock(HeartbeatSender.class)),
-            Instant::now,
-            Collections.emptyList());
+            Instant::now);
     context.start(
         "key",
         dummyWork,

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/ActiveWorkStateTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/ActiveWorkStateTest.java
@@ -65,8 +65,7 @@ public class ActiveWorkStateTest {
             workItem.getSerializedSize(),
             Watermarks.builder().setInputDataWatermark(Instant.EPOCH).build(),
             createWorkProcessingContext(),
-            Instant::now,
-            Collections.emptyList()),
+            Instant::now),
         ignored -> {});
   }
 
@@ -77,8 +76,7 @@ public class ActiveWorkStateTest {
             workItem.getSerializedSize(),
             Watermarks.builder().setInputDataWatermark(Instant.EPOCH).build(),
             createWorkProcessingContext(),
-            () -> Instant.EPOCH,
-            Collections.emptyList()),
+            () -> Instant.EPOCH),
         ignored -> {});
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/ComputationStateCacheTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/ComputationStateCacheTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.api.services.dataflow.model.MapTask;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -76,8 +75,7 @@ public class ComputationStateCacheTest {
                 new FakeGetDataClient(),
                 ignored -> {},
                 mock(HeartbeatSender.class)),
-            Instant::now,
-            Collections.emptyList()),
+            Instant::now),
         ignored -> {});
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/util/BoundedQueueExecutorTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/util/BoundedQueueExecutorTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -74,8 +73,7 @@ public class BoundedQueueExecutorTest {
                 new FakeGetDataClient(),
                 ignored -> {},
                 mock(HeartbeatSender.class)),
-            Instant::now,
-            Collections.emptyList()),
+            Instant::now),
         executeWorkFn);
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/commits/StreamingApplianceWorkCommitterTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/commits/StreamingApplianceWorkCommitterTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.mock;
 import com.google.api.services.dataflow.model.MapTask;
 import com.google.common.truth.Correspondence;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -75,8 +74,7 @@ public class StreamingApplianceWorkCommitterTest {
               throw new UnsupportedOperationException();
             },
             mock(HeartbeatSender.class)),
-        Instant::now,
-        Collections.emptyList());
+        Instant::now);
   }
 
   private static ComputationState createComputationState(String computationId) {

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/commits/StreamingEngineWorkCommitterTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/commits/StreamingEngineWorkCommitterTest.java
@@ -94,8 +94,7 @@ public class StreamingEngineWorkCommitterTest {
               throw new UnsupportedOperationException();
             },
             mock(HeartbeatSender.class)),
-        Instant::now,
-        Collections.emptyList());
+        Instant::now);
   }
 
   private static ComputationState createComputationState(String computationId) {

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillServerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillServerTest.java
@@ -95,6 +95,7 @@ import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.inprocess.InProcessServerBuil
 import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.stub.StreamObserver;
 import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.testing.GrpcCleanupRule;
 import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.util.MutableHandlerRegistry;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hamcrest.Matchers;
 import org.joda.time.Instant;
@@ -338,7 +339,7 @@ public class GrpcWindmillServerTest {
                 Instant synchronizedProcessingTime,
                 WorkItem workItem,
                 long serializedWorkItemSize,
-                Collection<LatencyAttribution> getWorkStreamLatencies) -> {
+                ImmutableList<LatencyAttribution> getWorkStreamLatencies) -> {
               latch.countDown();
               assertEquals(inputDataWatermark, new Instant(18));
               assertEquals(synchronizedProcessingTime, new Instant(17));
@@ -471,7 +472,7 @@ public class GrpcWindmillServerTest {
                 Instant synchronizedProcessingTime,
                 WorkItem workItem,
                 long serializedWorkItemSize,
-                Collection<LatencyAttribution> getWorkStreamLatencies) -> {
+                ImmutableList<LatencyAttribution> getWorkStreamLatencies) -> {
               assertEquals(inputDataWatermark, new Instant(18));
               assertEquals(synchronizedProcessingTime, new Instant(17));
               assertEquals(workItem.getKey(), ByteString.copyFromUtf8("somewhat_long_key"));
@@ -1344,7 +1345,7 @@ public class GrpcWindmillServerTest {
                 Instant synchronizedProcessingTime,
                 Windmill.WorkItem workItem,
                 long serializedWorkItemSize,
-                Collection<LatencyAttribution> getWorkStreamLatencies) -> latch.countDown());
+                ImmutableList<LatencyAttribution> getWorkStreamLatencies) -> latch.countDown());
     // Wait for 100 items or 30 seconds.
     assertTrue(latch.await(30, TimeUnit.SECONDS));
     // Confirm that we report at least as much throttle time as our server sent errors for.  We will
@@ -1388,7 +1389,7 @@ public class GrpcWindmillServerTest {
     // GET_WORK_IN_TRANSIT_TO_DISPATCHER: 1, 2, 3, 4 -> sum to 10
     // GET_WORK_IN_TRANSIT_TO_USER_WORKER: 34, 33, 32, 31 -> sum to 130
     Map<State, LatencyAttribution> latencies = new HashMap<>();
-    List<LatencyAttribution> attributions = tracker.getLatencyAttributions();
+    ImmutableList<LatencyAttribution> attributions = tracker.getLatencyAttributions();
     assertEquals(3, attributions.size());
     for (LatencyAttribution attribution : attributions) {
       latencies.put(attribution.getState(), attribution);
@@ -1440,7 +1441,7 @@ public class GrpcWindmillServerTest {
     // GET_WORK_IN_TRANSIT_TO_DISPATCHER: 1, 2, 3, 4 -> sum to 10
     // GET_WORK_IN_TRANSIT_TO_USER_WORKER: not observed due to skew
     Map<State, LatencyAttribution> latencies = new HashMap<>();
-    List<LatencyAttribution> attributions = tracker.getLatencyAttributions();
+    ImmutableList<LatencyAttribution> attributions = tracker.getLatencyAttributions();
     assertEquals(2, attributions.size());
     for (LatencyAttribution attribution : attributions) {
       latencies.put(attribution.getState(), attribution);

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/failures/WorkFailureProcessorTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/failures/WorkFailureProcessorTest.java
@@ -20,7 +20,6 @@ package org.apache.beam.runners.dataflow.worker.windmill.work.processing.failure
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -95,8 +94,7 @@ public class WorkFailureProcessorTest {
                 new FakeGetDataClient(),
                 ignored -> {},
                 mock(HeartbeatSender.class)),
-            clock,
-            new ArrayList<>()),
+            clock),
         processWorkFn);
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/work/refresh/ActiveWorkRefresherTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/work/refresh/ActiveWorkRefresherTest.java
@@ -54,7 +54,6 @@ import org.apache.beam.runners.dataflow.worker.windmill.state.WindmillStateCache
 import org.apache.beam.runners.direct.Clock;
 import org.apache.beam.vendor.grpc.v1p60p1.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.HashBasedTable;
-import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Table;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.joda.time.Duration;
@@ -133,8 +132,7 @@ public class ActiveWorkRefresherTest {
             Watermarks.builder().setInputDataWatermark(Instant.EPOCH).build(),
             Work.createProcessingContext(
                 "computationId", new FakeGetDataClient(), ignored -> {}, heartbeatSender),
-            A_LONG_TIME_AGO,
-            ImmutableList.of()),
+            A_LONG_TIME_AGO),
         processWork);
   }
 


### PR DESCRIPTION
1. Moving recordGetWorkStreamLatencies to run outside work submission loop
2. Change OutputReceiver::outputCounters from HashMap to LinkedHashmap

#33578