### PR TITLE
[Dataflow] Use ThreadLocalRandom instead of Random in OutputObjectAndByteCountert o reduce contention

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/util/common/worker/OutputObjectAndByteCounterTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/util/common/worker/OutputObjectAndByteCounterTest.java
@@ -92,13 +92,19 @@ public class OutputObjectAndByteCounterTest {
   }
 
   private OutputObjectAndByteCounter makeCounter(String name, int samplingPeriod, int seed) {
-    return new OutputObjectAndByteCounter(
+    OutputObjectAndByteCounter outputObjectAndByteCounter =
+        new OutputObjectAndByteCounter(
             new ElementByteSizeObservableCoder<>(StringUtf8Coder.of()),
             counterSet,
-            NameContextsForTests.nameContextForTest())
-        .setSamplingPeriod(samplingPeriod)
-        .setRandom(new Random(seed))
-        .countBytes(name);
+            NameContextsForTests.nameContextForTest()) {
+          private final Random random = new Random(seed);
+
+          @Override
+          protected Random getRandom() {
+            return random;
+          }
+        };
+    return outputObjectAndByteCounter.setSamplingPeriod(samplingPeriod).countBytes(name);
   }
 
   @Test


### PR DESCRIPTION
Example profile showing the relevant stacks <img width="1688" alt="Screenshot 2025-01-22 at 9 44 53 PM" src="https://github.com/user-attachments/assets/1a2e7d69-e429-4956-8cc0-0eec1629f14c" />

#33578