### PR TITLE
Revert "Pause delete images in public AR"

### DIFF
--- a/.test-infra/tools/stale_dataflow_prebuilt_image_cleaner.sh
+++ b/.test-infra/tools/stale_dataflow_prebuilt_image_cleaner.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 # Clean up private registry (us.gcr.io)
 # Images more than 5 day old and not the latest (either has latest label or newest)
 
-PUBLIC_REPOSITORIES=() # (beam-sdk beam_portability beamgrafana beammetricssyncjenkins beammetricssyncgithub)
+PUBLIC_REPOSITORIES=(beam-sdk beam_portability beamgrafana beammetricssyncjenkins beammetricssyncgithub)
 PRIVATE_REPOSITORIES=(java-postcommit-it python-postcommit-it jenkins github-actions)
 # set as the same as 6-week release period
 if [[ $OSTYPE == "linux-gnu"* ]]; then


### PR DESCRIPTION
Reverts apache/beam#32354

the artifact registry issue is resolved. This can be seen as no recent test flakiness due to disappearing private repo container (which still has clean up enabled)