### PR TITLE
[#31438] Trigger Precusor work for Prism.

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/engine/data.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/data.go
@@ -30,10 +30,27 @@ import (
 	"google.golang.org/protobuf/encoding/protowire"
 )
 
-// StateData is a "union" between Bag state and MultiMap state to increase common code.
+// StateData is a "union" between Bag, MultiMap, and Trigger state to increase
+// common code.
+//
+// Trigger state is never explicitly set by users, but occurs on demand when
+// a trigger requires state.
 type StateData struct {
 	Bag      [][]byte
 	Multimap map[string][][]byte
+
+	Trigger map[Trigger]triggerState
+}
+
+func (s *StateData) getTriggerState(key Trigger) triggerState {
+	if s.Trigger == nil {
+		s.Trigger = map[Trigger]triggerState{}
+	}
+	return s.Trigger[key]
+}
+
+func (s *StateData) setTriggerState(key Trigger, val triggerState) {
+	s.Trigger[key] = val
 }
 
 // TimerKey is for use as a key for timers.

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
@@ -1195,6 +1195,7 @@ func (ss *stageState) AddPending(newPending []element) int {
 		}
 		newPending = origPending
 	}
+	//slog.Warn("AddPending", "stage", ss.ID, "pending", newPending)
 	if ss.stateful {
 		if ss.pendingByKeys == nil {
 			ss.pendingByKeys = map[string]*dataAndTimers{}
@@ -1377,10 +1378,22 @@ keysPerBundle:
 			minTs = dnt.elements[0].timestamp
 		}
 
+		dataInBundle := false
+
 		// Can we pre-compute this bit when adding to pendingByKeys?
 		// startBundle is in run in a single scheduling goroutine, so moving per-element code
 		// to be computed by the bundle parallel goroutines will speed things up a touch.
 		for dnt.elements.Len() > 0 {
+			// We can't mix data and timers in the same bundle, as there's no
+			// guarantee which is processed first SDK side.
+			// If the bundle already contains data, then it's before the timer
+			// by the heap invariant, and must be processed before we can fire a timer.
+			// AKA, keep them seperate.
+			if len(toProcess) > 0 && // If we have already picked some elements AND
+				((dataInBundle && dnt.elements[0].IsTimer()) || // we're about to add a timer to a Bundle that already has data OR
+					(!dataInBundle && !dnt.elements[0].IsTimer())) { // we're about to add data to a bundle that already has a time
+				break
+			}
 			e := heap.Pop(&dnt.elements).(element)
 			if e.IsTimer() {
 				lastSet, ok := dnt.timers[timerKey{family: e.family, tag: e.tag, window: e.window}]
@@ -1395,6 +1408,8 @@ keysPerBundle:
 				holdsInBundle[e.holdTimestamp] += 1
 				// Clear the "fired" timer so subsequent matches can be ignored.
 				delete(dnt.timers, timerKey{family: e.family, tag: e.tag, window: e.window})
+			} else {
+				dataInBundle = true
 			}
 			toProcess = append(toProcess, e)
 			if OneElementPerKey {
@@ -1526,6 +1541,7 @@ func (ss *stageState) makeInProgressBundle(genBundID func() string, toProcess []
 	ss.inprogressKeysByBundle[bundID] = newKeys
 	ss.inprogressKeys.merge(newKeys)
 	ss.inprogressHoldsByBundle[bundID] = holdsInBundle
+	//slog.Warn("makeInProgressBundle", "stage", ss.ID, "toProcess", toProcess)
 	return bundID
 }
 

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
@@ -1395,7 +1395,9 @@ keysPerBundle:
 				break
 			}
 			e := heap.Pop(&dnt.elements).(element)
-			if e.IsTimer() {
+			if e.IsData() {
+				dataInBundle = true
+			} else {
 				lastSet, ok := dnt.timers[timerKey{family: e.family, tag: e.tag, window: e.window}]
 				if !ok {
 					timerCleared = true
@@ -1405,11 +1407,9 @@ keysPerBundle:
 					timerCleared = true
 					continue
 				}
-				holdsInBundle[e.holdTimestamp] += 1
+				holdsInBundle[e.holdTimestamp]++
 				// Clear the "fired" timer so subsequent matches can be ignored.
 				delete(dnt.timers, timerKey{family: e.family, tag: e.tag, window: e.window})
-			} else {
-				dataInBundle = true
 			}
 			toProcess = append(toProcess, e)
 			if OneElementPerKey {

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/strategy.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/strategy.go
@@ -23,12 +23,32 @@ import (
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/typex"
 )
 
+// This file is intended to consolidate handling of WindowingStrategy and trigger
+// logic independantly from the bulk of the ElementManager.
+//
+// Triggers by their nature only apply to Aggregation transforms, in particular:
+// GroupByKeys and CoGroupByKeys are aggregations.
+// Triggers also affect downstream side inputs. That is, a side input consumer
+// is vaccuously an aggregation.
+//
+// Triggers are PerKey+PerWindow, and they may or may not use state per trigger.
+//
+// The unique state per trigger is the trickiest bit to handle. In principle
+// it could just be handled by the existing state system, which might be
+// sufficient, but it's not prepared for unique tagging per trigger itself.
+// It would also add additional overhead since state is kept as the serialized
+// bytes, instead of in a manipulatable form.
+//
+// Instead, each key+window state cell contains a trigger specific state map,
+// handled via pointer equality from the trigger itself.
+
 // WinStrat configures the windowing strategy for the stage, based on the
 // stage's input PCollection.
 type WinStrat struct {
 	AllowedLateness time.Duration // Used to extend duration
 }
 
+// EarliestCompletion marks when we can close a window.
 func (ws WinStrat) EarliestCompletion(w typex.Window) mtime.Time {
 	return w.MaxTimestamp().Add(ws.AllowedLateness)
 }
@@ -36,3 +56,318 @@ func (ws WinStrat) EarliestCompletion(w typex.Window) mtime.Time {
 func (ws WinStrat) String() string {
 	return fmt.Sprintf("WinStrat[AllowedLateness:%v]", ws.AllowedLateness)
 }
+
+// triggerInput represents a Key + window + stage's trigger conditions.
+type triggerInput struct {
+	newElementCount    int  // The number of new elements since the last check.
+	endOfWindowReached bool // Whether or not the end of the window has been reached.
+}
+
+// Trigger represents a trigger for a windowing strategy.  A trigger determines when
+// to fire a window based on the arrival of elements and the passage of time.
+//
+// See https://s.apache.org/beam-triggers for a more detailed look at triggers.
+type Trigger interface {
+	// IsReady determines if the trigger is ready to fire based on the current state.
+	isReady(input triggerInput, state *StateData) bool
+	reset(state *StateData)
+
+	// TODO merging triggers and state for merging windows
+}
+
+// triggerState retains additional state for a given trigger execution.
+// Each trigger is responsible for maintaining it's own state as needed.
+type triggerState struct {
+	// finished indicates if the trigger has already fired or not.
+	finished bool
+	// extra is where additional data can be stored.
+	extra any
+}
+
+// TriggerNever is never ready.
+// There will only be an ON_TIME output and a final output at window expiration.
+type TriggerNever struct{}
+
+func (*TriggerNever) isReady(triggerInput, *StateData) bool {
+	return false
+}
+
+func (t *TriggerNever) reset(state *StateData) {}
+
+// TriggerAlways is always ready.
+// There will be an output for every element, and a final output at window expiration.
+// Equivalent to TriggerRepeatedly {TriggerElementCount{1}}
+type TriggerAlways struct{}
+
+func (*TriggerAlways) isReady(triggerInput, *StateData) bool {
+	return true
+}
+
+func (t *TriggerAlways) reset(state *StateData) {}
+
+// TriggerAfterAll is ready when all subTriggers are ready.
+// There will be an output when all subTriggers are ready.
+// Logically, an "AND" trigger.
+type TriggerAfterAll struct {
+	SubTriggers []Trigger
+}
+
+func (t *TriggerAfterAll) isReady(input triggerInput, state *StateData) bool {
+	ts := state.getTriggerState(t)
+	if ts.finished {
+		return false
+	}
+	// Track fired states.
+	if ts.extra == nil {
+		ts.extra = map[Trigger]bool{}
+	}
+	isFinished := ts.extra.(map[Trigger]bool)
+	for _, t := range t.SubTriggers {
+		// Don't re-evaluate.
+		if isFinished[t] {
+			continue
+		}
+		if t.isReady(input, state) {
+			isFinished[t] = true
+		}
+	}
+	ready := len(isFinished) == len(t.SubTriggers)
+	if ready {
+		ts.finished = true
+	}
+	state.setTriggerState(t, ts)
+	return ready
+}
+
+func (t *TriggerAfterAll) reset(state *StateData) {
+	for _, sub := range t.SubTriggers {
+		sub.reset(state)
+	}
+	delete(state.Trigger, t)
+}
+
+// TriggerAfterAny is ready the first time any of the subTriggers are ready.
+// Logically, an "OR" trigger.
+type TriggerAfterAny struct {
+	SubTriggers []Trigger
+}
+
+func (t *TriggerAfterAny) isReady(input triggerInput, state *StateData) bool {
+	ts := state.getTriggerState(t)
+	if ts.finished {
+		return false
+	}
+	anyReady := false
+	for _, t := range t.SubTriggers {
+		anyReady = t.isReady(input, state)
+		if anyReady {
+			break
+		}
+	}
+	if anyReady {
+		ts.finished = true
+		for _, sub := range t.SubTriggers {
+			// clear any subtrigger state, as we're fireing anyway.
+			sub.reset(state)
+		}
+	}
+	state.setTriggerState(t, ts)
+	return anyReady
+}
+
+func (t *TriggerAfterAny) reset(state *StateData) {
+	for _, sub := range t.SubTriggers {
+		sub.reset(state)
+	}
+	delete(state.Trigger, t)
+}
+
+// TriggerAfterEach processes each trigger before executing the next.
+// Starting with the first subtrigger, ready when the _current_ subtrigger
+// is ready. After output, advances the current trigger by one.
+type TriggerAfterEach struct {
+	SubTriggers []Trigger
+}
+
+func (t *TriggerAfterEach) isReady(input triggerInput, state *StateData) bool {
+	ts := state.getTriggerState(t)
+	if ts.finished {
+		return false
+	}
+	// Use extra for the current trigger index.
+	if ts.extra == nil {
+		ts.extra = int(0)
+	}
+	current := ts.extra.(int)
+	ready := false
+	if t.SubTriggers[current].isReady(input, state) {
+		current++
+		ready = true
+	}
+	if current >= len(t.SubTriggers) {
+		ts.finished = true
+	}
+	ts.extra = current
+	state.setTriggerState(t, ts)
+	return ready
+}
+
+func (t *TriggerAfterEach) reset(state *StateData) {
+	for _, sub := range t.SubTriggers {
+		sub.reset(state)
+	}
+	delete(state.Trigger, t)
+}
+
+// TriggerElementCount triggers when there have been at least the required number
+// of elements have arrived.
+type TriggerElementCount struct {
+	ElementCount int
+}
+
+func (t *TriggerElementCount) isReady(input triggerInput, state *StateData) bool {
+	ts := state.getTriggerState(t)
+	if ts.finished {
+		return false
+	}
+
+	if ts.extra == nil {
+		ts.extra = int(0)
+	}
+	count := ts.extra.(int) + input.newElementCount
+	ts.extra = count
+	ready := count >= t.ElementCount
+	if ready {
+		ts.finished = true
+	}
+	state.setTriggerState(t, ts)
+	return ready
+}
+
+func (t *TriggerElementCount) reset(state *StateData) {
+	delete(state.Trigger, t)
+}
+
+// TriggerOrFinally is ready whenever either of it's subtriggers fire.
+// Ceases to be ready after the Finally trigger isReady.
+type TriggerOrFinally struct {
+	Main    Trigger // repeated
+	Finally Trigger // terminates execution.
+}
+
+func (t *TriggerOrFinally) isReady(input triggerInput, state *StateData) bool {
+	ts := state.getTriggerState(t)
+	if ts.finished {
+		return false
+	}
+
+	mainReady := t.Main.isReady(input, state)
+	finallyReady := t.Finally.isReady(input, state)
+
+	if mainReady || finallyReady {
+		t.Main.reset(state)
+	}
+
+	if finallyReady {
+		t.Finally.reset(state)
+		ts.finished = true
+	}
+
+	state.setTriggerState(t, ts)
+	return mainReady || finallyReady
+}
+
+func (t *TriggerOrFinally) reset(state *StateData) {
+	t.Main.reset(state)
+	t.Finally.reset(state)
+	delete(state.Trigger, t)
+}
+
+// TriggerRepeatedly is a composite trigger that will fire whenever the Repeated trigger is ready.
+// If the Repeated trigger is finished, it's state will be reset.
+type TriggerRepeatedly struct {
+	Repeated Trigger
+}
+
+func (t *TriggerRepeatedly) isReady(input triggerInput, state *StateData) bool {
+	mainReady := t.Repeated.isReady(input, state)
+
+	// If the subtrigger is finished, reset it.
+	if repeatedTs := state.getTriggerState(t.Repeated); repeatedTs.finished {
+		t.Repeated.reset(state)
+	}
+	return mainReady
+}
+
+func (t *TriggerRepeatedly) reset(state *StateData) {
+	t.Repeated.reset(state)
+	delete(state.Trigger, t)
+}
+
+// TriggerAfterEndOfWindow is a composite trigger that will fire whenever the
+// the early Triggers are ready prior to the end of window, implicitly repeated.
+// After the end of window, the Late trigger will be implicitly repeated.
+type TriggerAfterEndOfWindow struct {
+	Early, Late Trigger
+}
+
+func (t *TriggerAfterEndOfWindow) isReady(input triggerInput, state *StateData) bool {
+	ts := state.getTriggerState(t)
+	if ts.finished {
+		return false
+	}
+	// There are too many places we may exit, use a defer to reset instead of
+	// doing it manually.
+	defer func() {
+		state.setTriggerState(t, ts)
+	}()
+
+	ready := false
+
+	if !state.getTriggerState(t.Early).finished {
+		// We're still on early firings.
+		// This trigger is ready if the early trigger is ready, or the end of window has happened.
+		ready = input.endOfWindowReached || t.Early.isReady(input, state)
+		if !input.endOfWindowReached {
+			// If it's not the end of window then this is an early firing, so
+			// reset, if it is finished.
+			if state.getTriggerState(t.Early).finished {
+				t.Early.reset(state)
+			}
+			return ready
+		}
+		// It must be the end of window firing.
+		earlyState := state.getTriggerState(t.Early)
+		// Set the early trigger to be finished, and *don't* reset it
+		// but do nil out the extra state. We need to keep the finished
+		// bit around to avoid further early triggers.
+		earlyState.finished = true
+		earlyState.extra = nil
+		state.setTriggerState(t.Early, earlyState)
+
+		if t.Late != nil {
+			// Zero out the late trigger as we're about to need it.
+			t.Late.reset(state)
+		}
+		return ready
+	} else if t.Late != nil {
+		ready = t.Late.isReady(input, state)
+		// Repeat forever.
+		if state.getTriggerState(t.Late).finished {
+			t.Late.reset(state)
+		}
+	} else {
+		ts.finished = true
+	}
+	return ready
+}
+
+func (t *TriggerAfterEndOfWindow) reset(state *StateData) {
+	t.Early.reset(state)
+	t.Late.reset(state)
+	delete(state.Trigger, t)
+}
+
+// TODO
+// TriggerAfterProcessingTime
+// TriggerDefault

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/strategy_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/strategy_test.go
@@ -185,6 +185,30 @@ func TestTriggers_isReady(t *testing.T) {
 				{triggerInput{newElementCount: 1}, false},
 			},
 		}, {
+			name: "afterEach_afterEach",
+			trig: &TriggerAfterEach{
+				SubTriggers: []Trigger{
+					&TriggerAfterEach{SubTriggers: []Trigger{&TriggerElementCount{3}, &TriggerElementCount{1}}},
+					&TriggerAfterEach{SubTriggers: []Trigger{&TriggerElementCount{3}, &TriggerElementCount{2}}},
+				},
+			},
+			inputs: []io{
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, true}, // ElmCount 3 is ready
+				{triggerInput{newElementCount: 1}, true}, // ElmCount 1 is ready
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, true}, // ElmCount 3 is ready
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, true}, // ElmCount 2 is ready
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+			},
+		}, {
 			name: "orFinally_2_7",
 			trig: &TriggerOrFinally{
 				Main:    &TriggerElementCount{2},

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/strategy_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/strategy_test.go
@@ -165,6 +165,26 @@ func TestTriggers_isReady(t *testing.T) {
 				{triggerInput{newElementCount: 1}, false},
 			},
 		}, {
+			name: "afterAll_afterEach_3_never",
+			trig: &TriggerAfterAll{
+				SubTriggers: []Trigger{
+					&TriggerAfterEach{SubTriggers: []Trigger{&TriggerElementCount{3}, &TriggerNever{}}},
+					&TriggerElementCount{5},
+				},
+			},
+			inputs: []io{
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false}, // ElmCount 2 is ready
+				{triggerInput{newElementCount: 1}, false}, // AfterEach(ElmCount 3) is ready,
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, true},  // ElmCount 5 is ready, so fire now.
+				{triggerInput{newElementCount: 1}, false}, // Should never fire again as a result.
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+			},
+		}, {
 			name: "orFinally_2_7",
 			trig: &TriggerOrFinally{
 				Main:    &TriggerElementCount{2},

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/strategy_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/strategy_test.go
@@ -345,8 +345,8 @@ func TestTriggers_isReady(t *testing.T) {
 				{triggerInput{newElementCount: 1}, false},
 				{triggerInput{newElementCount: 1}, true}, // Early is ready
 				{triggerInput{newElementCount: 1}, false},
-				{triggerInput{newElementCount: 1}, true},                           // Early is ready
-				{triggerInput{newElementCount: 1, endOfWindowReached: true}, true}, // End of window
+				{triggerInput{newElementCount: 1}, true},                            // Early is ready
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false}, // End of window
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
@@ -362,9 +362,8 @@ func TestTriggers_isReady(t *testing.T) {
 				{triggerInput{newElementCount: 1}, false},
 				{triggerInput{newElementCount: 1}, false},
 				{triggerInput{newElementCount: 1}, false},
-				{triggerInput{newElementCount: 1, endOfWindowReached: true}, true}, // End of window
-				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
-				{triggerInput{newElementCount: 1, endOfWindowReached: true}, true}, // Late
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false}, // End of window
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, true},  // Late
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, true}, // Late
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/strategy_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/strategy_test.go
@@ -228,6 +228,30 @@ func TestTriggers_isReady(t *testing.T) {
 				{triggerInput{newElementCount: 1}, false},
 			},
 		}, {
+			name: "orFinally_afterEach_2_1_7_afterEach_4_5",
+			trig: &TriggerOrFinally{
+				Main: &TriggerAfterEach{
+					SubTriggers: []Trigger{&TriggerElementCount{2}, &TriggerElementCount{1}, &TriggerElementCount{7}},
+				},
+				Finally: &TriggerAfterEach{
+					SubTriggers: []Trigger{&TriggerElementCount{4}, &TriggerElementCount{5}},
+				},
+			},
+			inputs: []io{
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, true},  // Main is ready
+				{triggerInput{newElementCount: 1}, true},  // Main is ready
+				{triggerInput{newElementCount: 1}, true},  // Finally is ready
+				{triggerInput{newElementCount: 1}, false}, // Should never fire again as a result.
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+			},
+		}, {
 			name: "repeated_afterEach_2_1_3",
 			trig: &TriggerRepeatedly{&TriggerAfterEach{
 				SubTriggers: []Trigger{
@@ -345,6 +369,22 @@ func TestTriggers_isReady(t *testing.T) {
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, true}, // Late
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, true}, // Late
+			},
+		}, {
+			name: "default",
+			trig: &TriggerDefault{},
+			inputs: []io{
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, true}, // End of window
+				{triggerInput{newElementCount: 2, endOfWindowReached: true}, true},
+				{triggerInput{newElementCount: 3, endOfWindowReached: true}, true},
+				{triggerInput{newElementCount: 4, endOfWindowReached: true}, true},
+				{triggerInput{newElementCount: 5, endOfWindowReached: true}, true},
+				{triggerInput{newElementCount: 6, endOfWindowReached: true}, true},
+				{triggerInput{newElementCount: 7, endOfWindowReached: true}, true},
 			},
 		},
 	}

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/strategy_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/strategy_test.go
@@ -393,8 +393,9 @@ func TestTriggers_isReady(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			state := StateData{}
 			for i, in := range test.inputs {
-				if got, want := test.trig.isReady(in.input, &state), in.shouldFire; got != want {
-					t.Errorf("%v: %#v.isReady([%d]%+v)) = %v, want %v; state: %v", test.name, test.trig, i, in, got, want, state.Trigger)
+				ws := WinStrat{Trigger: test.trig}
+				if got, want := ws.IsTriggerReady(in.input, &state), in.shouldFire; got != want {
+					t.Errorf("%v[%d]: %#v.isReady(%+v)) = %v, want %v; state: %v", test.name, i, test.trig, in, got, want, state.Trigger)
 				}
 			}
 		})

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/strategy_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/strategy_test.go
@@ -370,6 +370,38 @@ func TestTriggers_isReady(t *testing.T) {
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, true}, // Late
 			},
 		}, {
+			name: "afterEndOfWindow_NeitherSet",
+			trig: &TriggerAfterEndOfWindow{},
+			inputs: []io{
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false}, // End of window
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false}, // Late
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false}, // Late
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false}, // Late
+			},
+		}, {
+			name: "afterEndOfWindow_EarlyUnset_Late2",
+			trig: &TriggerAfterEndOfWindow{
+				Late: &TriggerElementCount{2},
+			},
+			inputs: []io{
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1}, false},
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false}, // End of window
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, true},  // Late
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, true}, // Late
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, true}, // Late
+			},
+		}, {
 			name: "default",
 			trig: &TriggerDefault{},
 			inputs: []io{

--- a/sdks/go/pkg/beam/runners/prism/internal/execute.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/execute.go
@@ -245,9 +245,13 @@ func executePipeline(ctx context.Context, wks map[string]*worker.W, j *jobservic
 					panic(err)
 				}
 				mayLP := func(v []byte) []byte {
+					//slog.Warn("teststream bytes", "value", string(v), "bytes", v)
 					return v
 				}
-				if cID != pyld.GetCoderId() {
+				// Hack for Java Strings in test stream, since it doesn't encode them correctly.
+				forceLP := cID == "StringUtf8Coder" || cID != pyld.GetCoderId()
+				if forceLP {
+					// slog.Warn("recoding TestStreamValue", "cID", cID, "newUrn", coders[cID].GetSpec().GetUrn(), "payloadCoder", pyld.GetCoderId(), "oldUrn", coders[pyld.GetCoderId()].GetSpec().GetUrn())
 					// The coder needed length prefixing. For simplicity, add a length prefix to each
 					// encoded element, since we will be sending a length prefixed coder to consume
 					// this anyway. This is simpler than trying to find all the re-written coders after the fact.
@@ -259,6 +263,7 @@ func executePipeline(ctx context.Context, wks map[string]*worker.W, j *jobservic
 						if _, err := buf.Write(v); err != nil {
 							panic(err)
 						}
+						//slog.Warn("teststream bytes - after LP", "value", string(v), "bytes", buf.Bytes())
 						return buf.Bytes()
 					}
 				}


### PR DESCRIPTION
Mostly locking in some fixes and work to avoid making Triggers impossible to review. 
This PR has 3 components.

* Adds the bulk of the Trigger State Machine to be used in a different PR.
  * Excludes handling Processing Time, and Merging Windows at this time.
  * https://s.apache.org/beam-triggers for general handling. 
  * Checked understanding against the Java TriggerStateMachine code which supports execution for Java runners.
  * Compressed the logic into less abstract form, and simplified shouldFire and Fire handling into a single isReady tree.
  * While it's building on Prism's state handling, it is *not* getting serialized and deserialized all the time, saving some memory and processing. 
* Fixes a bug WRT state and timer execution: Bundles can't mix timers and data, since there is no ordering guarantee on their processing. Timers or data can be processed first. This is a problem if the other group has later data, avoiding the correctness issue.
  * Fixed by never mixing Data and Timers in the same bundle. 
* Works around a legacy bug in Java's TestStream encodings where a value will be encoded with the deprecated "Outer" context, which leads to dropping length prefixes in the String encoder.
  * This mostly allows additional ValidatesRunner tests to pass and execute, critical for Trigger testing.

Part of #31438.

Actual use of the StateMachine will occur in a subsequent PR. Keeping the commented out debug prints for the time being. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
