### PR TITLE
Calculate byte size via sampling in StateBackedIterable if size is not cheap to calculate

### DIFF
--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/StateBackedIterable.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/StateBackedIterable.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.function.Supplier;
 import org.apache.beam.fn.harness.Cache;
 import org.apache.beam.fn.harness.Caches;
@@ -105,6 +106,12 @@ public class StateBackedIterable<T>
 
     private boolean observerNeedsAdvance = false;
     private boolean exceptionLogged = false;
+    private final Random randomGenerator = new Random();
+
+    // Lowest sampling probability: 0.001%.
+    private static final int SAMPLING_TOKEN_UPPER_BOUND = 1000000;
+    private static final int SAMPLING_CUTOFF = 10;
+    private int samplingToken = 0;
 
     static <T> WrappedObservingIterator<T> create(
         Iterator<T> iterator, org.apache.beam.sdk.coders.Coder<T> elementCoder) {
@@ -125,6 +132,18 @@ public class StateBackedIterable<T>
       this.elementCoder = elementCoder;
     }
 
+    private boolean sampleElement() {
+      // Sampling probability decreases as the element count is increasing.
+      // We unconditionally sample the first samplingCutoff elements. For the
+      // next samplingCutoff elements, the sampling probability drops from 100%
+      // to 50%. The probability of sampling the Nth element is:
+      // min(1, samplingCutoff / N), with an additional lower bound of
+      // samplingCutoff / samplingTokenUpperBound. This algorithm may be refined
+      // later.
+      samplingToken = Math.min(samplingToken + 1, SAMPLING_TOKEN_UPPER_BOUND);
+      return randomGenerator.nextInt(samplingToken) < SAMPLING_CUTOFF;
+    }
+
     @Override
     public boolean hasNext() {
       if (observerNeedsAdvance) {
@@ -138,15 +157,19 @@ public class StateBackedIterable<T>
     public T next() {
       T value = wrappedIterator.next();
       try {
-        elementCoder.registerByteSizeObserver(value, observerProxy);
-        if (observerProxy.getIsLazy()) {
-          // The observer will only be notified of bytes as the result
-          // is used. We defer advancing the observer until hasNext in an
-          // attempt to capture those bytes.
-          observerNeedsAdvance = true;
-        } else {
-          observerNeedsAdvance = false;
-          observerProxy.advance();
+        if (sampleElement() || elementCoder.isRegisterByteSizeObserverCheap(value)) {
+          observerProxy.setScalingFactor(
+              Math.max(samplingToken, SAMPLING_CUTOFF) / (double) SAMPLING_CUTOFF);
+          elementCoder.registerByteSizeObserver(value, observerProxy);
+          if (observerProxy.getIsLazy()) {
+            // The observer will only be notified of bytes as the result
+            // is used. We defer advancing the observer until hasNext in an
+            // attempt to capture those bytes.
+            observerNeedsAdvance = true;
+          } else {
+            observerNeedsAdvance = false;
+            observerProxy.advance();
+          }
         }
       } catch (Exception e) {
         if (!exceptionLogged) {

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/StateBackedIterable.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/StateBackedIterable.java
@@ -157,9 +157,10 @@ public class StateBackedIterable<T>
     public T next() {
       T value = wrappedIterator.next();
       try {
-        if (sampleElement() || elementCoder.isRegisterByteSizeObserverCheap(value)) {
+        boolean cheap = elementCoder.isRegisterByteSizeObserverCheap(value);
+        if (cheap || sampleElement()) {
           observerProxy.setScalingFactor(
-              Math.max(samplingToken, SAMPLING_CUTOFF) / (double) SAMPLING_CUTOFF);
+              cheap ? 1.0 : Math.max(samplingToken, SAMPLING_CUTOFF) / (double) SAMPLING_CUTOFF);
           elementCoder.registerByteSizeObserver(value, observerProxy);
           if (observerProxy.getIsLazy()) {
             // The observer will only be notified of bytes as the result

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/StateBackedIterable.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/StateBackedIterable.java
@@ -30,7 +30,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
+
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 import org.apache.beam.fn.harness.Cache;
 import org.apache.beam.fn.harness.Caches;
@@ -106,7 +107,6 @@ public class StateBackedIterable<T>
 
     private boolean observerNeedsAdvance = false;
     private boolean exceptionLogged = false;
-    private final Random randomGenerator = new Random();
 
     // Lowest sampling probability: 0.001%.
     private static final int SAMPLING_TOKEN_UPPER_BOUND = 1000000;
@@ -141,7 +141,7 @@ public class StateBackedIterable<T>
       // samplingCutoff / samplingTokenUpperBound. This algorithm may be refined
       // later.
       samplingToken = Math.min(samplingToken + 1, SAMPLING_TOKEN_UPPER_BOUND);
-      return randomGenerator.nextInt(samplingToken) < SAMPLING_CUTOFF;
+      return ThreadLocalRandom.current().nextInt(samplingToken) < SAMPLING_CUTOFF;
     }
 
     @Override

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/StateBackedIterableTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/StateBackedIterableTest.java
@@ -271,7 +271,7 @@ public class StateBackedIterableTest {
       // 5 comes from size and hasNext (see IterableLikeCoder)
       // observer receives scaled, StringUtf8Coder is not cheap so sampling may produce value that
       // is off
-      assertEquals(iterateBytes + 5, observer.total, 3);
+      assertEquals((float) iterateBytes + 5, (float) observer.total, 3);
     }
   }
 

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/StateBackedIterableTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/StateBackedIterableTest.java
@@ -269,8 +269,9 @@ public class StateBackedIterableTest {
               .sum();
       observer.advance();
       // 5 comes from size and hasNext (see IterableLikeCoder)
-      // observer receives scaled
-      assertTrue(iterateBytes + 5 >= observer.total);
+      // observer receives scaled, StringUtf8Coder is not cheap so sampling may produce value that is off
+      assertTrue(
+          com.google.common.math.DoubleMath.fuzzyEquals(iterateBytes + 5, observer.total, 3));
     }
   }
 

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/StateBackedIterableTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/StateBackedIterableTest.java
@@ -269,7 +269,8 @@ public class StateBackedIterableTest {
               .sum();
       observer.advance();
       // 5 comes from size and hasNext (see IterableLikeCoder)
-      // observer receives scaled, StringUtf8Coder is not cheap so sampling may produce value that is off
+      // observer receives scaled, StringUtf8Coder is not cheap so sampling may produce value that
+      // is off
       assertTrue(
           com.google.common.math.DoubleMath.fuzzyEquals(iterateBytes + 5, observer.total, 3));
     }

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/StateBackedIterableTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/StateBackedIterableTest.java
@@ -271,7 +271,7 @@ public class StateBackedIterableTest {
       // 5 comes from size and hasNext (see IterableLikeCoder)
       // observer receives scaled, StringUtf8Coder is not cheap so sampling may produce value that
       // is off
-      assertEquals(iterateBytes + 5,observer.total, 3);
+      assertEquals(iterateBytes + 5, observer.total, 3);
     }
   }
 

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/StateBackedIterableTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/StateBackedIterableTest.java
@@ -271,8 +271,7 @@ public class StateBackedIterableTest {
       // 5 comes from size and hasNext (see IterableLikeCoder)
       // observer receives scaled, StringUtf8Coder is not cheap so sampling may produce value that
       // is off
-      assertTrue(
-          com.google.common.math.DoubleMath.fuzzyEquals(iterateBytes + 5, observer.total, 3));
+      assertEquals(iterateBytes + 5,observer.total, 3);
     }
   }
 

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/StateBackedIterableTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/StateBackedIterableTest.java
@@ -269,7 +269,8 @@ public class StateBackedIterableTest {
               .sum();
       observer.advance();
       // 5 comes from size and hasNext (see IterableLikeCoder)
-      assertEquals(iterateBytes + 5, observer.total);
+      // observer receives scaled
+      assertTrue(iterateBytes + 5 >= observer.total);
     }
   }
 


### PR DESCRIPTION
For Dataflow V2, StateBackedIterable is iterated by readers after gbk shuffle. Examples are ParDo after GBK or merging combiners after GBK. 

[metrics.proto](https://github.com/apache/beam/blob/master/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/metrics.proto#L244) specifies that Sampling is used  because calculating the byte count involves serializing the elements which is CPU intensive. 

In case of StateBackedIterable sampling is not occurring which impacts performance of some of the pipelines that have expensive coders.

This change introduces sampling. 

Fully fixes #33620 as previous fix was improvement. 