### PR TITLE
JdbcIO - report schema as part of lineage

### DIFF
--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcUtil.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcUtil.java
@@ -679,7 +679,7 @@ public class JdbcUtil {
   @AutoValue
   abstract static class FQNComponents {
 
-    static String DEFAULT_SCHEMA = "default";
+    static final String DEFAULT_SCHEMA = "default";
 
     abstract String getScheme();
 

--- a/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcIOTest.java
+++ b/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcIOTest.java
@@ -248,7 +248,9 @@ public class JdbcIOTest implements Serializable {
     PipelineResult result = pipeline.run();
     assertThat(
         Lineage.query(result.metrics(), Lineage.Type.SOURCE),
-        hasItem(Lineage.getFqName("derby", ImmutableList.of("memory", "testDB", READ_TABLE_NAME))));
+        hasItem(
+            Lineage.getFqName(
+                "derby", ImmutableList.of("memory", "testDB", "default", READ_TABLE_NAME))));
   }
 
   @Test
@@ -271,7 +273,9 @@ public class JdbcIOTest implements Serializable {
     PipelineResult result = pipeline.run();
     assertThat(
         Lineage.query(result.metrics(), Lineage.Type.SOURCE),
-        hasItem(Lineage.getFqName("derby", ImmutableList.of("memory", "testDB", READ_TABLE_NAME))));
+        hasItem(
+            Lineage.getFqName(
+                "derby", ImmutableList.of("memory", "testDB", "default", READ_TABLE_NAME))));
   }
 
   @Test
@@ -543,7 +547,9 @@ public class JdbcIOTest implements Serializable {
       assertRowCount(DATA_SOURCE, tableName, EXPECTED_ROW_COUNT);
       assertThat(
           Lineage.query(result.metrics(), Lineage.Type.SINK),
-          hasItem(Lineage.getFqName("derby", ImmutableList.of("memory", "testDB", tableName))));
+          hasItem(
+              Lineage.getFqName(
+                  "derby", ImmutableList.of("memory", "testDB", "default", tableName))));
     } finally {
       DatabaseTestHelper.deleteTable(DATA_SOURCE, tableName);
     }

--- a/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcUtilTest.java
+++ b/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcUtilTest.java
@@ -348,20 +348,25 @@ public class JdbcUtilTest {
 
   @Test
   public void testExtractTableFromQuery() {
-    ImmutableList<KV<String, @Nullable String>> readCases =
+    ImmutableList<KV<String, @Nullable KV<String, String>>> readCases =
         ImmutableList.of(
-            KV.of("select * from table_1", "table_1"),
-            KV.of("SELECT a, b FROM [table-2]", "table-2"),
-            KV.of("drop table not-select", ""));
-    for (KV<String, @Nullable String> testCase : readCases) {
+            KV.of("select * from table_1", KV.of(null, "table_1")),
+            KV.of("select * from public.table_1", KV.of("public", "table_1")),
+            KV.of("select * from `select`", KV.of(null, "select")),
+            KV.of("select * from `public`.`select`", KV.of("public", "select")),
+            KV.of("SELECT a, b FROM [table-2]", KV.of(null, "table-2")),
+            KV.of("SELECT a, b FROM [public].[table-2]", KV.of("public", "table-2")),
+            KV.of("drop table not-select", null));
+    for (KV<String, @Nullable KV<String, String>> testCase : readCases) {
       assertEquals(testCase.getValue(), JdbcUtil.extractTableFromReadQuery(testCase.getKey()));
     }
-    ImmutableList<KV<String, @Nullable String>> writeCases =
+    ImmutableList<KV<String, @Nullable KV<String, String>>> writeCases =
         ImmutableList.of(
-            KV.of("insert into table_1 values ...", "table_1"),
-            KV.of("INSERT INTO [table-2] values ...", "table-2"),
-            KV.of("drop table not-select", ""));
-    for (KV<String, @Nullable String> testCase : writeCases) {
+            KV.of("insert into table_1 values ...", KV.of(null, "table_1")),
+            KV.of("INSERT INTO [table-2] values ...", KV.of(null, "table-2")),
+            KV.of("INSERT INTO [foo].[table-2] values ...", KV.of("foo", "table-2")),
+            KV.of("drop table not-select", null));
+    for (KV<String, @Nullable KV<String, String>> testCase : writeCases) {
       assertEquals(testCase.getValue(), JdbcUtil.extractTableFromWriteQuery(testCase.getKey()));
     }
   }


### PR DESCRIPTION
Fixes #33794

parses typical schemas,
reports default if missing to report correct amount of segments, 
 adds support for detecting backticked identifiers. 