### PR TITLE
Fix postcommit python arm workflow

### DIFF
--- a/sdks/python/apache_beam/ml/inference/sklearn_inference_it_test.py
+++ b/sdks/python/apache_beam/ml/inference/sklearn_inference_it_test.py
@@ -88,7 +88,6 @@ class SklearnInference(unittest.TestCase):
       true_label, expected_prediction = expected_outputs[i].split(',')
       self.assertEqual(predictions_dict[true_label], expected_prediction)
 
-
   # TODO(https://github.com/apache/beam/issues/33796) use older numpy version for python 3.9 and 3.10
   @unittest.skipIf((3, 9, 0) <= sys.version_info < (3, 11, 0), "Beam#33796")
   def test_sklearn_mnist_classification_large_model(self):

--- a/sdks/python/apache_beam/ml/inference/sklearn_inference_it_test.py
+++ b/sdks/python/apache_beam/ml/inference/sklearn_inference_it_test.py
@@ -54,6 +54,9 @@ def file_lines_sorted(filepath):
 @pytest.mark.uses_sklearn
 @pytest.mark.it_postcommit
 class SklearnInference(unittest.TestCase):
+
+  # TODO(https://github.com/apache/beam/issues/33796) use older numpy version for python 3.9 and 3.10
+  @unittest.skipIf((3, 9, 0) <= sys.version_info < (3, 11, 0), "Beam#33796")
   def test_sklearn_mnist_classification(self):
     test_pipeline = TestPipeline(is_integration_test=True)
     input_file = 'gs://apache-beam-ml/testing/inputs/it_mnist_data.csv'
@@ -85,6 +88,9 @@ class SklearnInference(unittest.TestCase):
       true_label, expected_prediction = expected_outputs[i].split(',')
       self.assertEqual(predictions_dict[true_label], expected_prediction)
 
+
+  # TODO(https://github.com/apache/beam/issues/33796) use older numpy version for python 3.9 and 3.10
+  @unittest.skipIf((3, 9, 0) <= sys.version_info < (3, 11, 0), "Beam#33796")
   def test_sklearn_mnist_classification_large_model(self):
     test_pipeline = TestPipeline(is_integration_test=True)
     input_file = 'gs://apache-beam-ml/testing/inputs/it_mnist_data.csv'
@@ -118,7 +124,8 @@ class SklearnInference(unittest.TestCase):
       self.assertEqual(predictions_dict[true_label], expected_prediction)
 
   # TODO(https://github.com/apache/beam/issues/27151) use model with sklearn 1.2
-  @unittest.skipIf(sys.version_info >= (3, 11, 0), "Beam#27151")
+  # TODO(https://github.com/apache/beam/issues/33796) use older numpy version for python 3.9 and 3.10
+  @unittest.skipIf(sys.version_info >= (3, 9, 0), "Beam#27151")
   def test_sklearn_regression(self):
     test_pipeline = TestPipeline(is_integration_test=True)
     input_file = 'gs://apache-beam-ml/testing/inputs/japanese_housing_test_data.csv'  # pylint: disable=line-too-long

--- a/sdks/python/apache_beam/ml/inference/sklearn_inference_it_test.py
+++ b/sdks/python/apache_beam/ml/inference/sklearn_inference_it_test.py
@@ -55,7 +55,7 @@ def file_lines_sorted(filepath):
 @pytest.mark.it_postcommit
 class SklearnInference(unittest.TestCase):
 
-  # TODO(https://github.com/apache/beam/issues/33796) use older numpy version for python 3.9 and 3.10
+  # TODO(https://github.com/apache/beam/issues/33796) use older numpy
   @unittest.skipIf((3, 9, 0) <= sys.version_info < (3, 11, 0), "Beam#33796")
   def test_sklearn_mnist_classification(self):
     test_pipeline = TestPipeline(is_integration_test=True)
@@ -88,7 +88,7 @@ class SklearnInference(unittest.TestCase):
       true_label, expected_prediction = expected_outputs[i].split(',')
       self.assertEqual(predictions_dict[true_label], expected_prediction)
 
-  # TODO(https://github.com/apache/beam/issues/33796) use older numpy version for python 3.9 and 3.10
+  # TODO(https://github.com/apache/beam/issues/33796) use older numpy
   @unittest.skipIf((3, 9, 0) <= sys.version_info < (3, 11, 0), "Beam#33796")
   def test_sklearn_mnist_classification_large_model(self):
     test_pipeline = TestPipeline(is_integration_test=True)
@@ -123,7 +123,7 @@ class SklearnInference(unittest.TestCase):
       self.assertEqual(predictions_dict[true_label], expected_prediction)
 
   # TODO(https://github.com/apache/beam/issues/27151) use model with sklearn 1.2
-  # TODO(https://github.com/apache/beam/issues/33796) use older numpy version for python 3.9 and 3.10
+  # TODO(https://github.com/apache/beam/issues/33796) use older numpy
   @unittest.skipIf(sys.version_info >= (3, 9, 0), "Beam#27151")
   def test_sklearn_regression(self):
     test_pipeline = TestPipeline(is_integration_test=True)


### PR DESCRIPTION
[#30760](https://github.com/apache/beam/issues/30760)
For now, disabled the tests for python 3.9 and 3.10 in `sklearn_inference_it_test.py` due to an incompatibility with the new `NumPy` versions. This issue caused the following error: `ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject.` Created the [issue](https://github.com/apache/beam/issues/33796) to investigate possible workarounds. 
Example of a job without the `ValueError` - https://github.com/akashorabek/beam/actions/runs/13031140520. (The failure in Python 3.12 is unrelated and is caused by an [existing issue](https://github.com/apache/beam/issues/33425) with the `build_wheels` task)

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
