### PR TITLE
SnowflakeIO: do not quote empty fields 

### DIFF
--- a/sdks/java/io/snowflake/src/main/java/org/apache/beam/sdk/io/snowflake/SnowflakeIO.java
+++ b/sdks/java/io/snowflake/src/main/java/org/apache/beam/sdk/io/snowflake/SnowflakeIO.java
@@ -1177,7 +1177,7 @@ public class SnowflakeIO {
         if (o instanceof String) {
           String field = (String) o;
           field = field.replace("'", "''");
-          field = quoteField(field);
+          field = quoteNonEmptyField(field);
 
           csvItems.add(field);
         } else {
@@ -1187,11 +1187,11 @@ public class SnowflakeIO {
       context.output(Joiner.on(",").useForNull("").join(csvItems));
     }
 
-    private String quoteField(String field) {
-      return quoteField(field, this.quotationMark);
+    private String quoteNonEmptyField(String field) {
+      return quoteNonEmptyField(field, this.quotationMark);
     }
 
-    private String quoteField(String field, String quotation) {
+    private String quoteNonEmptyField(String field, String quotation) {
       String quoted;
       if (field.isEmpty()) {
         quoted = field;

--- a/sdks/java/io/snowflake/src/main/java/org/apache/beam/sdk/io/snowflake/SnowflakeIO.java
+++ b/sdks/java/io/snowflake/src/main/java/org/apache/beam/sdk/io/snowflake/SnowflakeIO.java
@@ -1192,7 +1192,13 @@ public class SnowflakeIO {
     }
 
     private String quoteField(String field, String quotation) {
-      return String.format("%s%s%s", quotation, field, quotation);
+      String quoted;
+      if (field.isEmpty()) {
+        quoted = field;
+      } else {
+        quoted = String.format("%s%s%s", quotation, field, quotation);
+      }
+      return quoted;
     }
   }
 

--- a/sdks/java/io/snowflake/src/test/java/org/apache/beam/sdk/io/snowflake/test/unit/write/SnowflakeIOWriteTest.java
+++ b/sdks/java/io/snowflake/src/test/java/org/apache/beam/sdk/io/snowflake/test/unit/write/SnowflakeIOWriteTest.java
@@ -75,6 +75,7 @@ public class SnowflakeIOWriteTest {
     testDataInStrings.add("Third row with \"double\" quotation");
     testDataInStrings.add("Third row with double one \" quotation");
     testDataInStrings.add("Third row with double twice \"\" quotation");
+    testDataInStrings.add("");
   }
 
   @Before
@@ -208,7 +209,7 @@ public class SnowflakeIOWriteTest {
     List<String> escapedTestData =
         testDataInStrings.stream()
             .map(e -> e.replace("'", "''"))
-            .map(e -> String.format("\"%s\"", e))
+            .map(e -> e.isEmpty() ? "" : String.format("\"%s\"", e))
             .collect(Collectors.toList());
     assertTrue(TestUtils.areListsEqual(escapedTestData, actualData));
   }


### PR DESCRIPTION
When sending CSV to Snowflake for `COPY`, do not quote empty fields (`''`).

With some types, like integer, it leads to an error like this: `net.snowflake.client.jdbc.SnowflakeSQLException: Numeric value '' is not recognized`.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
