### PR TITLE
Adding handling of Nulled lists to beam_row_from_dict

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_tools.py
@@ -1606,11 +1606,13 @@ bigquery_v2_messages.TableSchema):
     # This requires that each row has all the fields in the schema.
     # However, it's possible that some nullable fields don't appear in the row.
     # For this case, we create the field with a `None` value
-    if name not in row and mode == "NULLABLE":
+    # None is also set when a repeated field is missing as BigQuery
+    # converts Null Repeated fields to empty lists
+    if name not in row and (mode == "NULLABLE" or mode == "REPEATED"):
       row[name] = None
 
     value = row[name]
-    if type in ["RECORD", "STRUCT"]:
+    if type in ["RECORD", "STRUCT"] and value:
       # if this is a list of records, we create a list of Beam Rows
       if mode == "REPEATED":
         list_of_beam_rows = []

--- a/sdks/python/apache_beam/io/gcp/bigquery_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_tools.py
@@ -1608,7 +1608,7 @@ bigquery_v2_messages.TableSchema):
     # For this case, we create the field with a `None` value
     # None is also set when a repeated field is missing as BigQuery
     # converts Null Repeated fields to empty lists
-    if name not in row and (mode == "NULLABLE" or mode == "REPEATED"):
+    if name not in row and mode != "REQUIRED":
       row[name] = None
 
     value = row[name]

--- a/sdks/python/apache_beam/io/gcp/bigquery_tools_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_tools_test.py
@@ -867,7 +867,15 @@ class TestBeamRowFromDict(unittest.TestCase):
     self.assertEqual(expected_beam_row, beam_row_from_dict(dict_row, schema))
 
   def test_dict_to_beam_row_all_types_nullable(self):
-    schema = {"fields": self.get_schema_fields_with_mode("nullable")}
+    schema_fields_with_nested = [{
+        "name": "nested_record",
+        "type": "record",
+        "mode": "repeated",
+        "fields": self.get_schema_fields_with_mode("nullable")
+    }]
+    schema_fields_with_nested.extend(
+        self.get_schema_fields_with_mode("nullable"))
+    schema = {"fields": schema_fields_with_nested}
     dict_row = {k: None for k in self.DICT_ROW}
 
     # input dict row with missing nullable fields should still yield a full
@@ -876,6 +884,7 @@ class TestBeamRowFromDict(unittest.TestCase):
     del dict_row['bool']
 
     expected_beam_row = beam.Row(
+        nested_record=None,
         str=None,
         bool=None,
         bytes=None,


### PR DESCRIPTION
Addresses #32155 and fixes the handling of missing repeated fields inside a dicts when converting a dict to a beam row. As described in the issue it matches BigQuery standard behaviour of converting Null repeated fields to empty arrays on insert.
https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#array_nulls 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
