### PR TITLE
[Go SDK + Protos] Fix Proto Spec for Pane encoding + Go SDK implementation.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -107,7 +107,7 @@
   * Fixed session window aggregation, which wasn't being performed per-key. ([#33542](https://github.com/apache/beam/issues/33542)).)
 * [Dataflow Streaming Appliance] Fixed commits failing with KeyCommitTooLargeException when a key outputs >180MB of results. [#33588](https://github.com/apache/beam/issues/33588).
 * Fixed a Dataflow template creation issue that ignores template file creation errors (Java) ([#33636](https://github.com/apache/beam/issues/33636))
-
+* Correctly documented Pane Encodings in the portability protocols ([#33840](https://github.com/apache/beam/issues/33840)).
 
 ## Security Fixes
 * Fixed (CVE-YYYY-NNNN)[https://www.cve.org/CVERecord?id=CVE-YYYY-NNNN] (Java/Python/Go) ([#X](https://github.com/apache/beam/issues/X)).

--- a/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/beam_runner_api.proto
@@ -969,9 +969,9 @@ message StandardCoders {
     //         10 - late
     //         11 - unknown
     //     * bit 6 is 1 if this is the last pane, 0 otherwise. 
-    //         Commonly set with `byte |= 0x01`
-    //     * bit 7 is 1 if this is the first pane, 0 otherwise.
     //         Commonly set with `byte |= 0x02`
+    //     * bit 7 is 1 if this is the first pane, 0 otherwise.
+    //         Commonly set with `byte |= 0x01`
     //
     //   element - The element incoded using the supplied element coder.
     //

--- a/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/beam_runner_api.proto
@@ -594,8 +594,8 @@ message BagStateSpec {
   string element_coder_id = 1;
 }
 
-// OrderedListState values are encoded with the var int encoded millis followed
-// by the value encoded by the provided coder.
+// OrderedListState values are encoded with the var int encoded
+// millis-since-epoch followed by the value encoded by the provided coder.
 // Be aware this is not the standard timestamp value encoding.
 message OrderedListStateSpec {
   string element_coder_id = 1;

--- a/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/beam_runner_api.proto
@@ -594,6 +594,9 @@ message BagStateSpec {
   string element_coder_id = 1;
 }
 
+// OrderedListState values are encoded with the var int encoded millis followed
+// by the value encoded by the provided coder.
+// Be aware this is not the standard timestamp value encoding.
 message OrderedListStateSpec {
   string element_coder_id = 1;
 }
@@ -946,7 +949,7 @@ message StandardCoders {
     //     coder.
     //
     //   pane - The first byte of the pane info determines which type of
-    //     encoding is used, as well as the is_first, is_last, and timing
+    //     encoding is used, as well as the is_first, is_last and timing
     //     fields. If this byte is bits [0 1 2 3 4 5 6 7], then:
     //     * bits [0 1 2 3] determine the encoding as follows:
     //         0000 - The entire pane info is encoded as a single byte.
@@ -954,7 +957,7 @@ message StandardCoders {
     //                as below, and the index and non-speculative index are
     //                both zero (and hence are not encoded here).
     //         0001 - The pane info is encoded as this byte plus a single
-    //                VarInt encoed integer representing the pane index. The
+    //                VarInt encoded integer representing the pane index. The
     //                non-speculative index can be derived as follows:
     //                  -1 if the pane is early, otherwise equal to index.
     //         0010 - The pane info is encoded as this byte plus two VarInt
@@ -965,8 +968,8 @@ message StandardCoders {
     //         01 - on time
     //         10 - late
     //         11 - unknown
-    //     * bit 6 is 1 if this is the first pane, 0 otherwise.
-    //     * bit 7 is 1 if this is the last pane, 0 otherwise.
+    //     * bit 6 is 1 if this is the last pane, 0 otherwise.
+    //     * bit 7 is 1 if this is the first pane, 0 otherwise.
     //
     //   element - The element incoded using the supplied element coder.
     //
@@ -1329,7 +1332,7 @@ message Trigger {
   message AfterSynchronizedProcessingTime {
   }
 
-  // The default trigger. Equivalent to Repeat { AfterEndOfWindow } but
+  // The default trigger. Equivalent to AfterEndOfWindow { Late: Always }} but
   // specially denoted to indicate the user did not alter the triggering.
   message Default {
   }
@@ -1339,12 +1342,12 @@ message Trigger {
     int32 element_count = 1;
   }
 
-  // Never ready. There will only be an ON_TIME output and a final
-  // output at window expiration.
+  // Never ready. There will only be an ON_TIME final output at window
+  // expiration.
   message Never {
   }
 
-  // Always ready. This can also be expressed as ElementCount(1) but
+  // Always ready. This can also be expressed as Repeat{ ElementCount(1) } but
   // is more explicit.
   message Always {
   }

--- a/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/beam_runner_api.proto
@@ -968,8 +968,10 @@ message StandardCoders {
     //         01 - on time
     //         10 - late
     //         11 - unknown
-    //     * bit 6 is 1 if this is the last pane, 0 otherwise.
+    //     * bit 6 is 1 if this is the last pane, 0 otherwise. 
+    //         Commonly set with `byte |= 0x01`
     //     * bit 7 is 1 if this is the first pane, 0 otherwise.
+    //         Commonly set with `byte |= 0x02`
     //
     //   element - The element incoded using the supplied element coder.
     //

--- a/sdks/go/pkg/beam/core/graph/coder/panes.go
+++ b/sdks/go/pkg/beam/core/graph/coder/panes.go
@@ -29,10 +29,10 @@ func EncodePane(v typex.PaneInfo, w io.Writer) error {
 
 	pane := byte(0)
 	if v.IsFirst {
-		pane |= 0x02
+		pane |= 0x01
 	}
 	if v.IsLast {
-		pane |= 0x01
+		pane |= 0x02
 	}
 	pane |= byte(v.Timing << 2)
 
@@ -64,10 +64,10 @@ func EncodePane(v typex.PaneInfo, w io.Writer) error {
 func NewPane(b byte) typex.PaneInfo {
 	pn := typex.NoFiringPane()
 
-	if !(b&0x02 == 2) {
+	if !(b&0x01 == 1) {
 		pn.IsFirst = false
 	}
-	if !(b&0x01 == 1) {
+	if !(b&0x02 == 2) {
 		pn.IsLast = false
 	}
 

--- a/sdks/go/pkg/beam/core/graph/window/trigger/trigger.go
+++ b/sdks/go/pkg/beam/core/graph/window/trigger/trigger.go
@@ -352,7 +352,7 @@ func (t *NeverTrigger) String() string {
 func (t NeverTrigger) trigger() {}
 
 // Never creates a Never Trigger that is never ready to fire.
-// There will only be an ON_TIME output and a final output at window expiration.
+// There will only be a single ON_TIME final output at window expiration + allowed lateness.
 func Never() *NeverTrigger {
 	return &NeverTrigger{}
 }

--- a/sdks/go/pkg/beam/core/typex/special.go
+++ b/sdks/go/pkg/beam/core/typex/special.go
@@ -98,6 +98,19 @@ const (
 	PaneUnknown PaneTiming = 3
 )
 
+func (t PaneTiming) String() string {
+	switch t {
+	case PaneEarly:
+		return "early"
+	case PaneOnTime:
+		return "ontime"
+	case PaneLate:
+		return "late"
+	default:
+		return "unknown"
+	}
+}
+
 // PaneInfo represents the output pane.
 type PaneInfo struct {
 	Timing                     PaneTiming


### PR DESCRIPTION
While implementing Triggers + Panes for Prism, I ran into inexplicable failing tests.

It turns out that portable encoding of panes in the protos *does not* match the implementations in the Python, and Java SDKs, or the internal Dataflow implementation, and never has in the 5 years since it was added to the protocol buffers.

Specifically, the bits for first and last panes are swapped with first being the 7 indexed bit, and last being the 6 indexed bit.

Compare Python and Java
 https://github.com/apache/beam/blob/master/sdks/python/apache_beam/utils/windowed_value.py#L92

https://github.com/apache/beam/blob/master/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/PaneInfo.java#L134

To Go's current implementation.

https://github.com/apache/beam/blob/release-2.62.0/sdks/go/pkg/beam/core/graph/coder/panes.go#L32

It is worth noting that the Go implemenation didn't have the swap some years ago when it was first added in https://github.com/apache/beam/commit/b0e9f2638cbaca822ee6a58bd8ec0e61db8e799e but it wasn't unit tested at the time.

But due to a different error in the implementation, the bit swap occurred in https://github.com/apache/beam/commit/657caa88c011cae818377f64f02afe9d18614da5 where it was made to match the spec in the protocol buffers on top of fixing the other error.

This error wasn't caught until now due to Triggers (and thus Panes) being among the last features implemented in the SDK, and the least tested due to no real portable implementations of TestStream necessary to exercise them. The Go SDK doesn't currently provide facilities to assert against specific pane properties, and it is unlikely for there to be user code for this since it seems like the Go SDK also doesn't propagate panes properly. See https://github.com/apache/beam/pull/31174/files and #31153 .

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
