### PR TITLE
[Portable BQ] default null list to empty list

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
@@ -35,6 +35,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -714,6 +715,9 @@ public class BigQueryUtils {
       if (fieldType.getNullable()) {
         return null;
       } else {
+        if (fieldType.getTypeName().isCollectionType()) {
+          return Collections.emptyList();
+        }
         throw new IllegalArgumentException(
             "Received null value for non-nullable field \"" + field.getName() + "\"");
       }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtilsTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtilsTest.java
@@ -450,6 +450,9 @@ public class BigQueryUtilsTest {
 
   private static final TableRow BQ_ENUM_ROW = new TableRow().set("color", "GREEN");
 
+  private static final Row NULL_ARRAY_ROW =
+      Row.withSchema(ARRAY_TYPE_NULLS).addValue(Collections.emptyList()).build();
+
   private static final Row ARRAY_ROW_NULLS =
       Row.withSchema(ARRAY_TYPE_NULLS).addValues((Object) Arrays.asList(123L, null, null)).build();
 
@@ -458,6 +461,8 @@ public class BigQueryUtilsTest {
 
   private static final Row MAP_ROW =
       Row.withSchema(MAP_MAP_TYPE).addValues(ImmutableMap.of("test", 123.456)).build();
+
+  private static final TableRow BQ_NULL_ARRAY_ROW = new TableRow().set("ids", null);
 
   private static final TableRow BQ_ARRAY_ROW_NULLS =
       new TableRow()
@@ -1019,6 +1024,12 @@ public class BigQueryUtilsTest {
   public void testToBeamRow_enum() {
     Row beamRow = BigQueryUtils.toBeamRow(ENUM_STRING_TYPE, BQ_ENUM_ROW);
     assertEquals(ENUM_STRING_ROW, beamRow);
+  }
+
+  @Test
+  public void testToBeamRow_nullArray() {
+    Row beamRow = BigQueryUtils.toBeamRow(ARRAY_TYPE_NULLS, BQ_NULL_ARRAY_ROW);
+    assertEquals(NULL_ARRAY_ROW, beamRow);
   }
 
   @Test


### PR DESCRIPTION
Fixes a problem where, in the DLQ, failed rows containing null values for list fields will fail to convert to Beam Rows.