### PR TITLE
SnowflakeIO: be consistent with backslash escape char

### DIFF
--- a/sdks/java/io/snowflake/src/main/java/org/apache/beam/sdk/io/snowflake/SnowflakeIO.java
+++ b/sdks/java/io/snowflake/src/main/java/org/apache/beam/sdk/io/snowflake/SnowflakeIO.java
@@ -1176,7 +1176,10 @@ public class SnowflakeIO {
       for (Object o : context.element()) {
         if (o instanceof String) {
           String field = (String) o;
-          field = field.replace("'", "''");
+          field = field.replace("\\", "\\\\");
+          if (!this.quotationMark.isEmpty()) {
+            field = field.replace(this.quotationMark, "\\" + this.quotationMark);
+          }
           field = quoteNonEmptyField(field);
 
           csvItems.add(field);

--- a/sdks/java/io/snowflake/src/test/java/org/apache/beam/sdk/io/snowflake/test/unit/write/SnowflakeIOWriteTest.java
+++ b/sdks/java/io/snowflake/src/test/java/org/apache/beam/sdk/io/snowflake/test/unit/write/SnowflakeIOWriteTest.java
@@ -208,7 +208,7 @@ public class SnowflakeIOWriteTest {
     List<String> actualData = FakeSnowflakeDatabase.getElements(FAKE_TABLE);
     List<String> escapedTestData =
         testDataInStrings.stream()
-            .map(e -> e.replace("'", "''"))
+            .map(e -> e.replace("\"", "\\\""))
             .map(e -> e.isEmpty() ? "" : String.format("\"%s\"", e))
             .collect(Collectors.toList());
     assertTrue(TestUtils.areListsEqual(escapedTestData, actualData));
@@ -233,8 +233,7 @@ public class SnowflakeIOWriteTest {
 
     List<String> actualData = FakeSnowflakeDatabase.getElements(FAKE_TABLE);
 
-    List<String> escapedTestData =
-        testDataInStrings.stream().map(e -> e.replace("'", "''")).collect(Collectors.toList());
-    assertTrue(TestUtils.areListsEqual(escapedTestData, actualData));
+    // no escape for blank quotation
+    assertTrue(TestUtils.areListsEqual(testDataInStrings, actualData));
   }
 }


### PR DESCRIPTION
Fixes failure with data containing quotes `'` or backslash `\`, to be consistent with PR #31779 that set backslash as the escape char for Snowflake CSV `COPY`.

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
