### PR TITLE
Upgrade jetty to latest 9.* for legacy worker

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/build.gradle
+++ b/runners/google-cloud-dataflow-java/worker/build.gradle
@@ -131,7 +131,7 @@ applyJavaNature(
             dependencies {
                 // We have to include jetty-server/jetty-servlet and all of its transitive dependencies
                 // which includes several org.eclipse.jetty artifacts + servlet-api
-                include(dependency("org.eclipse.jetty:.*:9.4.54.v20240208"))
+                include(dependency("org.eclipse.jetty:.*:9.4.56.v20240826"))
                 include(dependency("javax.servlet:javax.servlet-api:3.1.0"))
             }
             relocate("org.eclipse.jetty", getWorkerRelocatedPath("org.eclipse.jetty"))
@@ -200,8 +200,8 @@ dependencies {
     compileOnly "org.conscrypt:conscrypt-openjdk-uber:2.5.1"
 
     implementation "javax.servlet:javax.servlet-api:3.1.0"
-    implementation "org.eclipse.jetty:jetty-server:9.4.54.v20240208"
-    implementation "org.eclipse.jetty:jetty-servlet:9.4.54.v20240208"
+    implementation "org.eclipse.jetty:jetty-server:9.4.56.v20240826"
+    implementation "org.eclipse.jetty:jetty-servlet:9.4.56.v20240826"
     implementation library.java.avro
     implementation library.java.jackson_annotations
     implementation library.java.jackson_core


### PR DESCRIPTION
Fixes [CVE-2024-8184](https://github.com/advisories/GHSA-g8m5-722r-8whq)