### PR TITLE
Preempt issubclass error for generic types

### DIFF
--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -1329,6 +1329,10 @@ def is_consistent_with(sub, base):
   elif isinstance(sub, TypeConstraint):
     # Nothing but object lives above any type constraints.
     return base == object
+  elif is_typing_generic(base):
+    # Cannot check unsupported parameterized generic which will cause issubclass
+    # to fail with an exception.
+    return False
   return issubclass(sub, base)
 
 

--- a/sdks/python/apache_beam/typehints/typehints_test.py
+++ b/sdks/python/apache_beam/typehints/typehints_test.py
@@ -1354,6 +1354,7 @@ class DecoratorHelpers(TypeHintTestCase):
     self.assertFalse(is_consistent_with(object, str))
     self.assertTrue(is_consistent_with(str, Union[str, int]))
     self.assertFalse(is_consistent_with(Union[str, int], str))
+    self.assertFalse(is_consistent_with(str, NonBuiltInGeneric[str]))
 
   def test_positional_arg_hints(self):
     self.assertEqual(typehints.Any, _positional_arg_hints('x', {}))


### PR DESCRIPTION
Previously, parameterized generics that made it to the issubclass call would
fail and cause obscure stack traces to bubble up. Short-circuiting this logic
by unconditionally rejecting ensures the type check failure case will handle
the error message generation and display.