### PR TITLE
add hashcode/equals to WaitTest helper classes to avoid log error

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/WaitTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/WaitTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -94,6 +95,22 @@ public class WaitTest implements Serializable {
           .add("element", element)
           .add("watermarkUpdate", watermarkUpdate)
           .toString();
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(processingTime, element, watermarkUpdate);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (!(other instanceof Event)) {
+        return false;
+      }
+      Event<?> otherEvent = (Event<?>) other;
+      return Objects.equals(processingTime, otherEvent.processingTime)
+          && Objects.equals(watermarkUpdate, otherEvent.watermarkUpdate)
+          && Objects.equals(element, otherEvent.element);
     }
   }
 
@@ -237,6 +254,21 @@ public class WaitTest implements Serializable {
     public WindowExpirationValue(@Nullable Instant watermarkAdvance, long value) {
       this.watermarkAdvance = watermarkAdvance;
       this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (!(other instanceof WindowExpirationValue)) {
+        return false;
+      }
+      WindowExpirationValue otherValue = (WindowExpirationValue) other;
+      return Objects.equals(watermarkAdvance, otherValue.watermarkAdvance)
+          && value == otherValue.value;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(watermarkAdvance, value);
     }
   }
 


### PR DESCRIPTION
There are lots of error logs showing up otherwise.
See https://github.com/apache/beam/actions/runs/13367967271/job/37335398780?pr=33979 for example:

```org.apache.beam.sdk.transforms.WaitTest > testWindowExpiration STANDARD_ERROR
    [direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class org.apache.beam.sdk.schemas.SchemaCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element org.apache.beam.sdk.transforms.WaitTest$WindowExpirationValue@aaa632c
    [direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class org.apache.beam.sdk.schemas.SchemaCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element org.apache.beam.sdk.transforms.WaitTest$WindowExpirationValue@aaa632c
    [direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class org.apache.beam.sdk.schemas.SchemaCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element org.apache.beam.sdk.transforms.WaitTest$WindowExpirationValue@aaa632c
    [direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class org.apache.beam.sdk.schemas.SchemaCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element org.apache.beam.sdk.transforms.WaitTest$WindowExpirationValue@aaa632c
    [direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class org.apache.beam.sdk.schemas.SchemaCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element org.apache.beam.sdk.transforms.WaitTest$WindowExpirationValue@6cff1a6a
    [direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class org.apache.beam.sdk.schemas.SchemaCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element org.apache.beam.sdk.transforms.WaitTest$WindowExpirationValue@6cff1a6a
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
