### PR TITLE
[AnomalyDetection] Add threshold and aggregation functions.

### DIFF
--- a/sdks/python/apache_beam/ml/anomaly/aggregations.py
+++ b/sdks/python/apache_beam/ml/anomaly/aggregations.py
@@ -1,0 +1,263 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import collections
+import math
+import statistics
+from typing import Callable
+from typing import Iterable
+
+from apache_beam.ml.anomaly.base import AnomalyPrediction
+from apache_beam.ml.anomaly.base import AggregationFn
+from apache_beam.ml.anomaly.specifiable import specifiable
+
+
+class LabelAggregation(AggregationFn):
+  """Aggregates anomaly predictions based on their labels.
+
+  This is an abstract base class for `AggregationFn`s that combine multiple
+  `AnomalyPrediction` objects into a single `AnomalyPrediction` based on
+  the labels of the input predictions.
+
+  Args:
+    agg_func (Callable[[Iterable[int]], int]): A function that aggregates
+      a collection of anomaly labels (integers) into a single label.
+    include_history (bool): If True, include the input predictions in the
+      `agg_history` of the output. Defaults to False.
+  """
+  def __init__(
+      self,
+      agg_func: Callable[[Iterable[int]], int],
+      include_history: bool = False):
+    self._agg = agg_func
+    self._include_history = include_history
+    self._agg_model_id = None
+
+  def apply(
+      self, predictions: Iterable[AnomalyPrediction]) -> AnomalyPrediction:
+    """Applies the label aggregation function to a list of predictions.
+
+    Args:
+      predictions (Iterable[AnomalyPrediction]): A collection of
+        `AnomalyPrediction` objects to be aggregated.
+
+    Returns:
+      AnomalyPrediction: A single `AnomalyPrediction` object with the
+        aggregated label.
+    """
+    labels = [
+        prediction.label for prediction in predictions
+        if prediction.label is not None
+    ]
+
+    if len(labels) == 0:
+      return AnomalyPrediction(model_id=self._agg_model_id)
+
+    label = self._agg(labels)
+
+    history = list(predictions) if self._include_history else None
+
+    return AnomalyPrediction(
+        model_id=self._agg_model_id, label=label, agg_history=history)
+
+
+class ScoreAggregation(AggregationFn):
+  """Aggregates anomaly predictions based on their scores.
+
+  This is an abstract base class for `AggregationFn`s that combine multiple
+  `AnomalyPrediction` objects into a single `AnomalyPrediction` based on
+  the scores of the input predictions.
+
+  Args:
+    agg_func (Callable[[Iterable[float]], float]): A function that aggregates
+      a collection of anomaly scores (floats) into a single score.
+    include_history (bool): If True, include the input predictions in the
+      `agg_history` of the output. Defaults to False.
+  """
+  def __init__(
+      self,
+      agg_func: Callable[[Iterable[float]], float],
+      include_history: bool = False):
+    self._agg = agg_func
+    self._include_history = include_history
+    self._agg_model_id = None
+
+  def apply(
+      self, predictions: Iterable[AnomalyPrediction]) -> AnomalyPrediction:
+    """Applies the score aggregation function to a list of predictions.
+
+    Args:
+      predictions (Iterable[AnomalyPrediction]): A collection of
+        `AnomalyPrediction` objects to be aggregated.
+
+    Returns:
+      AnomalyPrediction: A single `AnomalyPrediction` object with the
+        aggregated score.
+    """
+    scores = [
+        prediction.score for prediction in predictions
+        if prediction.score is not None and not math.isnan(prediction.score)
+    ]
+    if len(scores) == 0:
+      return AnomalyPrediction(model_id=self._agg_model_id)
+
+    score = self._agg(scores)
+
+    history = list(predictions) if self._include_history else None
+
+    return AnomalyPrediction(
+        model_id=self._agg_model_id, score=score, agg_history=history)
+
+
+@specifiable
+class MajorityVote(LabelAggregation):
+  """Aggregates anomaly labels using majority voting.
+
+  This `AggregationFn` implements a majority voting strategy to combine
+  anomaly labels from multiple `AnomalyPrediction` objects. It counts the
+  occurrences of normal and outlier labels and selects the label with the
+  higher count as the aggregated label. In case of a tie, a tie-breaker
+  label is used.
+
+  Example:
+    If input labels are [normal, outlier, outlier, normal, outlier], and
+    normal_label=0, outlier_label=1, then the aggregated label will be
+    outlier (1) because outliers have a majority (3 vs 2).
+
+  Args:
+    normal_label (int): The integer label for normal predictions. Defaults to 0.
+    outlier_label (int): The integer label for outlier predictions. Defaults to
+      1.
+    tie_breaker (int): The label to return if there is a tie in votes.
+      Defaults to 0 (normal_label).
+    **kwargs: Additional keyword arguments to pass to the base
+      `LabelAggregation` class.
+  """
+  def __init__(self, normal_label=0, outlier_label=1, tie_breaker=0, **kwargs):
+    self._tie_breaker = tie_breaker
+    self._normal_label = normal_label
+    self._outlier_label = outlier_label
+
+    def inner(predictions: Iterable[int]) -> int:
+      counters = collections.Counter(predictions)
+      if counters[self._normal_label] < counters[self._outlier_label]:
+        vote = self._outlier_label
+      elif counters[self._normal_label] > counters[self._outlier_label]:
+        vote = self._normal_label
+      else:
+        vote = self._tie_breaker
+      return vote
+
+    super().__init__(agg_func=inner, **kwargs)
+
+
+# And scheme
+@specifiable
+class AllVote(LabelAggregation):
+  """Aggregates anomaly labels using an "all vote" (AND) scheme.
+
+  This `AggregationFn` implements an "all vote" strategy. It aggregates
+  anomaly labels such that the result is considered an outlier only if all
+  input `AnomalyPrediction` objects are labeled as outliers.
+
+  Example:
+    If input labels are [outlier, outlier, outlier], and outlier_label=1,
+    then the aggregated label will be outlier (1).
+    If input labels are [outlier, normal, outlier], and outlier_label=1,
+    then the aggregated label will be normal (0).
+
+  Args:
+    normal_label (int): The integer label for normal predictions. Defaults to 0.
+    outlier_label (int): The integer label for outlier predictions. Defaults to
+      1.
+    **kwargs: Additional keyword arguments to pass to the base
+      `LabelAggregation` class.
+  """
+  def __init__(self, normal_label=0, outlier_label=1, **kwargs):
+    self._normal_label = normal_label
+    self._outlier_label = outlier_label
+
+    def inner(predictions: Iterable[int]) -> int:
+      return self._outlier_label if all(
+          map(lambda p: p == self._outlier_label,
+              predictions)) else self._normal_label
+
+    super().__init__(agg_func=inner, **kwargs)
+
+
+# Or scheme
+@specifiable
+class AnyVote(LabelAggregation):
+  """Aggregates anomaly labels using an "any vote" (OR) scheme.
+
+  This `AggregationFn` implements an "any vote" strategy. It aggregates
+  anomaly labels such that the result is considered an outlier if at least
+  one of the input `AnomalyPrediction` objects is labeled as an outlier.
+
+  Example:
+    If input labels are [normal, normal, outlier], and outlier_label=1,
+    then the aggregated label will be outlier (1).
+    If input labels are [normal, normal, normal], and outlier_label=1,
+    then the aggregated label will be normal (0).
+
+  Args:
+    normal_label (int): The integer label for normal predictions. Defaults to 0.
+    outlier_label (int): The integer label for outlier predictions. Defaults to
+      1.
+    **kwargs: Additional keyword arguments to pass to the base
+      `LabelAggregation` class.
+  """
+  def __init__(self, normal_label=0, outlier_label=1, **kwargs):
+    self._normal_label = normal_label
+    self._outlier_label = outlier_label
+
+    def inner(predictions: Iterable[int]) -> int:
+      return self._outlier_label if any(
+          map(lambda p: p == self._outlier_label,
+              predictions)) else self._normal_label
+
+    super().__init__(agg_func=inner, **kwargs)
+
+
+@specifiable
+class AverageScore(ScoreAggregation):
+  """Aggregates anomaly scores by calculating their average.
+
+  This `AggregationFn` computes the average of the anomaly scores from a
+  collection of `AnomalyPrediction` objects.
+
+  Args:
+    **kwargs: Additional keyword arguments to pass to the base
+      `ScoreAggregation` class.
+  """
+  def __init__(self, **kwargs):
+    super().__init__(agg_func=statistics.mean, **kwargs)
+
+
+@specifiable
+class MaxScore(ScoreAggregation):
+  """Aggregates anomaly scores by selecting the maximum score.
+
+  This `AggregationFn` selects the highest anomaly score from a collection
+  of `AnomalyPrediction` objects as the aggregated score.
+
+  Args:
+    **kwargs: Additional keyword arguments to pass to the base
+      `ScoreAggregation` class.
+  """
+  def __init__(self, **kwargs):
+    super().__init__(agg_func=max, **kwargs)

--- a/sdks/python/apache_beam/ml/anomaly/aggregations_test.py
+++ b/sdks/python/apache_beam/ml/anomaly/aggregations_test.py
@@ -1,0 +1,120 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import logging
+import unittest
+
+from apache_beam.ml.anomaly.base import AnomalyPrediction
+from apache_beam.ml.anomaly import aggregations
+
+
+class MajorityVoteTest(unittest.TestCase):
+  def test_default(self):
+    normal = AnomalyPrediction(label=0)
+    outlier = AnomalyPrediction(label=1)
+    vote = aggregations.MajorityVote(_run_init=True).apply
+
+    self.assertEqual(vote([]), AnomalyPrediction())
+
+    self.assertEqual(vote([normal]), normal)
+
+    self.assertEqual(vote([outlier]), outlier)
+
+    self.assertEqual(vote([outlier, normal, normal]), normal)
+
+    self.assertEqual(vote([outlier, normal, outlier]), outlier)
+
+    # use normal to break ties by default
+    self.assertEqual(vote([outlier, normal]), normal)
+
+  def test_tie_breaker(self):
+    normal = AnomalyPrediction(label=0)
+    outlier = AnomalyPrediction(label=1)
+    vote = aggregations.MajorityVote(tie_breaker=1, _run_init=True).apply
+
+    self.assertEqual(vote([outlier, normal]), outlier)
+
+
+class AllVoteTest(unittest.TestCase):
+  def test_default(self):
+    normal = AnomalyPrediction(label=0)
+    outlier = AnomalyPrediction(label=1)
+    vote = aggregations.AllVote(_run_init=True).apply
+
+    self.assertEqual(vote([]), AnomalyPrediction())
+
+    self.assertEqual(vote([normal]), normal)
+
+    self.assertEqual(vote([outlier]), outlier)
+
+    # outlier is only labeled when everyone is outlier
+    self.assertEqual(vote([normal, normal, normal]), normal)
+    self.assertEqual(vote([outlier, normal, normal]), normal)
+    self.assertEqual(vote([outlier, normal, outlier]), normal)
+    self.assertEqual(vote([outlier, outlier, outlier]), outlier)
+
+
+class AnyVoteTest(unittest.TestCase):
+  def test_default(self):
+    normal = AnomalyPrediction(label=0)
+    outlier = AnomalyPrediction(label=1)
+    vote = aggregations.AnyVote(_run_init=True).apply
+
+    self.assertEqual(vote([]), AnomalyPrediction())
+
+    self.assertEqual(vote([normal]), normal)
+
+    self.assertEqual(vote([outlier]), outlier)
+
+    # outlier is labeled when at least one is outlier
+    self.assertEqual(vote([normal, normal, normal]), normal)
+    self.assertEqual(vote([outlier, normal, normal]), outlier)
+    self.assertEqual(vote([outlier, normal, outlier]), outlier)
+    self.assertEqual(vote([outlier, outlier, outlier]), outlier)
+
+
+class AverageScoreTest(unittest.TestCase):
+  def test_default(self):
+    avg = aggregations.AverageScore(_run_init=True).apply
+
+    self.assertEqual(avg([]), AnomalyPrediction())
+
+    self.assertEqual(
+        avg([AnomalyPrediction(score=1)]), AnomalyPrediction(score=1))
+
+    self.assertEqual(
+        avg([AnomalyPrediction(score=1), AnomalyPrediction(score=2)]),
+        AnomalyPrediction(score=1.5))
+
+
+class MaxScoreTest(unittest.TestCase):
+  def test_default(self):
+    avg = aggregations.MaxScore(_run_init=True).apply
+
+    self.assertEqual(avg([]), AnomalyPrediction())
+
+    self.assertEqual(
+        avg([AnomalyPrediction(score=1)]), AnomalyPrediction(score=1))
+
+    self.assertEqual(
+        avg([AnomalyPrediction(score=1), AnomalyPrediction(score=2)]),
+        AnomalyPrediction(score=2))
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/sdks/python/apache_beam/ml/anomaly/base.py
+++ b/sdks/python/apache_beam/ml/anomaly/base.py
@@ -61,8 +61,10 @@ class AnomalyResult():
   """A dataclass for the anomaly detection results"""
   #: The original input data.
   example: beam.Row
-  #: The `AnomalyPrediction` object containing the prediction.
-  prediction: AnomalyPrediction
+  #: The iterable of `AnomalyPrediction` objects containing the predictions.
+  #: Expect length 1 if it is a result for a non-ensemble detector or an
+  #: ensemble detector with an aggregation strategy applied.
+  predictions: Iterable[AnomalyPrediction]
 
 
 class ThresholdFn(abc.ABC):

--- a/sdks/python/apache_beam/ml/anomaly/base_test.py
+++ b/sdks/python/apache_beam/ml/anomaly/base_test.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import copy
 import logging
 import unittest
 
@@ -34,8 +35,11 @@ from apache_beam.ml.anomaly.specifiable import specifiable
 
 class TestAnomalyDetector(unittest.TestCase):
   def setUp(self) -> None:
-    # Remove all registered specifiable classes and reset.
+    self.saved_specifiable = copy.deepcopy(_KNOWN_SPECIFIABLE)
+
+  def tearDown(self) -> None:
     _KNOWN_SPECIFIABLE.clear()
+    _KNOWN_SPECIFIABLE.update(self.saved_specifiable)
 
   @parameterized.expand([(False, False), (True, False), (False, True),
                          (True, True)])
@@ -142,8 +146,11 @@ class TestAnomalyDetector(unittest.TestCase):
 
 class TestEnsembleAnomalyDetector(unittest.TestCase):
   def setUp(self) -> None:
-    # Remove all registered specifiable classes and reset.
+    self.saved_specifiable = copy.deepcopy(_KNOWN_SPECIFIABLE)
+
+  def tearDown(self) -> None:
     _KNOWN_SPECIFIABLE.clear()
+    _KNOWN_SPECIFIABLE.update(self.saved_specifiable)
 
   @parameterized.expand([(False, False), (True, False), (False, True),
                          (True, True)])

--- a/sdks/python/apache_beam/ml/anomaly/specifiable_test.py
+++ b/sdks/python/apache_beam/ml/anomaly/specifiable_test.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import copy
 import dataclasses
 import logging
 import unittest
@@ -32,8 +33,11 @@ from apache_beam.ml.anomaly.specifiable import specifiable
 
 class TestSpecifiable(unittest.TestCase):
   def setUp(self) -> None:
-    # Remove all registered specifiable classes and reset.
+    self.saved_specifiable = copy.deepcopy(_KNOWN_SPECIFIABLE)
+
+  def tearDown(self) -> None:
     _KNOWN_SPECIFIABLE.clear()
+    _KNOWN_SPECIFIABLE.update(self.saved_specifiable)
 
   def test_decorator_in_function_form(self):
     class A():
@@ -217,6 +221,13 @@ class TestSpecifiable(unittest.TestCase):
 
 
 class TestInitCallCount(unittest.TestCase):
+  def setUp(self) -> None:
+    self.saved_specifiable = copy.deepcopy(_KNOWN_SPECIFIABLE)
+
+  def tearDown(self) -> None:
+    _KNOWN_SPECIFIABLE.clear()
+    _KNOWN_SPECIFIABLE.update(self.saved_specifiable)
+
   def test_on_demand_init(self):
     @specifiable(on_demand_init=True, just_in_time_init=False)
     class FooOnDemand():
@@ -411,6 +422,13 @@ class Child_Error_2(Parent):
 
 
 class TestNestedSpecifiable(unittest.TestCase):
+  def setUp(self) -> None:
+    self.saved_specifiable = copy.deepcopy(_KNOWN_SPECIFIABLE)
+
+  def tearDown(self) -> None:
+    _KNOWN_SPECIFIABLE.clear()
+    _KNOWN_SPECIFIABLE.update(self.saved_specifiable)
+
   @parameterized.expand([[Child_1, 0], [Child_2, 0], [Child_1, 1], [Child_2, 1],
                          [Child_1, 2], [Child_2, 2]])
   def test_nested_specifiable(self, Child, mode):

--- a/sdks/python/apache_beam/ml/anomaly/thresholds.py
+++ b/sdks/python/apache_beam/ml/anomaly/thresholds.py
@@ -1,0 +1,319 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+from typing import cast
+from typing import Iterable
+from typing import Optional
+from typing import Tuple
+from typing import Union
+
+import apache_beam as beam
+from apache_beam.coders import DillCoder
+from apache_beam.ml.anomaly.base import AnomalyResult
+from apache_beam.ml.anomaly.base import ThresholdFn
+from apache_beam.ml.anomaly.specifiable import Spec
+from apache_beam.ml.anomaly.specifiable import specifiable
+from apache_beam.ml.anomaly.specifiable import Specifiable
+from apache_beam.ml.anomaly.univariate.quantile import QuantileTracker
+from apache_beam.ml.anomaly.univariate.quantile import BufferedSlidingQuantileTracker  # pylint: disable=line-too-long
+from apache_beam.transforms.userstate import ReadModifyWriteStateSpec
+from apache_beam.transforms.userstate import ReadModifyWriteRuntimeState
+
+
+class BaseThresholdDoFn(beam.DoFn):
+  """Applies a ThresholdFn to anomaly detection results.
+
+  This abstract base class defines the structure for DoFns that use a
+  `ThresholdFn` to convert anomaly scores into anomaly labels (e.g., normal
+  or outlier). It handles the core logic of applying the threshold function
+  and updating the prediction labels within `AnomalyResult` objects.
+
+  Args:
+    threshold_fn_spec (Spec): Specification defining the `ThresholdFn` to be
+      used.
+  """
+  def __init__(self, threshold_fn_spec: Spec):
+    self._threshold_fn_spec = threshold_fn_spec
+    self._threshold_fn: ThresholdFn
+
+  def _apply_threshold_to_predictions(
+      self, result: AnomalyResult) -> AnomalyResult:
+    """Updates the prediction labels in an AnomalyResult using the ThresholdFn.
+
+    Args:
+      result (AnomalyResult): The input `AnomalyResult` containing anomaly
+        scores.
+
+    Returns:
+      AnomalyResult: A new `AnomalyResult` with updated prediction labels
+        and threshold values.
+    """
+    predictions = [
+        dataclasses.replace(
+            p,
+            label=self._threshold_fn.apply(p.score),
+            threshold=self._threshold_fn.threshold) for p in result.predictions
+    ]
+    return dataclasses.replace(result, predictions=predictions)
+
+
+class StatelessThresholdDoFn(BaseThresholdDoFn):
+  """Applies a stateless ThresholdFn to anomaly detection results.
+
+  This DoFn is designed for stateless `ThresholdFn` implementations. It
+  initializes the `ThresholdFn` once during setup and applies it to each
+  incoming element without maintaining any state across elements.
+
+  Args:
+    threshold_fn_spec (Spec): Specification defining the `ThresholdFn` to be
+      used.
+
+  Raises:
+    AssertionError: If the provided `threshold_fn_spec` leads to the
+      creation of a stateful `ThresholdFn`.
+  """
+  def __init__(self, threshold_fn_spec: Spec):
+    threshold_fn_spec.config["_run_init"] = True
+    self._threshold_fn = cast(
+        ThresholdFn, Specifiable.from_spec(threshold_fn_spec))
+    assert not self._threshold_fn.is_stateful, \
+      "This DoFn can only take stateless function as threshold_fn"
+
+  def process(self, element: Tuple[Any, Tuple[Any, AnomalyResult]],
+              **kwargs) -> Iterable[Tuple[Any, Tuple[Any, AnomalyResult]]]:
+    """Processes a batch of anomaly results using a stateless ThresholdFn.
+
+    Args:
+      element (Tuple[Any, Tuple[Any, AnomalyResult]]): A tuple representing
+        an element in the Beam pipeline. It is expected to be in the format
+        `(key1, (key2, AnomalyResult))`, where key1 is the original input key,
+        and key2 is a disambiguating key for distinct data points.
+      **kwargs:  Additional keyword arguments passed to the `process` method
+        in Beam DoFns.
+
+    Yields:
+      Iterable[Tuple[Any, Tuple[Any, AnomalyResult]]]: An iterable containing
+        a single output element with the same structure as the input, but with
+        the `AnomalyResult` having updated prediction labels based on the
+        stateless `ThresholdFn`.
+    """
+    k1, (k2, result) = element
+    yield k1, (k2, self._apply_threshold_to_predictions(result))
+
+
+class StatefulThresholdDoFn(BaseThresholdDoFn):
+  """Applies a stateful ThresholdFn to anomaly detection results.
+
+  This DoFn is designed for stateful `ThresholdFn` implementations. It leverages
+  Beam's state management to persist and update the state of the `ThresholdFn`
+  across multiple elements. This is necessary for `ThresholdFn`s that need to
+  accumulate information or adapt over time, such as quantile-based thresholds.
+
+  Args:
+    threshold_fn_spec (Spec): Specification defining the `ThresholdFn` to be
+      used.
+
+  Raises:
+    AssertionError: If the provided `threshold_fn_spec` leads to the
+      creation of a stateless `ThresholdFn`.
+  """
+  THRESHOLD_STATE_INDEX = ReadModifyWriteStateSpec('saved_tracker', DillCoder())
+
+  def __init__(self, threshold_fn_spec: Spec):
+    threshold_fn_spec.config["_run_init"] = True
+    threshold_fn: ThresholdFn = cast(
+        ThresholdFn, Specifiable.from_spec(threshold_fn_spec))
+    assert threshold_fn.is_stateful, \
+      "This DoFn can only take stateful function as threshold_fn"
+    self._threshold_fn_spec = threshold_fn_spec
+
+  def process(
+      self,
+      element: Tuple[Any, Tuple[Any, AnomalyResult]],
+      threshold_state: Union[ReadModifyWriteRuntimeState,
+                             Any] = beam.DoFn.StateParam(THRESHOLD_STATE_INDEX),
+      **kwargs) -> Iterable[Tuple[Any, Tuple[Any, AnomalyResult]]]:
+    """Processes a batch of anomaly results using a stateful ThresholdFn.
+
+    For each input element, this DoFn retrieves the stateful `ThresholdFn` from
+    Beam state, initializes it if it's the first time, applies it to update
+    the prediction labels in the `AnomalyResult`, and then updates the state in
+    Beam for future elements.
+
+    Args:
+      element (Tuple[Any, Tuple[Any, AnomalyResult]]): A tuple representing
+        an element in the Beam pipeline. It is expected to be in the format
+        `(key1, (key2, AnomalyResult))`, where key1 is the original input key,
+        and key2 is a disambiguating key for distinct data points.
+      threshold_state (Union[ReadModifyWriteRuntimeState, Any]): A Beam state
+        parameter that provides access to the persisted state of the
+        `ThresholdFn`. It is automatically managed by Beam.
+      **kwargs: Additional keyword arguments passed to the `process` method
+        in Beam DoFns.
+
+    Yields:
+      Iterable[Tuple[Any, Tuple[Any, AnomalyResult]]]: An iterable containing
+        a single output element with the same structure as the input, but
+        with the `AnomalyResult` having updated prediction labels based on
+        the stateful `ThresholdFn`.
+    """
+    k1, (k2, result) = element
+
+    self._threshold_fn = threshold_state.read()
+    if self._threshold_fn is None:
+      self._threshold_fn: Specifiable = Specifiable.from_spec(
+          self._threshold_fn_spec)
+
+    yield k1, (k2, self._apply_threshold_to_predictions(result))
+
+    threshold_state.write(self._threshold_fn)
+
+
+@specifiable
+class FixedThreshold(ThresholdFn):
+  """Applies a fixed cutoff value to anomaly scores.
+
+  This `ThresholdFn` is stateless and uses a pre-defined cutoff value to
+  classify anomaly scores. Scores below the cutoff are considered normal, while
+  scores at or above the cutoff are classified as outliers.
+
+  Args:
+    cutoff (float): The fixed threshold value. Anomaly scores at or above this
+      value will be labeled as outliers.
+    **kwargs: Additional keyword arguments to be passed to the base
+      `ThresholdFn` constructor.
+  """
+  def __init__(self, cutoff: float, **kwargs):
+    super().__init__(**kwargs)
+    self._cutoff = cutoff
+
+  @property
+  def is_stateful(self) -> bool:
+    """Indicates whether this ThresholdFn is stateful.
+
+    Returns:
+      bool: Always False for `FixedThreshold` as it is stateless.
+    """
+    return False
+
+  @property
+  def threshold(self) -> float:
+    """Returns the fixed cutoff threshold value.
+
+    Returns:
+      float: The fixed threshold value.
+    """
+    return self._cutoff
+
+  def apply(self, score: Optional[float]) -> int:
+    """Applies the fixed threshold to an anomaly score.
+
+    Classifies the given anomaly score as normal or outlier based on the
+    predefined cutoff.
+
+    Args:
+      score (Optional[float]): The input anomaly score.
+
+    Returns:
+      int: The anomaly label (normal or outlier). Returns the normal label
+        if the score is None or less than the threshold, otherwise returns
+        the outlier label.
+    """
+    if score is None or score < self.threshold:
+      return self._normal_label
+
+    return self._outlier_label
+
+
+@specifiable
+class QuantileThreshold(ThresholdFn):
+  """Applies a quantile-based dynamic threshold to anomaly scores.
+
+  This `ThresholdFn` is stateful and uses a quantile tracker to dynamically
+  determine the threshold for anomaly detection. It estimates the specified
+  quantile of the incoming anomaly scores and uses this quantile value as the
+  threshold.
+
+  The threshold adapts over time as more data is processed, making it suitable
+  for scenarios where the distribution of anomaly scores may change.
+
+  Args:
+    quantile (Optional[float]): The quantile to be tracked (e.g., 0.95 for the
+      95th percentile). This value determines the dynamic threshold. Defaults to
+      0.95.
+    quantile_tracker (Optional[BufferedQuantileTracker]): An optional
+      pre-initialized quantile tracker. If provided, this tracker will be used;
+      otherwise, a `BufferedSlidingQuantileTracker` will be created with a
+      default window size of 100.
+    **kwargs: Additional keyword arguments to be passed to the base
+      `ThresholdFn` constructor.
+  """
+  def __init__(
+      self,
+      quantile: Optional[float] = 0.95,
+      quantile_tracker: Optional[QuantileTracker] = None,
+      **kwargs):
+    super().__init__(**kwargs)
+    if quantile_tracker is not None:
+      self._tracker = quantile_tracker
+    else:
+      self._tracker = BufferedSlidingQuantileTracker(
+          window_size=100, q=quantile)
+
+  @property
+  def is_stateful(self) -> bool:
+    """Indicates whether this ThresholdFn is stateful.
+
+    Returns:
+      bool: Always True for `QuantileThreshold` as it is stateful.
+    """
+    return True
+
+  @property
+  def threshold(self) -> float:
+    """Returns the current quantile-based threshold value.
+
+    Returns:
+      float: The dynamically calculated threshold value based on the quantile
+        tracker.
+    """
+    return self._tracker.get()
+
+  def apply(self, score: Optional[float]) -> int:
+    """Applies the quantile-based threshold to an anomaly score.
+
+    Updates the quantile tracker with the given score and classifies the score
+    as normal or outlier based on the current quantile threshold.
+
+    Args:
+      score (Optional[float]): The input anomaly score.
+
+    Returns:
+      int: The anomaly label (normal or outlier). Returns the normal label if
+        the score is None or less than the dynamic quantile threshold, otherwise
+        returns the outlier label.
+    """
+    self._tracker.push(score)
+
+    if score is None or score < self.threshold:
+      return self._normal_label
+
+    return self._outlier_label

--- a/sdks/python/apache_beam/ml/anomaly/thresholds_test.py
+++ b/sdks/python/apache_beam/ml/anomaly/thresholds_test.py
@@ -1,0 +1,228 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import logging
+import unittest
+
+import apache_beam as beam
+from apache_beam.ml.anomaly import thresholds
+from apache_beam.ml.anomaly.base import AnomalyPrediction
+from apache_beam.ml.anomaly.base import AnomalyResult
+from apache_beam.ml.anomaly.specifiable import Spec
+from apache_beam.ml.anomaly.univariate.quantile import SimpleSlidingQuantileTracker  # pylint: disable=line-too-long
+from apache_beam.ml.anomaly.univariate.quantile import BufferedSlidingQuantileTracker  # pylint: disable=line-too-long
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.testing.util import assert_that
+from apache_beam.testing.util import equal_to
+
+
+class TestFixedThreshold(unittest.TestCase):
+  def test_threshold(self):
+    input = [
+        (1, (2, AnomalyResult(beam.Row(x=10), [AnomalyPrediction(score=1)]))),
+        (1, (3, AnomalyResult(beam.Row(x=20), [AnomalyPrediction(score=2)]))),
+        (1, (4, AnomalyResult(beam.Row(x=20), [AnomalyPrediction(score=3)]))),
+    ]
+    expected = [
+        (
+            1,
+            (
+                2,
+                AnomalyResult(
+                    beam.Row(x=10),
+                    [AnomalyPrediction(score=1, label=0, threshold=2)]))),
+        (
+            1,
+            (
+                3,
+                AnomalyResult(
+                    beam.Row(x=20),
+                    [AnomalyPrediction(score=2, label=1, threshold=2)]))),
+        (
+            1,
+            (
+                4,
+                AnomalyResult(
+                    beam.Row(x=20),
+                    [AnomalyPrediction(score=3, label=1, threshold=2)]))),
+    ]
+    with TestPipeline() as p:
+      result = (
+          p
+          | beam.Create(input)
+          | beam.ParDo(
+              thresholds.StatelessThresholdDoFn(
+                  thresholds.FixedThreshold(2, normal_label=0,
+                                            outlier_label=1).to_spec())))  # type: ignore
+
+      assert_that(result, equal_to(expected))
+
+  def test_multiple_predictions(self):
+    input = [
+        (
+            1,
+            (
+                2,
+                AnomalyResult(
+                    beam.Row(x=10),
+                    [AnomalyPrediction(score=1), AnomalyPrediction(score=4)]))),
+        (
+            1,
+            (
+                3,
+                AnomalyResult(
+                    beam.Row(x=20),
+                    [AnomalyPrediction(score=2), AnomalyPrediction(score=0.5)
+                     ]))),
+    ]
+    expected = [
+        (
+            1,
+            (
+                2,
+                AnomalyResult(
+                    beam.Row(x=10),
+                    [
+                        AnomalyPrediction(score=1, label=0, threshold=2),
+                        AnomalyPrediction(score=4, label=1, threshold=2)
+                    ]))),
+        (
+            1,
+            (
+                3,
+                AnomalyResult(
+                    beam.Row(x=20),
+                    [
+                        AnomalyPrediction(score=2, label=1, threshold=2),
+                        AnomalyPrediction(score=0.5, label=0, threshold=2)
+                    ]))),
+    ]
+    with TestPipeline() as p:
+      result = (
+          p
+          | beam.Create(input)
+          | beam.ParDo(
+              thresholds.StatelessThresholdDoFn(
+                  thresholds.FixedThreshold(2, normal_label=0,
+                                            outlier_label=1).to_spec())))  # type: ignore
+
+      assert_that(result, equal_to(expected))
+
+
+class TestQuantileThreshold(unittest.TestCase):
+  def test_threshold(self):
+    # use the input data with two keys to test stateful threshold function
+    input = [
+        (1, (2, AnomalyResult(beam.Row(x=10), [AnomalyPrediction(score=1)]))),
+        (1, (3, AnomalyResult(beam.Row(x=20), [AnomalyPrediction(score=2)]))),
+        (1, (4, AnomalyResult(beam.Row(x=30), [AnomalyPrediction(score=3)]))),
+        (2, (2, AnomalyResult(beam.Row(x=40), [AnomalyPrediction(score=10)]))),
+        (2, (3, AnomalyResult(beam.Row(x=50), [AnomalyPrediction(score=20)]))),
+        (2, (4, AnomalyResult(beam.Row(x=60), [AnomalyPrediction(score=30)]))),
+    ]
+    expected = [
+        (
+            1,
+            (
+                2,
+                AnomalyResult(
+                    beam.Row(x=10),
+                    [AnomalyPrediction(score=1, label=1, threshold=1)]))),
+        (
+            1,
+            (
+                3,
+                AnomalyResult(
+                    beam.Row(x=20),
+                    [AnomalyPrediction(score=2, label=1, threshold=1.5)]))),
+        (
+            2,
+            (
+                2,
+                AnomalyResult(
+                    beam.Row(x=40),
+                    [AnomalyPrediction(score=10, label=1, threshold=10)]))),
+        (
+            2,
+            (
+                3,
+                AnomalyResult(
+                    beam.Row(x=50),
+                    [AnomalyPrediction(score=20, label=1, threshold=15)]))),
+        (
+            1,
+            (
+                4,
+                AnomalyResult(
+                    beam.Row(x=30),
+                    [AnomalyPrediction(score=3, label=1, threshold=2)]))),
+        (
+            2,
+            (
+                4,
+                AnomalyResult(
+                    beam.Row(x=60),
+                    [AnomalyPrediction(score=30, label=1, threshold=20)]))),
+    ]
+    with TestPipeline() as p:
+      result = (
+          p
+          | beam.Create(input)
+          # use median just for test convenience
+          | beam.ParDo(
+              thresholds.StatefulThresholdDoFn(
+                  thresholds.QuantileThreshold(
+                      quantile=0.5, normal_label=0,
+                      outlier_label=1).to_spec())))  # type: ignore
+
+      assert_that(result, equal_to(expected))
+
+  def test_quantile_tracker(self):
+    t1 = thresholds.QuantileThreshold()
+    self.assertTrue(isinstance(t1._tracker, BufferedSlidingQuantileTracker))
+    self.assertEqual(t1._tracker._q, 0.95)
+    self.assertEqual(t1.to_spec(), Spec("QuantileThreshold", config={}))
+
+    t2 = thresholds.QuantileThreshold(quantile=0.99)
+    self.assertTrue(isinstance(t2._tracker, BufferedSlidingQuantileTracker))
+    self.assertEqual(t2._tracker._q, 0.99)
+    self.assertEqual(
+        t2.to_spec(), Spec("QuantileThreshold", config={"quantile": 0.99}))
+
+    # argument quantile=0.9 is not used because quantile_tracker is set
+    t3 = thresholds.QuantileThreshold(
+        quantile=0.9, quantile_tracker=SimpleSlidingQuantileTracker(50, 0.975))
+    self.assertTrue(isinstance(t3._tracker, SimpleSlidingQuantileTracker))
+    self.assertEqual(t3._tracker._q, 0.975)
+    print(t3.to_spec())
+    self.assertEqual(
+        t3.to_spec(),
+        Spec(
+            "QuantileThreshold",
+            config={
+                'quantile': 0.9,
+                'quantile_tracker': Spec(
+                    type='SimpleSlidingQuantileTracker',
+                    config={
+                        'window_size': 50, 'q': 0.975
+                    })
+            }))
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()


### PR DESCRIPTION
Also include the following changes:
* change prediction to predictions (iterable) in AnomalyResult per reviews.
* fix some tests that contaminate _KNONW_SPECIFIABLE

This is a follow-up PR of https://github.com/apache/beam/pull/33845 and https://github.com/apache/beam/pull/33994.