### PR TITLE
Add UUID support in SpannerSchema

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerSchema.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerSchema.java
@@ -181,6 +181,9 @@ public abstract class SpannerSchema implements Serializable {
           if (spannerType.startsWith("STRING")) {
             return Type.string();
           }
+          if ("UUID".equals(spannerType)) {
+            return Type.string();
+          }
           if (spannerType.startsWith("BYTES")) {
             return Type.bytes();
           }
@@ -259,6 +262,9 @@ public abstract class SpannerSchema implements Serializable {
           }
           if (spannerType.startsWith("JSONB")) {
             return Type.pgJsonb();
+          }
+          if ("UUID".equals(spannerType)) {
+            return Type.string();
           }
           throw new IllegalArgumentException("Unknown spanner type " + spannerType);
         default:

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/SpannerSchemaTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/SpannerSchemaTest.java
@@ -41,10 +41,11 @@ public class SpannerSchemaTest {
             .addColumn("test", "protoVal", "PROTO<customer.app.TestMessage>")
             .addColumn("test", "enumVal", "ENUM<customer.app.TestEnum>")
             .addColumn("test", "tokens", "TOKENLIST")
+            .addColumn("test", "uuidCol", "UUID")
             .build();
 
     assertEquals(1, schema.getTables().size());
-    assertEquals(7, schema.getColumns("test").size());
+    assertEquals(8, schema.getColumns("test").size());
     assertEquals(1, schema.getKeyParts("test").size());
     assertEquals(Type.json(), schema.getColumns("test").get(3).getType());
     assertEquals(
@@ -52,6 +53,7 @@ public class SpannerSchemaTest {
     assertEquals(
         Type.protoEnum("customer.app.TestEnum"), schema.getColumns("test").get(5).getType());
     assertEquals(Type.bytes(), schema.getColumns("test").get(6).getType());
+    assertEquals(Type.string(), schema.getColumns("test").get(7).getType());
   }
 
   @Test
@@ -84,12 +86,14 @@ public class SpannerSchemaTest {
             .addColumn("test", "numericVal", "numeric")
             .addColumn("test", "commitTime", "spanner.commit_timestamp")
             .addColumn("test", "jsonbCol", "jsonb")
+            .addColumn("test", "uuidCol", "uuid")
             .build();
 
     assertEquals(1, schema.getTables().size());
-    assertEquals(5, schema.getColumns("test").size());
+    assertEquals(6, schema.getColumns("test").size());
     assertEquals(1, schema.getKeyParts("test").size());
     assertEquals(Type.timestamp(), schema.getColumns("test").get(3).getType());
+    assertEquals(Type.string(), schema.getColumns("test").get(5).getType());
   }
 
   @Test


### PR DESCRIPTION
Add support for UUID in `SpannerSchema.Column` class. This is needed to support UUID in Teleport.
R: @darshan-sj