### PR TITLE
add equals/hashCode to avoid coder warning

### DIFF
--- a/sdks/java/io/debezium/src/main/java/org/apache/beam/io/debezium/KafkaSourceConsumerFn.java
+++ b/sdks/java/io/debezium/src/main/java/org/apache/beam/io/debezium/KafkaSourceConsumerFn.java
@@ -375,7 +375,7 @@ public class KafkaSourceConsumerFn<T> extends DoFn<Map<String, String>, T> {
       }
       OffsetHolder otherOffset = (OffsetHolder) other;
       if (history == null) {
-        if (otherOffset.history != null) return false;
+        return otherOffset.history == null;
       } else {
         if (otherOffset.history == null) return false;
         if (history.size() != otherOffset.history.size()) {

--- a/sdks/java/io/debezium/src/main/java/org/apache/beam/io/debezium/KafkaSourceConsumerFn.java
+++ b/sdks/java/io/debezium/src/main/java/org/apache/beam/io/debezium/KafkaSourceConsumerFn.java
@@ -377,7 +377,9 @@ public class KafkaSourceConsumerFn<T> extends DoFn<Map<String, String>, T> {
       if (history == null) {
         return otherOffset.history == null;
       } else {
-        if (otherOffset.history == null) return false;
+        if (otherOffset.history == null) {
+          return false;
+        }
         if (history.size() != otherOffset.history.size()) {
           return false;
         }

--- a/sdks/java/io/debezium/src/main/java/org/apache/beam/io/debezium/KafkaSourceConsumerFn.java
+++ b/sdks/java/io/debezium/src/main/java/org/apache/beam/io/debezium/KafkaSourceConsumerFn.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import org.apache.beam.sdk.coders.Coder;
@@ -359,6 +360,24 @@ public class KafkaSourceConsumerFn<T> extends DoFn<Map<String, String>, T> {
         @Nullable List<?> history,
         @Nullable Integer fetchedRecords) {
       this(offset, history, fetchedRecords, null, -1L);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (!(other instanceof OffsetHolder)) {
+        return false;
+      }
+      OffsetHolder otherOffset = (OffsetHolder) other;
+      return Objects.equals(offset, otherOffset.offset)
+          && Objects.equals(history, otherOffset.history)
+          && Objects.equals(fetchedRecords, otherOffset.fetchedRecords)
+          && Objects.equals(maxRecords, otherOffset.maxRecords)
+          && Objects.equals(milisToRun, otherOffset.milisToRun);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(offset, history, fetchedRecords, maxRecords, milisToRun);
     }
   }
 

--- a/sdks/java/io/debezium/src/main/java/org/apache/beam/io/debezium/KafkaSourceConsumerFn.java
+++ b/sdks/java/io/debezium/src/main/java/org/apache/beam/io/debezium/KafkaSourceConsumerFn.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -37,6 +38,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -47,6 +49,9 @@ import org.apache.beam.sdk.transforms.splittabledofn.WatermarkEstimators;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Streams;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.hash.Hasher;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.hash.Hashing;
 import org.apache.kafka.connect.source.SourceConnector;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
@@ -73,7 +78,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>It might be initialized either as:
  *
- * <pre>KafkaSourceConsumerFn(connectorClass, SourceRecordMapper, maxRecords, milisecondsToRun)
+ * <pre>KafkaSourceConsumerFn(connectorClass, SourceRecordMapper, maxRecords, millisecondsToRun)
  * </pre>
  *
  * Or with a time limiter:
@@ -88,7 +93,7 @@ public class KafkaSourceConsumerFn<T> extends DoFn<Map<String, String>, T> {
   private final Class<? extends SourceConnector> connectorClass;
   private final SourceRecordMapper<T> fn;
 
-  private final Long milisecondsToRun;
+  private final Long millisecondsToRun;
   private final Integer maxRecords;
 
   private static DateTime startTime;
@@ -101,17 +106,18 @@ public class KafkaSourceConsumerFn<T> extends DoFn<Map<String, String>, T> {
    * @param connectorClass Supported Debezium connector class
    * @param fn a SourceRecordMapper
    * @param maxRecords Maximum number of records to fetch before finishing.
-   * @param milisecondsToRun Maximum time to run (in milliseconds)
+   * @param millisecondsToRun Maximum time to run (in milliseconds)
    */
+  @SuppressWarnings("unchecked")
   KafkaSourceConsumerFn(
       Class<?> connectorClass,
       SourceRecordMapper<T> fn,
       Integer maxRecords,
-      Long milisecondsToRun) {
+      Long millisecondsToRun) {
     this.connectorClass = (Class<? extends SourceConnector>) connectorClass;
     this.fn = fn;
     this.maxRecords = maxRecords;
-    this.milisecondsToRun = milisecondsToRun;
+    this.millisecondsToRun = millisecondsToRun;
   }
 
   /**
@@ -129,7 +135,7 @@ public class KafkaSourceConsumerFn<T> extends DoFn<Map<String, String>, T> {
   public OffsetHolder getInitialRestriction(@Element Map<String, String> unused)
       throws IOException {
     KafkaSourceConsumerFn.startTime = new DateTime();
-    return new OffsetHolder(null, null, null, this.maxRecords, this.milisecondsToRun);
+    return new OffsetHolder(null, null, null, this.maxRecords, this.millisecondsToRun);
   }
 
   @NewTracker
@@ -276,7 +282,7 @@ public class KafkaSourceConsumerFn<T> extends DoFn<Map<String, String>, T> {
     }
 
     long elapsedTime = System.currentTimeMillis() - KafkaSourceConsumerFn.startTime.getMillis();
-    if (milisecondsToRun != null && milisecondsToRun > 0 && elapsedTime >= milisecondsToRun) {
+    if (millisecondsToRun != null && millisecondsToRun > 0 && elapsedTime >= millisecondsToRun) {
       return ProcessContinuation.stop();
     } else {
       return ProcessContinuation.resume().withResumeDelay(Duration.standardSeconds(1));
@@ -337,27 +343,27 @@ public class KafkaSourceConsumerFn<T> extends DoFn<Map<String, String>, T> {
 
   static class OffsetHolder implements Serializable {
     public @Nullable Map<String, ?> offset;
-    public @Nullable List<?> history;
+    public @Nullable List<byte[]> history;
     public @Nullable Integer fetchedRecords;
     public @Nullable Integer maxRecords;
-    public final @Nullable Long milisToRun;
+    public final @Nullable Long millisToRun;
 
     OffsetHolder(
         @Nullable Map<String, ?> offset,
-        @Nullable List<?> history,
+        @Nullable List<byte[]> history,
         @Nullable Integer fetchedRecords,
         @Nullable Integer maxRecords,
-        @Nullable Long milisToRun) {
+        @Nullable Long millisToRun) {
       this.offset = offset;
       this.history = history == null ? new ArrayList<>() : history;
       this.fetchedRecords = fetchedRecords;
       this.maxRecords = maxRecords;
-      this.milisToRun = milisToRun;
+      this.millisToRun = millisToRun;
     }
 
     OffsetHolder(
         @Nullable Map<String, ?> offset,
-        @Nullable List<?> history,
+        @Nullable List<byte[]> history,
         @Nullable Integer fetchedRecords) {
       this(offset, history, fetchedRecords, null, -1L);
     }
@@ -368,16 +374,32 @@ public class KafkaSourceConsumerFn<T> extends DoFn<Map<String, String>, T> {
         return false;
       }
       OffsetHolder otherOffset = (OffsetHolder) other;
+      if (history == null) {
+        if (otherOffset.history != null) return false;
+      } else {
+        if (otherOffset.history == null) return false;
+        if (history.size() != otherOffset.history.size()) {
+          return false;
+        }
+        if (!Streams.zip(history.stream(), otherOffset.history.stream(), Arrays::equals)
+            .allMatch(Predicate.isEqual(true))) {
+          return false;
+        }
+      }
       return Objects.equals(offset, otherOffset.offset)
-          && Objects.equals(history, otherOffset.history)
           && Objects.equals(fetchedRecords, otherOffset.fetchedRecords)
           && Objects.equals(maxRecords, otherOffset.maxRecords)
-          && Objects.equals(milisToRun, otherOffset.milisToRun);
+          && Objects.equals(millisToRun, otherOffset.millisToRun);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(offset, history, fetchedRecords, maxRecords, milisToRun);
+      Hasher hasher = Hashing.goodFastHash(32).newHasher();
+      for (byte[] h : history) {
+        hasher.putInt(h.length);
+        hasher.putBytes(h);
+      }
+      return Objects.hash(offset, hasher.hash(), fetchedRecords, maxRecords, millisToRun);
     }
   }
 
@@ -414,7 +436,8 @@ public class KafkaSourceConsumerFn<T> extends DoFn<Map<String, String>, T> {
       int fetchedRecords =
           this.restriction.fetchedRecords == null ? 0 : this.restriction.fetchedRecords + 1;
       LOG.debug("------------Fetched records {} / {}", fetchedRecords, this.restriction.maxRecords);
-      LOG.debug("-------------- Time running: {} / {}", elapsedTime, (this.restriction.milisToRun));
+      LOG.debug(
+          "-------------- Time running: {} / {}", elapsedTime, (this.restriction.millisToRun));
       this.restriction.offset = position;
       this.restriction.fetchedRecords = fetchedRecords;
       LOG.debug("-------------- History: {}", this.restriction.history);
@@ -423,9 +446,9 @@ public class KafkaSourceConsumerFn<T> extends DoFn<Map<String, String>, T> {
       // the attempt to claim.
       // If we've reached neither, then we continue approve the claim.
       return (this.restriction.maxRecords == null || fetchedRecords < this.restriction.maxRecords)
-          && (this.restriction.milisToRun == null
-              || this.restriction.milisToRun == -1
-              || elapsedTime < this.restriction.milisToRun);
+          && (this.restriction.millisToRun == null
+              || this.restriction.millisToRun == -1
+              || elapsedTime < this.restriction.millisToRun);
     }
 
     @Override

--- a/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/KafkaSourceConsumerFnTest.java
+++ b/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/KafkaSourceConsumerFnTest.java
@@ -17,11 +17,14 @@
  */
 package org.apache.beam.io.debezium;
 
+import com.google.common.testing.EqualsTester;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.beam.io.debezium.KafkaSourceConsumerFn.OffsetHolder;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.MapCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
@@ -30,6 +33,8 @@ import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Charsets;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
 import org.apache.kafka.common.config.AbstractConfig;
@@ -50,6 +55,7 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class KafkaSourceConsumerFnTest implements Serializable {
+
   @Test
   public void testKafkaSourceConsumerFn() {
     Map<String, String> config =
@@ -105,7 +111,51 @@ public class KafkaSourceConsumerFnTest implements Serializable {
     pipeline.run().waitUntilFinish();
     Assert.assertEquals(1, CounterTask.getCountTasks());
   }
-}
+
+  @Test
+  public void testKafkaOffsetHolderEquality() {
+    EqualsTester tester = new EqualsTester();
+
+    HashMap<String, Integer> map = new HashMap<>();
+    map.put("a", 1);
+    map.put("b", 2);
+    ArrayList<byte[]> list = new ArrayList<>();
+    list.add("abc".getBytes(Charsets.US_ASCII));
+    list.add(new byte[0]);
+    tester.addEqualityGroup(
+        new OffsetHolder(
+            ImmutableMap.of("a", 1, "b", 2),
+            ImmutableList.of("abc".getBytes(Charsets.US_ASCII), new byte[0]),
+            1,
+            null,
+            -1L),
+        new OffsetHolder(map, list, 1, null, -1L),
+        new OffsetHolder(map, list, 1, null, -1L),
+        new OffsetHolder(map, list, 1));
+    tester.addEqualityGroup(new OffsetHolder(null, null, null, null, null));
+    tester.addEqualityGroup(
+        new OffsetHolder(
+            ImmutableMap.of("a", 1), ImmutableList.of("abc".getBytes(Charsets.US_ASCII)), 1));
+    tester.addEqualityGroup(
+        new OffsetHolder(
+            ImmutableMap.of("a", 1), ImmutableList.of("abc".getBytes(Charsets.US_ASCII)), 2));
+    tester.addEqualityGroup(
+        new OffsetHolder(
+            ImmutableMap.of("a", 1),
+            ImmutableList.of("abc".getBytes(Charsets.US_ASCII)),
+            1,
+            2,
+            null));
+    tester.addEqualityGroup(
+        new OffsetHolder(
+            ImmutableMap.of("a", 1),
+            ImmutableList.of("abc".getBytes(Charsets.US_ASCII)),
+            1,
+            3,
+            null));
+    tester.testEquals();
+  }
+};
 
 class CounterSourceConnector extends SourceConnector {
   public static class CounterSourceConnectorConfig extends AbstractConfig {

--- a/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/KafkaSourceConsumerFnTest.java
+++ b/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/KafkaSourceConsumerFnTest.java
@@ -33,7 +33,6 @@ import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Charsets;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
@@ -120,12 +119,12 @@ public class KafkaSourceConsumerFnTest implements Serializable {
     map.put("a", 1);
     map.put("b", 2);
     ArrayList<byte[]> list = new ArrayList<>();
-    list.add("abc".getBytes(Charsets.US_ASCII));
+    list.add("abc".getBytes(StandardCharsets.US_ASCII));
     list.add(new byte[0]);
     tester.addEqualityGroup(
         new OffsetHolder(
             ImmutableMap.of("a", 1, "b", 2),
-            ImmutableList.of("abc".getBytes(Charsets.US_ASCII), new byte[0]),
+            ImmutableList.of("abc".getBytes(StandardCharsets.US_ASCII), new byte[0]),
             1,
             null,
             -1L),
@@ -135,21 +134,25 @@ public class KafkaSourceConsumerFnTest implements Serializable {
     tester.addEqualityGroup(new OffsetHolder(null, null, null, null, null));
     tester.addEqualityGroup(
         new OffsetHolder(
-            ImmutableMap.of("a", 1), ImmutableList.of("abc".getBytes(Charsets.US_ASCII)), 1));
-    tester.addEqualityGroup(
-        new OffsetHolder(
-            ImmutableMap.of("a", 1), ImmutableList.of("abc".getBytes(Charsets.US_ASCII)), 2));
+            ImmutableMap.of("a", 1),
+            ImmutableList.of("abc".getBytes(StandardCharsets.US_ASCII)),
+            1));
     tester.addEqualityGroup(
         new OffsetHolder(
             ImmutableMap.of("a", 1),
-            ImmutableList.of("abc".getBytes(Charsets.US_ASCII)),
+            ImmutableList.of("abc".getBytes(StandardCharsets.US_ASCII)),
+            2));
+    tester.addEqualityGroup(
+        new OffsetHolder(
+            ImmutableMap.of("a", 1),
+            ImmutableList.of("abc".getBytes(StandardCharsets.US_ASCII)),
             1,
             2,
             null));
     tester.addEqualityGroup(
         new OffsetHolder(
             ImmutableMap.of("a", 1),
-            ImmutableList.of("abc".getBytes(Charsets.US_ASCII)),
+            ImmutableList.of("abc".getBytes(StandardCharsets.US_ASCII)),
             1,
             3,
             null));

--- a/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/KafkaSourceConsumerFnTest.java
+++ b/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/KafkaSourceConsumerFnTest.java
@@ -19,6 +19,7 @@ package org.apache.beam.io.debezium;
 
 import com.google.common.testing.EqualsTester;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;


### PR DESCRIPTION
Example warning
```
WARNING: Can't verify serialized elements of type OffsetHolder have well defined equals method. This may produce incorrect results on some PipelineRunner implementations
    Feb 20, 2025 11:02:40 AM org.apache.beam.sdk.util.MutationDetectors$CodedValueMutationDetector verifyUnmodifiedThrowingCheckedExceptions
    WARNING: Coder of type class org.apache.beam.sdk.coders.KvCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element KV{{topic=any, from=1, to=3, delay=0.2}, org.apache.beam.io.debezium.KafkaSourceConsumerFn$OffsetHolder@58983367}
    Feb 20, 2025 11:02:40 AM org.apache.beam.sdk.util.MutationDetectors$CodedValueMutationDetector verifyUnmodifiedThrowingCheckedExceptions
```
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
