### PR TITLE
add default port for HostAndPort instances used in Windmill

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/WindmillEndpoints.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/WindmillEndpoints.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
  */
 @AutoValue
 public abstract class WindmillEndpoints {
+  public static final int DEFAULT_WINDMILL_SERVICE_PORT = 443;
   private static final Logger LOG = LoggerFactory.getLogger(WindmillEndpoints.class);
   private static final WindmillEndpoints NO_ENDPOINTS =
       WindmillEndpoints.builder()
@@ -103,7 +104,8 @@ public abstract class WindmillEndpoints {
 
   private static Optional<HostAndPort> tryParseEndpointIntoHostAndPort(String directEndpoint) {
     try {
-      return Optional.of(HostAndPort.fromString(directEndpoint));
+      return Optional.of(
+          HostAndPort.fromString(directEndpoint).withDefaultPort(DEFAULT_WINDMILL_SERVICE_PORT));
     } catch (IllegalArgumentException e) {
       return Optional.empty();
     }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/WindmillChannelFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/WindmillChannelFactory.java
@@ -59,7 +59,6 @@ public final class WindmillChannelFactory {
       case GCP_SERVICE_ADDRESS:
         return remoteChannel(
             windmillServiceAddress.gcpServiceAddress(), windmillServiceRpcChannelTimeoutSec);
-      // switch is exhaustive will never happen.
       case AUTHENTICATED_GCP_SERVICE_ADDRESS:
         return remoteDirectChannel(
             windmillServiceAddress.authenticatedGcpServiceAddress(),
@@ -130,9 +129,7 @@ public final class WindmillChannelFactory {
   private static class WindmillChannelCreationException extends IllegalStateException {
     private WindmillChannelCreationException(HostAndPort endpoint, SSLException sourceException) {
       super(
-          String.format(
-              "Exception thrown when trying to create channel to endpoint={host:%s; port:%d}",
-              endpoint.getHost(), endpoint.hasPort() ? endpoint.getPort() : -1),
+          String.format("Exception thrown when trying to create channel to %s", endpoint),
           sourceException);
     }
   }


### PR DESCRIPTION
`HostAndPort#getPort` throws an `IllegalStateException` if `getPort` is called w/o a port set. 

Supply a default port in these cases. `443` is currently the default port specified in `DataflowStreamingPipelineOptions`

r: @scwhittle @acrites 

example error:
<img width="1126" alt="Screenshot 2025-02-24 at 7 43 33 PM" src="https://github.com/user-attachments/assets/cc2a1d44-9a79-4b22-ac0c-79dc919e9bb1" />


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
