### PR TITLE
Allow users to specify custom audit entries in pipeline options.

### DIFF
--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -29,6 +29,7 @@ https://github.com/apache/beam/blob/master/sdks/python/OWNERS
 
 # pytype: skip-file
 
+import ast
 import logging
 import re
 import time
@@ -125,14 +126,32 @@ def create_storage_client(pipeline_options, use_credentials=True):
     from google.api_core import client_info
     beam_client_info = client_info.ClientInfo(
         user_agent="apache-beam/%s (GPN:Beam)" % beam_version.__version__)
+
+    # Note: Custom audit entries with "job" key will overwrite this default.
+    extra_headers = {
+        "x-goog-custom-audit-job": google_cloud_options.job_name
+        if google_cloud_options.job_name else "UNKNOWN"
+    }
+
+    if google_cloud_options.custom_audit_entries is not None:
+      for entry in google_cloud_options.custom_audit_entries:
+        if entry.startswith('{'):
+          # in the format of {'key': value'}
+          sub_entries = ast.literal_eval(entry)
+          for key, value in sub_entries.items():
+            extra_headers[f"x-goog-custom-audit-{key}"] = value
+        else:
+          # in the format of 'key=value'
+          parts = entry.split('=', 1)
+          key = parts[0]
+          value = parts[1] if len(parts) > 1 else ''
+          extra_headers[f"x-goog-custom-audit-{key}"] = value
+
     return storage.Client(
         credentials=credentials.get_google_auth_credentials(),
         project=google_cloud_options.project,
         client_info=beam_client_info,
-        extra_headers={
-            "x-goog-custom-audit-job": google_cloud_options.job_name
-            if google_cloud_options.job_name else "UNKNOWN"
-        })
+        extra_headers=extra_headers)
   else:
     return storage.Client.create_anonymous_client()
 

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -29,7 +29,6 @@ https://github.com/apache/beam/blob/master/sdks/python/OWNERS
 
 # pytype: skip-file
 
-import ast
 import logging
 import re
 import time

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -127,25 +127,14 @@ def create_storage_client(pipeline_options, use_credentials=True):
     beam_client_info = client_info.ClientInfo(
         user_agent="apache-beam/%s (GPN:Beam)" % beam_version.__version__)
 
-    # Note: Custom audit entries with "job" key will overwrite this default.
     extra_headers = {
         "x-goog-custom-audit-job": google_cloud_options.job_name
         if google_cloud_options.job_name else "UNKNOWN"
     }
 
-    if google_cloud_options.custom_audit_entries is not None:
-      for entry in google_cloud_options.custom_audit_entries:
-        if entry.startswith('{'):
-          # in the format of {'key': value'}
-          sub_entries = ast.literal_eval(entry)
-          for key, value in sub_entries.items():
-            extra_headers[f"x-goog-custom-audit-{key}"] = value
-        else:
-          # in the format of 'key=value'
-          parts = entry.split('=', 1)
-          key = parts[0]
-          value = parts[1] if len(parts) > 1 else ''
-          extra_headers[f"x-goog-custom-audit-{key}"] = value
+    # Note: Custom audit entries with "job" key will overwrite the default above
+    if google_cloud_options.gcs_custom_audit_entries is not None:
+      extra_headers.update(google_cloud_options.gcs_custom_audit_entries)
 
     return storage.Client(
         credentials=credentials.get_google_auth_credentials(),

--- a/sdks/python/apache_beam/io/gcp/gcsio_test.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio_test.py
@@ -715,9 +715,8 @@ class TestGCSIO(unittest.TestCase):
 
     options = PipelineOptions([
         "--job_name=test-job-name",
-        "--custom-audit-entry=user=test-user-id",
-        "--custom-audit-entry=work=test-work-id",
-        "--custom-audit-entries={'id': '1234', \"status\": \"ok\"}"
+        "--gcs-custom-audit-entry=user=test-user-id",
+        "--gcs-custom-audit-entries={\"id\": \"1234\", \"status\": \"ok\"}"
     ])
 
     gcs = gcsio.GcsIO(pipeline_options=options)
@@ -741,7 +740,6 @@ class TestGCSIO(unittest.TestCase):
     self.assertIn(beam_user_agent, actual_headers['User-Agent'])
     self.assertEqual(actual_headers['x-goog-custom-audit-job'], 'test-job-name')
     self.assertEqual(actual_headers['x-goog-custom-audit-user'], 'test-user-id')
-    self.assertEqual(actual_headers['x-goog-custom-audit-work'], 'test-work-id')
     self.assertEqual(actual_headers['x-goog-custom-audit-id'], '1234')
     self.assertEqual(actual_headers['x-goog-custom-audit-status'], 'ok')
 

--- a/sdks/python/apache_beam/io/gcp/gcsio_test.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio_test.py
@@ -715,8 +715,8 @@ class TestGCSIO(unittest.TestCase):
 
     options = PipelineOptions([
         "--job_name=test-job-name",
-        "--gcs-custom-audit-entry=user=test-user-id",
-        "--gcs-custom-audit-entries={\"id\": \"1234\", \"status\": \"ok\"}"
+        "--gcs_custom_audit_entry=user=test-user-id",
+        "--gcs_custom_audit_entries={\"id\": \"1234\", \"status\": \"ok\"}"
     ])
 
     gcs = gcsio.GcsIO(pipeline_options=options)

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -951,6 +951,16 @@ class GoogleCloudOptions(PipelineOptions):
         action='store_true',
         help='Use blob generation when mutating blobs in GCSIO to '
         'mitigate race conditions at the cost of more HTTP requests.')
+    parser.add_argument(
+        '--custom-audit-entry',
+        '--custom-audit-entries',
+        dest='custom_audit_entries',
+        action='append',
+        default=None,
+        help='Custom information to be attached to audit logs. '
+        'Entries are key value pairs separated by = '
+        '(e.g. --custom-audit-entry key=value) or '
+        '(--custom-audit-entries=\'{ "user": "test", "id": "1234" }\').')
 
   def _create_default_gcs_bucket(self):
     try:

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -150,6 +150,16 @@ class _DictUnionAction(argparse.Action):
 
 
 class _GcsCustomAuditEntriesAction(argparse.Action):
+  """
+  Argparse Action for GCS custom audit entries.
+
+  According to Google Cloud Storage audit logging documentation
+  (https://cloud.google.com/storage/docs/audit-logging#add-custom-metadata), the
+  following limitations apply:
+  - keys must be 64 characters or less,
+  - values 1,200 characters or less, and
+  - a maximum of four custom metadata entries are permitted per request.
+  """
   MAX_KEY_LENGTH = 64
   MAX_VALUE_LENGTH = 1200
   MAX_ENTRIES = 4

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -176,13 +176,13 @@ class _GcsCustomAuditEntriesAction(argparse.Action):
     if len(key) > _GcsCustomAuditEntriesAction.MAX_KEY_LENGTH:
       raise argparse.ArgumentError(
           None,
-          "The key '%s' in gcs-custom-audit-entries exceeds the %d-character limit."  # pylint: disable=line-too-long
+          "The key '%s' in GCS custom audit entries exceeds the %d-character limit."  # pylint: disable=line-too-long
           % (key, _GcsCustomAuditEntriesAction.MAX_KEY_LENGTH))
 
     if len(value) > _GcsCustomAuditEntriesAction.MAX_VALUE_LENGTH:
       raise argparse.ArgumentError(
           None,
-          "The value '%s' in gcs-custom-audit-entries exceeds the %d-character limit."  # pylint: disable=line-too-long
+          "The value '%s' in GCS custom audit entries exceeds the %d-character limit."  # pylint: disable=line-too-long
           % (value, _GcsCustomAuditEntriesAction.MAX_VALUE_LENGTH))
 
     self._custom_audit_entries[f"x-goog-custom-audit-{key}"] = value
@@ -193,13 +193,13 @@ class _GcsCustomAuditEntriesAction(argparse.Action):
       setattr(namespace, self.dest, {})
       self._custom_audit_entries = getattr(namespace, self.dest)
 
-    if option_string == '--gcs-custom-audit-entries':
+    if option_string == '--gcs_custom_audit_entries':
       # in the format of {"key": "value"}
       assert (isinstance(values, str))
       sub_entries = json.loads(values)
       for key, value in sub_entries.items():
         self._add_entry(key, value)
-    else:  # option_string == '--gcs-custom-audit-entry'
+    else:  # option_string == '--gcs_custom_audit_entry'
       # in the format of 'key=value'
       assert (isinstance(values, str))
       parts = values.split('=', 1)
@@ -210,7 +210,7 @@ class _GcsCustomAuditEntriesAction(argparse.Action):
     if self._exceed_entry_limit():
       raise argparse.ArgumentError(
           None,
-          "The maximum allowed number of gcs-custom-audit-entries (including the default x-goo-custom-audit-job) is %d."  # pylint: disable=line-too-long
+          "The maximum allowed number of GCS custom audit entries (including the default x-goo-custom-audit-job) is %d."  # pylint: disable=line-too-long
           % _GcsCustomAuditEntriesAction.MAX_ENTRIES)
 
 
@@ -1017,15 +1017,15 @@ class GoogleCloudOptions(PipelineOptions):
         help='Use blob generation when mutating blobs in GCSIO to '
         'mitigate race conditions at the cost of more HTTP requests.')
     parser.add_argument(
-        '--gcs-custom-audit-entry',
-        '--gcs-custom-audit-entries',
+        '--gcs_custom_audit_entry',
+        '--gcs_custom_audit_entries',
         dest='gcs_custom_audit_entries',
         action=_GcsCustomAuditEntriesAction,
         default=None,
         help='Custom information to be attached to audit logs. '
         'Entries are key value pairs separated by = '
-        '(e.g. --gcs-custom-audit-entry key=value) or a JSON string '
-        '(e.g. --gcs-custom-audit-entries=\'{ "user": "test", "id": "12" }\').')
+        '(e.g. --gcs_custom_audit_entry key=value) or a JSON string '
+        '(e.g. --gcs_custom_audit_entries=\'{ "user": "test", "id": "12" }\').')
 
   def _create_default_gcs_bucket(self):
     try:

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -1014,7 +1014,7 @@ class GoogleCloudOptions(PipelineOptions):
         default=None,
         help='Custom information to be attached to audit logs. '
         'Entries are key value pairs separated by = '
-        '(e.g. --gcs-custom-audit-entry key=value) or a JSON string git '
+        '(e.g. --gcs-custom-audit-entry key=value) or a JSON string '
         '(e.g. --gcs-custom-audit-entries=\'{ "user": "test", "id": "12" }\').')
 
   def _create_default_gcs_bucket(self):

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -149,6 +149,61 @@ class _DictUnionAction(argparse.Action):
     getattr(namespace, self.dest).update(values)
 
 
+class _GcsCustomAuditEntriesAction(argparse.Action):
+  MAX_KEY_LENGTH = 64
+  MAX_VALUE_LENGTH = 1200
+  MAX_ENTRIES = 4
+
+  def _exceed_entry_limit(self):
+    if 'x-goog-custom-audit-job' in self._custom_audit_entries:
+      return len(
+          self._custom_audit_entries) > _GcsCustomAuditEntriesAction.MAX_ENTRIES
+    else:
+      return len(self._custom_audit_entries) > (
+          _GcsCustomAuditEntriesAction.MAX_ENTRIES - 1)
+
+  def _add_entry(self, key, value):
+    if len(key) > _GcsCustomAuditEntriesAction.MAX_KEY_LENGTH:
+      raise argparse.ArgumentError(
+          None,
+          "The key '%s' in gcs-custom-audit-entries exceeds the %d-character limit."  # pylint: disable=line-too-long
+          % (key, _GcsCustomAuditEntriesAction.MAX_KEY_LENGTH))
+
+    if len(value) > _GcsCustomAuditEntriesAction.MAX_VALUE_LENGTH:
+      raise argparse.ArgumentError(
+          None,
+          "The value '%s' in gcs-custom-audit-entries exceeds the %d-character limit."  # pylint: disable=line-too-long
+          % (value, _GcsCustomAuditEntriesAction.MAX_VALUE_LENGTH))
+
+    self._custom_audit_entries[f"x-goog-custom-audit-{key}"] = value
+
+  def __call__(self, parser, namespace, values, option_string=None):
+    if not hasattr(namespace,
+                   self.dest) or getattr(namespace, self.dest) is None:
+      setattr(namespace, self.dest, {})
+      self._custom_audit_entries = getattr(namespace, self.dest)
+
+    if option_string == '--gcs-custom-audit-entries':
+      # in the format of {"key": "value"}
+      assert (isinstance(values, str))
+      sub_entries = json.loads(values)
+      for key, value in sub_entries.items():
+        self._add_entry(key, value)
+    else:  # option_string == '--gcs-custom-audit-entry'
+      # in the format of 'key=value'
+      assert (isinstance(values, str))
+      parts = values.split('=', 1)
+      key = parts[0]
+      value = parts[1] if len(parts) > 1 else ''
+      self._add_entry(key, value)
+
+    if self._exceed_entry_limit():
+      raise argparse.ArgumentError(
+          None,
+          "The maximum allowed number of gcs-custom-audit-entries (including the default x-goo-custom-audit-job) is %d."  # pylint: disable=line-too-long
+          % _GcsCustomAuditEntriesAction.MAX_ENTRIES)
+
+
 class PipelineOptions(HasDisplayData):
   """This class and subclasses are used as containers for command line options.
 
@@ -952,15 +1007,15 @@ class GoogleCloudOptions(PipelineOptions):
         help='Use blob generation when mutating blobs in GCSIO to '
         'mitigate race conditions at the cost of more HTTP requests.')
     parser.add_argument(
-        '--custom-audit-entry',
-        '--custom-audit-entries',
-        dest='custom_audit_entries',
-        action='append',
+        '--gcs-custom-audit-entry',
+        '--gcs-custom-audit-entries',
+        dest='gcs_custom_audit_entries',
+        action=_GcsCustomAuditEntriesAction,
         default=None,
         help='Custom information to be attached to audit logs. '
         'Entries are key value pairs separated by = '
-        '(e.g. --custom-audit-entry key=value) or '
-        '(--custom-audit-entries=\'{ "user": "test", "id": "1234" }\').')
+        '(e.g. --gcs-custom-audit-entry key=value) or a JSON string git '
+        '(e.g. --gcs-custom-audit-entries=\'{ "user": "test", "id": "12" }\').')
 
   def _create_default_gcs_bucket(self):
     try:

--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -19,7 +19,6 @@
 
 # pytype: skip-file
 
-import argparse
 import json
 import logging
 import os

--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -725,9 +725,9 @@ class PipelineOptionsTest(unittest.TestCase):
 
   def test_gcs_custom_audit_entries(self):
     options = PipelineOptions([
-        '--gcs-custom-audit-entry=user=test-user',
-        '--gcs-custom-audit-entry=work=test-work',
-        '--gcs-custom-audit-entries={"job":"test-job", "id":"1234"}'
+        '--gcs_custom_audit_entry=user=test-user',
+        '--gcs_custom_audit_entry=work=test-work',
+        '--gcs_custom_audit_entries={"job":"test-job", "id":"1234"}'
     ])
     entries = options.view_as(GoogleCloudOptions).gcs_custom_audit_entries
     self.assertDictEqual(
@@ -742,7 +742,7 @@ class PipelineOptionsTest(unittest.TestCase):
   @mock.patch('apache_beam.options.pipeline_options._BeamArgumentParser.error')
   def test_gcs_custom_audit_entries_with_errors(self, mock_error):
     long_key = 'a' * 65
-    options = PipelineOptions([f'--gcs-custom-audit-entry={long_key}=1'])
+    options = PipelineOptions([f'--gcs_custom_audit_entry={long_key}=1'])
     _ = options.view_as(GoogleCloudOptions).gcs_custom_audit_entries
     self.assertRegex(
         mock_error.call_args[0][0],
@@ -751,7 +751,7 @@ class PipelineOptionsTest(unittest.TestCase):
     mock_error.reset_mock()
 
     long_value = 'b' * 1201
-    options = PipelineOptions([f'--gcs-custom-audit-entry=key={long_value}'])
+    options = PipelineOptions([f'--gcs_custom_audit_entry=key={long_value}'])
     _ = options.view_as(GoogleCloudOptions).gcs_custom_audit_entries
     self.assertRegex(
         mock_error.call_args[0][0],
@@ -760,29 +760,29 @@ class PipelineOptionsTest(unittest.TestCase):
     mock_error.reset_mock()
 
     options = PipelineOptions([
-        '--gcs-custom-audit-entry=a=1',
-        '--gcs-custom-audit-entry=b=2',
-        '--gcs-custom-audit-entry=c=3',
-        '--gcs-custom-audit-entry=d=4',
-        '--gcs-custom-audit-entry=job=test-job'
+        '--gcs_custom_audit_entry=a=1',
+        '--gcs_custom_audit_entry=b=2',
+        '--gcs_custom_audit_entry=c=3',
+        '--gcs_custom_audit_entry=d=4',
+        '--gcs_custom_audit_entry=job=test-job'
     ])
     _ = options.view_as(GoogleCloudOptions).gcs_custom_audit_entries
     self.assertRegex(
         mock_error.call_args[0][0],
-        'The maximum allowed number of gcs-custom-audit-entries .*')
+        'The maximum allowed number of GCS custom audit entries .*')
 
     mock_error.reset_mock()
 
     options = PipelineOptions([
-        '--gcs-custom-audit-entry=a=1',
-        '--gcs-custom-audit-entry=b=2',
-        '--gcs-custom-audit-entry=c=3',
-        '--gcs-custom-audit-entry=d=4'
+        '--gcs_custom_audit_entry=a=1',
+        '--gcs_custom_audit_entry=b=2',
+        '--gcs_custom_audit_entry=c=3',
+        '--gcs_custom_audit_entry=d=4'
     ])
     _ = options.view_as(GoogleCloudOptions).gcs_custom_audit_entries
     self.assertRegex(
         mock_error.call_args[0][0],
-        'The maximum allowed number of gcs-custom-audit-entries .*')
+        'The maximum allowed number of GCS custom audit entries .*')
 
   def _check_errors(self, options, validator, expected):
     if has_gcsio:


### PR DESCRIPTION
Users can use pipeline options `--gcs-custom-audit-entry` or `--gcs-custom-audit-entries` to specify custom information that will be attached to audit logs.

For example, when a user specifies an entry with of `key:value`, a header entry of `x-goog-custom-audit-key:value` will be included in the request.

See https://cloud.google.com/storage/docs/audit-logging#add-custom-metadata for more details.

(Internal bug id: 398744411)