### PR TITLE
Spark Runner : Replace queueStream with custom DStream in Spark streaming Flatten transform

### DIFF
--- a/.github/trigger_files/beam_PostCommit_Java_ValidatesRunner_Spark.json
+++ b/.github/trigger_files/beam_PostCommit_Java_ValidatesRunner_Spark.json
@@ -4,5 +4,6 @@
   "https://github.com/apache/beam/pull/31798": "noting that PR #31798 should run this test",
   "https://github.com/apache/beam/pull/32546": "noting that PR #32546 should run this test",
   "https://github.com/apache/beam/pull/33267": "noting that PR #33267 should run this test",
-  "https://github.com/apache/beam/pull/33322": "noting that PR #33322 should run this test"
+  "https://github.com/apache/beam/pull/33322": "noting that PR #33322 should run this test",
+  "https://github.com/apache/beam/pull/34080": "noting that PR #34080 should run this test"
 }

--- a/.github/trigger_files/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming.json
+++ b/.github/trigger_files/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming.json
@@ -3,5 +3,6 @@
   "https://github.com/apache/beam/pull/31156": "noting that PR #31156 should run this test",
   "https://github.com/apache/beam/pull/31798": "noting that PR #31798 should run this test",
   "https://github.com/apache/beam/pull/32546": "noting that PR #32546 should run this test",
-  "https://github.com/apache/beam/pull/33267": "noting that PR #33267 should run this test"
+  "https://github.com/apache/beam/pull/33267": "noting that PR #33267 should run this test",
+  "https://github.com/apache/beam/pull/34080": "noting that PR #34080 should run this test"
 }

--- a/.github/trigger_files/beam_PostCommit_Java_ValidatesRunner_Spark_Java11.json
+++ b/.github/trigger_files/beam_PostCommit_Java_ValidatesRunner_Spark_Java11.json
@@ -4,5 +4,6 @@
   "https://github.com/apache/beam/pull/31798": "noting that PR #31798 should run this test",
   "https://github.com/apache/beam/pull/32546": "noting that PR #32546 should run this test",
   "https://github.com/apache/beam/pull/33267": "noting that PR #33267 should run this test",
-  "https://github.com/apache/beam/pull/33322": "noting that PR #33322 should run this test"
+  "https://github.com/apache/beam/pull/33322": "noting that PR #33322 should run this test",
+  "https://github.com/apache/beam/pull/34080": "noting that PR #34080 should run this test"
 }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/TestSparkPipelineOptions.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/TestSparkPipelineOptions.java
@@ -35,7 +35,8 @@ public interface TestSparkPipelineOptions extends SparkPipelineOptions, TestPipe
   void setForceStreaming(boolean forceStreaming);
 
   @Description("A hard-coded expected number of assertions for this test pipeline.")
-  @Nullable Integer getExpectedAssertions();
+  @Nullable
+  Integer getExpectedAssertions();
 
   void setExpectedAssertions(Integer expectedAssertions);
 

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/TestSparkPipelineOptions.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/TestSparkPipelineOptions.java
@@ -35,8 +35,7 @@ public interface TestSparkPipelineOptions extends SparkPipelineOptions, TestPipe
   void setForceStreaming(boolean forceStreaming);
 
   @Description("A hard-coded expected number of assertions for this test pipeline.")
-  @Nullable
-  Integer getExpectedAssertions();
+  @Nullable Integer getExpectedAssertions();
 
   void setExpectedAssertions(Integer expectedAssertions);
 
@@ -47,6 +46,12 @@ public interface TestSparkPipelineOptions extends SparkPipelineOptions, TestPipe
   Long getStopPipelineWatermark();
 
   void setStopPipelineWatermark(Long stopPipelineWatermark);
+
+  @Description("Whether to delete the checkpoint directory after the pipeline execution.")
+  @Default.Boolean(true)
+  boolean isDeleteCheckpointDir();
+
+  void setDeleteCheckpointDir(boolean deleteCheckpointDir);
 
   /**
    * A factory to provide the default watermark to stop a pipeline that reads from an unbounded

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/TestSparkRunner.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/TestSparkRunner.java
@@ -106,8 +106,10 @@ public final class TestSparkRunner extends PipelineRunner<SparkPipelineResult> {
             isOneOf(PipelineResult.State.STOPPED, PipelineResult.State.DONE));
       } finally {
         try {
-          // cleanup checkpoint dir.
-          FileUtils.deleteDirectory(new File(testSparkOptions.getCheckpointDir()));
+          if (testSparkOptions.isDeleteCheckpointDir()) {
+            // cleanup checkpoint dir.
+            FileUtils.deleteDirectory(new File(testSparkOptions.getCheckpointDir()));
+          }
         } catch (IOException e) {
           throw new RuntimeException("Failed to clear checkpoint tmp dir.", e);
         }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SingleEmitInputDStream.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SingleEmitInputDStream.java
@@ -23,9 +23,6 @@ import org.apache.spark.streaming.StreamingContext;
 import org.apache.spark.streaming.Time;
 import org.apache.spark.streaming.dstream.ConstantInputDStream;
 import org.apache.spark.streaming.dstream.QueueInputDStream;
-import org.joda.time.Instant;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import scala.Option;
 
 /**
@@ -44,8 +41,6 @@ import scala.Option;
  */
 public class SingleEmitInputDStream<T> extends ConstantInputDStream<T> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(SingleEmitInputDStream.class);
-
   private boolean emitted = false;
 
   public SingleEmitInputDStream(StreamingContext ssc, RDD<T> rdd) {
@@ -55,11 +50,9 @@ public class SingleEmitInputDStream<T> extends ConstantInputDStream<T> {
   @Override
   public Option<RDD<T>> compute(Time validTime) {
     if (this.emitted) {
-      LOG.info("{} already emitted.", getClass().getSimpleName());
       return Option.apply(this.emptyRDD());
     } else {
       this.emitted = true;
-      LOG.info("{} emitted at1 {}", getClass().getSimpleName(), Instant.now());
       return super.compute(validTime);
     }
   }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SingleEmitInputDStream.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SingleEmitInputDStream.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.spark.translation;
+
+import org.apache.spark.api.java.JavaSparkContext$;
+import org.apache.spark.rdd.RDD;
+import org.apache.spark.streaming.StreamingContext;
+import org.apache.spark.streaming.Time;
+import org.apache.spark.streaming.dstream.ConstantInputDStream;
+import org.apache.spark.streaming.dstream.QueueInputDStream;
+import org.joda.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Option;
+
+/**
+ * A specialized {@link ConstantInputDStream} that emits its RDD exactly once. Alternative to {@link
+ * QueueInputDStream} when checkpointing is required.
+ *
+ * <p>Features:
+ *
+ * <ul>
+ *   <li>Supports checkpointing
+ *   <li>Guarantees single emission of data
+ *   <li>Returns empty RDD after first emission
+ * </ul>
+ *
+ * @param <T> The type of elements in the RDD
+ */
+public class SingleEmitInputDStream<T> extends ConstantInputDStream<T> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SingleEmitInputDStream.class);
+
+  private boolean emitted = false;
+
+  public SingleEmitInputDStream(StreamingContext ssc, RDD<T> rdd) {
+    super(ssc, rdd, JavaSparkContext$.MODULE$.fakeClassTag());
+  }
+
+  @Override
+  public Option<RDD<T>> compute(Time validTime) {
+    if (this.emitted) {
+      LOG.info("{} already emitted.", getClass().getSimpleName());
+      return Option.apply(this.emptyRDD());
+    } else {
+      this.emitted = true;
+      LOG.info("{} emitted at1 {}", getClass().getSimpleName(), Instant.now());
+      return super.compute(validTime);
+    }
+  }
+
+  private RDD<T> emptyRDD() {
+    return this.context().sparkContext().emptyRDD(JavaSparkContext$.MODULE$.fakeClassTag());
+  }
+}

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/SingleEmitInputDStreamTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/SingleEmitInputDStreamTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.spark.translation;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItems;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.List;
+import org.apache.beam.runners.spark.SparkContextRule;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.JavaSparkContext$;
+import org.apache.spark.rdd.RDD;
+import org.apache.spark.streaming.Duration;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import scala.Option;
+
+/**
+ * Tests for {@link SingleEmitInputDStream} class which ensures data is emitted exactly once in
+ * Spark streaming context.
+ */
+public class SingleEmitInputDStreamTest implements Serializable {
+  @ClassRule public static SparkContextRule sparkContext = new SparkContextRule();
+  @Rule public transient TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private final Duration checkpointDuration = new Duration(500L);
+
+  /** Creates a temporary directory for storing checkpoints before each test execution. */
+  @Before
+  public void init() {
+    try {
+      temporaryFolder.create();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void singleEmitInputDStreamShouldBeEmitOnlyOnce() {
+    // Initialize Spark contexts
+    JavaSparkContext jsc = sparkContext.getSparkContext();
+    JavaStreamingContext jssc = new JavaStreamingContext(jsc, checkpointDuration);
+
+    // Create test data and wrap it in SingleEmitInputDStream
+    final SingleEmitInputDStream<String> singleEmitInputDStream = singleEmitInputDSTream(jsc, jssc);
+    singleEmitInputDStream.checkpoint(checkpointDuration);
+
+    // First computation: should return the original data
+    Option<RDD<String>> rddOption = singleEmitInputDStream.compute(null);
+    RDD<String> rdd = rddOption.get();
+    JavaRDD<String> javaRDD = JavaRDD.fromRDD(rdd, JavaSparkContext$.MODULE$.fakeClassTag());
+    List<String> collect = javaRDD.collect();
+    assertNotNull(collect);
+    assertThat(collect, hasItems("foo", "bar"));
+
+    // Second computation: should return empty RDD since data was already emitted
+    rddOption = singleEmitInputDStream.compute(null);
+    rdd = rddOption.get();
+    javaRDD = JavaRDD.fromRDD(rdd, JavaSparkContext$.MODULE$.fakeClassTag());
+    collect = javaRDD.collect();
+    assertNotNull(collect);
+    assertThat(collect, empty());
+  }
+
+  private SingleEmitInputDStream<String> singleEmitInputDSTream(
+      JavaSparkContext jsc, JavaStreamingContext jssc) {
+    final JavaRDD<String> stringRDD = jsc.parallelize(Lists.newArrayList("foo", "bar"));
+    final SingleEmitInputDStream<String> singleEmitInputDStream =
+        new SingleEmitInputDStream<>(jssc.ssc(), stringRDD.rdd());
+    return singleEmitInputDStream;
+  }
+
+  @Test
+  public void singleEmitInputDStreamShouldBeEmptyAfterCheckpointRecovery()
+      throws InterruptedException {
+    // Set up checkpoint directory
+    String checkpointPath = temporaryFolder.getRoot().getPath();
+
+    // Initialize Spark contexts with checkpoint configuration
+    JavaSparkContext jsc = sparkContext.getSparkContext();
+    jsc.setCheckpointDir(checkpointPath);
+    JavaStreamingContext jssc = new JavaStreamingContext(jsc, checkpointDuration);
+    jssc.checkpoint(checkpointPath);
+
+    // Create test data and configure SingleEmitInputDStream
+    final SingleEmitInputDStream<String> singleEmitInputDStream = singleEmitInputDSTream(jsc, jssc);
+    singleEmitInputDStream.checkpoint(checkpointDuration);
+
+    // Register output operation required by Spark Streaming
+    singleEmitInputDStream.print();
+
+    // Compute initial RDD and verify original data is present
+    Option<RDD<String>> rddOption = singleEmitInputDStream.compute(null);
+    RDD<String> rdd = rddOption.get();
+
+    JavaRDD<String> javaRDD = JavaRDD.fromRDD(rdd, JavaSparkContext$.MODULE$.fakeClassTag());
+    List<String> collect = javaRDD.collect();
+    assertNotNull(collect);
+    assertThat(collect, hasItems("foo", "bar"));
+
+    // Start streaming context to create checkpoint data
+    jssc.start();
+    // Wait for checkpoint to be created and written
+    jssc.awaitTerminationOrTimeout(1000);
+    // Ensure clean shutdown and checkpoint writing
+    jssc.stop(true, true);
+
+    // Recover streaming context from checkpoint
+    JavaStreamingContext recoveredJssc =
+        JavaStreamingContext.getOrCreate(
+            checkpointPath,
+            () -> {
+              throw new RuntimeException(
+                  "Should not create new context, should recover from checkpoint");
+            });
+
+    try {
+      // Extract recovered DStream from the restored context
+      @SuppressWarnings("unchecked")
+      SingleEmitInputDStream<String> recoveredDStream =
+          (SingleEmitInputDStream<String>) recoveredJssc.ssc().graph().getInputStreams()[0];
+
+      // Compute RDD from recovered DStream and verify it's empty
+      Option<RDD<String>> recoveredRddOption = recoveredDStream.compute(null);
+      RDD<String> recoveredRdd = recoveredRddOption.get();
+      JavaRDD<String> recoveredJavaRdd =
+          JavaRDD.fromRDD(recoveredRdd, JavaSparkContext$.MODULE$.fakeClassTag());
+      List<String> recoveredCollect = recoveredJavaRdd.collect();
+
+      // Verify that recovered DStream produces empty results
+      assertNotNull(recoveredCollect);
+      assertThat(recoveredCollect, empty());
+
+    } finally {
+      // Ensure recovered context is properly cleaned up
+      recoveredJssc.stop(true, true);
+    }
+  }
+}

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/StreamingTransformTranslatorTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/StreamingTransformTranslatorTest.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.spark.translation.streaming;
+
+import static org.apache.beam.sdk.metrics.MetricResultsMatchers.attemptedMetricsResult;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+
+import java.io.IOException;
+import java.io.Serializable;
+import org.apache.beam.runners.spark.StreamingTest;
+import org.apache.beam.runners.spark.TestSparkPipelineOptions;
+import org.apache.beam.runners.spark.TestSparkRunner;
+import org.apache.beam.runners.spark.UsesCheckpointRecovery;
+import org.apache.beam.runners.spark.io.MicrobatchSource;
+import org.apache.beam.runners.spark.metrics.MetricsAccumulator;
+import org.apache.beam.runners.spark.util.GlobalWatermarkHolder;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.io.GenerateSequence;
+import org.apache.beam.sdk.metrics.Distribution;
+import org.apache.beam.sdk.metrics.DistributionResult;
+import org.apache.beam.sdk.metrics.MetricNameFilter;
+import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.beam.sdk.metrics.MetricsFilter;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.Flatten;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.WithTimestamps;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Optional;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+
+/** Test suite for {@link StreamingTransformTranslator}. */
+public class StreamingTransformTranslatorTest implements Serializable {
+
+  @Rule public transient TemporaryFolder temporaryFolder = new TemporaryFolder();
+  public transient Pipeline p;
+
+  /** Creates a temporary directory for storing checkpoints before each test execution. */
+  @Before
+  public void init() {
+    try {
+      temporaryFolder.create();
+      System.out.println("Checkpoint Directory = " + temporaryFolder.getRoot().getPath());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Tests that Flatten transform of Bounded and Unbounded PCollections correctly recovers from
+   * checkpoint.
+   *
+   * <p>Test scenario:
+   *
+   * <ol>
+   *   <li>First run:
+   *       <ul>
+   *         <li>Flattens Bounded PCollection(0-9) with Unbounded PCollection
+   *         <li>Stops pipeline after 400ms
+   *         <li>Validates metrics results
+   *       </ul>
+   *   <li>Second run (recovery from checkpoint):
+   *       <ul>
+   *         <li>Recovers from previous state and continues execution
+   *         <li>Stops pipeline after 1 second
+   *         <li>Validates accumulated metrics results
+   *       </ul>
+   * </ol>
+   */
+  @Category({UsesCheckpointRecovery.class, StreamingTest.class})
+  @Test
+  public void testFlattenPCollResumeFromCheckpoint() {
+    final MetricsFilter metricsFilter =
+        MetricsFilter.builder()
+            .addNameFilter(MetricNameFilter.inNamespace(PAssertFn.class))
+            .build();
+
+    PipelineResult res = run(Optional.of(new Instant(400)), false);
+
+    // Verify metrics for Bounded PCollection (sum of 0-9 = 45, count = 10)
+    assertThat(
+        res.metrics().queryMetrics(metricsFilter).getDistributions(),
+        hasItem(
+            attemptedMetricsResult(
+                PAssertFn.class.getName(),
+                "distribution",
+                "BoundedAssert",
+                DistributionResult.create(45, 10, 0L, 9L))));
+
+    // Verify metrics for Flattened result after first run
+    assertThat(
+        res.metrics().queryMetrics(metricsFilter).getDistributions(),
+        hasItem(
+            attemptedMetricsResult(
+                PAssertFn.class.getName(),
+                "distribution",
+                "FlattenedAssert",
+                DistributionResult.create(45, 10, 0L, 9L))));
+
+    // Clean up state
+    clean();
+
+    // Second run: recover from checkpoint
+    res = runAgain();
+
+    // Verify Bounded PCollection metrics remain the same
+    assertThat(
+        res.metrics().queryMetrics(metricsFilter).getDistributions(),
+        hasItem(
+            attemptedMetricsResult(
+                PAssertFn.class.getName(),
+                "distribution",
+                "BoundedAssert",
+                DistributionResult.create(45, 10, 0L, 9L))));
+
+    // Verify Flattened results show accumulated values from both runs
+    assertThat(
+        res.metrics().queryMetrics(metricsFilter).getDistributions(),
+        hasItem(
+            attemptedMetricsResult(
+                PAssertFn.class.getName(),
+                "distribution",
+                "FlattenedAssert",
+                DistributionResult.create(91, 14, 0, 13))));
+  }
+
+  /** Restarts the pipeline from checkpoint. Sets pipeline to stop after 1 second. */
+  private PipelineResult runAgain() {
+    return run(Optional.of(Instant.ofEpochMilli(Duration.standardSeconds(1L).getMillis())), true);
+  }
+
+  /**
+   * Sets up and runs the test pipeline.
+   *
+   * @param stopWatermarkOption Watermark at which to stop the pipeline
+   * @param deleteCheckpointDir Whether to delete checkpoint directory after completion
+   */
+  private PipelineResult run(Optional<Instant> stopWatermarkOption, boolean deleteCheckpointDir) {
+    TestSparkPipelineOptions options =
+        PipelineOptionsFactory.create().as(TestSparkPipelineOptions.class);
+    options.setSparkMaster("local[*]");
+    options.setRunner(TestSparkRunner.class);
+    options.setCheckpointDir(temporaryFolder.getRoot().getPath());
+    if (stopWatermarkOption.isPresent()) {
+      options.setStopPipelineWatermark(stopWatermarkOption.get().getMillis());
+    }
+    options.setDeleteCheckpointDir(deleteCheckpointDir);
+
+    p = Pipeline.create(options);
+
+    final PCollection<Long> bounded =
+        p.apply("Bounded", GenerateSequence.from(0).to(10))
+            .apply("BoundedAssert", ParDo.of(new PAssertFn()));
+
+    final PCollection<Long> unbounded =
+        p.apply("Unbounded", GenerateSequence.from(10).withRate(3, Duration.standardSeconds(1)))
+            .apply(WithTimestamps.of(e -> Instant.now()));
+
+    final PCollection<Long> flattened = bounded.apply(Flatten.with(unbounded));
+
+    flattened.apply("FlattenedAssert", ParDo.of(new PAssertFn()));
+    return p.run();
+  }
+
+  /**
+   * Cleans up accumulated state between test runs. Clears metrics, watermarks, and microbatch
+   * source cache.
+   */
+  @After
+  public void clean() {
+    MetricsAccumulator.clear();
+    GlobalWatermarkHolder.clear();
+    MicrobatchSource.clearCache();
+  }
+
+  /**
+   * DoFn that tracks element distribution through metrics. Used to verify correct processing of
+   * elements in both bounded and unbounded streams.
+   */
+  private static class PAssertFn extends DoFn<Long, Long> {
+    private final Distribution distribution = Metrics.distribution(PAssertFn.class, "distribution");
+
+    @ProcessElement
+    public void process(@Element Long element, OutputReceiver<Long> output) {
+      distribution.update(element);
+      output.output(element);
+    }
+  }
+}


### PR DESCRIPTION
**Please** add a meaningful description for your change here

fixes #18144
fixes #20426

This PR replaces Spark's queueStream with a custom SingleEmitInputDStream implementation 
for the Flatten transform in Spark streaming. The queueStream was not checkpoint-able, 
which caused issues when recovering pipelines with flattened bounded and unbounded PCollections.

The custom SingleEmitInputDStream ensures:
- Proper checkpoint recovery for Flatten transform
- Single emission of bounded data in streaming context
- Reliable handling of mixed bounded/unbounded PCollections

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
