### PR TITLE
Fix the case when update_compatibility_version is used without argument.

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -591,6 +591,8 @@ class StreamingOptions(PipelineOptions):
     parser.add_argument(
         '--update_compatibility_version',
         default=None,
+        nargs='?',
+        const=None,
         help='Attempt to produce a pipeline compatible with the given prior '
         'version of the Beam SDK. '
         'See for example, https://cloud.google.com/dataflow/docs/guides/'


### PR DESCRIPTION
Improve the handling of the `update_compatibility_version` option.

- When the argument is not provided, the default value `None` is used.
- Previously, using the argument as a standalone flag (e.g., `--update_compatibility_version`) resulted in an exception. This has been corrected to also resolve to `None`, aligning with the intended behavior.
- Explicitly providing a version (e.g., `--update_compatibility_version=2.63.0`) will use that specified value.

(Internal bug id: 398402007, 399132073)