### PR TITLE
[Java] Allow users to specify GCS custom audit entries in pipeline options 

### DIFF
--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/options/GcsOptions.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/options/GcsOptions.java
@@ -186,7 +186,10 @@ public interface GcsOptions extends ApplicationNameOptions, GcpOptions, Pipeline
   @Description("Get key-value pairs to be stored as custom information in GCS audit logs")
   GcsCustomAuditEntries getGcsCustomAuditEntries();
 
-  @Description("Set key-value pairs to be stored as custom information in GCS audit logs")
+  @Description(
+      "Set key-value pairs to be stored as custom information in GCS audit logs. To"
+          + " specify these entries via command line, use"
+          + " `--gcsCustomAuditEntries={\"user\":\"test-user\", \"work\":\"test-work\", \"job\":\"test-job\", \"id\":\"1234\"}`")
   void setGcsCustomAuditEntries(GcsCustomAuditEntries entries);
 
   /**
@@ -230,7 +233,7 @@ public interface GcsOptions extends ApplicationNameOptions, GcpOptions, Pipeline
 
     private static final String CUSTOM_AUDIT_ENTRY_TMPL = "x-goog-custom-audit-%s";
 
-    private static final String CUSTOM_AUDIT_JOB_ENTRY_KEY =
+    public static final String CUSTOM_AUDIT_JOB_ENTRY_KEY =
         String.format(CUSTOM_AUDIT_ENTRY_TMPL, "job");
 
     boolean exceedsEntryLimit() {

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/Transport.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/Transport.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.gcp.util;
 
+import static org.apache.beam.sdk.extensions.gcp.options.GcsOptions.GcsCustomAuditEntries.CUSTOM_AUDIT_JOB_ENTRY_KEY;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Strings.isNullOrEmpty;
 
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
@@ -128,7 +129,7 @@ public class Transport {
     String jobName = Optional.ofNullable(options.getJobName()).orElse("UNKNOWN");
 
     ImmutableMap.Builder<String, String> builder =
-        new ImmutableMap.Builder<String, String>().put("x-goog-custom-audit-job", jobName);
+        new ImmutableMap.Builder<String, String>().put(CUSTOM_AUDIT_JOB_ENTRY_KEY, jobName);
 
     Map<String, String> customAuditEntries = options.getGcsCustomAuditEntries();
     if (customAuditEntries != null && customAuditEntries.size() > 0) {

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/Transport.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/Transport.java
@@ -130,9 +130,10 @@ public class Transport {
     ImmutableMap.Builder<String, String> builder =
         new ImmutableMap.Builder<String, String>().put("x-goog-custom-audit-job", jobName);
 
-    Map<String, String> custom_audit_entries = options.getGcsCustomAuditEntries();
-    if (custom_audit_entries != null && custom_audit_entries.size() > 0)
-      builder.putAll(custom_audit_entries);
+    Map<String, String> customAuditEntries = options.getGcsCustomAuditEntries();
+    if (customAuditEntries != null && customAuditEntries.size() > 0) {
+      builder.putAll(customAuditEntries);
+    }
 
     // Note: Custom audit entries with "job" key will overwrite the default above
     retryHttpRequestInitializer.setHttpHeaders(builder.buildKeepingLast());

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/options/GcsOptionsTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/options/GcsOptionsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.gcp.options;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link org.apache.beam.sdk.extensions.gcp.options.GcsOptions}. */
+@RunWith(JUnit4.class)
+public class GcsOptionsTest {
+  private static final String LONG_KEY = String.join("", Collections.nCopies(65, "a"));
+  private static final String ENTRY_WITH_LONG_KEY =
+      String.format("--gcsCustomAuditEntries={\"%s\":\"my_value\"}", LONG_KEY);
+  private static final String LONG_VALUE = String.join("", Collections.nCopies(1201, "b"));
+  private static final String ENTRY_WITH_LONG_VALUE =
+      String.format("--gcsCustomAuditEntries={\"my_key\":\"%s\"}", LONG_VALUE);
+  private static final String TOO_MANY_ENTRIES_WITHOUT_JOB =
+      "--gcsCustomAuditEntries={\"a\":\"1\", \"b\":\"2\", \"c\":\"3\", \"d\":\"4\"}";
+  private static final String TOO_MANY_ENTRIES_WITH_JOB =
+      "--gcsCustomAuditEntries={\"a\":\"1\", \"b\":\"2\", \"c\":\"3\", \"job\":\"123\", \"d\":\"4\"}";
+
+  @Test
+  public void testEntries() throws Exception {
+    GcsOptions options =
+        PipelineOptionsFactory.fromArgs(
+                "--gcsCustomAuditEntries={\"user\":\"test-user\", \"work\":\"test-work\", \"job\":\"test-job\", \"id\":\"1234\"}")
+            .as(GcsOptions.class);
+
+    Map<String, String> expected = new HashMap<String, String>();
+    expected.put("x-goog-custom-audit-user", "test-user");
+    expected.put("x-goog-custom-audit-work", "test-work");
+    expected.put("x-goog-custom-audit-job", "test-job");
+    expected.put("x-goog-custom-audit-id", "1234");
+    assertEquals(expected, options.getGcsCustomAuditEntries());
+  }
+
+  @Test
+  public void testEntriesWithErrors() throws Exception {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PipelineOptionsFactory.fromArgs(ENTRY_WITH_LONG_KEY).as(GcsOptions.class));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PipelineOptionsFactory.fromArgs(ENTRY_WITH_LONG_VALUE).as(GcsOptions.class));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PipelineOptionsFactory.fromArgs(TOO_MANY_ENTRIES_WITHOUT_JOB).as(GcsOptions.class));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PipelineOptionsFactory.fromArgs(TOO_MANY_ENTRIES_WITH_JOB).as(GcsOptions.class));
+  }
+}


### PR DESCRIPTION
This PR implements the same functionality of #34062 in Java SDK.