### PR TITLE
Fix Docker dev environment set up

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -60,11 +60,6 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 ###
-# Set Python3.6 as default
-###
-RUN alias python=python3.6
-
-###
 # Install grpcio-tools mypy-protobuf for `python3 sdks/python/setup.py sdist` to work
 ###
 RUN pip3 install grpcio-tools mypy-protobuf

--- a/dev-support/docker/pkglist
+++ b/dev-support/docker/pkglist
@@ -29,7 +29,7 @@ vim
 locales
 wget
 time
-openjdk-8-jdk
+openjdk-11-jdk
 python3-setuptools
 python3-pip
 python3.9
@@ -46,7 +46,6 @@ python3.11-distutils
 python3.11-venv
 python3.12
 python3.12-dev
-python3.12-distutils
 python3.12-venv
 tox
 docker.io


### PR DESCRIPTION
**Please** add a meaningful description for your change here

I was setting up the dev environment using Docker and came across these errors...

1. python12-disutils not found - From https://docs.python.org/3.10/whatsnew/3.10.html#distutils-deprecated, it looks like ```distutils``` is deprecated and removed in python 3.12 in place of ```setuptools``` which we already installed with ```python3-setuptools```. 
2. NullPointerException when running task :sdks:java:core:compileJava - From the Docker image I was using Java 8 and got this NPE error. If I used Java 11, it was fine. Based on the ```contributor-docs/code-change-guide.md```, Java 11 is preferrable but in the ```CONTRIBUTING.md``` Java 8 is still being recommended...

![beam-docker-dev-error](https://github.com/user-attachments/assets/32032473-ce34-4182-bf37-bd5ce77dc16b)


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
