### PR TITLE
Fix Docker build error by adding fallback for python3.12-distutils

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -41,16 +41,16 @@ ENV DEBCONF_TERSE true
 # Update and install common packages
 ###
 RUN apt -q update \
-    && apt install -y software-properties-common apt-utils apt-transport-https ca-certificates \
-    && add-apt-repository -y ppa:deadsnakes/ppa \
-    && apt -q update
+   && apt install -y software-properties-common apt-utils apt-transport-https ca-certificates \
+   && add-apt-repository -y ppa:deadsnakes/ppa \
+   && apt -q update
 
-    RUN mkdir /package
-    COPY pkglist /package/pkglist
-    RUN apt-get -q install -y --no-install-recommends \
-        $(grep -v '^#' /package/pkglist | grep -v 'python3.12-distutils' | cat) \
-        python3-distutils \
-        && (apt-get -q install -y python3.12-distutils 2>/dev/null || echo "python3.12-distutils not available, using python3-distutils")
+RUN mkdir /package
+COPY pkglist /package/pkglist
+RUN apt-get -q install -y --no-install-recommends \
+    $(grep -v '^#' /package/pkglist | grep -v 'python3.12-distutils' | cat) \
+    python3-distutils \
+    && (apt-get -q install -y python3.12-distutils 2>/dev/null || echo "python3.12-distutils not available, using python3-distutils")
 
 ###
 # Set the locale ( see https://stackoverflow.com/a/28406007/114196 )

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -51,12 +51,6 @@ RUN apt-get -q install -y --no-install-recommends \
     $(grep -v '^#' /package/pkglist | grep -v 'python3.12-distutils' | cat) \
     python3-distutils \
     && (apt-get -q install -y python3.12-distutils 2>/dev/null || echo "python3.12-distutils not available, using python3-distutils")
-RUN mkdir /package
-COPY pkglist /package/pkglist
-RUN apt-get -q install -y --no-install-recommends \
-    $(grep -v '^#' /package/pkglist | grep -v 'python3.12-distutils' | cat) \
-    python3-distutils \
-    && (apt-get -q install -y python3.12-distutils 2>/dev/null || echo "python3.12-distutils not available, using python3-distutils")
 
 ###
 # Set the locale ( see https://stackoverflow.com/a/28406007/114196 )

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -41,13 +41,16 @@ ENV DEBCONF_TERSE true
 # Update and install common packages
 ###
 RUN apt -q update \
-   && apt install -y software-properties-common apt-utils apt-transport-https ca-certificates \
-   && add-apt-repository -y ppa:deadsnakes/ppa \
-   && apt -q update
+    && apt install -y software-properties-common apt-utils apt-transport-https ca-certificates \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt -q update
 
-RUN mkdir /package
-COPY pkglist /package/pkglist
-RUN apt-get -q install -y --no-install-recommends $(grep -v '^#' /package/pkglist | cat)
+    RUN mkdir /package
+    COPY pkglist /package/pkglist
+    RUN apt-get -q install -y --no-install-recommends \
+        $(grep -v '^#' /package/pkglist | grep -v 'python3.12-distutils' | cat) \
+        python3-distutils \
+        && (apt-get -q install -y python3.12-distutils 2>/dev/null || echo "python3.12-distutils not available, using python3-distutils")
 
 ###
 # Set the locale ( see https://stackoverflow.com/a/28406007/114196 )


### PR DESCRIPTION
**Please** add a meaningful description for your change here

The Ubuntu 20.04 base image with the deadsnakes/ppa does not provide the
python3.12-distutils package as a separate entity, causing the Docker build
to fail. This commit modifies the Dockerfile to:
- Exclude python3.12-distutils from the initial apt-get install command
  using grep.
- Install python3-distutils as a fallback, which provides distutils support
  for the default Python version.
- Add a conditional installation attempt for python3.12-distutils, suppressing
  errors and logging a message if unavailable.

This ensures build compatibility across environments where python3.12-distutils
may not be available. Tested successfully with the updated Dockerfile.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
