### PR TITLE
introduce flags for customizing standard providers using their own YA…

### DIFF
--- a/sdks/python/apache_beam/yaml/integration_tests.py
+++ b/sdks/python/apache_beam/yaml/integration_tests.py
@@ -165,7 +165,7 @@ def create_test_methods(spec):
         stack.enter_context(
             mock.patch(
                 'apache_beam.yaml.yaml_provider.standard_providers',
-                lambda: providers))
+                lambda _: providers))
         for fixture in spec.get('fixtures', []):
           vars[fixture['name']] = stack.enter_context(
               python_callable.PythonCallableWithSource.

--- a/sdks/python/apache_beam/yaml/main.py
+++ b/sdks/python/apache_beam/yaml/main.py
@@ -93,6 +93,23 @@ def _parse_arguments(argv):
   return parser.parse_known_args(argv)
 
 
+def _parse_overrides_arguments(argv):
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '--pipeline_schema_yaml_file',
+      default=None,
+      help='The YAML file contains definitions for pipeline schema.')
+  parser.add_argument(
+      '--standard_io_yaml_file',
+      default=None,
+      help='The YAML file contains definitions for stanard I/O providers.')
+  parser.add_argument(
+      '--standard_providers_yaml_file',
+      default=None,
+      help='The YAML file contains definitions for other standard providers.')
+  return parser.parse_known_args(argv)
+
+
 def _pipeline_spec_from_args(known_args):
   if known_args.yaml_pipeline_file and known_args.yaml_pipeline:
     raise ValueError(
@@ -124,6 +141,7 @@ def _fix_xlang_instant_coding():
 def run(argv=None):
   argv = _preparse_jinja_flags(argv)
   known_args, pipeline_args = _parse_arguments(argv)
+  overrides_args, pipeline_args = _parse_overrides_arguments(pipeline_args)
   pipeline_template = _pipeline_spec_from_args(known_args)
   pipeline_yaml = yaml_transform.expand_jinja(
       pipeline_template, known_args.jinja_variables or {})
@@ -151,7 +169,8 @@ def run(argv=None):
           p,
           pipeline_spec,
           validate_schema=known_args.json_schema_validation,
-          pipeline_path=known_args.yaml_pipeline_file)
+          pipeline_path=known_args.yaml_pipeline_file,
+          pipeline_overrides=vars(overrides_args))  # convert Namespace to dict.
       print("Running pipeline...")
 
 

--- a/sdks/python/apache_beam/yaml/yaml_provider.py
+++ b/sdks/python/apache_beam/yaml/yaml_provider.py
@@ -1348,11 +1348,22 @@ def merge_providers(*provider_sets) -> Mapping[str, Iterable[Provider]]:
   return result
 
 
-def standard_providers():
+def standard_providers(overrides=None):
   from apache_beam.yaml.yaml_combine import create_combine_providers
   from apache_beam.yaml.yaml_mapping import create_mapping_providers
   from apache_beam.yaml.yaml_join import create_join_providers
   from apache_beam.yaml.yaml_io import io_providers
+
+  if overrides and overrides.get('standard_io_yaml_file'):
+    standard_io_providers = load_providers(overrides['standard_io_yaml_file'])
+  else:
+    standard_io_providers = io_providers()
+  if overrides and overrides.get('standard_providers_yaml_file'):
+    other_standard_providers = load_providers(
+        overrides['standard_providers_yaml_file'])
+  else:
+    other_standard_providers = load_providers(
+        os.path.join(os.path.dirname(__file__), 'standard_providers.yaml'))
 
   return merge_providers(
       YamlProviders.create_builtin_provider(),
@@ -1360,9 +1371,8 @@ def standard_providers():
       create_mapping_providers(),
       create_combine_providers(),
       create_join_providers(),
-      io_providers(),
-      load_providers(
-          os.path.join(os.path.dirname(__file__), 'standard_providers.yaml')))
+      standard_io_providers,
+      other_standard_providers)
 
 
 def _file_digest(fileobj, digest):


### PR DESCRIPTION
Allow customization of standard providers via YAML files

This commit introduces two new command-line flags, `--standard_io_yaml_file` and `--standard_providers_yaml_file`, enabling users to customize the standard providers used when executing Apache Beam YAML pipelines.

-   `--standard_io_yaml_file`: Specifies a YAML file containing definitions for standard I/O providers, allowing users to override or extend the default I/O providers.
-   `--standard_providers_yaml_file`: Specifies a YAML file containing definitions for other standard providers (i.e., non-I/O providers), providing similar customization capabilities.

The `standard_providers` function in `yaml_provider.py` has been updated to load providers from these user-specified files if provided, falling back to the default standard providers if the flags are not used.

These changes provide greater flexibility and extensibility when defining and running Beam pipelines with YAML, allowing users to tailor the available transforms and I/O connectors to their specific needs.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
