### PR TITLE
Putting the default retry settings which was overridden in Dataflow templates

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerAccessor.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerAccessor.java
@@ -153,8 +153,10 @@ public class SpannerAccessor implements AutoCloseable {
           commitSettings.getRetrySettings().toBuilder();
       commitSettings.setRetrySettings(
           commitRetrySettingsBuilder
-              .setTotalTimeoutDuration(java.time.Duration.ofMillis(commitDeadline.get().getMillis()))
-              .setMaxRpcTimeoutDuration(java.time.Duration.ofMillis(commitDeadline.get().getMillis()))
+              .setTotalTimeoutDuration(
+                  java.time.Duration.ofMillis(commitDeadline.get().getMillis()))
+              .setMaxRpcTimeoutDuration(
+                  java.time.Duration.ofMillis(commitDeadline.get().getMillis()))
               .setInitialRpcTimeoutDuration(
                   java.time.Duration.ofMillis(commitDeadline.get().getMillis()))
               .build());

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerAccessor.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerAccessor.java
@@ -177,7 +177,14 @@ public class SpannerAccessor implements AutoCloseable {
               .setInitialRpcTimeout(org.threeten.bp.Duration.ofMinutes(120))
               .setMaxRpcTimeout(org.threeten.bp.Duration.ofMinutes(120))
               .setTotalTimeout(org.threeten.bp.Duration.ofMinutes(120))
+              .setRpcTimeoutMultiplier(1.0)
+              .setInitialRetryDelay(org.threeten.bp.Duration.ofSeconds(2))
+              .setMaxRetryDelay(org.threeten.bp.Duration.ofSeconds(60))
+              .setRetryDelayMultiplier(1.5)
+              .setMaxAttempts(100)
               .build());
+      // This property sets the default timeout between 2 response packets in the client library.
+      System.setProperty("com.google.cloud.spanner.watchdogTimeoutSeconds", "7200");
     }
 
     SpannerStubSettings.Builder spannerStubSettingsBuilder =

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerAccessor.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerAccessor.java
@@ -176,9 +176,9 @@ public class SpannerAccessor implements AutoCloseable {
           executeStreamingSqlSettings.getRetrySettings().toBuilder();
       executeStreamingSqlSettings.setRetrySettings(
           executeSqlStreamingRetrySettings
-              .setInitialRpcTimeoutDuration(java.time.Duration.ofMinutes(120))
-              .setMaxRpcTimeoutDuration(java.time.Duration.ofMinutes(120))
-              .setTotalTimeoutDuration(java.time.Duration.ofMinutes(120))
+              .setInitialRpcTimeoutDuration(java.time.Duration.ofHours(2))
+              .setMaxRpcTimeoutDuration(java.time.Duration.ofHours(2))
+              .setTotalTimeoutDuration(java.time.Duration.ofHours(2))
               .setRpcTimeoutMultiplier(1.0)
               .setInitialRetryDelayDuration(java.time.Duration.ofSeconds(2))
               .setMaxRetryDelayDuration(java.time.Duration.ofSeconds(60))

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerAccessor.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerAccessor.java
@@ -153,10 +153,10 @@ public class SpannerAccessor implements AutoCloseable {
           commitSettings.getRetrySettings().toBuilder();
       commitSettings.setRetrySettings(
           commitRetrySettingsBuilder
-              .setTotalTimeout(org.threeten.bp.Duration.ofMillis(commitDeadline.get().getMillis()))
-              .setMaxRpcTimeout(org.threeten.bp.Duration.ofMillis(commitDeadline.get().getMillis()))
-              .setInitialRpcTimeout(
-                  org.threeten.bp.Duration.ofMillis(commitDeadline.get().getMillis()))
+              .setTotalTimeoutDuration(java.time.Duration.ofMillis(commitDeadline.get().getMillis()))
+              .setMaxRpcTimeoutDuration(java.time.Duration.ofMillis(commitDeadline.get().getMillis()))
+              .setInitialRpcTimeoutDuration(
+                  java.time.Duration.ofMillis(commitDeadline.get().getMillis()))
               .build());
     }
 
@@ -174,12 +174,12 @@ public class SpannerAccessor implements AutoCloseable {
           executeStreamingSqlSettings.getRetrySettings().toBuilder();
       executeStreamingSqlSettings.setRetrySettings(
           executeSqlStreamingRetrySettings
-              .setInitialRpcTimeout(org.threeten.bp.Duration.ofMinutes(120))
-              .setMaxRpcTimeout(org.threeten.bp.Duration.ofMinutes(120))
-              .setTotalTimeout(org.threeten.bp.Duration.ofMinutes(120))
+              .setInitialRpcTimeoutDuration(java.time.Duration.ofMinutes(120))
+              .setMaxRpcTimeoutDuration(java.time.Duration.ofMinutes(120))
+              .setTotalTimeoutDuration(java.time.Duration.ofMinutes(120))
               .setRpcTimeoutMultiplier(1.0)
-              .setInitialRetryDelay(org.threeten.bp.Duration.ofSeconds(2))
-              .setMaxRetryDelay(org.threeten.bp.Duration.ofSeconds(60))
+              .setInitialRetryDelayDuration(java.time.Duration.ofSeconds(2))
+              .setMaxRetryDelayDuration(java.time.Duration.ofSeconds(60))
               .setRetryDelayMultiplier(1.5)
               .setMaxAttempts(100)
               .build());


### PR DESCRIPTION
Putting the default retry settings for spanner which was overridden in Dataflow templates Dataflow templates

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
