### PR TITLE
Correctly parse labels if they are passed as a single string instead of a list

### DIFF
--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
@@ -447,6 +447,8 @@ class Job(object):
     if self.google_cloud_options.labels:
       self.proto.labels = dataflow.Job.LabelsValue()
       labels = self.google_cloud_options.labels
+      if isinstance(labels, str):
+        labels = [labels]
       for label in labels:
         if '{' in label:
           label = ast.literal_eval(label)

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
@@ -449,6 +449,8 @@ class Job(object):
       labels = self.google_cloud_options.labels
       if isinstance(labels, str):
         labels = [labels]
+      elif isinstance(labels, dict):
+        labels = [str(labels)]
       for label in labels:
         if '{' in label:
           label = ast.literal_eval(label)

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
@@ -885,6 +885,42 @@ class UtilTest(unittest.TestCase):
     self.assertEqual('count', job.proto.labels.additionalProperties[2].key)
     self.assertEqual('3', job.proto.labels.additionalProperties[2].value)
 
+    pipeline_options = PipelineOptions([
+        '--project',
+        'test_project',
+        '--job_name',
+        'test_job_name',
+        '--temp_location',
+        'gs://test-location/temp'
+    ])
+    pipeline_options.view_as(GoogleCloudOptions).labels = { "name": "wrench", "mass": "1_3kg", "count": "3" }
+    job = apiclient.Job(pipeline_options, beam_runner_api_pb2.Pipeline())
+    self.assertEqual(3, len(job.proto.labels.additionalProperties))
+    self.assertEqual('name', job.proto.labels.additionalProperties[0].key)
+    self.assertEqual('wrench', job.proto.labels.additionalProperties[0].value)
+    self.assertEqual('mass', job.proto.labels.additionalProperties[1].key)
+    self.assertEqual('1_3kg', job.proto.labels.additionalProperties[1].value)
+    self.assertEqual('count', job.proto.labels.additionalProperties[2].key)
+    self.assertEqual('3', job.proto.labels.additionalProperties[2].value)
+
+    pipeline_options = PipelineOptions([
+        '--project',
+        'test_project',
+        '--job_name',
+        'test_job_name',
+        '--temp_location',
+        'gs://test-location/temp'
+    ])
+    pipeline_options.view_as(GoogleCloudOptions).labels = '{ "name": "wrench", "mass": "1_3kg", "count": "3" }'
+    job = apiclient.Job(pipeline_options, beam_runner_api_pb2.Pipeline())
+    self.assertEqual(3, len(job.proto.labels.additionalProperties))
+    self.assertEqual('name', job.proto.labels.additionalProperties[0].key)
+    self.assertEqual('wrench', job.proto.labels.additionalProperties[0].value)
+    self.assertEqual('mass', job.proto.labels.additionalProperties[1].key)
+    self.assertEqual('1_3kg', job.proto.labels.additionalProperties[1].value)
+    self.assertEqual('count', job.proto.labels.additionalProperties[2].key)
+    self.assertEqual('3', job.proto.labels.additionalProperties[2].value)
+
   def test_experiment_use_multiple_sdk_containers(self):
     pipeline_options = PipelineOptions([
         '--project',

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
@@ -893,7 +893,9 @@ class UtilTest(unittest.TestCase):
         '--temp_location',
         'gs://test-location/temp'
     ])
-    pipeline_options.view_as(GoogleCloudOptions).labels = { "name": "wrench", "mass": "1_3kg", "count": "3" }
+    pipeline_options.view_as(GoogleCloudOptions).labels = {
+        "name": "wrench", "mass": "1_3kg", "count": "3"
+    }
     job = apiclient.Job(pipeline_options, beam_runner_api_pb2.Pipeline())
     self.assertEqual(3, len(job.proto.labels.additionalProperties))
     self.assertEqual('name', job.proto.labels.additionalProperties[0].key)
@@ -911,7 +913,9 @@ class UtilTest(unittest.TestCase):
         '--temp_location',
         'gs://test-location/temp'
     ])
-    pipeline_options.view_as(GoogleCloudOptions).labels = '{ "name": "wrench", "mass": "1_3kg", "count": "3" }'
+    pipeline_options.view_as(
+        GoogleCloudOptions
+    ).labels = '{ "name": "wrench", "mass": "1_3kg", "count": "3" }'
     job = apiclient.Job(pipeline_options, beam_runner_api_pb2.Pipeline())
     self.assertEqual(3, len(job.proto.labels.additionalProperties))
     self.assertEqual('name', job.proto.labels.additionalProperties[0].key)


### PR DESCRIPTION
Right now, if you submit a job like:

```
options = PipelineOptions()
options.view_as(StandardOptions).runner = "DataflowRunner"
<other options>
options.view_as(GoogleCloudOptions).labels = {'env': 'bluecore-qa-extensibility', 'team': 'cdp-vertical'}

with beam.Pipeline(options=options) as p:
  <do stuff>
```

The job does not correctly recognize the labels. We could validate and fail because labels is expected to be a list, but that might break existing (mostly working) pipelines. This is an in between where we can still do a best effort to correctly identify/use the user's labels.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
