### PR TITLE
 Add Documentation Hint for Template Job Creation in DataflowRunner

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -201,6 +201,15 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Please see <a href="https://cloud.google.com/dataflow/security-and-permissions">Google Cloud
  * Dataflow Security and Permissions</a> for more details.
+ * 
+ * <p>DataflowRunner now supports creating job templates using the {@code --templateLocation} option.
+ * If this option is set, the runner will generate a template instead of running the pipeline immediately.
+ *
+ * Example:
+ * <pre>{@code
+ * --runner=DataflowRunner
+ * --templateLocation=gs://your-bucket/templates/my-template
+ * }</pre>
  */
 @SuppressWarnings({
   "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)


### PR DESCRIPTION

This PR resolves [#18217](https://github.com/apache/beam/issues/18217) by improving the SDK documentation for DataflowPipelineOptions and DataflowRunner.
Changes Made:
Added a hint to the setTemplateLocation method, clarifying its role in creating template jobs in Google Dataflow.
Addressed potential confusion caused by the removal of DataflowTemplateRunner.
 Enhanced documentation to improve developer experience and save time.

Let me know if any further improvements are needed. Thanks!