### PR TITLE
Move ExecutionStateTracker.nextBundleLullDurationReportMs reset attempt to resolve race detection

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/ExecutionStateTracker.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/ExecutionStateTracker.java
@@ -150,7 +150,7 @@ public class ExecutionStateTracker implements Comparable<ExecutionStateTracker> 
 
   private long transitionsAtLastSample = 0;
   private long nextLullReportMs = LULL_REPORT_MS;
-  private long nextBundleLullDurationReportMs = BUNDLE_LULL_REPORT_MS;
+  private volatile long nextBundleLullDurationReportMs = BUNDLE_LULL_REPORT_MS;
 
   public ExecutionStateTracker(ExecutionStateSampler sampler) {
     this.sampler = sampler;

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/ExecutionStateTracker.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/ExecutionStateTracker.java
@@ -150,7 +150,7 @@ public class ExecutionStateTracker implements Comparable<ExecutionStateTracker> 
 
   private long transitionsAtLastSample = 0;
   private long nextLullReportMs = LULL_REPORT_MS;
-  private volatile long nextBundleLullDurationReportMs = BUNDLE_LULL_REPORT_MS;
+  private long nextBundleLullDurationReportMs = BUNDLE_LULL_REPORT_MS;
 
   public ExecutionStateTracker(ExecutionStateSampler sampler) {
     this.sampler = sampler;
@@ -167,6 +167,7 @@ public class ExecutionStateTracker implements Comparable<ExecutionStateTracker> 
     millisSinceLastTransition = 0;
     transitionsAtLastSample = 0;
     nextLullReportMs = LULL_REPORT_MS;
+    nextBundleLullDurationReportMs = BUNDLE_LULL_REPORT_MS;
   }
 
   @VisibleForTesting
@@ -258,7 +259,6 @@ public class ExecutionStateTracker implements Comparable<ExecutionStateTracker> 
     }
     this.trackedThread = null;
     millisSinceBundleStart = 0;
-    nextBundleLullDurationReportMs = BUNDLE_LULL_REPORT_MS;
   }
 
   public ExecutionState getCurrentState() {

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/util/common/worker/MapTaskExecutorTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/util/common/worker/MapTaskExecutorTest.java
@@ -279,10 +279,9 @@ public class MapTaskExecutorTest {
    * containers returned by {@link getMetricContainers}.
    */
   public void testGetMetricContainers() throws Exception {
-    ExecutionStateSampler sampler = ExecutionStateSampler.newForTest();
     ExecutionStateTracker stateTracker =
         new DataflowExecutionStateTracker(
-            sampler,
+            ExecutionStateSampler.newForTest(),
             new TestDataflowExecutionState(
                 NameContext.forStage("testStage"),
                 "other",
@@ -329,7 +328,8 @@ public class MapTaskExecutorTest {
                 }
               }
             });
-    sampler.start();
+
+    assertEquals(TimeUnit.MINUTES.toMillis(10), stateTracker.getNextBundleLullDurationReportMs());
     try (MapTaskExecutor executor = new MapTaskExecutor(operations, counterSet, stateTracker)) {
       // Call execute so that we run all the counters
       executor.execute();
@@ -344,7 +344,6 @@ public class MapTaskExecutorTest {
           context3.metricsContainer().getUpdates().counterUpdates(),
           contains(metricUpdate("TestMetric", "MetricCounter", o3, 3L)));
       assertEquals(0, stateTracker.getMillisSinceBundleStart());
-      assertEquals(TimeUnit.MINUTES.toMillis(10), stateTracker.getNextBundleLullDurationReportMs());
     }
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/util/common/worker/MapTaskExecutorTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/util/common/worker/MapTaskExecutorTest.java
@@ -279,9 +279,10 @@ public class MapTaskExecutorTest {
    * containers returned by {@link getMetricContainers}.
    */
   public void testGetMetricContainers() throws Exception {
+    ExecutionStateSampler sampler = ExecutionStateSampler.newForTest();
     ExecutionStateTracker stateTracker =
         new DataflowExecutionStateTracker(
-            ExecutionStateSampler.newForTest(),
+            sampler,
             new TestDataflowExecutionState(
                 NameContext.forStage("testStage"),
                 "other",
@@ -328,7 +329,7 @@ public class MapTaskExecutorTest {
                 }
               }
             });
-
+    sampler.start();
     try (MapTaskExecutor executor = new MapTaskExecutor(operations, counterSet, stateTracker)) {
       // Call execute so that we run all the counters
       executor.execute();


### PR DESCRIPTION
in an attempt to fix "data race ExecutionStateTracker.java:261 in org.apache.beam.runners.core.metrics.ExecutionStateTracker.deactivate()V" reported by internal test (internal bug: 401543527)

The source already declared "millisSinceBundleStart" volatile. "nextBundleLullDurationReportMs" operated by the same methods "reportBundleLull" should be consistent with it

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
