### PR TITLE
[IcebergIO] Filter out data files that have already been committed

### DIFF
--- a/.github/trigger_files/IO_Iceberg_Integration_Tests.json
+++ b/.github/trigger_files/IO_Iceberg_Integration_Tests.json
@@ -1,4 +1,4 @@
 {
     "comment": "Modify this file in a trivial way to cause this test suite to run.",
-    "modification": 2
+    "modification": 3
 }


### PR DESCRIPTION
Makes the sink more resilient to bundle retries.

Fixes #34074