### PR TITLE
do not block other threads from health checking if a stream is blocked

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcCommitWorkStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcCommitWorkStream.java
@@ -150,7 +150,7 @@ final class GrpcCommitWorkStream
   }
 
   @Override
-  public void sendHealthCheck() throws WindmillStreamShutdownException {
+  protected void sendHealthCheck() throws WindmillStreamShutdownException {
     if (hasPendingRequests()) {
       StreamingCommitWorkRequest.Builder builder = StreamingCommitWorkRequest.newBuilder();
       builder.addCommitChunkBuilder().setRequestId(HEARTBEAT_REQUEST_ID);

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDirectGetWorkStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDirectGetWorkStream.java
@@ -238,7 +238,7 @@ final class GrpcDirectGetWorkStream
   }
 
   @Override
-  public void sendHealthCheck() throws WindmillStreamShutdownException {
+  protected void sendHealthCheck() throws WindmillStreamShutdownException {
     trySend(HEALTH_CHECK_REQUEST);
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetDataStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetDataStream.java
@@ -296,7 +296,7 @@ final class GrpcGetDataStream
   }
 
   @Override
-  public void sendHealthCheck() throws WindmillStreamShutdownException {
+  protected void sendHealthCheck() throws WindmillStreamShutdownException {
     if (hasPendingRequests()) {
       trySend(HEALTH_CHECK_REQUEST);
     }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetWorkStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetWorkStream.java
@@ -166,7 +166,7 @@ final class GrpcGetWorkStream
   }
 
   @Override
-  public void sendHealthCheck() throws WindmillStreamShutdownException {
+  protected void sendHealthCheck() throws WindmillStreamShutdownException {
     trySend(HEALTH_CHECK);
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillStreamFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillStreamFactory.java
@@ -155,7 +155,7 @@ public class GrpcWindmillStreamFactory implements StatusDataProvider {
                   Instant reportThreshold =
                       Instant.now().minus(Duration.millis(healthCheckIntervalMillis));
                   for (AbstractWindmillStream<?, ?> stream : streamFactory.streamRegistry) {
-                    stream.maybeSendHealthCheck(reportThreshold);
+                    stream.maybeScheduleHealthCheck(reportThreshold);
                   }
                 }
               },

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/AbstractWindmillStreamTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/AbstractWindmillStreamTest.java
@@ -36,6 +36,8 @@ import org.apache.beam.sdk.util.FluentBackoff;
 import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.stub.CallStreamObserver;
 import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.stub.StreamObserver;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.Uninterruptibles;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -61,42 +63,9 @@ public class AbstractWindmillStreamTest {
 
   @Test
   public void testShutdown_notBlockedBySend() throws InterruptedException, ExecutionException {
-    CountDownLatch sendBlocker = new CountDownLatch(1);
+    TestCallStreamObserver callStreamObserver = new TestCallStreamObserver();
     Function<StreamObserver<Integer>, StreamObserver<Integer>> clientFactory =
-        ignored ->
-            new CallStreamObserver<Integer>() {
-              @Override
-              public void onNext(Integer integer) {
-                try {
-                  sendBlocker.await();
-                } catch (InterruptedException e) {
-                  throw new RuntimeException(e);
-                }
-              }
-
-              @Override
-              public void onError(Throwable throwable) {}
-
-              @Override
-              public void onCompleted() {}
-
-              @Override
-              public boolean isReady() {
-                return false;
-              }
-
-              @Override
-              public void setOnReadyHandler(Runnable runnable) {}
-
-              @Override
-              public void disableAutoInboundFlowControl() {}
-
-              @Override
-              public void request(int i) {}
-
-              @Override
-              public void setMessageCompression(boolean b) {}
-            };
+        ignored -> callStreamObserver;
 
     TestStream testStream = newStream(clientFactory);
     testStream.start();
@@ -110,12 +79,75 @@ public class AbstractWindmillStreamTest {
     // Sleep a bit to give sendExecutor time to execute the send().
     Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
 
-    sendBlocker.countDown();
+    callStreamObserver.unblockSend();
     assertThat(sendFuture.get()).isInstanceOf(WindmillStreamShutdownException.class);
+  }
+
+  @Test
+  public void testMaybeSendHealthCheck() throws InterruptedException, ExecutionException {
+    TestCallStreamObserver callStreamObserver = new TestCallStreamObserver();
+    Function<StreamObserver<Integer>, StreamObserver<Integer>> clientFactory =
+        ignored -> callStreamObserver;
+
+    TestStream testStream = newStream(clientFactory);
+    testStream.start();
+    ExecutorService sendExecutor = Executors.newSingleThreadExecutor();
+    Instant reportingThreshold = Instant.now().minus(Duration.millis(1));
+    Future<?> sendFuture =
+        sendExecutor.submit(() -> testStream.maybeSendHealthCheck(reportingThreshold));
+
+    // Sleep a bit to give sendExecutor time to execute the send().
+    Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+
+    callStreamObserver.unblockSend();
+
+    // Make sure the future completes.
+    sendFuture.get();
+
+    assertThat(testStream.numHealthChecks.get()).isEqualTo(1);
+    testStream.shutdown();
+  }
+
+  @Test
+  public void testMaybeSendHealthCheck_doesNotSendIfLastSendLessThanThreshold()
+      throws ExecutionException, InterruptedException {
+    TestCallStreamObserver callStreamObserver = new TestCallStreamObserver();
+    Function<StreamObserver<Integer>, StreamObserver<Integer>> clientFactory =
+        ignored -> callStreamObserver;
+
+    TestStream testStream = newStream(clientFactory);
+    testStream.start();
+    ExecutorService sendExecutor = Executors.newSingleThreadExecutor();
+    Future<?> sendFuture =
+        sendExecutor.submit(
+            () -> {
+              try {
+                testStream.trySend(1);
+              } catch (WindmillStreamShutdownException e) {
+                throw new RuntimeException(e);
+              }
+
+              // Sleep a bit to give sendExecutor time to execute the send().
+              Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+
+              // Set a really long reporting threshold.
+              Instant reportingThreshold = Instant.now().minus(Duration.standardHours(1));
+              // Should not send health checks since we just sent the above message.
+              testStream.maybeSendHealthCheck(reportingThreshold);
+              testStream.maybeSendHealthCheck(reportingThreshold);
+            });
+
+    callStreamObserver.unblockSend();
+
+    // Make sure the future completes.
+    sendFuture.get();
+    assertThat(testStream.numHealthChecks.get()).isEqualTo(0);
+    testStream.shutdown();
   }
 
   private static class TestStream extends AbstractWindmillStream<Integer, Integer> {
     private final AtomicInteger numStarts = new AtomicInteger();
+    private final AtomicInteger numHealthChecks = new AtomicInteger();
 
     private TestStream(
         Function<StreamObserver<Integer>, StreamObserver<Integer>> clientFactory,
@@ -148,19 +180,59 @@ public class AbstractWindmillStreamTest {
     @Override
     protected void startThrottleTimer() {}
 
-    public void testSend(Integer i)
-        throws ResettableThrowingStreamObserver.StreamClosedException,
-            WindmillStreamShutdownException {
+    public void testSend(Integer i) throws WindmillStreamShutdownException {
       trySend(i);
     }
 
     @Override
-    protected void sendHealthCheck() {}
+    protected void sendHealthCheck() {
+      numHealthChecks.incrementAndGet();
+    }
 
     @Override
     protected void appendSpecificHtml(PrintWriter writer) {}
 
     @Override
     protected void shutdownInternal() {}
+  }
+
+  private static class TestCallStreamObserver extends CallStreamObserver<Integer> {
+    private final CountDownLatch sendBlocker = new CountDownLatch(1);
+
+    private void unblockSend() {
+      sendBlocker.countDown();
+    }
+
+    @Override
+    public void onNext(Integer integer) {
+      try {
+        sendBlocker.await();
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    public void onError(Throwable throwable) {}
+
+    @Override
+    public void onCompleted() {}
+
+    @Override
+    public boolean isReady() {
+      return true;
+    }
+
+    @Override
+    public void setOnReadyHandler(Runnable runnable) {}
+
+    @Override
+    public void disableAutoInboundFlowControl() {}
+
+    @Override
+    public void request(int i) {}
+
+    @Override
+    public void setMessageCompression(boolean b) {}
   }
 }


### PR DESCRIPTION
Currently a single blocked stream can prevent health checks from multiple streams.  Use the stream's internal executor to hand do the health check RPC in a way that does not block the health check scheduling thread.

R: @acrites @scwhittle 


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
