### PR TITLE
docs: fix typo in snippets_test.py

### DIFF
--- a/sdks/python/apache_beam/examples/snippets/snippets_test.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets_test.py
@@ -1153,7 +1153,7 @@ class SnippetsTest(unittest.TestCase):
           pcollection | WindowInto(
               FixedWindows(1 * 60),
               trigger=AfterWatermark(late=AfterProcessingTime(10 * 60)),
-              allowed_lateness=10,
+              allowed_lateness=2 * 24 * 60 * 60,
               accumulation_mode=AccumulationMode.DISCARDING)
           # [END model_composite_triggers]
           | 'group' >> beam.GroupByKey()


### PR DESCRIPTION
Fix typo in docs related to **9.5.2. Composition with AfterWatermark**
[https://beam.apache.org/documentation/programming-guide/#composite-afterwatermark](https://github.com/apache/beam/pull/url)

addresses [#34224](https://github.com/apache/beam/issues/34224)