### PR TITLE
Fix typo in BigQuery Python Documentation

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -238,7 +238,7 @@ also take a callable that receives a table reference.
 
 Chaining of operations after WriteToBigQuery
 --------------------------------------------
-WritToBigQuery returns an object with several PCollections that consist of
+WriteToBigQuery returns an object with several PCollections that consist of
 metadata about the write operations. These are useful to inspect the write
 operation and follow with the results::
 


### PR DESCRIPTION
Corrects a minor typo in Apache Beam Python SDK documentation. The method WriteToBigQuery was incorrectly written as WritToBigQuery in the documentation. 

fixes #34300
