### PR TITLE
Remove cancelled tasks from ReadOperation queue when shutting down

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/ReadOperation.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/ReadOperation.java
@@ -228,9 +228,10 @@ public class ReadOperation extends Operation {
                   + "Waiting for it to terminate 10 minutes before forcing");
           scheduler.awaitTermination(10, TimeUnit.MINUTES);
           if (!scheduler.isTerminated()) {
-            LOG.error("Failed to terminate periodic progress reporting in 10 "
-                      + "minutes. Trying to force termination then waiting "
-                      + "indefinitely...");
+            LOG.error(
+                "Failed to terminate periodic progress reporting in 10 "
+                    + "minutes. Trying to force termination then waiting "
+                    + "indefinitely...");
             scheduler.shutdownNow();
             scheduler.awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS);
           }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/ReadOperation.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/ReadOperation.java
@@ -221,6 +221,7 @@ public class ReadOperation extends Operation {
         readerIterator.setProgressFromIterator();
       } finally {
         scheduler.shutdown();
+        scheduler.purge();
         scheduler.awaitTermination(1, TimeUnit.MINUTES);
         if (!scheduler.isTerminated()) {
           LOG.error(


### PR DESCRIPTION
In some cases it is possible for a thread pool executor to hang on cancelled tasks when awaitTermination is called - https://bugs.openjdk.org/browse/JDK-7069418 - and we've seen some hangs in practice.

This attempts to fix the problem by waiting up to 10 minutes before forcing a hard termination. I don't have a repro of the initial problem, so I can't be sure this is a fix. But it should be low risk and may resolve the issue, if not it will give more telemetry next time. The downside of this seems fairly minimal since we're almost definitely already in a bad state if we encounter this.

Internal issue: b/401998125

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
