### PR TITLE
Fix pandas doctests sensitive to NumpyExtensionArray formatting.

### DIFF
--- a/sdks/python/apache_beam/dataframe/doctests.py
+++ b/sdks/python/apache_beam/dataframe/doctests.py
@@ -288,6 +288,12 @@ class _DeferrredDataframeOutputChecker(doctest.OutputChecker):
         want = sort_and_normalize(want)
       except Exception:
         got = traceback.format_exc()
+
+    if sys.version_info < (3,11) and 'NumpyExtensionArray' in got:
+      # Work around formatting differences (np.int32(1) vs 1).
+      got = re.sub('np.(int32|str_)[(]([^()]+)[)]', r'\2', got)
+      got = re.sub('np.complex128[(]([^()]+)[)]', r'(\1)', got)
+
     return want, got
 
   @property

--- a/sdks/python/apache_beam/dataframe/doctests.py
+++ b/sdks/python/apache_beam/dataframe/doctests.py
@@ -289,7 +289,7 @@ class _DeferrredDataframeOutputChecker(doctest.OutputChecker):
       except Exception:
         got = traceback.format_exc()
 
-    if sys.version_info < (3,11) and 'NumpyExtensionArray' in got:
+    if sys.version_info < (3, 11) and 'NumpyExtensionArray' in got:
       # Work around formatting differences (np.int32(1) vs 1).
       got = re.sub('np.(int32|str_)[(]([^()]+)[)]', r'\2', got)
       got = re.sub('np.complex128[(]([^()]+)[)]', r'(\1)', got)


### PR DESCRIPTION
This should resolve the apache_beam/dataframe/pandas_doctests_test.py::DoctestTest::test_top_level failure sometimes seen in beam_PreCommit_Python_Dataframes.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
