### PR TITLE
[Dataflow Streaming] Optimize serialization of small commits

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/FanOutStreamingEngineWorkerHarness.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/FanOutStreamingEngineWorkerHarness.java
@@ -40,7 +40,6 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.beam.repackaged.core.org.apache.commons.lang3.tuple.Pair;
-import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc.CloudWindmillServiceV1Alpha1Stub;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.GetWorkRequest;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.JobHeader;
 import org.apache.beam.runners.dataflow.worker.windmill.WindmillConnection;
@@ -56,6 +55,7 @@ import org.apache.beam.runners.dataflow.worker.windmill.client.getdata.Throttlin
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.GrpcDispatcherClient;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.GrpcWindmillStreamFactory;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs.ChannelCachingStubFactory;
+import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs.CloudWindmillServiceV1Alpha1CustomStub;
 import org.apache.beam.runners.dataflow.worker.windmill.client.throttling.ThrottleTimer;
 import org.apache.beam.runners.dataflow.worker.windmill.work.WorkItemScheduler;
 import org.apache.beam.runners.dataflow.worker.windmill.work.budget.GetWorkBudget;
@@ -445,7 +445,7 @@ public final class FanOutStreamingEngineWorkerHarness implements StreamingWorker
     return windmillStreamSender;
   }
 
-  private CloudWindmillServiceV1Alpha1Stub createWindmillStub(Endpoint endpoint) {
+  private CloudWindmillServiceV1Alpha1CustomStub createWindmillStub(Endpoint endpoint) {
     return endpoint
         .directEndpoint()
         .map(channelCachingStubFactory::createWindmillServiceStub)

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/WindmillConnection.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/WindmillConnection.java
@@ -20,8 +20,8 @@ package org.apache.beam.runners.dataflow.worker.windmill;
 import com.google.auto.value.AutoValue;
 import java.util.Optional;
 import java.util.function.Function;
-import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc.CloudWindmillServiceV1Alpha1Stub;
 import org.apache.beam.runners.dataflow.worker.windmill.WindmillEndpoints.Endpoint;
+import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs.CloudWindmillServiceV1Alpha1CustomStub;
 import org.apache.beam.sdk.annotations.Internal;
 
 @AutoValue
@@ -31,7 +31,7 @@ public abstract class WindmillConnection {
 
   public static WindmillConnection from(
       Endpoint windmillEndpoint,
-      Function<Endpoint, CloudWindmillServiceV1Alpha1Stub> endpointToStubFn) {
+      Function<Endpoint, CloudWindmillServiceV1Alpha1CustomStub> endpointToStubFn) {
     WindmillConnection.Builder windmillWorkerConnection = WindmillConnection.builder();
 
     windmillEndpoint.workerToken().ifPresent(windmillWorkerConnection::setBackendWorkerToken);
@@ -50,7 +50,7 @@ public abstract class WindmillConnection {
 
   public abstract Optional<WindmillServiceAddress> directEndpoint();
 
-  public abstract CloudWindmillServiceV1Alpha1Stub stub();
+  public abstract CloudWindmillServiceV1Alpha1CustomStub stub();
 
   @AutoValue.Builder
   public abstract static class Builder {
@@ -58,7 +58,7 @@ public abstract class WindmillConnection {
 
     public abstract Builder setDirectEndpoint(WindmillServiceAddress value);
 
-    public abstract Builder setStub(CloudWindmillServiceV1Alpha1Stub stub);
+    public abstract Builder setStub(CloudWindmillServiceV1Alpha1CustomStub stub);
 
     public abstract WindmillConnection build();
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDispatcherClient.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDispatcherClient.java
@@ -34,9 +34,8 @@ import org.apache.beam.runners.dataflow.options.DataflowWorkerHarnessOptions;
 import org.apache.beam.runners.dataflow.worker.streaming.config.StreamingGlobalConfig;
 import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillMetadataServiceV1Alpha1Grpc;
 import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillMetadataServiceV1Alpha1Grpc.CloudWindmillMetadataServiceV1Alpha1Stub;
-import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc;
-import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc.CloudWindmillServiceV1Alpha1Stub;
 import org.apache.beam.runners.dataflow.worker.windmill.WindmillServiceAddress;
+import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs.CloudWindmillServiceV1Alpha1CustomStub;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs.WindmillStubFactory;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs.WindmillStubFactoryFactory;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
@@ -101,7 +100,7 @@ public class GrpcDispatcherClient {
   public static GrpcDispatcherClient forTesting(
       DataflowWorkerHarnessOptions options,
       WindmillStubFactoryFactory windmillStubFactoryFactory,
-      List<CloudWindmillServiceV1Alpha1Stub> windmillServiceStubs,
+      List<CloudWindmillServiceV1Alpha1CustomStub> windmillServiceStubs,
       List<CloudWindmillMetadataServiceV1Alpha1Stub> windmillMetadataServiceStubs,
       Set<HostAndPort> dispatcherEndpoints) {
     Preconditions.checkArgument(
@@ -115,8 +114,8 @@ public class GrpcDispatcherClient {
         new Random());
   }
 
-  public CloudWindmillServiceV1Alpha1Stub getWindmillServiceStub() {
-    ImmutableList<CloudWindmillServiceV1Alpha1Stub> windmillServiceStubs =
+  public CloudWindmillServiceV1Alpha1CustomStub getWindmillServiceStub() {
+    ImmutableList<CloudWindmillServiceV1Alpha1CustomStub> windmillServiceStubs =
         dispatcherStubs.get().windmillServiceStubs();
     Preconditions.checkState(
         !windmillServiceStubs.isEmpty(), "windmillServiceEndpoint has not been set");
@@ -231,7 +230,7 @@ public class GrpcDispatcherClient {
 
     private static DispatcherStubs create(
         Set<HostAndPort> endpoints,
-        List<CloudWindmillServiceV1Alpha1Stub> windmillServiceStubs,
+        List<CloudWindmillServiceV1Alpha1CustomStub> windmillServiceStubs,
         List<CloudWindmillMetadataServiceV1Alpha1Stub> windmillMetadataServiceStubs) {
       Preconditions.checkState(
           endpoints.size() == windmillServiceStubs.size()
@@ -245,7 +244,7 @@ public class GrpcDispatcherClient {
 
     private static DispatcherStubs create(
         ImmutableSet<HostAndPort> newDispatcherEndpoints, WindmillStubFactory windmillStubFactory) {
-      ImmutableList.Builder<CloudWindmillServiceV1Alpha1Stub> windmillServiceStubs =
+      ImmutableList.Builder<CloudWindmillServiceV1Alpha1CustomStub> windmillServiceStubs =
           ImmutableList.builder();
       ImmutableList.Builder<CloudWindmillMetadataServiceV1Alpha1Stub> windmillMetadataServiceStubs =
           ImmutableList.builder();
@@ -262,10 +261,10 @@ public class GrpcDispatcherClient {
           windmillMetadataServiceStubs.build());
     }
 
-    private static CloudWindmillServiceV1Alpha1Stub createWindmillServiceStub(
+    private static CloudWindmillServiceV1Alpha1CustomStub createWindmillServiceStub(
         HostAndPort endpoint, WindmillStubFactory windmillStubFactory) {
       if (LOCALHOST.equals(endpoint.getHost())) {
-        return CloudWindmillServiceV1Alpha1Grpc.newStub(localhostChannel(endpoint.getPort()));
+        return CloudWindmillServiceV1Alpha1CustomStub.newStub(localhostChannel(endpoint.getPort()));
       }
 
       return windmillStubFactory.createWindmillServiceStub(WindmillServiceAddress.create(endpoint));
@@ -292,7 +291,7 @@ public class GrpcDispatcherClient {
 
     abstract ImmutableSet<HostAndPort> dispatcherEndpoints();
 
-    abstract ImmutableList<CloudWindmillServiceV1Alpha1Stub> windmillServiceStubs();
+    abstract ImmutableList<CloudWindmillServiceV1Alpha1CustomStub> windmillServiceStubs();
 
     abstract ImmutableList<CloudWindmillMetadataServiceV1Alpha1Stub> windmillMetadataServiceStubs();
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillServer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillServer.java
@@ -34,8 +34,6 @@ import org.apache.beam.runners.dataflow.DataflowRunner;
 import org.apache.beam.runners.dataflow.options.DataflowWorkerHarnessOptions;
 import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillMetadataServiceV1Alpha1Grpc;
 import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillMetadataServiceV1Alpha1Grpc.CloudWindmillMetadataServiceV1Alpha1Stub;
-import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc;
-import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc.CloudWindmillServiceV1Alpha1Stub;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.CommitWorkRequest;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.CommitWorkResponse;
@@ -53,6 +51,7 @@ import org.apache.beam.runners.dataflow.worker.windmill.WindmillServerStub;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStream.CommitWorkStream;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStream.GetDataStream;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStream.GetWorkStream;
+import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs.CloudWindmillServiceV1Alpha1CustomStub;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs.WindmillStubFactoryFactory;
 import org.apache.beam.runners.dataflow.worker.windmill.client.throttling.StreamingEngineThrottleTimers;
 import org.apache.beam.runners.dataflow.worker.windmill.work.WorkItemReceiver;
@@ -156,11 +155,11 @@ public final class GrpcWindmillServer extends WindmillServerStub {
       long clientId,
       WindmillStubFactoryFactory windmillStubFactoryFactory) {
     ManagedChannel inProcessChannel = inProcessChannel(name);
-    CloudWindmillServiceV1Alpha1Stub stub =
-        CloudWindmillServiceV1Alpha1Grpc.newStub(inProcessChannel);
+    CloudWindmillServiceV1Alpha1CustomStub stub =
+        CloudWindmillServiceV1Alpha1CustomStub.newStub(inProcessChannel);
     CloudWindmillMetadataServiceV1Alpha1Stub metadataStub =
         CloudWindmillMetadataServiceV1Alpha1Grpc.newStub(inProcessChannel);
-    List<CloudWindmillServiceV1Alpha1Stub> windmillServiceStubs = Lists.newArrayList(stub);
+    List<CloudWindmillServiceV1Alpha1CustomStub> windmillServiceStubs = Lists.newArrayList(stub);
     List<CloudWindmillMetadataServiceV1Alpha1Stub> windmillMetadataServiceStubs =
         Lists.newArrayList(metadataStub);
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillStreamFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillStreamFactory.java
@@ -35,7 +35,6 @@ import java.util.function.Supplier;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.beam.runners.dataflow.worker.status.StatusDataProvider;
 import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillMetadataServiceV1Alpha1Grpc.CloudWindmillMetadataServiceV1Alpha1Stub;
-import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc.CloudWindmillServiceV1Alpha1Stub;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.ComputationHeartbeatResponse;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.GetWorkRequest;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.JobHeader;
@@ -49,6 +48,7 @@ import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStream.Ge
 import org.apache.beam.runners.dataflow.worker.windmill.client.commits.WorkCommitter;
 import org.apache.beam.runners.dataflow.worker.windmill.client.getdata.GetDataClient;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.observers.StreamObserverFactory;
+import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs.CloudWindmillServiceV1Alpha1CustomStub;
 import org.apache.beam.runners.dataflow.worker.windmill.client.throttling.ThrottleTimer;
 import org.apache.beam.runners.dataflow.worker.windmill.work.WorkItemReceiver;
 import org.apache.beam.runners.dataflow.worker.windmill.work.WorkItemScheduler;
@@ -203,7 +203,7 @@ public class GrpcWindmillStreamFactory implements StatusDataProvider {
   }
 
   public GetWorkStream createGetWorkStream(
-      CloudWindmillServiceV1Alpha1Stub stub,
+      CloudWindmillServiceV1Alpha1CustomStub stub,
       GetWorkRequest request,
       ThrottleTimer getWorkThrottleTimer,
       WorkItemReceiver processWorkItem) {
@@ -245,7 +245,7 @@ public class GrpcWindmillStreamFactory implements StatusDataProvider {
   }
 
   public GetDataStream createGetDataStream(
-      CloudWindmillServiceV1Alpha1Stub stub, ThrottleTimer getDataThrottleTimer) {
+      CloudWindmillServiceV1Alpha1CustomStub stub, ThrottleTimer getDataThrottleTimer) {
     return GrpcGetDataStream.create(
         NO_BACKEND_WORKER_TOKEN,
         responseObserver -> withDefaultDeadline(stub).getDataStream(responseObserver),
@@ -279,7 +279,8 @@ public class GrpcWindmillStreamFactory implements StatusDataProvider {
   }
 
   public CommitWorkStream createCommitWorkStream(
-      CloudWindmillServiceV1Alpha1Stub stub, ThrottleTimer commitWorkThrottleTimer) {
+      CloudWindmillServiceV1Alpha1CustomStub stub, ThrottleTimer commitWorkThrottleTimer) {
+
     return GrpcCommitWorkStream.create(
         NO_BACKEND_WORKER_TOKEN,
         responseObserver -> withDefaultDeadline(stub).commitWorkStream(responseObserver),

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/ChannelCachingRemoteStubFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/ChannelCachingRemoteStubFactory.java
@@ -21,8 +21,6 @@ import com.google.auth.Credentials;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillMetadataServiceV1Alpha1Grpc;
 import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillMetadataServiceV1Alpha1Grpc.CloudWindmillMetadataServiceV1Alpha1Stub;
-import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc;
-import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc.CloudWindmillServiceV1Alpha1Stub;
 import org.apache.beam.runners.dataflow.worker.windmill.WindmillServiceAddress;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.auth.VendoredCredentialsAdapter;
 import org.apache.beam.sdk.annotations.Internal;
@@ -46,10 +44,10 @@ public final class ChannelCachingRemoteStubFactory implements ChannelCachingStub
   }
 
   @Override
-  public CloudWindmillServiceV1Alpha1Stub createWindmillServiceStub(
+  public CloudWindmillServiceV1Alpha1CustomStub createWindmillServiceStub(
       WindmillServiceAddress serviceAddress) {
-    CloudWindmillServiceV1Alpha1Stub windmillServiceStub =
-        CloudWindmillServiceV1Alpha1Grpc.newStub(channelCache.get(serviceAddress));
+    CloudWindmillServiceV1Alpha1CustomStub windmillServiceStub =
+        CloudWindmillServiceV1Alpha1CustomStub.newStub(channelCache.get(serviceAddress));
     return serviceAddress.getKind() != WindmillServiceAddress.Kind.AUTHENTICATED_GCP_SERVICE_ADDRESS
         ? windmillServiceStub.withCallCredentials(
             MoreCallCredentials.from(new VendoredCredentialsAdapter(gcpCredentials)))

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/CloudWindmillServiceV1Alpha1CustomStub.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/CloudWindmillServiceV1Alpha1CustomStub.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs;
+
+import static org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc.*;
+
+import java.io.InputStream;
+import javax.annotation.Nullable;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill.StreamingCommitResponse;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill.StreamingCommitWorkRequest;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill.StreamingCommitWorkRequestOverlay;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill.StreamingGetWorkRequest;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill.StreamingGetWorkResponseChunk;
+import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.CallOptions;
+import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.Channel;
+import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.MethodDescriptor;
+import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.MethodDescriptor.Marshaller;
+import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.protobuf.ProtoUtils;
+import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.stub.AbstractStub;
+import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.stub.ClientCalls;
+import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.stub.StreamObserver;
+
+public class CloudWindmillServiceV1Alpha1CustomStub
+    extends AbstractStub<CloudWindmillServiceV1Alpha1CustomStub> {
+
+  private static final MethodDescriptor<CommitRequest, StreamingCommitResponse>
+      COMMIT_METHOD_DESCRIPTOR =
+          MethodDescriptor.<CommitRequest, StreamingCommitResponse>newBuilder()
+              .setFullMethodName(getCommitWorkStreamMethod().getFullMethodName())
+              .setIdempotent(getCommitWorkStreamMethod().isIdempotent())
+              .setRequestMarshaller(new CommitRequestMarshaller())
+              .setSafe(getCommitWorkStreamMethod().isSafe())
+              .setType(getCommitWorkStreamMethod().getType())
+              .setResponseMarshaller(getCommitWorkStreamMethod().getResponseMarshaller())
+              .setSchemaDescriptor(getCommitWorkStreamMethod().getSchemaDescriptor())
+              .setSampledToLocalTracing(getCommitWorkStreamMethod().isSampledToLocalTracing())
+              .build();
+
+  private CloudWindmillServiceV1Alpha1CustomStub(Channel channel, CallOptions callOptions) {
+    super(channel, callOptions);
+  }
+
+  @Override
+  protected CloudWindmillServiceV1Alpha1CustomStub build(Channel channel, CallOptions callOptions) {
+    return new CloudWindmillServiceV1Alpha1CustomStub(channel, callOptions);
+  }
+
+  /** Creates a new CloudWindmillServiceV1Alpha1CustomStub */
+  public static CloudWindmillServiceV1Alpha1CustomStub newStub(Channel channel) {
+    return CloudWindmillServiceV1Alpha1CustomStub.newStub(
+        CloudWindmillServiceV1Alpha1CustomStub::new, channel);
+  }
+
+  /** Streams commit of previously acquired work. Response is a stream. */
+  public StreamObserver<CommitRequest> commitWorkStream(
+      StreamObserver<StreamingCommitResponse> responseObserver) {
+    return ClientCalls.asyncBidiStreamingCall(
+        getChannel().newCall(COMMIT_METHOD_DESCRIPTOR, getCallOptions()), responseObserver);
+  }
+
+  /** Gets streaming dataflow work. Response is a stream. */
+  public StreamObserver<StreamingGetWorkRequest> getWorkStream(
+      StreamObserver<StreamingGetWorkResponseChunk> responseObserver) {
+    return ClientCalls.asyncBidiStreamingCall(
+        getChannel().newCall(getGetWorkStreamMethod(), getCallOptions()), responseObserver);
+  }
+
+  /** Gets data from windmill. Response is a stream. */
+  public StreamObserver<
+          org.apache.beam.runners.dataflow.worker.windmill.Windmill.StreamingGetDataRequest>
+      getDataStream(
+          StreamObserver<
+                  org.apache.beam.runners.dataflow.worker.windmill.Windmill
+                      .StreamingGetDataResponse>
+              responseObserver) {
+    return ClientCalls.asyncBidiStreamingCall(
+        getChannel().newCall(getGetDataStreamMethod(), getCallOptions()), responseObserver);
+  }
+
+  // Holder class containing either StreamingCommitWorkRequest or
+  // StreamingCommitWorkRequestOverlay.
+  public static class CommitRequest {
+    @Nullable final StreamingCommitWorkRequest request;
+    @Nullable final StreamingCommitWorkRequestOverlay overlay;
+
+    public CommitRequest(StreamingCommitWorkRequest request) {
+      this.request = request;
+      this.overlay = null;
+    }
+
+    public CommitRequest(StreamingCommitWorkRequestOverlay overlay) {
+      this.request = null;
+      this.overlay = overlay;
+    }
+
+    @Nullable
+    public StreamingCommitWorkRequest getRequest() {
+      return request;
+    }
+
+    @Nullable
+    public StreamingCommitWorkRequestOverlay getOverlay() {
+      return overlay;
+    }
+  }
+
+  // Both protos have identical wire format and serialized StreamingCommitWorkRequestOverlay
+  // can be deserialized into StreamingCommitWorkRequest.
+  private static class CommitRequestMarshaller implements Marshaller<CommitRequest> {
+    private static final Marshaller<StreamingCommitWorkRequestOverlay> OVERLAY_MARSHELLER =
+        ProtoUtils.marshaller(StreamingCommitWorkRequestOverlay.getDefaultInstance());
+    private static final Marshaller<StreamingCommitWorkRequest> REQUEST_MARSHALLER =
+        ProtoUtils.marshaller(StreamingCommitWorkRequest.getDefaultInstance());
+
+    @Override
+    public InputStream stream(CommitRequest commitRequest) {
+      if (commitRequest.request != null) {
+        return REQUEST_MARSHALLER.stream(commitRequest.request);
+      }
+      return OVERLAY_MARSHELLER.stream(commitRequest.overlay);
+    }
+
+    @Override
+    public CommitRequest parse(InputStream inputStream) {
+      return new CommitRequest(REQUEST_MARSHALLER.parse(inputStream));
+    }
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/WindmillStubFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/WindmillStubFactory.java
@@ -18,14 +18,14 @@
 package org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs;
 
 import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillMetadataServiceV1Alpha1Grpc.CloudWindmillMetadataServiceV1Alpha1Stub;
-import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc.CloudWindmillServiceV1Alpha1Stub;
 import org.apache.beam.runners.dataflow.worker.windmill.WindmillServiceAddress;
 import org.apache.beam.sdk.annotations.Internal;
 
 /** Used to create stubs to talk to Streaming Engine. */
 @Internal
 public interface WindmillStubFactory {
-  CloudWindmillServiceV1Alpha1Stub createWindmillServiceStub(WindmillServiceAddress serviceAddress);
+  CloudWindmillServiceV1Alpha1CustomStub createWindmillServiceStub(
+      WindmillServiceAddress serviceAddress);
 
   CloudWindmillMetadataServiceV1Alpha1Stub createWindmillMetadataServiceStub(
       WindmillServiceAddress serviceAddress);

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/harness/WindmillStreamSenderTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/harness/WindmillStreamSenderTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.GetWorkRequest;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.JobHeader;
 import org.apache.beam.runners.dataflow.worker.windmill.WindmillConnection;
@@ -36,6 +35,7 @@ import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStream.Ge
 import org.apache.beam.runners.dataflow.worker.windmill.client.commits.WorkCommitter;
 import org.apache.beam.runners.dataflow.worker.windmill.client.getdata.GetDataClient;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.GrpcWindmillStreamFactory;
+import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs.CloudWindmillServiceV1Alpha1CustomStub;
 import org.apache.beam.runners.dataflow.worker.windmill.client.throttling.ThrottleTimer;
 import org.apache.beam.runners.dataflow.worker.windmill.work.WorkItemScheduler;
 import org.apache.beam.runners.dataflow.worker.windmill.work.budget.GetWorkBudget;
@@ -82,7 +82,7 @@ public class WindmillStreamSenderTest {
     grpcCleanup.register(inProcessChannel);
     connection =
         WindmillConnection.builder()
-            .setStub(CloudWindmillServiceV1Alpha1Grpc.newStub(inProcessChannel))
+            .setStub(CloudWindmillServiceV1Alpha1CustomStub.newStub(inProcessChannel))
             .build();
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcCommitWorkStreamTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcCommitWorkStreamTest.java
@@ -34,6 +34,7 @@ import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Al
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStream;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.observers.StreamObserverCancelledException;
+import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs.CloudWindmillServiceV1Alpha1CustomStub;
 import org.apache.beam.runners.dataflow.worker.windmill.client.throttling.ThrottleTimer;
 import org.apache.beam.vendor.grpc.v1p69p0.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.ManagedChannel;
@@ -106,7 +107,7 @@ public class GrpcCommitWorkStreamTest {
             GrpcWindmillStreamFactory.of(TEST_JOB_HEADER)
                 .build()
                 .createCommitWorkStream(
-                    CloudWindmillServiceV1Alpha1Grpc.newStub(inProcessChannel),
+                    CloudWindmillServiceV1Alpha1CustomStub.newStub(inProcessChannel),
                     new ThrottleTimer());
     commitWorkStream.start();
     return commitWorkStream;

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDirectGetWorkStreamTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDirectGetWorkStreamTest.java
@@ -42,6 +42,7 @@ import org.apache.beam.runners.dataflow.worker.windmill.Windmill.WorkItem;
 import org.apache.beam.runners.dataflow.worker.windmill.WindmillConnection;
 import org.apache.beam.runners.dataflow.worker.windmill.client.commits.WorkCommitter;
 import org.apache.beam.runners.dataflow.worker.windmill.client.getdata.GetDataClient;
+import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs.CloudWindmillServiceV1Alpha1CustomStub;
 import org.apache.beam.runners.dataflow.worker.windmill.client.throttling.ThrottleTimer;
 import org.apache.beam.runners.dataflow.worker.windmill.work.WorkItemScheduler;
 import org.apache.beam.runners.dataflow.worker.windmill.work.budget.GetWorkBudget;
@@ -143,7 +144,7 @@ public class GrpcDirectGetWorkStreamTest {
                 .build()
                 .createDirectGetWorkStream(
                     WindmillConnection.builder()
-                        .setStub(CloudWindmillServiceV1Alpha1Grpc.newStub(inProcessChannel))
+                        .setStub(CloudWindmillServiceV1Alpha1CustomStub.newStub(inProcessChannel))
                         .build(),
                     Windmill.GetWorkRequest.newBuilder()
                         .setClientId(TEST_JOB_HEADER.getClientId())

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDispatcherClientTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDispatcherClientTest.java
@@ -28,8 +28,8 @@ import java.util.Collection;
 import java.util.List;
 import org.apache.beam.runners.dataflow.options.DataflowWorkerHarnessOptions;
 import org.apache.beam.runners.dataflow.worker.streaming.config.StreamingGlobalConfig;
-import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc.CloudWindmillServiceV1Alpha1Stub;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.UserWorkerRunnerV1Settings;
+import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs.CloudWindmillServiceV1Alpha1CustomStub;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs.IsolationChannel;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs.WindmillStubFactoryFactoryImpl;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -58,23 +58,23 @@ public class GrpcDispatcherClientTest {
           GrpcDispatcherClient.create(options, new WindmillStubFactoryFactoryImpl(options));
       // Create first time with Isolated channels disabled
       dispatcherClient.onJobConfig(getGlobalConfig(/*useWindmillIsolatedChannels=*/ false));
-      CloudWindmillServiceV1Alpha1Stub stub1 = dispatcherClient.getWindmillServiceStub();
-      CloudWindmillServiceV1Alpha1Stub stub2 = dispatcherClient.getWindmillServiceStub();
+      CloudWindmillServiceV1Alpha1CustomStub stub1 = dispatcherClient.getWindmillServiceStub();
+      CloudWindmillServiceV1Alpha1CustomStub stub2 = dispatcherClient.getWindmillServiceStub();
       assertSame(stub2, stub1);
       assertThat(stub1.getChannel(), not(instanceOf(IsolationChannel.class)));
 
       // Enable Isolated channels
       dispatcherClient.onJobConfig(getGlobalConfig(/*useWindmillIsolatedChannels=*/ true));
-      CloudWindmillServiceV1Alpha1Stub stub3 = dispatcherClient.getWindmillServiceStub();
+      CloudWindmillServiceV1Alpha1CustomStub stub3 = dispatcherClient.getWindmillServiceStub();
       assertNotSame(stub3, stub1);
 
       assertThat(stub3.getChannel(), instanceOf(IsolationChannel.class));
-      CloudWindmillServiceV1Alpha1Stub stub4 = dispatcherClient.getWindmillServiceStub();
+      CloudWindmillServiceV1Alpha1CustomStub stub4 = dispatcherClient.getWindmillServiceStub();
       assertSame(stub3, stub4);
 
       // Disable Isolated channels
       dispatcherClient.onJobConfig(getGlobalConfig(/*useWindmillIsolatedChannels=*/ false));
-      CloudWindmillServiceV1Alpha1Stub stub5 = dispatcherClient.getWindmillServiceStub();
+      CloudWindmillServiceV1Alpha1CustomStub stub5 = dispatcherClient.getWindmillServiceStub();
       assertNotSame(stub4, stub5);
       assertThat(stub5.getChannel(), not(instanceOf(IsolationChannel.class)));
     }
@@ -109,22 +109,22 @@ public class GrpcDispatcherClientTest {
 
       // Job setting disabled, PipelineOption enabled
       dispatcherClient.onJobConfig(getGlobalConfig(/*useWindmillIsolatedChannels=*/ false));
-      CloudWindmillServiceV1Alpha1Stub stub1 = dispatcherClient.getWindmillServiceStub();
-      CloudWindmillServiceV1Alpha1Stub stub2 = dispatcherClient.getWindmillServiceStub();
+      CloudWindmillServiceV1Alpha1CustomStub stub1 = dispatcherClient.getWindmillServiceStub();
+      CloudWindmillServiceV1Alpha1CustomStub stub2 = dispatcherClient.getWindmillServiceStub();
       assertSame(stub2, stub1);
       assertThat(stub1.getChannel(), classMatcher);
 
       // Job setting enabled
       dispatcherClient.onJobConfig(getGlobalConfig(/*useWindmillIsolatedChannels=*/ true));
-      CloudWindmillServiceV1Alpha1Stub stub3 = dispatcherClient.getWindmillServiceStub();
+      CloudWindmillServiceV1Alpha1CustomStub stub3 = dispatcherClient.getWindmillServiceStub();
       assertSame(stub3, stub1);
 
-      CloudWindmillServiceV1Alpha1Stub stub4 = dispatcherClient.getWindmillServiceStub();
+      CloudWindmillServiceV1Alpha1CustomStub stub4 = dispatcherClient.getWindmillServiceStub();
       assertSame(stub3, stub4);
 
       // Job setting disabled
       dispatcherClient.onJobConfig(getGlobalConfig(/*useWindmillIsolatedChannels=*/ false));
-      CloudWindmillServiceV1Alpha1Stub stub5 = dispatcherClient.getWindmillServiceStub();
+      CloudWindmillServiceV1Alpha1CustomStub stub5 = dispatcherClient.getWindmillServiceStub();
       assertSame(stub4, stub5);
     }
   }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetDataStreamTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetDataStreamTest.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStreamShutdownException;
+import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs.CloudWindmillServiceV1Alpha1CustomStub;
 import org.apache.beam.runners.dataflow.worker.windmill.client.throttling.ThrottleTimer;
 import org.apache.beam.vendor.grpc.v1p69p0.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.ManagedChannel;
@@ -100,7 +101,7 @@ public class GrpcGetDataStreamTest {
                 .setSendKeyedGetDataRequests(false)
                 .build()
                 .createGetDataStream(
-                    CloudWindmillServiceV1Alpha1Grpc.newStub(inProcessChannel),
+                    CloudWindmillServiceV1Alpha1CustomStub.newStub(inProcessChannel),
                     new ThrottleTimer());
     getDataStream.start();
     return getDataStream;

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/testing/FakeWindmillStubFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/testing/FakeWindmillStubFactory.java
@@ -19,10 +19,10 @@ package org.apache.beam.runners.dataflow.worker.windmill.testing;
 
 import java.util.function.Supplier;
 import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillMetadataServiceV1Alpha1Grpc;
-import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc;
 import org.apache.beam.runners.dataflow.worker.windmill.WindmillServiceAddress;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs.ChannelCache;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs.ChannelCachingStubFactory;
+import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs.CloudWindmillServiceV1Alpha1CustomStub;
 import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.ManagedChannel;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
 
@@ -35,9 +35,9 @@ public final class FakeWindmillStubFactory implements ChannelCachingStubFactory 
   }
 
   @Override
-  public CloudWindmillServiceV1Alpha1Grpc.CloudWindmillServiceV1Alpha1Stub
-      createWindmillServiceStub(WindmillServiceAddress serviceAddress) {
-    return CloudWindmillServiceV1Alpha1Grpc.newStub(channelCache.get(serviceAddress));
+  public CloudWindmillServiceV1Alpha1CustomStub createWindmillServiceStub(
+      WindmillServiceAddress serviceAddress) {
+    return CloudWindmillServiceV1Alpha1CustomStub.newStub(channelCache.get(serviceAddress));
   }
 
   @Override

--- a/runners/google-cloud-dataflow-java/worker/windmill/src/main/proto/windmill.proto
+++ b/runners/google-cloud-dataflow-java/worker/windmill/src/main/proto/windmill.proto
@@ -848,6 +848,17 @@ message StreamingCommitWorkRequest {
   repeated StreamingCommitRequestChunk commit_chunk = 2;
 }
 
+// overlay proto for StreamingCommitWorkRequest
+// all fields except commit_chunk
+// must be identical to StreamingCommitWorkRequest
+//
+// Instead of StreamingCommitRequestChunk we use StreamingCommitRequestChunkOverlay
+// for commit_chunk here to reduce serialization overhead on small messages
+message StreamingCommitWorkRequestOverlay {
+  optional JobHeader header = 1;
+  repeated StreamingCommitRequestChunkOverlay commit_chunk = 2;
+}
+
 message JobHeader {
   optional string job_id = 1;
   optional string project_id = 2;
@@ -882,6 +893,21 @@ message StreamingCommitRequestChunk {
   // before handing off to the WindmillHost for processing.
   optional int64 remaining_bytes_for_work_item = 4;
   optional bytes serialized_work_item_commit = 5;
+}
+
+// Overlay proto for StreamingCommitRequestChunk
+// All fields except work_item_commit must be identical to the ones
+// in StreamingCommitRequestChunk
+//
+// work_item_commit is a WorkItemCommitRequest here instead of bytes
+// For commits fitting in a single chunk we directly serialize
+// WorkItemCommitRequest to grpc buffers.
+message StreamingCommitRequestChunkOverlay {
+  optional fixed64 request_id = 1;
+  optional string computation_id = 2;
+  optional fixed64 sharding_key = 3;
+  optional int64 remaining_bytes_for_work_item = 4;
+  optional WorkItemCommitRequest work_item_commit = 5;
 }
 
 message StreamingCommitResponse {


### PR DESCRIPTION
Prior to this change all commit chunks were serialized first and then sent to GRPC layer as StreamingCommitRequestChunk.
With this change small commits that don't span chunks are sent as it is without the intermediate serialization using StreamingCommitRequestChunkOverlay to GRPC layer. #33578

Example old profile: 
![image](https://github.com/user-attachments/assets/2f17bade-5163-40c9-88b7-863442686a06)

Example new prrofile: ![image](https://github.com/user-attachments/assets/ff23afcb-1ac1-4d61-add0-a62a5c9876f1)