### PR TITLE
Revert "Support directory separator for Python local filesystem"

### DIFF
--- a/sdks/python/apache_beam/io/textio.py
+++ b/sdks/python/apache_beam/io/textio.py
@@ -20,7 +20,6 @@
 # pytype: skip-file
 
 import logging
-import os
 from functools import partial
 from typing import TYPE_CHECKING
 from typing import Any
@@ -782,8 +781,6 @@ class ReadFromText(PTransform):
     """
 
     super().__init__(**kwargs)
-    if file_pattern and not os.path.dirname(file_pattern):
-      file_pattern = os.path.join('.', file_pattern)
     self._source = self._source_class(
         file_pattern,
         min_bundle_size,

--- a/sdks/python/apache_beam/io/textio_test.py
+++ b/sdks/python/apache_beam/io/textio_test.py
@@ -23,7 +23,6 @@ import glob
 import gzip
 import logging
 import os
-import platform
 import shutil
 import tempfile
 import unittest
@@ -197,23 +196,6 @@ class TextSourceTest(unittest.TestCase):
     file_name, expected_data = write_data(TextSourceTest.DEFAULT_NUM_RECORDS)
     assert len(expected_data) == TextSourceTest.DEFAULT_NUM_RECORDS
     self._run_read_test(file_name, expected_data)
-
-  @unittest.skipIf(platform.system() == 'Windows', 'Skipping on Windows')
-  def test_read_from_text_file_pattern_with_dot_slash(self):
-    cwd = os.getcwd()
-    expected = ['abc', 'de']
-    with TempDir() as temp_dir:
-      temp_dir.create_temp_file(suffix='.txt', lines=[b'a', b'b', b'c'])
-      temp_dir.create_temp_file(suffix='.txt', lines=[b'd', b'e'])
-
-      os.chdir(temp_dir.get_path())
-      with TestPipeline() as p:
-        dot_slash = p | 'ReadDotSlash' >> ReadFromText('./*.txt')
-        no_dot_slash = p | 'ReadNoSlash' >> ReadFromText('*.txt')
-
-        assert_that(dot_slash, equal_to(expected))
-        assert_that(no_dot_slash, equal_to(expected))
-      os.chdir(cwd)
 
   def test_read_single_file_smaller_than_default_buffer(self):
     file_name, expected_data = write_data(TextSourceTest.DEFAULT_NUM_RECORDS)


### PR DESCRIPTION
Reverts apache/beam#34318

Internal bug: 405114293