### PR TITLE
add graceful restart mechanism for GetWorkStream to prevent DEADLINE_…

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/WindmillStreamSender.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/WindmillStreamSender.java
@@ -188,9 +188,9 @@ final class WindmillStreamSender implements GetWorkBudgetSpender, StreamSender {
     workCommitter.stop();
     commitWorkStream.shutdown();
     try {
-      if (!Preconditions.checkNotNull(streamStarter)
+      if (!Preconditions.checkNotNull(streamManagerExecutor)
           .awaitTermination(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-        streamStarter.shutdownNow();
+        streamManagerExecutor.shutdownNow();
       }
       Preconditions.checkNotNull(getDataStream)
           .awaitTermination(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/AsyncStreamCloser.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/AsyncStreamCloser.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.windmill.client;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.UncheckedTimeoutException;
+import org.slf4j.Logger;
+
+/** Allows an interface for queueing streams to be closed asynchronously. */
+@ThreadSafe
+final class AsyncStreamCloser {
+  private static final String STREAM_CLOSER_THREAD_NAME_FORMAT = "StreamCloserThread-%d";
+  private final Logger logger;
+  private final BlockingQueue<ResettableThrowingStreamObserver<?>> streamsToClose;
+  private final ExecutorService streamCloserExecutor;
+
+  @GuardedBy("this")
+  private boolean isRunning;
+
+  AsyncStreamCloser(Logger logger) {
+    this.logger = logger;
+    streamsToClose = new LinkedBlockingQueue<>();
+    streamCloserExecutor =
+        Executors.newSingleThreadExecutor(
+            new ThreadFactoryBuilder().setNameFormat(STREAM_CLOSER_THREAD_NAME_FORMAT).build());
+  }
+
+  /** Returns true if the stream is successfully scheduled to be closed. */
+  synchronized boolean tryScheduleForClosure(ResettableThrowingStreamObserver<?> stream) {
+    if (isRunning) {
+      streamsToClose.add(stream);
+      return true;
+    }
+
+    return false;
+  }
+
+  synchronized void start() throws WindmillStreamShutdownException {
+    if (!isRunning) {
+      try {
+        streamCloserExecutor.execute(
+            () -> {
+              while (true) {
+                try {
+                  timeoutStream(streamsToClose.take());
+                } catch (InterruptedException e) {
+                  // Drain streamsToClose to prevent any dangling StreamObservers.
+                  streamsToClose.forEach(this::timeoutStream);
+                  break;
+                }
+              }
+            });
+        isRunning = true;
+      } catch (RejectedExecutionException e) {
+        // Stream has already been shutdown.
+        throw new WindmillStreamShutdownException("Stream has been previously shutdown.");
+      }
+    }
+  }
+
+  synchronized void shutdown() {
+    streamCloserExecutor.shutdown();
+    try {
+      if (!streamCloserExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+        streamCloserExecutor.shutdownNow();
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UncheckedTimeoutException(
+          "Interrupted while waiting for streamCloserExecutor to terminate.", e);
+    } finally {
+      isRunning = false;
+    }
+  }
+
+  private void timeoutStream(ResettableThrowingStreamObserver<?> streamObserver) {
+    try {
+      streamObserver.onCompleted();
+    } catch (IllegalStateException onErrorException) {
+      // The delegate above was already terminated via onError or onComplete.
+      // Fallthrough since this is possibly due to queued onNext() calls that are being made from
+      // previously blocked threads.
+    } catch (RuntimeException onErrorException) {
+      logger.warn("Encountered unexpected error when timing out StreamObserver.", onErrorException);
+    } catch (ResettableThrowingStreamObserver.StreamClosedException
+        | WindmillStreamShutdownException e) {
+      logger.debug("Stream has already been closed or shutdown.");
+    }
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/ResettableThrowingStreamObserver.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/ResettableThrowingStreamObserver.java
@@ -17,6 +17,10 @@
  */
 package org.apache.beam.runners.dataflow.worker.windmill.client;
 
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
@@ -26,6 +30,7 @@ import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.observers.Te
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.stub.StreamObserver;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 
 /**
@@ -42,6 +47,7 @@ import org.slf4j.Logger;
 final class ResettableThrowingStreamObserver<T> {
   private final Supplier<TerminatingStreamObserver<T>> streamObserverFactory;
   private final Logger logger;
+  private final AsyncStreamCloser streamCloser;
 
   @GuardedBy("this")
   private @Nullable TerminatingStreamObserver<T> delegateStreamObserver;
@@ -62,6 +68,7 @@ final class ResettableThrowingStreamObserver<T> {
     this.streamObserverFactory = streamObserverFactory;
     this.logger = logger;
     this.delegateStreamObserver = null;
+    this.streamCloser = new AsyncStreamCloser();
   }
 
   private synchronized StreamObserver<T> delegate()
@@ -76,6 +83,11 @@ final class ResettableThrowingStreamObserver<T> {
     }
 
     return Preconditions.checkNotNull(delegateStreamObserver, "requestObserver cannot be null.");
+  }
+
+  /** Starts a background thread that will {@link #release()}ed StreamObservers. */
+  synchronized void startAsyncStreamCloser() {
+    streamCloser.start();
   }
 
   /** Creates a new delegate to use for future {@link StreamObserver} methods. */
@@ -146,6 +158,15 @@ final class ResettableThrowingStreamObserver<T> {
     isCurrentStreamClosed = true;
   }
 
+  /**
+   * Releases current stream to the {@link AsyncStreamCloser}, which will close the stream w/o
+   * blocking the calling thread. Marks the stream as closed until {@link #reset()} reopens it.
+   */
+  public synchronized void release() throws StreamClosedException, WindmillStreamShutdownException {
+    streamCloser.scheduleClosure(delegate());
+    isCurrentStreamClosed = true;
+  }
+
   synchronized boolean isClosed() {
     return isCurrentStreamClosed;
   }
@@ -157,6 +178,78 @@ final class ResettableThrowingStreamObserver<T> {
   static final class StreamClosedException extends Exception {
     StreamClosedException(String s) {
       super(s);
+    }
+  }
+
+  static final class InternalStreamTimeout extends Throwable {
+    private static final InternalStreamTimeout INSTANCE = new InternalStreamTimeout();
+
+    private InternalStreamTimeout() {}
+
+    static boolean isInternalTimeout(Throwable t) {
+      while (t != null) {
+        if (t == INSTANCE) {
+          return true;
+        }
+        t = t.getCause();
+      }
+      return false;
+    }
+  }
+
+  private final class AsyncStreamCloser {
+    private final BlockingQueue<StreamObserver<T>> streamsToClose;
+    private final ExecutorService streamCloserExecutor;
+
+    @GuardedBy("this")
+    private boolean started;
+
+    private AsyncStreamCloser() {
+      streamsToClose = new LinkedBlockingQueue<>();
+      streamCloserExecutor =
+          Executors.newSingleThreadExecutor(
+              new ThreadFactoryBuilder().setNameFormat("StreamCloserThread-%d").build());
+    }
+
+    private synchronized void start() {
+      if (!started) {
+        streamCloserExecutor.execute(
+            () -> {
+              while (!isPoisoned()) {
+                try {
+                  timeoutStream(streamsToClose.take());
+                } catch (InterruptedException e) {
+                  // Drain streamsToClose to prevent any dangling StreamObservers.
+                  streamsToClose.forEach(this::timeoutStream);
+                  break;
+                }
+              }
+            });
+        started = true;
+      }
+    }
+
+    private void timeoutStream(StreamObserver<T> streamObserver) {
+      try {
+        streamObserver.onError(InternalStreamTimeout.INSTANCE);
+      } catch (IllegalStateException onErrorException) {
+        // The delegate above was already terminated via onError or onComplete.
+        // Fallthrough since this is possibly due to queued onNext() calls that are being made from
+        // previously blocked threads.
+      } catch (RuntimeException onErrorException) {
+        logger.warn(
+            "Encountered unexpected error when timing out StreamObserver.", onErrorException);
+      }
+    }
+
+    private boolean isPoisoned() {
+      synchronized (ResettableThrowingStreamObserver.this) {
+        return isPoisoned;
+      }
+    }
+
+    private void scheduleClosure(StreamObserver<T> stream) {
+      streamsToClose.add(stream);
     }
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/WindmillStreamTTL.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/WindmillStreamTTL.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.windmill.client;
+
+import com.google.auto.value.AutoValue;
+import java.util.concurrent.TimeUnit;
+import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
+
+/**
+ * Time to live for a {@link WindmillStream}. This should be less than a stream's deadline since we
+ * use this to internally restart the stream before we will get a {@link
+ * org.apache.beam.vendor.grpc.v1p69p0.io.grpc.Status#DEADLINE_EXCEEDED} errors.
+ */
+@Internal
+@AutoValue
+public abstract class WindmillStreamTTL {
+
+  private static final WindmillStreamTTL NO_TTL = createInternal(-1, TimeUnit.SECONDS);
+
+  public static WindmillStreamTTL create(int time, TimeUnit unit) {
+    Preconditions.checkState(time > 0, "TTL time must be greater than 0.");
+    return createInternal(time, unit);
+  }
+
+  private static WindmillStreamTTL createInternal(int time, TimeUnit unit) {
+    return new AutoValue_WindmillStreamTTL(time, unit);
+  }
+
+  public static WindmillStreamTTL noTtl() {
+    return NO_TTL;
+  }
+
+  public abstract int time();
+
+  public abstract TimeUnit unit();
+
+  final boolean isValidTtl() {
+    return time() > 0;
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcCommitWorkStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcCommitWorkStream.java
@@ -41,6 +41,7 @@ import org.apache.beam.runners.dataflow.worker.windmill.Windmill.WorkItemCommitR
 import org.apache.beam.runners.dataflow.worker.windmill.client.AbstractWindmillStream;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStream.CommitWorkStream;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStreamShutdownException;
+import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStreamTTL;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.observers.StreamObserverFactory;
 import org.apache.beam.runners.dataflow.worker.windmill.client.throttling.ThrottleTimer;
 import org.apache.beam.sdk.util.BackOff;
@@ -75,7 +76,8 @@ final class GrpcCommitWorkStream
       ThrottleTimer commitWorkThrottleTimer,
       JobHeader jobHeader,
       AtomicLong idGenerator,
-      int streamingRpcBatchLimit) {
+      int streamingRpcBatchLimit,
+      WindmillStreamTTL streamTimeout) {
     super(
         LOG,
         "CommitWorkStream",
@@ -84,7 +86,8 @@ final class GrpcCommitWorkStream
         streamObserverFactory,
         streamRegistry,
         logEveryNStreamFailures,
-        backendWorkerToken);
+        backendWorkerToken,
+        streamTimeout);
     pending = new ConcurrentHashMap<>();
     this.idGenerator = idGenerator;
     this.jobHeader = jobHeader;
@@ -103,7 +106,8 @@ final class GrpcCommitWorkStream
       ThrottleTimer commitWorkThrottleTimer,
       JobHeader jobHeader,
       AtomicLong idGenerator,
-      int streamingRpcBatchLimit) {
+      int streamingRpcBatchLimit,
+      WindmillStreamTTL streamTimeout) {
     return new GrpcCommitWorkStream(
         backendWorkerToken,
         startCommitWorkRpcFn,
@@ -114,7 +118,8 @@ final class GrpcCommitWorkStream
         commitWorkThrottleTimer,
         jobHeader,
         idGenerator,
-        streamingRpcBatchLimit);
+        streamingRpcBatchLimit,
+        streamTimeout);
   }
 
   @Override

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDirectGetWorkStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDirectGetWorkStream.java
@@ -35,6 +35,7 @@ import org.apache.beam.runners.dataflow.worker.windmill.Windmill.WorkItem;
 import org.apache.beam.runners.dataflow.worker.windmill.client.AbstractWindmillStream;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStream.GetWorkStream;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStreamShutdownException;
+import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStreamTTL;
 import org.apache.beam.runners.dataflow.worker.windmill.client.commits.WorkCommitter;
 import org.apache.beam.runners.dataflow.worker.windmill.client.getdata.GetDataClient;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.GetWorkResponseChunkAssembler.AssembledWorkItem;
@@ -107,7 +108,8 @@ final class GrpcDirectGetWorkStream
       HeartbeatSender heartbeatSender,
       GetDataClient getDataClient,
       WorkCommitter workCommitter,
-      WorkItemScheduler workItemScheduler) {
+      WorkItemScheduler workItemScheduler,
+      WindmillStreamTTL streamTimeout) {
     super(
         LOG,
         "GetWorkStream",
@@ -116,7 +118,8 @@ final class GrpcDirectGetWorkStream
         streamObserverFactory,
         streamRegistry,
         logEveryNStreamFailures,
-        backendWorkerToken);
+        backendWorkerToken,
+        streamTimeout);
     this.requestHeader = requestHeader;
     this.getWorkThrottleTimer = getWorkThrottleTimer;
     this.workItemScheduler = workItemScheduler;
@@ -150,7 +153,8 @@ final class GrpcDirectGetWorkStream
       HeartbeatSender heartbeatSender,
       GetDataClient getDataClient,
       WorkCommitter workCommitter,
-      WorkItemScheduler workItemScheduler) {
+      WorkItemScheduler workItemScheduler,
+      WindmillStreamTTL streamTimeout) {
     return new GrpcDirectGetWorkStream(
         backendWorkerToken,
         startGetWorkRpcFn,
@@ -164,7 +168,8 @@ final class GrpcDirectGetWorkStream
         heartbeatSender,
         getDataClient,
         workCommitter,
-        workItemScheduler);
+        workItemScheduler,
+        streamTimeout);
   }
 
   private static Watermarks createWatermarks(

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetDataStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetDataStream.java
@@ -51,6 +51,7 @@ import org.apache.beam.runners.dataflow.worker.windmill.Windmill.StreamingGetDat
 import org.apache.beam.runners.dataflow.worker.windmill.client.AbstractWindmillStream;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStream.GetDataStream;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStreamShutdownException;
+import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStreamTTL;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.GrpcGetDataStreamRequests.QueuedBatch;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.GrpcGetDataStreamRequests.QueuedRequest;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.observers.StreamObserverFactory;
@@ -95,7 +96,8 @@ final class GrpcGetDataStream
       AtomicLong idGenerator,
       int streamingRpcBatchLimit,
       boolean sendKeyedGetDataRequests,
-      Consumer<List<Windmill.ComputationHeartbeatResponse>> processHeartbeatResponses) {
+      Consumer<List<Windmill.ComputationHeartbeatResponse>> processHeartbeatResponses,
+      WindmillStreamTTL streamTimeout) {
     super(
         LOG,
         "GetDataStream",
@@ -104,7 +106,8 @@ final class GrpcGetDataStream
         streamObserverFactory,
         streamRegistry,
         logEveryNStreamFailures,
-        backendWorkerToken);
+        backendWorkerToken,
+        streamTimeout);
     this.idGenerator = idGenerator;
     this.getDataThrottleTimer = getDataThrottleTimer;
     this.jobHeader = jobHeader;
@@ -128,7 +131,8 @@ final class GrpcGetDataStream
       AtomicLong idGenerator,
       int streamingRpcBatchLimit,
       boolean sendKeyedGetDataRequests,
-      Consumer<List<Windmill.ComputationHeartbeatResponse>> processHeartbeatResponses) {
+      Consumer<List<Windmill.ComputationHeartbeatResponse>> processHeartbeatResponses,
+      WindmillStreamTTL streamTimeout) {
     return new GrpcGetDataStream(
         backendWorkerToken,
         startGetDataRpcFn,
@@ -141,7 +145,8 @@ final class GrpcGetDataStream
         idGenerator,
         streamingRpcBatchLimit,
         sendKeyedGetDataRequests,
-        processHeartbeatResponses);
+        processHeartbeatResponses,
+        streamTimeout);
   }
 
   private static WindmillStreamShutdownException shutdownExceptionFor(QueuedBatch batch) {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetWorkStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetWorkStream.java
@@ -30,6 +30,7 @@ import org.apache.beam.runners.dataflow.worker.windmill.Windmill.StreamingGetWor
 import org.apache.beam.runners.dataflow.worker.windmill.client.AbstractWindmillStream;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStream.GetWorkStream;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStreamShutdownException;
+import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStreamTTL;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.GetWorkResponseChunkAssembler.AssembledWorkItem;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.observers.StreamObserverFactory;
 import org.apache.beam.runners.dataflow.worker.windmill.client.throttling.ThrottleTimer;
@@ -72,7 +73,8 @@ final class GrpcGetWorkStream
       int logEveryNStreamFailures,
       boolean requestBatchedGetWorkResponse,
       ThrottleTimer getWorkThrottleTimer,
-      WorkItemReceiver receiver) {
+      WorkItemReceiver receiver,
+      WindmillStreamTTL streamTimeout) {
     super(
         LOG,
         "GetWorkStream",
@@ -81,7 +83,8 @@ final class GrpcGetWorkStream
         streamObserverFactory,
         streamRegistry,
         logEveryNStreamFailures,
-        backendWorkerToken);
+        backendWorkerToken,
+        streamTimeout);
     this.request = request;
     this.getWorkThrottleTimer = getWorkThrottleTimer;
     this.receiver = receiver;
@@ -104,7 +107,8 @@ final class GrpcGetWorkStream
       int logEveryNStreamFailures,
       boolean requestBatchedGetWorkResponse,
       ThrottleTimer getWorkThrottleTimer,
-      WorkItemReceiver receiver) {
+      WorkItemReceiver receiver,
+      WindmillStreamTTL streamTimeout) {
     return new GrpcGetWorkStream(
         backendWorkerToken,
         startGetWorkRpcFn,
@@ -115,7 +119,8 @@ final class GrpcGetWorkStream
         logEveryNStreamFailures,
         requestBatchedGetWorkResponse,
         getWorkThrottleTimer,
-        receiver);
+        receiver,
+        streamTimeout);
   }
 
   private void sendRequestExtension(long moreItems, long moreBytes) {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetWorkerMetadataStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetWorkerMetadataStream.java
@@ -30,6 +30,7 @@ import org.apache.beam.runners.dataflow.worker.windmill.WindmillEndpoints;
 import org.apache.beam.runners.dataflow.worker.windmill.client.AbstractWindmillStream;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStream.GetWorkerMetadataStream;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStreamShutdownException;
+import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStreamTTL;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.observers.StreamObserverFactory;
 import org.apache.beam.runners.dataflow.worker.windmill.client.throttling.ThrottleTimer;
 import org.apache.beam.sdk.util.BackOff;
@@ -60,7 +61,8 @@ public final class GrpcGetWorkerMetadataStream
       int logEveryNStreamFailures,
       JobHeader jobHeader,
       ThrottleTimer getWorkerMetadataThrottleTimer,
-      Consumer<WindmillEndpoints> serverMappingConsumer) {
+      Consumer<WindmillEndpoints> serverMappingConsumer,
+      WindmillStreamTTL streamTimeout) {
     super(
         LOG,
         "GetWorkerMetadataStream",
@@ -69,7 +71,8 @@ public final class GrpcGetWorkerMetadataStream
         streamObserverFactory,
         streamRegistry,
         logEveryNStreamFailures,
-        "");
+        "",
+        streamTimeout);
     this.workerMetadataRequest = WorkerMetadataRequest.newBuilder().setHeader(jobHeader).build();
     this.getWorkerMetadataThrottleTimer = getWorkerMetadataThrottleTimer;
     this.serverMappingConsumer = serverMappingConsumer;
@@ -86,7 +89,8 @@ public final class GrpcGetWorkerMetadataStream
       int logEveryNStreamFailures,
       JobHeader jobHeader,
       ThrottleTimer getWorkerMetadataThrottleTimer,
-      Consumer<WindmillEndpoints> serverMappingUpdater) {
+      Consumer<WindmillEndpoints> serverMappingUpdater,
+      WindmillStreamTTL streamTimeout) {
     return new GrpcGetWorkerMetadataStream(
         startGetWorkerMetadataRpcFn,
         backoff,
@@ -95,7 +99,8 @@ public final class GrpcGetWorkerMetadataStream
         logEveryNStreamFailures,
         jobHeader,
         getWorkerMetadataThrottleTimer,
-        serverMappingUpdater);
+        serverMappingUpdater,
+        streamTimeout);
   }
 
   /**

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillStreamFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillStreamFactory.java
@@ -74,7 +74,7 @@ public class GrpcWindmillStreamFactory implements StatusDataProvider {
 
   private static final long DEFAULT_STREAM_RPC_DEADLINE_SECONDS = 300;
 
-  // 15 minutes less than DIRECT_PATH_STREAM_DEADLINE to allow for drains.
+  // 15 minutes less than withDirectPathDeadline() to allow for drains.
   private static final WindmillStreamTTL DIRECT_PATH_STREAM_TIMEOUT =
       WindmillStreamTTL.create(45, TimeUnit.MINUTES);
 
@@ -128,9 +128,7 @@ public class GrpcWindmillStreamFactory implements StatusDataProvider {
     this.streamIdGenerator = new AtomicLong();
   }
 
-  /**
-   * @implNote Used for {@link AutoBuilder} {@link Builder} class, do not call directly.
-   */
+  /** @implNote Used for {@link AutoBuilder} {@link Builder} class, do not call directly. */
   static GrpcWindmillStreamFactory create(
       JobHeader jobHeader,
       int logEveryNStreamFailures,

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillStreamFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillStreamFactory.java
@@ -191,7 +191,11 @@ public class GrpcWindmillStreamFactory implements StatusDataProvider {
     return stub.withDeadlineAfter(DEFAULT_STREAM_RPC_DEADLINE_SECONDS, TimeUnit.SECONDS);
   }
 
-  private static <T extends AbstractStub<T>> T withLongDeadline(T stub) {
+  /**
+   * Set a longer deadline for directpath since we have explicit semantics on when to open and close
+   * the streams w/ the fan out metadata.
+   */
+  private static <T extends AbstractStub<T>> T withDirectPathDeadline(T stub) {
     // Deadlines are absolute points in time, so generate a new one everytime this function is
     // called.
     return stub.withDeadlineAfter(1, TimeUnit.HOURS);
@@ -239,7 +243,7 @@ public class GrpcWindmillStreamFactory implements StatusDataProvider {
     return GrpcDirectGetWorkStream.create(
         connection.backendWorkerToken(),
         responseObserver ->
-            withLongDeadline(connection.currentStub()).getWorkStream(responseObserver),
+            withDirectPathDeadline(connection.currentStub()).getWorkStream(responseObserver),
         request,
         grpcBackOff.get(),
         newStreamObserverFactory(),
@@ -275,7 +279,7 @@ public class GrpcWindmillStreamFactory implements StatusDataProvider {
     return GrpcGetDataStream.create(
         connection.backendWorkerToken(),
         responseObserver ->
-            withLongDeadline(connection.currentStub()).getDataStream(responseObserver),
+            withDirectPathDeadline(connection.currentStub()).getDataStream(responseObserver),
         grpcBackOff.get(),
         newStreamObserverFactory(),
         streamRegistry,
@@ -308,7 +312,7 @@ public class GrpcWindmillStreamFactory implements StatusDataProvider {
     return GrpcCommitWorkStream.create(
         connection.backendWorkerToken(),
         responseObserver ->
-            withLongDeadline(connection.currentStub()).commitWorkStream(responseObserver),
+            withDirectPathDeadline(connection.currentStub()).commitWorkStream(responseObserver),
         grpcBackOff.get(),
         newStreamObserverFactory(),
         streamRegistry,
@@ -351,7 +355,7 @@ public class GrpcWindmillStreamFactory implements StatusDataProvider {
   }
 
   @VisibleForTesting
-  final ImmutableSet<AbstractWindmillStream<?, ?>> streamRegistry() {
+  ImmutableSet<AbstractWindmillStream<?, ?>> streamRegistry() {
     return ImmutableSet.copyOf(streamRegistry);
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/observers/DirectStreamObserver.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/observers/DirectStreamObserver.java
@@ -161,7 +161,7 @@ final class DirectStreamObserver<T> implements TerminatingStreamObserver<T> {
 
         if (totalSecondsWaited > OUTPUT_CHANNEL_CONSIDERED_STALLED_SECONDS) {
           LOG.info(
-              "Output channel stalled for {}s, outbound thread {}.",
+              "Output channel stalled for {}s waiting to be ready, outbound thread {}.",
               totalSecondsWaited,
               Thread.currentThread().getName());
         }
@@ -220,10 +220,9 @@ final class DirectStreamObserver<T> implements TerminatingStreamObserver<T> {
     return inactivityTimeout > 0
         ? "Waited "
             + totalSecondsWaited
-            + "s which exceeds given deadline of "
+            + "s which exceeds given timeout of "
             + inactivityTimeout
-            + "s for the outboundObserver to become ready meaning "
-            + "that the stream deadline was not respected."
+            + "s for the outboundObserver to become ready."
         : "Output channel has been blocked for "
             + totalSecondsWaited
             + "s. Restarting stream internally.";

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/observers/StreamObserverFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/observers/StreamObserverFactory.java
@@ -49,15 +49,15 @@ public abstract class StreamObserverFactory {
     @Override
     public <ResponseT, RequestT> TerminatingStreamObserver<RequestT> from(
         Function<StreamObserver<ResponseT>, StreamObserver<RequestT>> clientFactory,
-        StreamObserver<ResponseT> inboundObserver) {
+        StreamObserver<ResponseT> responseObserver) {
       AdvancingPhaser phaser = new AdvancingPhaser(1);
-      CallStreamObserver<RequestT> outboundObserver =
+      CallStreamObserver<RequestT> wrappedResponseObserver =
           (CallStreamObserver<RequestT>)
               clientFactory.apply(
                   new ForwardingClientResponseObserver<ResponseT, RequestT>(
-                      inboundObserver, phaser::arrive, phaser::forceTermination));
+                      responseObserver, phaser::arrive, phaser::forceTermination));
       return new DirectStreamObserver<>(
-          phaser, outboundObserver, inactivityTimeout, messagesBetweenIsReadyChecks);
+          phaser, wrappedResponseObserver, inactivityTimeout, messagesBetweenIsReadyChecks);
     }
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/observers/StreamObserverFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/observers/StreamObserverFactory.java
@@ -29,8 +29,8 @@ import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.stub.StreamObserver;
  */
 public abstract class StreamObserverFactory {
   public static StreamObserverFactory direct(
-      long deadlineSeconds, int messagesBetweenIsReadyChecks) {
-    return new Direct(deadlineSeconds, messagesBetweenIsReadyChecks);
+      long inactivityTimeout, int messagesBetweenIsReadyChecks) {
+    return new Direct(inactivityTimeout, messagesBetweenIsReadyChecks);
   }
 
   public abstract <ResponseT, RequestT> TerminatingStreamObserver<RequestT> from(
@@ -38,11 +38,11 @@ public abstract class StreamObserverFactory {
       StreamObserver<ResponseT> responseObserver);
 
   private static class Direct extends StreamObserverFactory {
-    private final long deadlineSeconds;
+    private final long inactivityTimeout;
     private final int messagesBetweenIsReadyChecks;
 
-    Direct(long deadlineSeconds, int messagesBetweenIsReadyChecks) {
-      this.deadlineSeconds = deadlineSeconds;
+    Direct(long inactivityTimeout, int messagesBetweenIsReadyChecks) {
+      this.inactivityTimeout = inactivityTimeout;
       this.messagesBetweenIsReadyChecks = messagesBetweenIsReadyChecks;
     }
 
@@ -57,7 +57,7 @@ public abstract class StreamObserverFactory {
                   new ForwardingClientResponseObserver<ResponseT, RequestT>(
                       inboundObserver, phaser::arrive, phaser::forceTermination));
       return new DirectStreamObserver<>(
-          phaser, outboundObserver, deadlineSeconds, messagesBetweenIsReadyChecks);
+          phaser, outboundObserver, inactivityTimeout, messagesBetweenIsReadyChecks);
     }
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/harness/WindmillStreamSenderTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/harness/WindmillStreamSenderTest.java
@@ -20,6 +20,7 @@ package org.apache.beam.runners.dataflow.worker.streaming.harness;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -226,7 +227,7 @@ public class WindmillStreamSenderTest {
     windmillStreamSender.start();
     windmillStreamSender.close();
 
-    verify(mockGetWorkStream).shutdown();
+    verify(mockGetWorkStream, atLeastOnce()).shutdown();
     verify(mockGetDataStream).shutdown();
     verify(mockCommitWorkStream).shutdown();
   }
@@ -268,7 +269,6 @@ public class WindmillStreamSenderTest {
     verify(mockGetDataStream, times(0)).start();
     verify(mockCommitWorkStream, times(0)).start();
 
-    verify(mockGetWorkStream).shutdown();
     verify(mockGetDataStream).shutdown();
     verify(mockCommitWorkStream).shutdown();
   }


### PR DESCRIPTION
GetWorkStream was previously terminating due to `DEADLINE_EXCEEDED` status leading to stream breaks and unnecessary retry spikes in the streaming backend.

- Add GetWorkStream management loop that gracefully terminates and restarts the stream
- Extend deadlines of direct streams to 1hr for less churn in restarting the streams internally
- Add worker token to stream manager thread name

R: @scwhittle @acrites 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
