### PR TITLE
Feature: Yaml JdbcIO partitioning for ReadRows

### DIFF
--- a/playground/frontend/playground_components/assets/symbols/java.g.yaml
+++ b/playground/frontend/playground_components/assets/symbols/java.g.yaml
@@ -6331,6 +6331,8 @@ JdbcReadSchemaTransformProvider:
   - getFetchSize
   - getJdbcUrl
   - getLocation
+  - getPartitionColumn
+  - getNumPartitions
   - getOutputParallelization
   - getPassword
   - getReadQuery
@@ -6344,6 +6346,8 @@ JdbcReadSchemaTransformProvider:
   - setFetchSize
   - setJdbcUrl
   - setLocation
+  - setPartitionColumn
+  - setNumPartitions
   - setOutputParallelization
   - setPassword
   - setReadQuery

--- a/playground/frontend/playground_components/assets/symbols/java.g.yaml
+++ b/playground/frontend/playground_components/assets/symbols/java.g.yaml
@@ -6331,8 +6331,6 @@ JdbcReadSchemaTransformProvider:
   - getFetchSize
   - getJdbcUrl
   - getLocation
-  - getPartitionColumn
-  - getNumPartitions
   - getOutputParallelization
   - getPassword
   - getReadQuery
@@ -6346,8 +6344,6 @@ JdbcReadSchemaTransformProvider:
   - setFetchSize
   - setJdbcUrl
   - setLocation
-  - setPartitionColumn
-  - setNumPartitions
   - setOutputParallelization
   - setPassword
   - setReadQuery

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcReadSchemaTransformProvider.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcReadSchemaTransformProvider.java
@@ -33,6 +33,7 @@ import org.apache.beam.sdk.schemas.transforms.SchemaTransform;
 import org.apache.beam.sdk.schemas.transforms.SchemaTransformProvider;
 import org.apache.beam.sdk.schemas.transforms.TypedSchemaTransformProvider;
 import org.apache.beam.sdk.values.PCollectionRowTuple;
+import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Strings;
 import org.checkerframework.checker.initialization.qual.Initialized;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -213,25 +214,67 @@ public class JdbcReadSchemaTransformProvider
 
     @Override
     public PCollectionRowTuple expand(PCollectionRowTuple input) {
-      String query = config.getReadQuery();
-      if (query == null) {
-        query = String.format("SELECT * FROM %s", config.getLocation());
+
+      boolean readQueryPresent =
+          (config.getReadQuery() != null && !"".equals(config.getReadQuery()));
+      boolean locationPresent = (config.getLocation() != null && !"".equals(config.getLocation()));
+
+      if (readQueryPresent && locationPresent) {
+        throw new IllegalArgumentException("Query and Table are mutually exclusive configurations");
       }
-      JdbcIO.ReadRows readRows =
-          JdbcIO.readRows().withDataSourceConfiguration(dataSourceConfiguration()).withQuery(query);
-      Integer fetchSize = config.getFetchSize();
-      if (fetchSize != null && fetchSize > 0) {
-        readRows = readRows.withFetchSize(fetchSize);
+      if (!readQueryPresent && !locationPresent) {
+        throw new IllegalArgumentException("Either Query or Table must be specified.");
       }
-      Boolean outputParallelization = config.getOutputParallelization();
-      if (outputParallelization != null) {
-        readRows = readRows.withOutputParallelization(outputParallelization);
+
+      @Nullable String partitionColumn = config.getPartitionColumn();
+      @Nullable String location = config.getLocation();
+      if (partitionColumn != null) {
+        JdbcIO.ReadWithPartitions<Row, ?> readRowsWithParitions =
+            JdbcIO.<Row>readWithPartitions()
+                .withDataSourceConfiguration(dataSourceConfiguration())
+                .withTable(location)
+                .withPartitionColumn(partitionColumn)
+                .withRowOutput();
+
+        @Nullable Integer partitions = config.getNumPartitions();
+        if (partitions != null) {
+          readRowsWithParitions = readRowsWithParitions.withNumPartitions(partitions);
+        }
+
+        @Nullable Integer fetchSize = config.getFetchSize();
+        if (fetchSize != null && fetchSize > 0) {
+          readRowsWithParitions = readRowsWithParitions.withFetchSize(fetchSize);
+        }
+
+        @Nullable Boolean disableAutoCommit = config.getDisableAutoCommit();
+        if (disableAutoCommit != null) {
+          readRowsWithParitions = readRowsWithParitions.withDisableAutoCommit(disableAutoCommit);
+        }
+        return PCollectionRowTuple.of("output", input.getPipeline().apply(readRowsWithParitions));
+      } else {
+        @Nullable String readQuery = config.getReadQuery();
+        if (readQuery == null) {
+          readQuery = String.format("SELECT * FROM %s", location);
+        }
+        JdbcIO.ReadRows readRows =
+            JdbcIO.readRows()
+                .withDataSourceConfiguration(dataSourceConfiguration())
+                .withQuery(readQuery);
+
+        @Nullable Integer fetchSize = config.getFetchSize();
+        if (fetchSize != null && fetchSize > 0) {
+          readRows = readRows.withFetchSize(fetchSize);
+        }
+        @Nullable Boolean outputParallelization = config.getOutputParallelization();
+        if (outputParallelization != null) {
+          readRows = readRows.withOutputParallelization(outputParallelization);
+        }
+        @Nullable Boolean disableAutoCommit = config.getDisableAutoCommit();
+        if (disableAutoCommit != null) {
+          readRows = readRows.withDisableAutoCommit(disableAutoCommit);
+        }
+        return PCollectionRowTuple.of("output", input.getPipeline().apply(readRows));
       }
-      Boolean disableAutoCommit = config.getDisableAutoCommit();
-      if (disableAutoCommit != null) {
-        readRows = readRows.withDisableAutoCommit(disableAutoCommit);
-      }
-      return PCollectionRowTuple.of("output", input.getPipeline().apply(readRows));
     }
   }
 
@@ -293,6 +336,14 @@ public class JdbcReadSchemaTransformProvider
     @SchemaFieldDescription("Name of the table to read from.")
     @Nullable
     public abstract String getLocation();
+
+    @SchemaFieldDescription("Name of a column of numeric type that will be used for partitioning.")
+    @Nullable
+    public abstract String getPartitionColumn();
+
+    @SchemaFieldDescription("The number of partitions")
+    @Nullable
+    public abstract Integer getNumPartitions();
 
     @SchemaFieldDescription(
         "Whether to reshuffle the resulting PCollection so results are distributed to all workers.")
@@ -367,6 +418,10 @@ public class JdbcReadSchemaTransformProvider
       public abstract Builder setPassword(String value);
 
       public abstract Builder setLocation(String value);
+
+      public abstract Builder setPartitionColumn(String value);
+
+      public abstract Builder setNumPartitions(Integer value);
 
       public abstract Builder setReadQuery(String value);
 

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcReadSchemaTransformProvider.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcReadSchemaTransformProvider.java
@@ -215,10 +215,17 @@ public class JdbcReadSchemaTransformProvider
     @Override
     public PCollectionRowTuple expand(PCollectionRowTuple input) {
 
+      boolean partitionColumnPresent =
+          (config.getPartitionColumn() != null && !"".equals(config.getPartitionColumn()));
       boolean readQueryPresent =
           (config.getReadQuery() != null && !"".equals(config.getReadQuery()));
       boolean locationPresent = (config.getLocation() != null && !"".equals(config.getLocation()));
 
+      // Reading with partitions only supports table argument.
+      if (partitionColumnPresent && !locationPresent) {
+        throw new IllegalArgumentException("Table must be specified to read with partitions.");
+      }
+      // If you specify a readQuery, it is to be used instead of a table.
       if (readQueryPresent && locationPresent) {
         throw new IllegalArgumentException("Query and Table are mutually exclusive configurations");
       }
@@ -226,6 +233,7 @@ public class JdbcReadSchemaTransformProvider
         throw new IllegalArgumentException("Either Query or Table must be specified.");
       }
 
+      // If we define a partition column, we follow a different route.
       @Nullable String partitionColumn = config.getPartitionColumn();
       @Nullable String location = config.getLocation();
       if (partitionColumn != null) {
@@ -391,12 +399,17 @@ public class JdbcReadSchemaTransformProvider
 
       boolean readQueryPresent = (getReadQuery() != null && !"".equals(getReadQuery()));
       boolean locationPresent = (getLocation() != null && !"".equals(getLocation()));
+      boolean partitionColumnPresent =
+          (getPartitionColumn() != null && !"".equals(getPartitionColumn()));
 
       if (readQueryPresent && locationPresent) {
         throw new IllegalArgumentException("Query and Table are mutually exclusive configurations");
       }
       if (!readQueryPresent && !locationPresent) {
         throw new IllegalArgumentException("Either Query or Table must be specified.");
+      }
+      if (partitionColumnPresent && !locationPresent) {
+        throw new IllegalArgumentException("Table must be specified to read with partitions.");
       }
     }
 

--- a/sdks/python/apache_beam/yaml/standard_io.yaml
+++ b/sdks/python/apache_beam/yaml/standard_io.yaml
@@ -218,6 +218,8 @@
         password: 'password'
         query: 'read_query'
         table: 'location'
+        partition_column : 'partition_column'
+        num_partitions: 'num_partitions'
         type: 'jdbc_type'
         username: 'username'
       'WriteToJdbc':

--- a/sdks/python/apache_beam/yaml/standard_io.yaml
+++ b/sdks/python/apache_beam/yaml/standard_io.yaml
@@ -219,7 +219,7 @@
         query: 'read_query'
         table: 'location'
         partition_column : 'partition_column'
-        num_partitions: 'num_partitions'
+        partitions: 'partitions'
         type: 'jdbc_type'
         username: 'username'
       'WriteToJdbc':


### PR DESCRIPTION
addresses #34349 Beam Yaml JdbcIO partitioning

- [x] Extend [JdbcReadSchemaTransformProvider](https://github.com/Polber/beam/blob/master/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcReadSchemaTransformProvider.java) to accept readRowsWithPartitions as a parameter.
- [x] Add Unit Tests in [JdbcReadSchemaTransformProviderTest](https://github.com/apache/beam/blob/4a7f19d997395264aaed32adde544fa340ce6124/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcReadSchemaTransformProviderTest.java#L48)
- [x] Update the mapping in [standard_io.yaml](https://github.com/apache/beam/blob/master/sdks/python/apache_beam/yaml/standard_io.yaml#L195)

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
