### PR TITLE
Remove legacy setup.py clean command

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -3033,12 +3033,6 @@ class BeamModulePlugin implements Plugin<Project> {
       def cleanPython = project.tasks.register('cleanPython') {
         doLast {
           def activate = "${project.ext.envdir}/bin/activate"
-          project.exec {
-            executable 'sh'
-            args '-c', "if [ -e ${activate} ]; then " +
-                ". ${activate} && cd ${pythonRootDir} && pip install pyyaml jinja2 && python setup.py clean; " +
-                "fi"
-          }
           project.delete project.buildDir     // Gradle build directory
           project.delete project.ext.envdir   // virtualenv directory
           project.delete "$project.projectDir/target"   // tox work directory


### PR DESCRIPTION
I don't see any evidence of `python setup.py clean` doing any useful cleaning.

In a clean repo, I have built apache-beam via:

`python3 -m build --sdist`, and also installed via `pip install -e .`

This created 146 untracked files:

``` 
(py310) 15:29:09 ::python$  git ls-files . --ignored --exclude-standard --others | wc -l
146
```

The number didn't change after running `python setup.py clean`, so i don't see any value that it is adding, yet it requires additional deps and trips peoples's workflows.