### PR TITLE
Support Time Partitioned Test Tables in BigqueryResourceManager

### DIFF
--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/bigquery/BigQueryResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/bigquery/BigQueryResourceManager.java
@@ -35,7 +35,6 @@ import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.TableResult;
 import com.google.cloud.bigquery.TimePartitioning;
-
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -273,9 +272,9 @@ public final class BigQueryResourceManager implements ResourceManager {
     }
   }
 
-
   /**
-   * Creates a table within the current dataset given a table name, schema and time partitioning properties.
+   * Creates a table within the current dataset given a table name, schema and time partitioning
+   * properties.
    *
    * <p>This table will automatically expire 1 hour after creation if not cleaned up manually or by
    * calling the {@link BigQueryResourceManager#cleanupAll()} method.
@@ -288,9 +287,11 @@ public final class BigQueryResourceManager implements ResourceManager {
    * @return The TableId (reference) to the table
    * @throws BigQueryResourceManagerException if there is an error creating the table in BigQuery.
    */
-  public synchronized TableId createTimePartitionedTable(String tableName, Schema schema, TimePartitioning timePartitioning)
+  public synchronized TableId createTimePartitionedTable(
+      String tableName, Schema schema, TimePartitioning timePartitioning)
       throws BigQueryResourceManagerException {
-    return createTable(tableName, schema, timePartitioning, System.currentTimeMillis() + 3600000); // 1h
+    return createTimePartitionedTable(
+        tableName, schema, timePartitioning, System.currentTimeMillis() + 3600000); // 1h
   }
 
   /**
@@ -322,7 +323,8 @@ public final class BigQueryResourceManager implements ResourceManager {
 
     // Check time partition details
     if (timePartitioning == null) {
-      throw new IllegalArgumentException("A valid TimePartition object must be provided to create a time paritioned table. Use createTable instead to create non-partitioned tables.");
+      throw new IllegalArgumentException(
+          "A valid TimePartition object must be provided to create a time paritioned table. Use createTable instead to create non-partitioned tables.");
     }
 
     // Create a default dataset if this resource manager has not already created one
@@ -331,24 +333,30 @@ public final class BigQueryResourceManager implements ResourceManager {
     }
     checkHasDataset();
 
-    LOG.info("Creating time partitioned table using tableName '{}' on field '{}'.", tableName, timePartitioning.getField());
+    LOG.info(
+        "Creating time partitioned table using tableName '{}' on field '{}'.",
+        tableName,
+        timePartitioning.getField());
 
     // Create the table if it does not already exist in the dataset
     try {
       TableId tableId = TableId.of(dataset.getDatasetId().getDataset(), tableName);
       if (bigQuery.getTable(tableId) == null) {
         StandardTableDefinition tableDefinition =
-          StandardTableDefinition.newBuilder()
-            .setSchema(schema)
-            .setTimePartitioning(timePartitioning)
-            .build();
+            StandardTableDefinition.newBuilder()
+                .setSchema(schema)
+                .setTimePartitioning(timePartitioning)
+                .build();
         TableInfo tableInfo =
             TableInfo.newBuilder(tableId, tableDefinition)
                 .setExpirationTime(expirationTimeMillis)
                 .build();
         bigQuery.create(tableInfo);
         LOG.info(
-            "Successfully created table {}.{} partitioned on {}", dataset.getDatasetId().getDataset(), tableName, timePartitioning.getField());
+            "Successfully created table {}.{} partitioned on {}",
+            dataset.getDatasetId().getDataset(),
+            tableName,
+            timePartitioning.getField());
 
         return tableId;
       } else {
@@ -359,7 +367,6 @@ public final class BigQueryResourceManager implements ResourceManager {
       throw new BigQueryResourceManagerException("Failed to create table.", e);
     }
   }
-
 
   /**
    * Writes a given row into a table. This method requires {@link

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/bigquery/BigQueryResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/bigquery/BigQueryResourceManager.java
@@ -36,7 +36,6 @@ import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.TableResult;
 import com.google.cloud.bigquery.TimePartitioning;
 
-import java.sql.Time;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/bigquery/BigQueryResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/bigquery/BigQueryResourceManager.java
@@ -34,6 +34,9 @@ import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.TableResult;
+import com.google.cloud.bigquery.TimePartitioning;
+
+import java.sql.Time;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -270,6 +273,94 @@ public final class BigQueryResourceManager implements ResourceManager {
       throw new BigQueryResourceManagerException("Failed to create table.", e);
     }
   }
+
+
+  /**
+   * Creates a table within the current dataset given a table name, schema and time partitioning properties.
+   *
+   * <p>This table will automatically expire 1 hour after creation if not cleaned up manually or by
+   * calling the {@link BigQueryResourceManager#cleanupAll()} method.
+   *
+   * <p>Note: Implementations may do dataset creation here, if one does not already exist.
+   *
+   * @param tableName The name of the table.
+   * @param schema A schema object that defines the table.
+   * @param timePartitioning A TimePartition object that defines time partitioning details.
+   * @return The TableId (reference) to the table
+   * @throws BigQueryResourceManagerException if there is an error creating the table in BigQuery.
+   */
+  public synchronized TableId createTimePartitionedTable(String tableName, Schema schema, TimePartitioning timePartitioning)
+      throws BigQueryResourceManagerException {
+    return createTable(tableName, schema, timePartitioning, System.currentTimeMillis() + 3600000); // 1h
+  }
+
+  /**
+   * Creates a table within the current dataset given a table name and schema.
+   *
+   * <p>This table will automatically expire at the time specified by {@code expirationTime} if not
+   * cleaned up manually or by calling the {@link BigQueryResourceManager#cleanupAll()} method.
+   *
+   * <p>Note: Implementations may do dataset creation here, if one does not already exist.
+   *
+   * @param tableName The name of the table.
+   * @param schema A schema object that defines the table.
+   * @param timePartitioning A TimePartition object that defines time partitioning details.
+   * @param expirationTimeMillis Sets the time when this table expires, in milliseconds since the
+   *     epoch.
+   * @return The TableId (reference) to the table
+   * @throws BigQueryResourceManagerException if there is an error creating the table in BigQuery.
+   */
+  public synchronized TableId createTimePartitionedTable(
+      String tableName, Schema schema, TimePartitioning timePartitioning, Long expirationTimeMillis)
+      throws BigQueryResourceManagerException {
+    // Check table ID
+    BigQueryResourceManagerUtils.checkValidTableId(tableName);
+
+    // Check schema
+    if (schema == null) {
+      throw new IllegalArgumentException("A valid schema must be provided to create a table.");
+    }
+
+    // Check time partition details
+    if (timePartitioning == null) {
+      throw new IllegalArgumentException("A valid TimePartition object must be provided to create a time paritioned table. Use createTable instead to create non-partitioned tables.");
+    }
+
+    // Create a default dataset if this resource manager has not already created one
+    if (dataset == null) {
+      createDataset(DEFAULT_DATASET_REGION);
+    }
+    checkHasDataset();
+
+    LOG.info("Creating time partitioned table using tableName '{}' on field '{}'.", tableName, timePartitioning.getField());
+
+    // Create the table if it does not already exist in the dataset
+    try {
+      TableId tableId = TableId.of(dataset.getDatasetId().getDataset(), tableName);
+      if (bigQuery.getTable(tableId) == null) {
+        StandardTableDefinition tableDefinition =
+          StandardTableDefinition.newBuilder()
+            .setSchema(schema)
+            .setTimePartitioning(timePartitioning)
+            .build();
+        TableInfo tableInfo =
+            TableInfo.newBuilder(tableId, tableDefinition)
+                .setExpirationTime(expirationTimeMillis)
+                .build();
+        bigQuery.create(tableInfo);
+        LOG.info(
+            "Successfully created table {}.{} partitioned on {}", dataset.getDatasetId().getDataset(), tableName, timePartitioning.getField());
+
+        return tableId;
+      } else {
+        throw new IllegalStateException(
+            "Table " + tableId + " already exists for dataset " + datasetId + ".");
+      }
+    } catch (Exception e) {
+      throw new BigQueryResourceManagerException("Failed to create table.", e);
+    }
+  }
+
 
   /**
    * Writes a given row into a table. This method requires {@link

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/bigquery/BigQueryResourceManagerTest.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/bigquery/BigQueryResourceManagerTest.java
@@ -36,6 +36,7 @@ import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.StandardTableDefinition;
 import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
@@ -49,6 +50,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -236,7 +238,7 @@ public class BigQueryResourceManagerTest {
     verify(bigQuery).create(tableCaptor.capture());
     TableInfo capturedTableInfo = tableCaptor.getValue();
     StandardTableDefinition capturedTableDefinition = capturedTableInfo.getDefinition();
-    TimePartitioning capturedTimePartitioning = capturedTableDefinition.getTimePartitiong();
+    TimePartitioning capturedTimePartitioning = capturedTableDefinition.getTimePartitioning();
     assertThat(capturedTimePartitioning).isEqualTo(timePartition);
   }
 

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/bigquery/BigQueryResourceManagerTest.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/bigquery/BigQueryResourceManagerTest.java
@@ -47,8 +47,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -80,9 +80,8 @@ public class BigQueryResourceManagerTest {
   public void setUp() {
     schema = Schema.of(Field.of("name", StandardSQLTypeName.STRING));
     rowToInsert = RowToInsert.of("1", ImmutableMap.of("name", "Jake"));
-    timePartition = TimePartitioning.newBuilder(TimePartitioning.Type.HOUR)
-        .setField(PARTITION_FIELD) 
-        .build();
+    timePartition =
+        TimePartitioning.newBuilder(TimePartitioning.Type.HOUR).setField(PARTITION_FIELD).build();
     testManager = new BigQueryResourceManager(TEST_ID, PROJECT_ID, bigQuery);
   }
 
@@ -172,20 +171,25 @@ public class BigQueryResourceManagerTest {
     verify(bigQuery).create(any(DatasetInfo.class));
   }
 
-
   @Test
   public void testCreateTimePartitionedTableShouldThrowErrorWhenTableNameIsNotValid() {
-    assertThrows(IllegalArgumentException.class, () -> testManager.createTimePartitionedTable("", schema, timePartition));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> testManager.createTimePartitionedTable("", schema, timePartition));
   }
 
   @Test
   public void testCreateTimePartitionedTableShouldThrowErrorWhenSchemaIsNull() {
-    assertThrows(IllegalArgumentException.class, () -> testManager.createTimePartitionedTable(TABLE_NAME, null, timePartition));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> testManager.createTimePartitionedTable(TABLE_NAME, null, timePartition));
   }
 
   @Test
   public void testCreateTimePartitionedTableShouldThrowErrorWhenPartitionInfoIsNull() {
-    assertThrows(IllegalArgumentException.class, () -> testManager.createTimePartitionedTable(TABLE_NAME, schema, null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> testManager.createTimePartitionedTable(TABLE_NAME, schema, null));
   }
 
   @Test
@@ -205,7 +209,8 @@ public class BigQueryResourceManagerTest {
     when(bigQuery.create(any(TableInfo.class))).thenThrow(BigQueryException.class);
 
     assertThrows(
-        BigQueryResourceManagerException.class, () -> testManager.createTimePartitionedTable(TABLE_NAME, schema, timePartition));
+        BigQueryResourceManagerException.class,
+        () -> testManager.createTimePartitionedTable(TABLE_NAME, schema, timePartition));
   }
 
   @Test
@@ -215,7 +220,8 @@ public class BigQueryResourceManagerTest {
     when(bigQuery.getTable(any())).thenReturn(any());
 
     assertThrows(
-        BigQueryResourceManagerException.class, () -> testManager.createTimePartitionedTable(TABLE_NAME, schema, timePartition));
+        BigQueryResourceManagerException.class,
+        () -> testManager.createTimePartitionedTable(TABLE_NAME, schema, timePartition));
   }
 
   @Test
@@ -233,8 +239,6 @@ public class BigQueryResourceManagerTest {
     TimePartitioning capturedTimePartitioning = capturedTableDefinition.getTimePartitiong();
     assertThat(capturedTimePartitioning).isEqualTo(timePartition);
   }
-
-
 
   @Test
   public void testWriteShouldThrowErrorWhenDatasetDoesNotExist() {


### PR DESCRIPTION
Goal: I would like to be able to set up time partitioned testing tables using BigqueryResourceManager.

Issue: fixes #34470 , and is a blocker for https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/2273 in DataflowTemplates


------------------------

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
