### PR TITLE
Fn Runner Watermark issue

### DIFF
--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
@@ -423,8 +423,7 @@ class TransformContext(object):
       is_drain=False):
     self.components = components
     self.known_runner_urns = known_runner_urns
-    self.runner_only_urns = known_runner_urns - frozenset(
-        [common_urns.primitives.FLATTEN.urn])
+    self.runner_only_urns = known_runner_urns
     self._known_coder_urns = set.union(
         # Those which are required.
         self._REQUIRED_CODER_URNS,


### PR DESCRIPTION
Proposing a solution to https://github.com/apache/beam/issues/26190 . 
It appears the Flatten was not setting a watermark, which caused following steps not to execute.  

The issue was returning errors on beam versions 2.39 onwards, and it  potentially produced unstable results before 2.39.  

There are meaningful TODOs mentioned: 
`# TODO(robertwb): Possibly fuse multi-input flattens into one of the stages.`
`# TODO(pabloem): Consider case where there are various producers`

It makes parts of the code redundant, a refactoring could be considered. 
For now, I would like to test if this change evaluate correctly. 
