### PR TITLE
Fix looker metrics

### DIFF
--- a/.github/workflows/refresh_looker_metrics.yml
+++ b/.github/workflows/refresh_looker_metrics.yml
@@ -18,8 +18,6 @@
 name: Refresh Looker Performance Metrics
 
 on:
-  schedule:
-    - cron: '10 10 * * 1'
   workflow_dispatch:
     inputs:
       READ_ONLY:

--- a/website/www/site/data/performance.yaml
+++ b/website/www/site/data/performance.yaml
@@ -186,19 +186,19 @@ looks:
           title: AvgThroughputBytesPerSec by Version
         - id: DVhGKTmJWknSvfQVPQ9FDrvPYgdJ2dFd
           title: AvgThroughputElementsPerSec by Version
-    tensorflowmnist:
-      write:
-        folder: 75
-        cost:
-          - id: Vs9ZHMkCkrSgJF7FCPdQS5HwK8PQTyWb
-            title: RunTime and EstimatedCost
-        date:
-          - id: 7mYxWj4hDXQp2SZ28vMNTCZGhWcPQdwJ
-            title: AvgThroughputBytesPerSec by Date
-          - id: bWhWQ9t2jKGscc9ghgH77wRszTxwW8mM
-            title: AvgThroughputElementsPerSec by Date
-        version:
-          - id: y3jVqx2xKcZGpkMBTSCZCpGMPPFHrC8V
-            title: AvgThroughputBytesPerSec by Version
-          - id: YdD9SMWCDNJ7wCY4WZwyd2Jt9Ts38FY2
-            title: AvgThroughputElementsPerSec by Version
+  tensorflowmnist:
+    write:
+      folder: 75
+      cost:
+        - id: Vs9ZHMkCkrSgJF7FCPdQS5HwK8PQTyWb
+          title: RunTime and EstimatedCost
+      date:
+        - id: 7mYxWj4hDXQp2SZ28vMNTCZGhWcPQdwJ
+          title: AvgThroughputBytesPerSec by Date
+        - id: bWhWQ9t2jKGscc9ghgH77wRszTxwW8mM
+          title: AvgThroughputElementsPerSec by Date
+      version:
+        - id: y3jVqx2xKcZGpkMBTSCZCpGMPPFHrC8V
+          title: AvgThroughputBytesPerSec by Version
+        - id: YdD9SMWCDNJ7wCY4WZwyd2Jt9Ts38FY2
+          title: AvgThroughputElementsPerSec by Version


### PR DESCRIPTION
Changes:
- Fix `tensorflowmnist` section on website
- Remove schedule trigger for `refresh_looker_metrics` workflow.

Explanation: We're using Looker Cloud (Google Cloud core) with active API3 credentials, which allows us to successfully authenticate and call most Looker API endpoints such as `search_looks` or `run_look`. However, when we attempt to call render-related methods like `create_look_render_task`, the API returns an error requiring an OAuth login (or OAuth session expired).
 
This happens because in Looker Cloud, API3 tokens do not create a full OAuth session, which is required for rendering visualizations. One possible workaround I am considering in the short term is manually logging into Looker via a browser to activate a user session, and then running the workflow (via workflow_dispatch) while that session is still active. ([Tested](https://github.com/Amar3tto/beam/actions/runs/13628737980/job/38091607540) this)

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
