### PR TITLE
Add an v-2.XX.0-RC00 tag to master when release branch is cut to enable git describe

### DIFF
--- a/.github/workflows/cut_release_branch.yml
+++ b/.github/workflows/cut_release_branch.yml
@@ -97,6 +97,12 @@ jobs:
     steps:
       - name: Validate Next Version
         run: |
+          if [[ ${RELEASE} =~ ([0-9]+\.[0-9]+) ]]; then
+            echo "RELEASE_CUT_TAG=v${RELEASE}.0-RC00" >> $GITHUB_ENV
+          else
+            echo "The input for RELEASE does not match a valid format [0-9]+\.[0-9]+"
+            exit 1
+          fi
           if [[ $NEXT_RELEASE =~ ([0-9]+\.[0-9]+) ]]; then
             echo "NEXT_VERSION_IN_BASE_BRANCH=${BASH_REMATCH[1]}.0" >> $GITHUB_ENV
           else
@@ -116,7 +122,9 @@ jobs:
           sed -i -e "s/master: {}/master: {}\n    release-${RELEASE}: {}/g" .asf.yaml
       - name: Update master branch
         run: |
-          bash "${SCRIPT_DIR}/set_version.sh" "${NEXT_VERSION_IN_BASE_BRANCH}"
+          bash "${SCRIPT_DIR}/set_version.sh" "${NEXT_VERSION_IN_BASE_BRANCH}" "--add-tag" "${RELEASE_CUT_TAG}"
+          echo "==============tag RC00 to current master branch================"
+          git push origin tag "${RELEASE_CUT_TAG}"
           echo "==============Update master branch as following================"
           git diff
           echo "==============================================================="

--- a/release/src/main/scripts/set_version.sh
+++ b/release/src/main/scripts/set_version.sh
@@ -25,7 +25,7 @@
 set -e
 
 function usage() {
-  echo 'Usage: set_version.sh <version> [--release] [--debug] [--git-add]'
+  echo 'Usage: set_version.sh <version> [--release] [--debug] [--git-add] [--add-tag]'
 }
 
 IS_SNAPSHOT_VERSION=yes
@@ -50,6 +50,11 @@ while [[ $# -gt 0 ]] ; do
       shift
       ;;
 
+      --add-tag)
+      shift
+      ADD_TAG="$1"
+      shift
+      ;;
       *)
       if [[ -z "$TARGET_VERSION" ]] ; then
         TARGET_VERSION="$1"
@@ -72,6 +77,10 @@ fi
 if ! [[ ${TARGET_VERSION} =~ ([0-9]+\.[0-9]+\.[0-9]+) ]];
   then  echo "The input for TARGET_VERSION: ${TARGET_VERSION} does not match a valid format [0-9]+\.[0-9]+\.[0-9]+"
   exit 1
+fi
+
+if [[ -n $ADD_TAG ]] ; then
+  git tag "$ADD_TAG"
 fi
 
 if [[ -z "$IS_SNAPSHOT_VERSION" ]] ; then


### PR DESCRIPTION
**Please** add a meaningful description for your change here

Add a tag (e.g. v-2.64.0-RC00) to master branch when release is cut.

Currently, `git describe` inquiry on master branch gives `jupyterlab-sidepanel-v3.0.0`, this confused some internal import tool parse the version to 3.0.0 (see: cl/741579610)

by introducing a v-2.xx.0-RC00 on master branch `git describe` can have expected results

Tested on fork: https://github.com/Abacn/beam/actions/runs/14227274801

It does created a tag: https://github.com/Abacn/beam/tree/v2.65.0-RC00

after this is merged, I'm going to manually push v2.64.0-RC00 points to 24c230510be8b5e400021e8325ea654481c13698 (the branch right before 2.65.0-SNAPSHOT)

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
