### PR TITLE
Add reducers for threading.Lock and EnumDescriptor.

### DIFF
--- a/sdks/python/apache_beam/internal/cloudpickle_pickler.py
+++ b/sdks/python/apache_beam/internal/cloudpickle_pickler.py
@@ -30,6 +30,7 @@ dump_session and load_session are no-ops.
 import base64
 import bz2
 import io
+import sys
 import threading
 import zlib
 
@@ -40,10 +41,65 @@ try:
 except (ImportError, ModuleNotFoundError):
   pass
 
+
+def _get_proto_enum_descriptor_class():
+  try:
+    from google.protobuf.internal import api_implementation
+  except ImportError:
+    return None
+
+  implementation_type = api_implementation.Type()
+
+  if implementation_type == 'upb':
+    try:
+      from google._upb._message import EnumDescriptor
+      return EnumDescriptor
+    except ImportError:
+      pass
+  elif implementation_type == 'cpp':
+    try:
+      from google.protobuf.pyext._message import EnumDescriptor
+      return EnumDescriptor
+    except ImportError:
+      pass
+  elif implementation_type == 'python':
+    try:
+      from google.protobuf.internal.python_message import EnumDescriptor
+      return EnumDescriptor
+    except ImportError:
+      pass
+
+  return None
+
+
+EnumDescriptor = _get_proto_enum_descriptor_class()
+
 # Pickling, especially unpickling, causes broken module imports on Python 3
 # if executed concurrently, see: BEAM-8651, http://bugs.python.org/issue38884.
 _pickle_lock = threading.RLock()
 RLOCK_TYPE = type(_pickle_lock)
+LOCK_TYPE = type(threading.Lock())
+
+
+def _reconstruct_enum_descriptor(full_name):
+  for _, module in sys.modules.items():
+    if not hasattr(module, 'DESCRIPTOR'):
+      continue
+
+    for _, attr_value in vars(module).items():
+      if not hasattr(attr_value, 'DESCRIPTOR'):
+        continue
+
+      if hasattr(attr_value.DESCRIPTOR, 'enum_types_by_name'):
+        for (_, enum_desc) in attr_value.DESCRIPTOR.enum_types_by_name.items():
+          if enum_desc.full_name == full_name:
+            return enum_desc
+  raise ImportError(f'Could not find enum descriptor: {full_name}')
+
+
+def _pickle_enum_descriptor(obj):
+  full_name = obj.full_name
+  return _reconstruct_enum_descriptor, (full_name, )
 
 
 def dumps(o, enable_trace=True, use_zlib=False) -> bytes:
@@ -59,6 +115,12 @@ def dumps(o, enable_trace=True, use_zlib=False) -> bytes:
         pickler.dispatch_table[RLOCK_TYPE] = _pickle_rlock
       except NameError:
         pass
+      try:
+        pickler.dispatch_table[LOCK_TYPE] = _lock_reducer
+      except NameError:
+        pass
+      if EnumDescriptor is not None:
+        pickler.dispatch_table[EnumDescriptor] = _pickle_enum_descriptor
       pickler.dump(o)
       s = file.getvalue()
 
@@ -104,6 +166,10 @@ def _create_absl_flags():
 
 def _pickle_rlock(obj):
   return RLOCK_TYPE, tuple([])
+
+
+def _lock_reducer(obj):
+  return threading.Lock, tuple([])
 
 
 def dump_session(file_path):

--- a/sdks/python/apache_beam/internal/cloudpickle_pickler_test.py
+++ b/sdks/python/apache_beam/internal/cloudpickle_pickler_test.py
@@ -26,11 +26,20 @@ import unittest
 from apache_beam.internal import module_test
 from apache_beam.internal.cloudpickle_pickler import dumps
 from apache_beam.internal.cloudpickle_pickler import loads
+from apache_beam.portability.api import beam_runner_api_pb2
 
 
 class PicklerTest(unittest.TestCase):
 
   NO_MAPPINGPROXYTYPE = not hasattr(types, "MappingProxyType")
+
+  def test_pickle_enum_descriptor(self):
+    TimeDomain = beam_runner_api_pb2.TimeDomain.Enum
+
+    def fn():
+      return TimeDomain.EVENT_TIME
+
+    self.assertEqual(fn(), loads(dumps(fn))())
 
   def test_basics(self):
     self.assertEqual([1, 'a', ('z', )], loads(dumps([1, 'a', ('z', )])))
@@ -96,6 +105,12 @@ class PicklerTest(unittest.TestCase):
     rlock_type = type(rlock_instance)
 
     self.assertIsInstance(loads(dumps(rlock_instance)), rlock_type)
+
+  def test_pickle_lock(self):
+    lock_instance = threading.Lock()
+    lock_type = type(lock_instance)
+
+    self.assertIsInstance(loads(dumps(lock_instance)), lock_type)
 
   @unittest.skipIf(NO_MAPPINGPROXYTYPE, 'test if MappingProxyType introduced')
   def test_dump_and_load_mapping_proxy(self):


### PR DESCRIPTION
#21298

EnumDescriptors:
Cloudpickle encodes globals from main module to be able to recreate them in the runtime environment. Dill is more lightweight and just expects the main session to be loaded.

EnumDescriptors cannot be pickled because of complex cythonized code. This PR adds a way to serialize enum descriptors by reference for cloudpickle

Locks:
Dill has built in support for pickling locks. Cloudpickle added similar functionality for RLocks https://github.com/apache/beam/blob/fdb285d91f86fd345a254e082c025fc6db624c96/sdks/python/apache_beam/internal/cloudpickle_pickler.py#L106. This PR adds the same for reguar threading.Lock


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
