### PR TITLE
Fix PostCommit Python Dependency and PreCommit Python ML tests

### DIFF
--- a/sdks/python/apache_beam/ml/rag/chunking/langchain_test.py
+++ b/sdks/python/apache_beam/ml/rag/chunking/langchain_test.py
@@ -167,7 +167,7 @@ class LangChainChunkingTest(unittest.TestCase):
       def check_token_lengths(chunks):
         for chunk in chunks:
           # Verify each chunk's token length is within limits
-          num_tokens = len(tokenizer.encode(chunk.content.text))
+          num_tokens = len(tokenizer.tokenize(chunk.content.text))
           if not num_tokens <= 10:
             raise BeamAssertException(
                 f"Chunk has {num_tokens} tokens, expected <= 10")

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -105,6 +105,8 @@ commands =
 
 [testenv:py{39,310,311}-ml]
 # Don't set TMPDIR to avoid "AF_UNIX path too long" errors in certain tests.
+deps =
+  accelerate>=1.6.0
 setenv =
 extras = test,gcp,dataframe,ml_test
 commands =
@@ -115,6 +117,8 @@ commands =
 [testenv:py312-ml]
 # many packages do not support py3.12
 # Don't set TMPDIR to avoid "AF_UNIX path too long" errors in certain tests.
+deps =
+  accelerate>=1.6.0
 setenv =
 extras = test,gcp,dataframe,p312_ml_test
 commands =
@@ -466,6 +470,7 @@ deps =
   448: torch>=2.0.0,<2.1.0
   latest: transformers>=4.48.0
   latest: torch>=2.0.0
+  latest: accelerate>=1.6.0
   tensorflow==2.12.0
   protobuf==4.25.5
 extras = test,gcp,ml_test
@@ -494,6 +499,7 @@ commands =
 [testenv:py{39,310}-embeddings]
 deps =
   sentence-transformers==3.3.1
+  accelerate>=1.6.0
 passenv = HF_INFERENCE_TOKEN
 extras = test,gcp
 commands =


### PR DESCRIPTION
Fixes: [#31285](https://github.com/apache/beam/issues/31285), [#30799](https://github.com/apache/beam/issues/30799)
Successful PostCommit Python Dependency example: https://github.com/akashorabek/beam/actions/runs/14305849321
Successful PreCommit Python ML tests with ML deps installed example: https://github.com/akashorabek/beam/actions/runs/14305842322

Explicitly installed latest `accelerate` for tests that require the latest version of `transformers (4.51.0)`, since otherwise it throws the error: "NameError: name 'init_empty_weights' is not defined". The solution is described [here](https://github.com/huggingface/transformers/issues/37326#issuecomment-2781631737). Also switched from encode to tokenize in langchain_test.py.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
