### PR TITLE
Ensure SpannerConfig uses correct default when host set to null

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerAccessor.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerAccessor.java
@@ -218,13 +218,7 @@ public class SpannerAccessor implements AutoCloseable {
     if (serviceFactory != null) {
       builder.setServiceFactory(serviceFactory);
     }
-    ValueProvider<String> host = spannerConfig.getHost();
-    if (host != null) {
-      String hostValue = host.get();
-      if (hostValue != null && !hostValue.trim().isEmpty()) {
-        builder.setHost(host.get());
-      }
-    }
+    builder.setHost(spannerConfig.getHostValue());
     ValueProvider<String> emulatorHost = spannerConfig.getEmulatorHost();
     if (emulatorHost != null) {
       builder.setEmulatorHost(emulatorHost.get());

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerConfig.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerConfig.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.io.gcp.spanner;
 
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Strings.isNullOrEmpty;
 
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.StatusCode.Code;
@@ -57,6 +58,13 @@ public abstract class SpannerConfig implements Serializable {
   public abstract @Nullable ValueProvider<String> getDatabaseId();
 
   public abstract @Nullable ValueProvider<String> getHost();
+
+  public String getHostValue() {
+    if (getHost() == null || isNullOrEmpty(getHost().get())) {
+      return DEFAULT_HOST;
+    }
+    return getHost().get();
+  }
 
   public abstract @Nullable ValueProvider<String> getEmulatorHost();
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/SpannerAccessorTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/SpannerAccessorTest.java
@@ -164,4 +164,91 @@ public class SpannerAccessorTest {
     assertEquals("test-role", options.getDatabaseRole());
     assertEquals(testCredential, options.getCredentials());
   }
+
+  private static final String DEFAULT_HOST = "https://batch-spanner.googleapis.com/";
+
+  @Test
+  public void testBuildSpannerOptionsWithNoHost() {
+    SpannerConfig config1 =
+        SpannerConfig.create()
+            .toBuilder()
+            .setServiceFactory(serviceFactory)
+            .setProjectId(StaticValueProvider.of("project"))
+            .setInstanceId(StaticValueProvider.of("test1"))
+            .setDatabaseId(StaticValueProvider.of("test1"))
+            .build();
+
+    assertEquals(DEFAULT_HOST, config1.getHostValue());
+    SpannerOptions options = SpannerAccessor.buildSpannerOptions(config1);
+    assertEquals(DEFAULT_HOST, options.getHost());
+  }
+
+  @Test
+  public void testBuildSpannerOptionsWithNullHost() {
+    SpannerConfig config1 =
+        SpannerConfig.create()
+            .toBuilder()
+            .setServiceFactory(serviceFactory)
+            .setHost((StaticValueProvider<String>) null)
+            .setProjectId(StaticValueProvider.of("project"))
+            .setInstanceId(StaticValueProvider.of("test1"))
+            .setDatabaseId(StaticValueProvider.of("test1"))
+            .build();
+
+    assertEquals(DEFAULT_HOST, config1.getHostValue());
+    SpannerOptions options = SpannerAccessor.buildSpannerOptions(config1);
+    assertEquals(DEFAULT_HOST, options.getHost());
+  }
+
+  @Test
+  public void testBuildSpannerOptionsWithNullHostValue() {
+    SpannerConfig config1 =
+        SpannerConfig.create()
+            .toBuilder()
+            .setServiceFactory(serviceFactory)
+            .setHost(StaticValueProvider.of((String) null))
+            .setProjectId(StaticValueProvider.of("project"))
+            .setInstanceId(StaticValueProvider.of("test1"))
+            .setDatabaseId(StaticValueProvider.of("test1"))
+            .build();
+
+    assertEquals(DEFAULT_HOST, config1.getHostValue());
+    SpannerOptions options = SpannerAccessor.buildSpannerOptions(config1);
+    assertEquals(DEFAULT_HOST, options.getHost());
+  }
+
+  @Test
+  public void testBuildSpannerOptionsWithEmptyHost() {
+    SpannerConfig config1 =
+        SpannerConfig.create()
+            .toBuilder()
+            .setServiceFactory(serviceFactory)
+            .setHost(StaticValueProvider.of(""))
+            .setProjectId(StaticValueProvider.of("project"))
+            .setInstanceId(StaticValueProvider.of("test1"))
+            .setDatabaseId(StaticValueProvider.of("test1"))
+            .build();
+
+    assertEquals(DEFAULT_HOST, config1.getHostValue());
+    SpannerOptions options = SpannerAccessor.buildSpannerOptions(config1);
+    assertEquals(DEFAULT_HOST, options.getHost());
+  }
+
+  @Test
+  public void testBuildSpannerOptionsWithCustomHost() {
+    final String host = "https://alternative-host.example.org";
+    SpannerConfig config1 =
+        SpannerConfig.create()
+            .toBuilder()
+            .setServiceFactory(serviceFactory)
+            .setHost(StaticValueProvider.of(host))
+            .setProjectId(StaticValueProvider.of("project"))
+            .setInstanceId(StaticValueProvider.of("test1"))
+            .setDatabaseId(StaticValueProvider.of("test1"))
+            .build();
+
+    assertEquals(host, config1.getHostValue());
+    SpannerOptions options = SpannerAccessor.buildSpannerOptions(config1);
+    assertEquals(host, options.getHost());
+  }
 }


### PR DESCRIPTION
Add method to SpannerConfig to obtain the host value, using the correct default when the host ValueProvider is null, or has a null or empty value.

Fixes #34600

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
