### PR TITLE
Fix a flatten flaky test when two flattens are used sequentially.

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/handlerunner.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/handlerunner.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"reflect"
 	"sort"
+	"strings"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/coder"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/mtime"
@@ -108,12 +109,40 @@ func (h *runner) handleFlatten(tid string, t *pipepb.PTransform, comps *pipepb.C
 		// they're written out to the runner in the same fashion.
 		// This may stop being necessary once Flatten Unzipping happens in the optimizer.
 		outPCol := comps.GetPcollections()[outColID]
+		outCoderID := outPCol.CoderId
+		outCoder := comps.GetCoders()[outCoderID]
+		coderSubs := map[string]*pipepb.Coder{}
 		pcollSubs := map[string]*pipepb.PCollection{}
+
+		if !strings.HasPrefix(outCoderID, "cf_") {
+			// Create a new coder id for the flatten output PCollection and use
+			// this coder id for all input PCollections
+			outCoderID = "cf_" + outColID
+			outCoder = proto.Clone(outCoder).(*pipepb.Coder)
+			coderSubs[outCoderID] = outCoder
+
+			pcollSubs[outColID] = proto.Clone(outPCol).(*pipepb.PCollection)
+			pcollSubs[outColID].CoderId = outCoderID
+
+			outPCol = pcollSubs[outColID]
+		}
+
 		for _, p := range t.GetInputs() {
 			inPCol := comps.GetPcollections()[p]
 			if inPCol.CoderId != outPCol.CoderId {
-				pcollSubs[p] = proto.Clone(inPCol).(*pipepb.PCollection)
-				pcollSubs[p].CoderId = outPCol.CoderId
+				if strings.HasPrefix(inPCol.CoderId, "cf_") {
+					// The input pcollection is the output of another flatten:
+					//     e.g. [[a, b] | Flatten], c] | Flatten
+					// In this case, we just point the input coder id to the new flatten
+					// output coder, so any upstream input pcollections will use the new
+					// output coder.
+					coderSubs[inPCol.CoderId] = outCoder
+				} else {
+					// Create a substitute PCollection for this input with the flatten
+					// output coder id
+					pcollSubs[p] = proto.Clone(inPCol).(*pipepb.PCollection)
+					pcollSubs[p].CoderId = outPCol.CoderId
+				}
 			}
 		}
 
@@ -125,6 +154,7 @@ func (h *runner) handleFlatten(tid string, t *pipepb.PTransform, comps *pipepb.C
 					tid: t,
 				},
 				Pcollections: pcollSubs,
+				Coders:       coderSubs,
 			},
 			RemovedLeaves: nil,
 			ForcedRoots:   forcedRoots,


### PR DESCRIPTION
We see some test flakiness (https://github.com/apache/beam/actions/workflows/beam_PreCommit_Prism_Python.yml) after #34582. 


Here is a simple pipeline to reproduce:
```python
with beam.Pipeline(options=options) as p:
  side1 = p | 'side1' >> beam.Create([('a', 1)])
  side2 = p | 'side2' >> beam.Create([('b', 2)])
  third_element = [('another_type')]

  side3 = p | 'side3' >> beam.Create(third_element)
  side = (side1, side2) | 'Flatten1' >> beam.Flatten()
  _ = (side, side3) | 'Flatten2' >> beam.Flatten() | beam.Map(print)
```

In #34582, we replace the coder ids in the input PCollections of each flatten transform. However, if there are multiple flatten transforms **and** they are connected to each other, the order of replacing matters:
- If we replace the coder of `Flatten1` and then `Flatten2`:
  - the coder of `side1` and `side2` will be `Coder(Tuple[str, int])`
  - the coder of `side` (flattened output of `side1` and `side2`) and `side3` will be `Coder(Tuple[str])`
- If we replace the coder of `Flatten2` and then `Flatten1`: 
  - the coder of `side` (flattened output of `side1` and `side2`) and `side3` will be `Coder(Tuple[str])`
  - the coder of `side1` and `side2` will also be `Coder(Tuple[str])` (same as the coder of `side`)

The first scenario will cause some problem during prism handling runner transform of flatten, because when it tries to collect elements of `Flatten2`, it will get elements encoded with `Coder(Tuple[str, int]))` from `side1` and `side2`, and elements encoded with `Coder(Tuple[str])` from `side3`.

addresses #34587