### PR TITLE
Use component coder when handling nullable coder in prism.

### DIFF
--- a/runners/prism/java/build.gradle
+++ b/runners/prism/java/build.gradle
@@ -110,8 +110,6 @@ def sickbayTests = [
     'org.apache.beam.sdk.transforms.GroupIntoBatchesTest.testWithShardedKeyInGlobalWindow',
 
     // Java side dying during execution.
-    // https://github.com/apache/beam/issues/32930
-    'org.apache.beam.sdk.transforms.FlattenTest.testFlattenMultipleCoders',
     // Stream corruption error java side: failed:java.io.StreamCorruptedException: invalid stream header: 206E6F74
     // Likely due to prism't coder changes.
     'org.apache.beam.sdk.transforms.FlattenTest.testFlattenWithDifferentInputAndOutputCoders2',

--- a/sdks/go/pkg/beam/runners/prism/internal/coders.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/coders.go
@@ -281,6 +281,9 @@ func pullDecoderNoAlloc(c *pipepb.Coder, coders map[string]*pipepb.Coder) func(i
 		}
 	case urns.CoderIterable:
 		ccids := c.GetComponentCoderIds()
+		if len(ccids) != 1 {
+			panic(fmt.Sprintf("Iterable coder must have only one component: %s", prototext.Format(c)))
+		}
 		ed := pullDecoderNoAlloc(coders[ccids[0]], coders)
 		return func(r io.Reader) {
 			l, _ := coder.DecodeInt32(r)
@@ -288,7 +291,6 @@ func pullDecoderNoAlloc(c *pipepb.Coder, coders map[string]*pipepb.Coder) func(i
 				ed(r)
 			}
 		}
-
 	case urns.CoderKV:
 		ccids := c.GetComponentCoderIds()
 		if len(ccids) != 2 {


### PR DESCRIPTION
The original NullableCoder implementation incorrectly assumed its component coder was always length-prefixed (LP'd).

In scenarios like a test [`testFlattenMultipleCoders`](https://github.com/apache/beam/blob/61cf27fdef56a8c43572e20a350aa1109d17d3aa/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/FlattenTest.java#L188) using `Nullable[VarLong]`, the inner `VarLongCoder` would not be LP'd by the prism runner. This decoder mismatch caused incorrect bytes to be read for the element, leading to incorrect buffer offsets.

Notice that the PR only fixes `org.apache.beam.sdk.transforms.FlattenTest.testFlattenMultipleCoders`. The fact that the other test `org.apache.beam.sdk.transforms.FlattenTest.testFlattenWithDifferentInputAndOutputCoders2` still fails implies a separate root cause.

addresses #32930
