### PR TITLE
Add an experiment to make prism server a singleton

### DIFF
--- a/sdks/python/apache_beam/runners/portability/prism_runner.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner.py
@@ -39,8 +39,8 @@ from apache_beam.options import pipeline_options
 from apache_beam.runners.portability import job_server
 from apache_beam.runners.portability import portable_runner
 from apache_beam.transforms import environments
-from apache_beam.utils import subprocess_server
 from apache_beam.utils import shared
+from apache_beam.utils import subprocess_server
 from apache_beam.version import __version__ as beam_version
 
 # pytype: skip-file

--- a/sdks/python/apache_beam/runners/portability/prism_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner_test.py
@@ -39,7 +39,7 @@ from apache_beam.runners.portability import portable_runner_test
 from apache_beam.runners.portability import prism_runner
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
-from apache_beam.utils import subprocess_server
+from apache_beam.utils import shared
 
 # Run as
 #
@@ -396,7 +396,7 @@ class PrismRunnerSingletonTest(unittest.TestCase):
     ) as mock_prism_server:
 
       # Reset the class-level singleton for every fresh run
-      prism_runner.PrismRunner._PrismRunner__singleton = None
+      prism_runner.PrismRunner.shared_handle = shared.Shared()
 
       runner = prism_runner.PrismRunner()
       runner.default_job_server(options)


### PR DESCRIPTION
Follow-up to #34616, addressing #33623.

Introduces an experimental feature for Prism Runner to maintain only a single background Prism server instance. This is beneficial in environments like Google Colab where long-lived Python processes may trigger Prism Runner multiple times across different pipeline executions.