### PR TITLE
Revert "Fix GCP auth step for GitHub Actions workflows"

### DIFF
--- a/.github/workflows/beam_PostCommit_Python_Arm.yml
+++ b/.github/workflows/beam_PostCommit_Python_Arm.yml
@@ -85,12 +85,11 @@ jobs:
           sudo curl -L https://github.com/docker/compose/releases/download/1.22.0/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
       - name: Authenticate on GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/setup-gcloud@v0
         with:
-          service_account: ${{ secrets.GCP_SA_EMAIL }}
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: GCloud Docker credential helper

--- a/.github/workflows/beam_Publish_Beam_SDK_Snapshots.yml
+++ b/.github/workflows/beam_Publish_Beam_SDK_Snapshots.yml
@@ -95,12 +95,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Authenticate on GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/setup-gcloud@v0
         with:
-          service_account: ${{ secrets.GCP_SA_EMAIL }}
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
       - name: GCloud Docker credential helper
         run: |
           gcloud auth configure-docker ${{ env.docker_registry }}

--- a/.github/workflows/beam_Python_ValidatesContainer_Dataflow_ARM.yml
+++ b/.github/workflows/beam_Python_ValidatesContainer_Dataflow_ARM.yml
@@ -75,12 +75,11 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
       - name: Authenticate on GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/setup-gcloud@v0
         with:
-          service_account: ${{ secrets.GCP_SA_EMAIL }}
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: GCloud Docker credential helper

--- a/.github/workflows/refresh_looker_metrics.yml
+++ b/.github/workflows/refresh_looker_metrics.yml
@@ -43,10 +43,9 @@ jobs:
           python-version: 3.11
       - run: pip install requests google-cloud-storage looker-sdk
       - name: Authenticate on GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/setup-gcloud@v0
         with:
-          service_account: ${{ secrets.GCP_SA_EMAIL }}
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
       - run: python .test-infra/tools/refresh_looker_metrics.py

--- a/.github/workflows/republish_released_docker_containers.yml
+++ b/.github/workflows/republish_released_docker_containers.yml
@@ -72,12 +72,10 @@ jobs:
         with:
           python-version: '3.9'
       - name: Authenticate on GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/setup-gcloud@v0
         with:
-          service_account: ${{ secrets.GCP_SA_EMAIL }}
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Remove default github maven configuration


### PR DESCRIPTION
Reverts apache/beam#34624

This didn't fix the underlying issue - https://github.com/apache/beam/actions/runs/14446457300/job/40508116220 and took us from flaky to permared