### PR TITLE
Revert "Fail Fast if Resources Do Not Exist in Kafka Cluster"

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -1908,15 +1908,7 @@ public class KafkaIO {
               }
             } else {
               for (String topic : topics) {
-                List<PartitionInfo> partitionInfoList = consumer.partitionsFor(topic);
-                checkState(
-                    partitionInfoList != null && !partitionInfoList.isEmpty(),
-                    "Could not find any partitions info for topic "
-                        + topic
-                        + ". Please check Kafka configuration and make sure "
-                        + "that provided topics exist.");
-
-                for (PartitionInfo p : partitionInfoList) {
+                for (PartitionInfo p : consumer.partitionsFor(topic)) {
                   partitions.add(new TopicPartition(p.topic(), p.partition()));
                 }
               }

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedSource.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedSource.java
@@ -23,12 +23,9 @@ import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Pr
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
 import org.apache.beam.sdk.io.UnboundedSource;
@@ -40,7 +37,6 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Joiner;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -93,7 +89,7 @@ class KafkaUnboundedSource<K, V> extends UnboundedSource<KafkaRecord<K, V>, Kafk
           for (String topic : topics) {
             List<PartitionInfo> partitionInfoList = consumer.partitionsFor(topic);
             checkState(
-                partitionInfoList != null && !partitionInfoList.isEmpty(),
+                partitionInfoList != null,
                 "Could not find any partitions info. Please check Kafka configuration and make sure "
                     + "that provided topics exist.");
             for (PartitionInfo p : partitionInfoList) {
@@ -104,34 +100,8 @@ class KafkaUnboundedSource<K, V> extends UnboundedSource<KafkaRecord<K, V>, Kafk
         }
       }
     } else {
-      final Map<String, List<Integer>> topicsAndPartitions = new HashMap<>();
       for (TopicPartition p : partitions) {
-        topicsAndPartitions.computeIfAbsent(p.topic(), k -> new ArrayList<>()).add(p.partition());
-      }
-      try (Consumer<?, ?> consumer = spec.getConsumerFactoryFn().apply(spec.getConsumerConfig())) {
-        for (Map.Entry<String, List<Integer>> e : topicsAndPartitions.entrySet()) {
-          final String providedTopic = e.getKey();
-          final List<Integer> providedPartitions = e.getValue();
-          final Set<Integer> partitionsForTopic;
-          try {
-            partitionsForTopic =
-                consumer.partitionsFor(providedTopic).stream()
-                    .map(PartitionInfo::partition)
-                    .collect(Collectors.toSet());
-            for (Integer p : providedPartitions) {
-              checkState(
-                  partitionsForTopic.contains(p),
-                  "Partition "
-                      + p
-                      + " does not exist for topic "
-                      + providedTopic
-                      + ". Please check Kafka configuration.");
-            }
-          } catch (KafkaException exception) {
-            LOG.warn("Unable to access cluster. Skipping fail fast checks.");
-          }
-          Lineage.getSources().add("kafka", ImmutableList.of(bootStrapServers, providedTopic));
-        }
+        Lineage.getSources().add("kafka", ImmutableList.of(bootStrapServers, p.topic()));
       }
     }
 

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/WatchForKafkaTopicPartitions.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/WatchForKafkaTopicPartitions.java
@@ -18,7 +18,6 @@
 package org.apache.beam.sdk.io.kafka;
 
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.MoreObjects.firstNonNull;
-import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -190,14 +189,7 @@ class WatchForKafkaTopicPartitions extends PTransform<PBegin, PCollection<KafkaS
         kafkaConsumerFactoryFn.apply(kafkaConsumerConfig)) {
       if (topics != null && !topics.isEmpty()) {
         for (String topic : topics) {
-          List<PartitionInfo> partitionInfoList = kafkaConsumer.partitionsFor(topic);
-          checkState(
-              partitionInfoList != null && !partitionInfoList.isEmpty(),
-              "Could not find any partitions info for topic "
-                  + topic
-                  + ". Please check Kafka configuration and make sure "
-                  + "that provided topics exist.");
-          for (PartitionInfo partition : partitionInfoList) {
+          for (PartitionInfo partition : kafkaConsumer.partitionsFor(topic)) {
             current.add(new TopicPartition(topic, partition.partition()));
           }
         }

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOIT.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOIT.java
@@ -37,7 +37,6 @@ import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
-import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.coders.NullableCoder;
@@ -89,7 +88,6 @@ import org.apache.beam.sdk.values.PCollectionRowTuple;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TypeDescriptors;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Strings;
-import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableSet;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
@@ -112,7 +110,6 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
@@ -170,8 +167,6 @@ public class KafkaIOIT {
 
   @Rule public TestPipeline readPipeline = TestPipeline.create();
 
-  @Rule public ExpectedException thrown = ExpectedException.none();
-
   private static ExperimentalOptions sdfPipelineOptions;
 
   static {
@@ -214,99 +209,6 @@ public class KafkaIOIT {
     if (kafkaContainer != null) {
       kafkaContainer.stop();
     }
-  }
-
-  @Test
-  public void testKafkaIOFailsFastWithInvalidPartitions() throws IOException {
-    thrown.expect(Pipeline.PipelineExecutionException.class);
-    thrown.expectMessage(
-        "Partition 1000 does not exist for topic "
-            + options.getKafkaTopic()
-            + ". Please check Kafka configuration.");
-
-    // Use streaming pipeline to read Kafka records.
-    readPipeline.getOptions().as(Options.class).setStreaming(true);
-    TopicPartition invalidPartition = new TopicPartition(options.getKafkaTopic(), 1000);
-    readPipeline.apply(
-        "Read from unbounded Kafka",
-        readFromKafka().withTopicPartitions(ImmutableList.of(invalidPartition)));
-
-    PipelineResult readResult = readPipeline.run();
-    PipelineResult.State readState =
-        readResult.waitUntilFinish(Duration.standardSeconds(options.getReadTimeout()));
-
-    // call asynchronous deleteTopics first since cancelIfTimeouted is blocking.
-    tearDownTopic(options.getKafkaTopic());
-    cancelIfTimeouted(readResult, readState);
-  }
-
-  @Test
-  public void testKafkaIOFailsFastWithInvalidTopics() throws IOException {
-    // This test will fail on versions before 2.3.0 due to the non-existence of the
-    // allow.auto.create.topics
-    // flag. This can be removed when/if support for this older version is dropped.
-    String actualVer = AppInfoParser.getVersion();
-    assumeFalse(actualVer.compareTo("2.0.0") >= 0 && actualVer.compareTo("2.3.0") < 0);
-
-    thrown.expect(Pipeline.PipelineExecutionException.class);
-    thrown.expectMessage(
-        "Could not find any partitions info for topic invalid_topic. Please check Kafka configuration"
-            + " and make sure that provided topics exist.");
-
-    // Use streaming pipeline to read Kafka records.
-    sdfReadPipeline.getOptions().as(Options.class).setStreaming(true);
-    String invalidTopic = "invalid_topic";
-    sdfReadPipeline.apply(
-        "Read from unbounded Kafka",
-        KafkaIO.<byte[], byte[]>read()
-            .withConsumerConfigUpdates(ImmutableMap.of("allow.auto.create.topics", "false"))
-            .withBootstrapServers(options.getKafkaBootstrapServerAddresses())
-            .withTopics(ImmutableList.of(invalidTopic))
-            .withKeyDeserializer(ByteArrayDeserializer.class)
-            .withValueDeserializer(ByteArrayDeserializer.class));
-
-    PipelineResult readResult = sdfReadPipeline.run();
-    PipelineResult.State readState =
-        readResult.waitUntilFinish(Duration.standardSeconds(options.getReadTimeout()));
-
-    // call asynchronous deleteTopics first since cancelIfTimeouted is blocking.
-    tearDownTopic(options.getKafkaTopic());
-    cancelIfTimeouted(readResult, readState);
-  }
-
-  @Test
-  public void testKafkaIOFailsFastWithInvalidTopicsAndDynamicRead() throws IOException {
-    // This test will fail on versions before 2.3.0 due to the non-existence of the
-    // allow.auto.create.topics
-    // flag. This can be removed when/if support for this older version is dropped.
-    String actualVer = AppInfoParser.getVersion();
-    assumeFalse(actualVer.compareTo("2.0.0") >= 0 && actualVer.compareTo("2.3.0") < 0);
-
-    thrown.expect(Pipeline.PipelineExecutionException.class);
-    thrown.expectMessage(
-        "Could not find any partitions info for topic invalid_topic. Please check Kafka configuration"
-            + " and make sure that provided topics exist.");
-
-    // Use streaming pipeline to read Kafka records.
-    sdfReadPipeline.getOptions().as(Options.class).setStreaming(true);
-    String invalidTopic = "invalid_topic";
-    sdfReadPipeline.apply(
-        "Read from unbounded Kafka",
-        KafkaIO.<byte[], byte[]>read()
-            .withConsumerConfigUpdates(ImmutableMap.of("allow.auto.create.topics", "false"))
-            .withBootstrapServers(options.getKafkaBootstrapServerAddresses())
-            .withTopics(ImmutableList.of(invalidTopic))
-            .withDynamicRead(Duration.standardSeconds(5))
-            .withKeyDeserializer(ByteArrayDeserializer.class)
-            .withValueDeserializer(ByteArrayDeserializer.class));
-
-    PipelineResult readResult = sdfReadPipeline.run();
-    PipelineResult.State readState =
-        readResult.waitUntilFinish(Duration.standardSeconds(options.getReadTimeout()));
-
-    // call asynchronous deleteTopics first since cancelIfTimeouted is blocking.
-    tearDownTopic(options.getKafkaTopic());
-    cancelIfTimeouted(readResult, readState);
   }
 
   @Test


### PR DESCRIPTION
Reverts apache/beam#34258

The original change breaks Kafka job submission without access to kafka clusters https://github.com/apache/beam/issues/34630