### PR TITLE
Get rid of unnecessary cogbk when running offline detector.

### DIFF
--- a/sdks/python/apache_beam/ml/anomaly/transforms.py
+++ b/sdks/python/apache_beam/ml/anomaly/transforms.py
@@ -21,7 +21,6 @@ from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import Iterable
-from typing import List
 from typing import Optional
 from typing import Tuple
 from typing import TypeVar


### PR DESCRIPTION
Improve the performance of offline detectors by putting the original example in the key and removing unnecessary `CoGroupByKey` step.