### PR TITLE
Fail Fast if Resources Do Not Exist in Kafka Cluster.

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIOReadImplementationCompatibility.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIOReadImplementationCompatibility.java
@@ -138,6 +138,7 @@ class KafkaIOReadImplementationCompatibility {
       }
     },
     OFFSET_DEDUPLICATION(LEGACY),
+    LOG_TOPIC_VERIFICATION,
     ;
 
     private final @NonNull ImmutableSet<KafkaIOReadImplementation> supportedImplementations;

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/WatchForKafkaTopicPartitions.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/WatchForKafkaTopicPartitions.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.io.kafka;
 
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.MoreObjects.firstNonNull;
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -189,7 +190,14 @@ class WatchForKafkaTopicPartitions extends PTransform<PBegin, PCollection<KafkaS
         kafkaConsumerFactoryFn.apply(kafkaConsumerConfig)) {
       if (topics != null && !topics.isEmpty()) {
         for (String topic : topics) {
-          for (PartitionInfo partition : kafkaConsumer.partitionsFor(topic)) {
+          List<PartitionInfo> partitionInfoList = kafkaConsumer.partitionsFor(topic);
+          checkState(
+              partitionInfoList != null && !partitionInfoList.isEmpty(),
+              "Could not find any partitions info for topic "
+                  + topic
+                  + ". Please check Kafka configuration and make sure "
+                  + "that provided topics exist.");
+          for (PartitionInfo partition : partitionInfoList) {
             current.add(new TopicPartition(topic, partition.partition()));
           }
         }

--- a/sdks/java/io/kafka/upgrade/src/main/java/org/apache/beam/sdk/io/kafka/upgrade/KafkaIOTranslation.java
+++ b/sdks/java/io/kafka/upgrade/src/main/java/org/apache/beam/sdk/io/kafka/upgrade/KafkaIOTranslation.java
@@ -109,6 +109,7 @@ public class KafkaIOTranslation {
             .addNullableByteArrayField("value_deserializer_provider")
             .addNullableByteArrayField("check_stop_reading_fn")
             .addNullableInt64Field("consumer_polling_timeout")
+            .addNullableBooleanField("log_topic_verification")
             .build();
 
     @Override
@@ -217,6 +218,9 @@ public class KafkaIOTranslation {
         throw new RuntimeException(
             "Upgrading KafkaIO read transforms that have `withBadRecordErrorHandler` property set"
                 + " is not supported yet.");
+      }
+      if (transform.getLogTopicVerification() != null) {
+        fieldValues.put("log_topic_verification", transform.getLogTopicVerification());
       }
 
       fieldValues.put("redistribute", transform.isRedistributed());

--- a/sdks/java/io/kafka/upgrade/src/test/java/org/apache/beam/sdk/io/kafka/upgrade/KafkaIOTranslationTest.java
+++ b/sdks/java/io/kafka/upgrade/src/test/java/org/apache/beam/sdk/io/kafka/upgrade/KafkaIOTranslationTest.java
@@ -78,6 +78,7 @@ public class KafkaIOTranslationTest {
         "getValueDeserializerProvider", "value_deserializer_provider");
     READ_TRANSFORM_SCHEMA_MAPPING.put("getCheckStopReadingFn", "check_stop_reading_fn");
     READ_TRANSFORM_SCHEMA_MAPPING.put("getConsumerPollingTimeout", "consumer_polling_timeout");
+    READ_TRANSFORM_SCHEMA_MAPPING.put("getLogTopicVerification", "log_topic_verification");
   }
 
   // A mapping from Write transform builder methods to the corresponding schema fields in


### PR DESCRIPTION
This PR is a fix and reintroduction of https://github.com/apache/beam/pull/34258.
ORIGINAL DESCRIPTION: If a specified topic or partition do not exist in a kafka cluster, the pipeline should fail before submission. There are some caveats to this, such as whether or not the cluster is reachable, so we only fail in the case where the cluster is reachable but the specified partitions or topics are not present.

This PR also adds a new change to address https://github.com/apache/beam/issues/34630 which details an error if the local machine cannot connect to the cluster during verification steps. The error is no longer thrown and a new test case has been added to verify this issue no longer happens.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
