### PR TITLE
Ignore test_flatten_and_gbk for spark and samza runners.

### DIFF
--- a/sdks/python/apache_beam/runners/portability/samza_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/samza_runner_test.py
@@ -145,7 +145,9 @@ class SamzaRunnerTest(portable_runner_test.PortableRunnerTest):
   def test_flatten_and_gbk(self):
     # Blocked on support for transcoding
     # https://github.com/apache/beam/issues/20984
-    super().test_flatten_and_gbk(with_transcoding=False)
+    # Also blocked on support of flatten and groupby sharing the same input
+    # https://github.com/apache/beam/issues/34647
+    raise unittest.SkipTest("https://github.com/apache/beam/issues/34647")
 
   def test_pack_combiners(self):
     # Stages produced by translations.pack_combiners are fused

--- a/sdks/python/apache_beam/runners/portability/spark_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/spark_runner_test.py
@@ -180,7 +180,9 @@ class SparkRunnerTest(portable_runner_test.PortableRunnerTest):
   def test_flatten_and_gbk(self):
     # Blocked on support for transcoding
     # https://github.com/apache/beam/issues/19504
-    super().test_flatten_and_gbk(with_transcoding=False)
+    # Also blocked on support of flatten and groupby sharing the same input
+    # https://github.com/apache/beam/issues/34647
+    raise unittest.SkipTest("https://github.com/apache/beam/issues/34647")
 
   def test_custom_merging_window(self):
     raise unittest.SkipTest("https://github.com/apache/beam/issues/20641")


### PR DESCRIPTION
fixes #30645
fixes #30657

Tracking issue: #34647