### PR TITLE
Provide kafka unbounded reader to checkpoint mark when offset based deduplication is supported.

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaCheckpointMark.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaCheckpointMark.java
@@ -39,7 +39,7 @@ public class KafkaCheckpointMark implements UnboundedSource.CheckpointMark {
   private List<PartitionMark> partitions;
 
   @AvroIgnore
-  private KafkaUnboundedReader<?, ?> reader; // Present when offsets need to be committed.
+  private KafkaUnboundedReader<?, ?> reader;
 
   private boolean commitOffsetsInFinalize;
 

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaCheckpointMark.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaCheckpointMark.java
@@ -38,8 +38,7 @@ public class KafkaCheckpointMark implements UnboundedSource.CheckpointMark {
 
   private List<PartitionMark> partitions;
 
-  @AvroIgnore
-  private KafkaUnboundedReader<?, ?> reader;
+  @AvroIgnore private KafkaUnboundedReader<?, ?> reader;
 
   private boolean commitOffsetsInFinalize;
 

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaCheckpointMark.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaCheckpointMark.java
@@ -21,7 +21,6 @@ import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Pr
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Optional;
 import org.apache.avro.reflect.AvroIgnore;
 import org.apache.beam.sdk.coders.DefaultCoder;
 import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
@@ -35,21 +34,25 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Joiner;
  */
 @DefaultCoder(AvroCoder.class)
 public class KafkaCheckpointMark implements UnboundedSource.CheckpointMark {
+  private static final long OFFSET_DEDUP_PARTITIONS_PER_SPLIT = 1;
 
   private List<PartitionMark> partitions;
 
   @AvroIgnore
-  private Optional<KafkaUnboundedReader<?, ?>> reader; // Present when offsets need to be committed.
+  private KafkaUnboundedReader<?, ?> reader; // Present when offsets need to be committed.
+
+  private boolean commitOffsetsInFinalize;
 
   @SuppressWarnings("initialization") // Avro will set the fields by breaking abstraction
   private KafkaCheckpointMark() {} // for Avro
 
-  private static final long OFFSET_DEDUP_PARTITIONS_PER_SPLIT = 1;
-
   public KafkaCheckpointMark(
-      List<PartitionMark> partitions, Optional<KafkaUnboundedReader<?, ?>> reader) {
+      List<PartitionMark> partitions,
+      KafkaUnboundedReader<?, ?> reader,
+      boolean commitOffsetsInFinalize) {
     this.partitions = partitions;
     this.reader = reader;
+    this.commitOffsetsInFinalize = commitOffsetsInFinalize;
   }
 
   public List<PartitionMark> getPartitions() {
@@ -58,7 +61,10 @@ public class KafkaCheckpointMark implements UnboundedSource.CheckpointMark {
 
   @Override
   public void finalizeCheckpoint() {
-    reader.ifPresent(r -> r.finalizeCheckpointMarkAsync(this));
+    if (!commitOffsetsInFinalize) {
+      return;
+    }
+    reader.finalizeCheckpointMarkAsync(this);
     // Is it ok to commit asynchronously, or should we wait till this (or newer) is committed?
     // Often multiple marks would be finalized at once, since we only need to finalize the latest,
     // it is better to wait a little while. Currently maximum delay is same as KAFKA_POLL_TIMEOUT
@@ -72,11 +78,7 @@ public class KafkaCheckpointMark implements UnboundedSource.CheckpointMark {
 
   @Override
   public byte[] getOffsetLimit() {
-    if (!reader.isPresent()) {
-      throw new RuntimeException(
-          "KafkaCheckpointMark reader is not present while calling getOffsetLimit().");
-    }
-    if (!reader.get().offsetBasedDeduplicationSupported()) {
+    if (!reader.offsetBasedDeduplicationSupported()) {
       throw new RuntimeException(
           "Unexpected getOffsetLimit() called while KafkaUnboundedReader not configured for offset deduplication.");
     }

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java
@@ -268,7 +268,8 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
                         p.nextOffset,
                         p.lastWatermark.getMillis()))
             .collect(Collectors.toList()),
-        source.getSpec().isCommitOffsetsInFinalizeEnabled() ? Optional.of(this) : Optional.empty());
+        this,
+        source.getSpec().isCommitOffsetsInFinalizeEnabled());
   }
 
   @Override

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java
@@ -268,8 +268,9 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
                         p.nextOffset,
                         p.lastWatermark.getMillis()))
             .collect(Collectors.toList()),
-        this,
-        source.getSpec().isCommitOffsetsInFinalizeEnabled());
+        source.getSpec().isCommitOffsetsInFinalizeEnabled() || offsetBasedDeduplicationSupported()
+            ? Optional.of(this)
+            : Optional.empty());
   }
 
   @Override


### PR DESCRIPTION
KafkaCheckpointMark previously did not have the reader available which was required for offset deduplication.

This changes to always provide the reader for committing offsets and offset deduplication.

------------------------

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
