### PR TITLE
Add withReshuffle(boolean) option to FileIO.matchAll() 

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileIOTest.java
@@ -125,6 +125,13 @@ public class FileIOTest implements Serializable {
 
     PAssert.that(
             p.apply(
+                    "Create existing without reshuffle",
+                    Create.of(tmpFolder.getRoot().getAbsolutePath() + "/*"))
+                .apply("MatchAll without reshuffle", FileIO.matchAll().withReshuffle(false)))
+        .containsInAnyOrder(firstMetadata, secondMetadata);
+
+    PAssert.that(
+            p.apply(
                 "Match non-existing ALLOW",
                 FileIO.match()
                     .filepattern(tmpFolder.getRoot().getAbsolutePath() + "/blah")


### PR DESCRIPTION

### What
This PR adds a new method `withReshuffle(boolean)` to `FileIO.matchAll()` to allow disabling the automatic reshuffling step (`Reshuffle.viaRandomKey()`).

### Why
Currently, `FileIO.matchAll()` always applies a `Reshuffle` step. While this improves performance for wildcard patterns that expand into many files, it is not ideal when processing a large static list of file paths (e.g., 1M+). In such cases, reshuffling can block downstream fusion and autoscaling.

This feature allows advanced users to opt out of reshuffling to improve performance and fusion behavior.

### How
- Added a `getReshuffle()` property to the `MatchAll` AutoValue class, defaulting to `true`.
- Updated the `expand()` method to conditionally apply the reshuffle based on the property.
- Added `withReshuffle(boolean)` for API access.
- Updated `FileIOTest` to verify the reshuffle toggle behavior.

### Fixes
Fixes: #33330

---

- [x] This addresses an open issue (`fixes #33330`)
- [x] Tested and verified the updated behavior
- [ ] I will update `CHANGES.md` upon approval if necessary

