### PR TITLE
Support customizing how built-in types are pickled for cloudpickle

### DIFF
--- a/sdks/python/apache_beam/internal/cloudpickle/__init__.py
+++ b/sdks/python/apache_beam/internal/cloudpickle/__init__.py
@@ -9,6 +9,7 @@ __all__ = [  # noqa
     "__version__",
     "Pickler",
     "CloudPickler",
+    "PurePythonPickler",
     "dumps",
     "loads",
     "dump",

--- a/sdks/python/apache_beam/internal/cloudpickle_pickler.py
+++ b/sdks/python/apache_beam/internal/cloudpickle_pickler.py
@@ -111,7 +111,7 @@ def dumps(o, enable_trace=True, use_zlib=False) -> bytes:
   """For internal use only; no backwards-compatibility guarantees."""
   with _pickle_lock:
     with io.BytesIO() as file:
-      pickler = cloudpickle.CloudPickler(file)
+      pickler = cloudpickle.PurePythonPickler(file)
       try:
         pickler.dispatch_table[type(flags.FLAGS)] = _pickle_absl_flags
       except NameError:


### PR DESCRIPTION
This is to enable customizing how sets are serialized to increase the pickling determinism. I'm modifying the vendored cloudpickle as a stop-gap measure until the cloudpickle maintainers review https://github.com/cloudpipe/cloudpickle/pull/563.

Note: It's easiest to review this change with the setting to hide whitespace.

Issue: #34410 