### PR TITLE
Fix handling of collections.Counter types

### DIFF
--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -452,6 +452,14 @@ def convert_to_beam_type(typ):
       args = (typehints.TypeVariable('T'), ) * arity
   elif matched_entry.arity == -1:
     arity = len_args
+  # Counters are special dict types that are implicitly parameterized to
+  # [T, int], so we fix cases where they only have one argument to match
+  # a more traditional dict hint.
+  elif len_args == 1 and _safe_issubclass(getattr(typ, '__origin__', typ),
+                                          collections.Counter):
+    args = (args[0], int)
+    len_args = 2
+    arity = matched_entry.arity
   else:
     arity = matched_entry.arity
     if len_args != arity:

--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -264,6 +264,10 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
             typehints.Dict[str, int]),
         ('count', collections.Counter[str, int], typehints.Dict[str, int]),
         (
+            'single param counter',
+            collections.Counter[str],
+            typehints.Dict[str, int]),
+        (
             'bare callable',
             collections.abc.Callable,
             collections.abc.Callable,


### PR DESCRIPTION
`collections.Counter` types are special dictionary cases where they generally only accept one type parameter to act as the key, while the value is implicitly always an `int`. Beam incorrectly handled these types when properly hinted with only one type, as they are dictionaries but were only being defined with arity 1 instead of 2. This adds a check to correct this issue and an associated test case. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
