### PR TITLE
[BigQueryIO] support MicrosInstant type (for xlang)

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
@@ -753,6 +753,8 @@ public class BigQueryUtils {
         return LocalDate.parse(jsonBQString);
       } else if (fieldType.isLogicalType(SqlTypes.TIME.getIdentifier())) {
         return LocalTime.parse(jsonBQString);
+      } else if (fieldType.isLogicalType(SqlTypes.TIMESTAMP.getIdentifier())) {
+        return java.time.Instant.parse(jsonBQString);
       }
     }
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtilsTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtilsTest.java
@@ -1136,6 +1136,24 @@ public class BigQueryUtilsTest {
     assertEquals(expected, actual);
   }
 
+  /**
+   * Dedicated test for MicrosInstant logical type because this type is intended only for
+   * cross-language use-cases. This is a one-way mapping from BQ --> Beam based on Beam Schema.
+   */
+  @Test
+  public void testToBeamRow_timestamp_micros() {
+    Schema schema =
+        Schema.builder().addLogicalTypeField("timestamp_micros", SqlTypes.TIMESTAMP).build();
+    Row beamRow =
+        BigQueryUtils.toBeamRow(
+            schema, new TableRow().set("timestamp_micros", "2024-08-10T16:52:07.123456Z"));
+    Row expectedRow =
+        Row.withSchema(schema)
+            .addValue(java.time.Instant.parse("2024-08-10T16:52:07.123456Z"))
+            .build();
+    assertEquals(expectedRow, beamRow);
+  }
+
   @Test
   public void testToTableSpec() {
     TableReference withProject =


### PR DESCRIPTION
tl;dr just adding some missing logic to support converting BQ timestamp type --> Java logical timestamp type --> Python timestamp type

We have some existing Schema translation between Python and Java SDKs for Timestamps. A Python Timestamp [maps](https://github.com/apache/beam/blob/73739725633f76e1a960e61171e498df1be9012f/sdks/python/apache_beam/typehints/schemas.py#L36) to a Java MicrosInstant (aka [SqlTypes.TIMESTAMP](https://github.com/apache/beam/blob/73739725633f76e1a960e61171e498df1be9012f/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/SqlTypes.java#L42))

Writing timestamps to BQ Storage Write API with the Python SDK works fine, but when a row fails and we try converting the BQ type back to a MicrosInstant, we get the following error:
```
java.lang.UnsupportedOperationException: Converting BigQuery type 'class java.lang.String' to 'LOGICAL_TYPE<beam:logical_type:micros_instant:v1> NOT NULL' is not supported
	at org.apache.beam.sdk.io.gcp.bigquery.BigQueryUtils.toBeamValue(BigQueryUtils.java:802)
	at org.apache.beam.sdk.io.gcp.bigquery.BigQueryUtils.lambda$toBeamRow$6(BigQueryUtils.java:693)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Collections$2.tryAdvance(Collections.java:5073)
	at java.base/java.util.Collections$2.forEachRemaining(Collections.java:5081)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at org.apache.beam.sdk.io.gcp.bigquery.BigQueryUtils.toBeamRow(BigQueryUtils.java:694)
```

We're just missing some logic that accounts for when we want to convert a BQ timestamp to a MicrosInstant. I believe this was neglected because MicrosInstant isn't meant to be used as a Java native type.