### PR TITLE
Add a md5sum check before overwriting a cached prism file

### DIFF
--- a/sdks/python/apache_beam/runners/portability/prism_runner.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner.py
@@ -237,6 +237,10 @@ class PrismJobServer(job_server.SubprocessJobServer):
         # The path is local and exists, use directly.
         return self._path
 
+      if FileSystems.exists(self._path):
+        # The path is in one of the supported filesystems.
+        return self._path
+
       # Check if the path is a URL.
       url = urllib.parse.urlparse(self._path)
       if not url.scheme:

--- a/sdks/python/apache_beam/runners/portability/prism_runner.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner.py
@@ -83,7 +83,7 @@ class PrismRunner(portable_runner.PortableRunner):
 
 
 def _md5sum(filename, block_size=8192) -> str:
-  md5 =hashlib.md5()
+  md5 = hashlib.md5()
   with open(filename, 'rb') as f:
     while True:
       data = f.read(block_size)
@@ -94,7 +94,7 @@ def _md5sum(filename, block_size=8192) -> str:
 
 
 def _rename_if_different(src, dst):
-  assert(os.path.isfile(src))
+  assert (os.path.isfile(src))
 
   if os.path.isfile(dst):
     if _md5sum(src) != _md5sum(dst):
@@ -130,7 +130,6 @@ class PrismJobServer(job_server.SubprocessJobServer):
 
     job_options = options.view_as(pipeline_options.JobServerOptions)
     self._job_port = job_options.job_port
-
 
   @classmethod
   def maybe_unzip_and_make_executable(

--- a/sdks/python/apache_beam/runners/portability/prism_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner_test.py
@@ -245,32 +245,37 @@ class PrismJobServerTest(unittest.TestCase):
     rmtree(self.local_dir)
     pass
 
-  def _make_local_bin(self):
-    with open(self.local_bin_path, 'wb'):
+  def _make_local_bin(self, fn = None):
+    fn = fn or self.local_bin_path
+    with open(fn, 'wb'):
       pass
 
-  def _make_local_zip(self):
-    with zipfile.ZipFile(self.local_zip_path, 'w', zipfile.ZIP_DEFLATED):
+  def _make_local_zip(self, fn = None):
+    fn = fn or self.local_zip_path
+    with zipfile.ZipFile(fn, 'w', zipfile.ZIP_DEFLATED):
       pass
 
-  def _make_cache_bin(self):
-    with open(self.cache_bin_path, 'wb'):
+  def _make_cache_bin(self, fn = None):
+    fn = fn or self.cache_bin_path
+    with open(fn, 'wb'):
       pass
 
-  def _make_cache_zip(self):
-    with zipfile.ZipFile(self.cache_zip_path, 'w', zipfile.ZIP_DEFLATED):
+  def _make_cache_zip(self, fn = None):
+    fn = fn or self.cache_zip_path
+    with zipfile.ZipFile(fn, 'w', zipfile.ZIP_DEFLATED):
       pass
 
-  def _extract_side_effect(self, a, path=None):
+  def _extract_side_effect(self, fn, path=None):
     if path is None:
-      return a
+      return fn
 
+    full_path = os.path.join(str(path), fn)
     if path.startswith(self.cache_dir):
-      self._make_cache_bin()
+      self._make_cache_bin(full_path)
     else:
-      self._make_local_bin()
+      self._make_local_bin(full_path)
 
-    return os.path.join(str(path), a)
+    return full_path
 
   @parameterized.expand([[True, True], [True, False], [False, True],
                          [False, False]])
@@ -352,7 +357,11 @@ class PrismJobServerTest(unittest.TestCase):
     with mock.patch(
         'apache_beam.runners.portability.prism_runner.urlopen') as mock_urlopen:
       mock_response = mock.MagicMock()
-      mock_response.read.return_value = b''
+      if has_cache_zip:
+        with open(self.cache_zip_path, 'rb') as f:
+          mock_response.read.side_effect = [f.read(), b'']
+      else:
+        mock_response.read.return_value = b''
       mock_urlopen.return_value = mock_response
       with mock.patch('zipfile.is_zipfile') as mock_is_zipfile:
         with mock.patch('zipfile.ZipFile') as mock_zipfile_init:

--- a/sdks/python/apache_beam/runners/portability/prism_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner_test.py
@@ -245,22 +245,22 @@ class PrismJobServerTest(unittest.TestCase):
     rmtree(self.local_dir)
     pass
 
-  def _make_local_bin(self, fn = None):
+  def _make_local_bin(self, fn=None):
     fn = fn or self.local_bin_path
     with open(fn, 'wb'):
       pass
 
-  def _make_local_zip(self, fn = None):
+  def _make_local_zip(self, fn=None):
     fn = fn or self.local_zip_path
     with zipfile.ZipFile(fn, 'w', zipfile.ZIP_DEFLATED):
       pass
 
-  def _make_cache_bin(self, fn = None):
+  def _make_cache_bin(self, fn=None):
     fn = fn or self.cache_bin_path
     with open(fn, 'wb'):
       pass
 
-  def _make_cache_zip(self, fn = None):
+  def _make_cache_zip(self, fn=None):
     fn = fn or self.cache_zip_path
     with zipfile.ZipFile(fn, 'w', zipfile.ZIP_DEFLATED):
       pass


### PR DESCRIPTION
Add a md5sum check before overwriting a cached file.

Additionally, we add support for using GCS path as prism location.

Particularly, to set the prism location for running a pipeline, we can use `--prism_location`. The following scenarios are now supported:
- `--prism_location=/path/to/bin_or_zip`
- `--prism_location=https://github.com/apache/beam/releases/download/...`
- `--prism_location=https://github.com/apache/beam/releases/tag/...`
- `--prism_location=gs://bucket/path/to/bin_or_zip`    <- newly supported case


