### PR TITLE
Skip this failed test until further investigation is done.

### DIFF
--- a/sdks/python/apache_beam/io/gcp/gcsio_retry_test.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio_retry_test.py
@@ -34,6 +34,7 @@ except ImportError:
   api_exceptions = None
 
 
+@unittest.skip("https://github.com/apache/beam/issues/34736")
 @unittest.skipIf((gcsio_retry is None or api_exceptions is None),
                  'GCP dependencies are not installed')
 class TestGCSIORetry(unittest.TestCase):


### PR DESCRIPTION
Temporarily silent the noise from `TestGCSIORetry.test_retry_on_throttling`.

Revert this once issue https://github.com/apache/beam/issues/34736 is fixed.