### PR TITLE
Remove myself from java reviewers and focus on python and go.

### DIFF
--- a/.github/REVIEWERS.yml
+++ b/.github/REVIEWERS.yml
@@ -22,6 +22,7 @@ labels:
     reviewers:
       - jrmccluskey
       - lostluck
+      - shunping
     exclusionList: []
   - name: Python
     reviewers:
@@ -39,7 +40,6 @@ labels:
       - chamikaramj
       - m-trieu
       - kennknowles
-      - shunping
       - robertwb
     exclusionList: []
   - name: spanner


### PR DESCRIPTION
To help streamline review assignments and focus my efforts, I'll be opting out of Java reviews and dedicating more of my review capacity to Python and Go going forward.