### PR TITLE
Streamline non-cached state backed iterable.

### DIFF
--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/StateBackedIterable.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/StateBackedIterable.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 import org.apache.beam.fn.harness.Cache;
-import org.apache.beam.fn.harness.Caches;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.StateKey;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.StateRequest;
 import org.apache.beam.sdk.coders.IterableLikeCoder;
@@ -90,8 +89,7 @@ public class StateBackedIterable<T>
         StateRequest.newBuilder().setInstructionId(instructionId).setStateKey(stateKey).build();
     this.prefix = prefix;
     this.suffix =
-        StateFetchingIterators.readAllAndDecodeStartingFrom(
-            Caches.subCache(cache, stateKey), beamFnStateClient, request, elemCoder);
+        StateFetchingIterators.readAllAndDecodeStartingFrom(beamFnStateClient, request, elemCoder);
     this.elemCoder = elemCoder;
   }
 

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/StateBackedIterableTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/StateBackedIterableTest.java
@@ -32,7 +32,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
-import org.apache.beam.fn.harness.Cache;
 import org.apache.beam.fn.harness.Caches;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.StateKey;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
@@ -109,75 +108,6 @@ public class StateBackedIterableTest {
       assertEquals(expected, Lists.newArrayList(iterable));
       assertEquals(expected, Lists.newArrayList(iterable));
       assertEquals(expected, Lists.newArrayList(iterable));
-    }
-
-    @Test
-    public void testReiterationCached() throws Exception {
-      FakeBeamFnStateClient fakeBeamFnStateClient =
-          new FakeBeamFnStateClient(
-              StringUtf8Coder.of(),
-              ImmutableMap.of(
-                  key("nonEmptySuffix"), asList("C", "D", "E", "F", "G", "H", "I", "J", "K"),
-                  key("emptySuffix"), asList()));
-
-      StateBackedIterable<String> iterable =
-          new StateBackedIterable<>(
-              Caches.eternal(),
-              fakeBeamFnStateClient,
-              "instruction",
-              key(suffixKey),
-              StringUtf8Coder.of(),
-              prefix);
-
-      // Ensure that the load is lazy
-      assertEquals(0, fakeBeamFnStateClient.getCallCount());
-      assertEquals(expected, Lists.newArrayList(iterable));
-      // We expect future reiterations to not perform any loads
-      int callCount = fakeBeamFnStateClient.getCallCount();
-      assertEquals(expected, Lists.newArrayList(iterable));
-      assertEquals(expected, Lists.newArrayList(iterable));
-      assertEquals(callCount, fakeBeamFnStateClient.getCallCount());
-    }
-
-    @Test
-    public void testCacheKeyIsUnique() throws Exception {
-      // Share a cache for multiple iterables leads to distinct keys being used.
-      Cache cache = Caches.eternal();
-      FakeBeamFnStateClient fakeBeamFnStateClient =
-          new FakeBeamFnStateClient(
-              StringUtf8Coder.of(),
-              ImmutableMap.of(
-                  key("nonEmptySuffix"), asList("C", "D", "E", "F", "G", "H", "I", "J", "K"),
-                  key("emptySuffix"), asList(),
-                  key("otherIterable"), asList("Z")));
-
-      StateBackedIterable<String> otherIterable =
-          new StateBackedIterable<>(
-              cache,
-              fakeBeamFnStateClient,
-              "instruction",
-              key("otherIterable"),
-              StringUtf8Coder.of(),
-              Collections.emptyList());
-      // Ensure that the load is lazy
-      assertEquals(0, fakeBeamFnStateClient.getCallCount());
-      assertEquals(asList("Z"), Lists.newArrayList(otherIterable));
-
-      StateBackedIterable<String> iterable =
-          new StateBackedIterable<>(
-              cache,
-              fakeBeamFnStateClient,
-              "instruction",
-              key(suffixKey),
-              StringUtf8Coder.of(),
-              prefix);
-
-      assertEquals(expected, Lists.newArrayList(iterable));
-      // We expect future reiterations to not perform any loads
-      int callCount = fakeBeamFnStateClient.getCallCount();
-      assertEquals(expected, Lists.newArrayList(iterable));
-      assertEquals(expected, Lists.newArrayList(iterable));
-      assertEquals(callCount, fakeBeamFnStateClient.getCallCount());
     }
 
     @Test


### PR DESCRIPTION
Avoids all the bookeeping logic of creating and caching blocks of elements, which in addition to reducing total work and simplifying the codepaths allows decoded elements to be ephemerally decoded and consumed one at a time rather than storing them in large lists even when actual caching is disabled which should play much better with the garbage collector.

Note that this disables caching of the tail of GBK iterables, which will result in more side input reads and possible performance degradation for those GBKs whose value iterables are too large to fit over the Data API but small enough to be substantially cached *and* are re-iterated. IMHO this is a reasonable tradeoff as (1) large values like this are the antithesis of what one wants to place in the cache (which can result in evicting all other values over the course of iteration) and (2) this provides increased performance (and in many cases avoiding outright failure, e.g. due to GC memory thrashing) for the common usecase of no re-iteration (including writing lots of data to fixed shards/dynamic destinations), and the most common case of re-iteration (CoGBK) does its own caching anyway.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
