### PR TITLE
34749 reflect datum factory cache

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -89,6 +89,7 @@
 * Fixed X (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
 * Fixed read Beam rows from cross-lang transform (for example, ReadFromJdbc) involving negative 32-bit integers incorrectly decoded to large integers ([#34089](https://github.com/apache/beam/issues/34089))
 * (Java) Fixed SDF-based KafkaIO (ReadFromKafkaViaSDF) to properly handle custom deserializers that extend Deserializer<Row> interface([#34505](https://github.com/apache/beam/pull/34505))
+* (Java) Fixed memory allocation issue in `AvroDatumFactory.ReflectDatumFactory` where the same avro DatumReader and DatumWriter were created over and over ([#34750](https://github.com/apache/beam/pull/34750))
 
 ## Security Fixes
 * Fixed [CVE-YYYY-NNNN](https://www.cve.org/CVERecord?id=CVE-YYYY-NNNN) (Java/Python/Go) ([#X](https://github.com/apache/beam/issues/X)).

--- a/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/io/AvroDatumFactory.java
+++ b/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/io/AvroDatumFactory.java
@@ -187,6 +187,10 @@ public abstract class AvroDatumFactory<T>
       }
     }
 
+    public static <T> ReflectDatumFactory<T> of(Class<T> type) {
+      return new ReflectDatumFactory<>(type);
+    }
+
     public ReflectDatumFactory(Class<T> type) {
       super(type);
     }
@@ -198,7 +202,7 @@ public abstract class AvroDatumFactory<T>
           return (ReflectDatumReader<T>)
               READER_CACHE.get(new SchemaPair(writer, reader), () -> createReader(writer, reader));
         } catch (ExecutionException e) {
-          // ignore
+          throw new RuntimeException(e);
         }
       }
       return createReader(writer, reader);
@@ -210,14 +214,10 @@ public abstract class AvroDatumFactory<T>
         try {
           return (ReflectDatumWriter<T>) WRITER_CACHE.get(writer, () -> createWriter(writer));
         } catch (ExecutionException e) {
-          // ignore
+          throw new RuntimeException(e);
         }
       }
       return createWriter(writer);
-    }
-
-    public static <T> ReflectDatumFactory<T> of(Class<T> type) {
-      return new ReflectDatumFactory<>(type);
     }
 
     private ReflectDatumReader<T> createReader(Schema writer, Schema reader) {

--- a/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/io/ReflectDatumFactoryWithCacheTest.java
+++ b/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/io/ReflectDatumFactoryWithCacheTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.avro.io;
+
+import org.apache.avro.Schema;
+import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ReflectDatumFactoryWithCacheTest {
+
+  @Test
+  public void whenCacheIsEnabledThenAvroReaderAndWriterAreCreatedOnlyOnce() {
+    // cache is enabled by default,
+    // so no need to set the beam.avro.reflectdatumfactory.cachesize property
+    AvroDatumFactory.ReflectDatumFactory<MyClass> factory =
+        new AvroDatumFactory.ReflectDatumFactory<>(MyClass.class);
+    Schema schema = AvroCoder.of(MyClass.class).getSchema();
+
+    Assert.assertSame(factory.apply(schema), factory.apply(schema));
+    Assert.assertSame(factory.apply(schema, schema), factory.apply(schema, schema));
+  }
+
+  static class MyClass {
+    public String field1;
+  }
+}

--- a/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/io/ReflectDatumFactoryWithoutCacheTest.java
+++ b/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/io/ReflectDatumFactoryWithoutCacheTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.avro.io;
+
+import org.apache.avro.Schema;
+import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ReflectDatumFactoryWithoutCacheTest {
+
+  @Test
+  public void whenCacheIsDisabledThenAvroReaderAndWriterAreCreatedEachTime() {
+    System.setProperty("beam.avro.reflectdatumfactory.cachesize", "-1"); // disable cache
+
+    AvroDatumFactory.ReflectDatumFactory<MyClass> factory =
+        new AvroDatumFactory.ReflectDatumFactory<>(MyClass.class);
+    Schema schema = AvroCoder.of(ReflectDatumFactoryWithCacheTest.MyClass.class).getSchema();
+
+    Assert.assertNotSame(factory.apply(schema), factory.apply(schema));
+    Assert.assertNotSame(factory.apply(schema, schema), factory.apply(schema, schema));
+  }
+
+  static class MyClass {
+    public String field1;
+  }
+}


### PR DESCRIPTION
`org.apache.beam.sdk.extensions.avro.io.AvroDatumFactory.ReflectDatumFactory` uses cache to avoid to re-create `ReflectDatumReader` and `ReflectDatumWriter` that were previously created for the same schemas.

This addresses #34749.

After applying this fix (manually in my code), I see very relevant memory allocation improvements. The heap profile shows that now `org.apache.beam.sdk.extensions.avro.io.AvroDatumFactory.ReflectDatumFactory#apply(org.apache.avro.Schema, org.apache.avro.Schema)` is responsible for 0.512% of allocations, down from 27.7%

<img width="1630" alt="image" src="https://github.com/user-attachments/assets/7da052d0-2454-4950-b678-1eecb4a6b696" />

This has a good impact on memory used, and also on cpu (likely for the cpu saved on GC), allowing that specific streaming pipeline to run on 2 to 3 (depending on traffic) n2d-standard-4 VMs instead of 4 such VMs. 

