### PR TITLE
Improve the apache beam type system to handle TypedDict.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,6 +98,7 @@ update_compatibility_version to a previous Beam version e.g. "2.64.0".
 * Fixed X (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
 * Fixed read Beam rows from cross-lang transform (for example, ReadFromJdbc) involving negative 32-bit integers incorrectly decoded to large integers ([#34089](https://github.com/apache/beam/issues/34089))
 * (Java) Fixed SDF-based KafkaIO (ReadFromKafkaViaSDF) to properly handle custom deserializers that extend Deserializer<Row> interface([#34505](https://github.com/apache/beam/pull/34505))
+* [Python] `TypedDict` typehints are now compatible with `Mapping` and `Dict` type annotations.
 
 ## Security Fixes
 * Fixed [CVE-YYYY-NNNN](https://www.cve.org/CVERecord?id=CVE-YYYY-NNNN) (Java/Python/Go) ([#X](https://github.com/apache/beam/issues/X)).

--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -33,7 +33,6 @@ try:
 except ImportError:
   from typing_extensions import is_typeddict
 
-
 from apache_beam.typehints import typehints
 
 T = TypeVar('T')

--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -28,12 +28,12 @@ import typing
 from typing import Generic
 from typing import TypeVar
 
+from apache_beam.typehints import typehints
+
 try:
   from typing import is_typeddict
 except ImportError:
   from typing_extensions import is_typeddict
-
-from apache_beam.typehints import typehints
 
 T = TypeVar('T')
 

--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -28,6 +28,12 @@ import typing
 from typing import Generic
 from typing import TypeVar
 
+try:
+  from typing import is_typeddict
+except ImportError:
+  from typing_extensions import is_typeddict
+
+
 from apache_beam.typehints import typehints
 
 T = TypeVar('T')
@@ -359,7 +365,7 @@ def convert_to_beam_type(typ):
     # to the correct type constraint in Beam
     # This is needed to fix https://github.com/apache/beam/issues/33356
     pass
-  elif typing.is_typeddict(typ):
+  elif is_typeddict(typ):
     # Special-case for the TypedDict constructor, which is not actually a type,
     # and therefore fails to be recognised as compatible with Dict or Mapping.
     return typehints.Dict[str, typehints.Any]

--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -359,7 +359,10 @@ def convert_to_beam_type(typ):
     # to the correct type constraint in Beam
     # This is needed to fix https://github.com/apache/beam/issues/33356
     pass
-
+  elif typing.is_typeddict(typ):
+    # Special-case for the TypedDict constructor, which is not actually a type,
+    # and therefore fails to be recognised as compatible with Dict or Mapping.
+    return typehints.Dict[str, typehints.Any]
   elif typ_module not in _CONVERTED_MODULES and not is_builtin(typ):
     # Only translate primitives and types from collections.abc and typing.
     return typ

--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -64,6 +64,11 @@ class _TestEnum(enum.Enum):
   BAR = enum.auto()
 
 
+class _TestTypedDict(typing.TypedDict):
+  foo: int
+  bar: str
+
+
 class NativeTypeCompatibilityTest(unittest.TestCase):
   def test_convert_to_beam_type(self):
     test_cases = [
@@ -262,6 +267,7 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
             'default dict',
             collections.defaultdict[str, int],
             typehints.Dict[str, int]),
+        ('typed dict', _TestTypedDict, typehints.Dict[str, typehints.Any]),
         ('count', collections.Counter[str, int], typehints.Dict[str, int]),
         (
             'single param counter',


### PR DESCRIPTION
`TypedDict` is not a type, but a constructor of `dict` that supplies type hints to static type checkers about the keys. As a result, `TypedDict`s are not compatible with Mapping or Dict, giving errors like this:

```
apache_beam.typehints.decorators.TypeCheckError: Input type hint violation at MyPipelineStage: expected Mapping[<class 'str'>, Any], got <class 'google3.my_pipeline.MyCoolTypedDict'>
```

This implementation could be improved. For one thing, something which is typed as accepting a `TypedDict` will happily accept a `dict[str, Any]`, which is not as strict as it could be. For another, we could be more specific about the key type (e.g. a union of all types found in the `TypedDict`). However, I think this is a distinct improvement on the current state and will unbreak some of our pipelines.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
