### PR TITLE
Revert "Unpin Dataflow legacy worker container for Nexmark test (#33224)"

### DIFF
--- a/.github/trigger_files/beam_PostCommit_Java_Nexmark_Dataflow.json
+++ b/.github/trigger_files/beam_PostCommit_Java_Nexmark_Dataflow.json
@@ -1,3 +1,3 @@
 {
-  "modification": 1
+  "modification": 2
 }

--- a/sdks/java/testing/nexmark/build.gradle
+++ b/sdks/java/testing/nexmark/build.gradle
@@ -118,7 +118,11 @@ def getNexmarkArgs = {
       }
     } else {
       def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":runners:google-cloud-dataflow-java:worker").shadowJar.archivePath
+      // Provide job with a customizable worker jar.
+      // With legacy worker jar, containerImage is set to empty (i.e. to use the internal build).
+      // More context and discussions can be found in PR#6694.
       nexmarkArgsList.add("--dataflowWorkerJar=${dataflowWorkerJar}".toString())
+      nexmarkArgsList.add('--workerHarnessContainerImage=')
 
       def nexmarkProfile =  project.findProperty(nexmarkProfilingProperty) ?: ""
       if (nexmarkProfile.equals("true")) {


### PR DESCRIPTION
The side effect of #33224 is that the test no longer working during release branch verification, as Dataflow container does not exist yet

The internal versionless legacy worker container already moved to Java 11, so we can revert it now

This reverts commit 96962011e7e323c568a6594fd1d93a3b8b6a4861.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
