### PR TITLE
Add Git commit SHA to artifacts using buildnumber-maven-plugin (#18227)

### DIFF
--- a/sdks/java/maven-archetypes/starter/pom.xml
+++ b/sdks/java/maven-archetypes/starter/pom.xml
@@ -81,5 +81,40 @@
         </plugin>
       </plugins>
     </pluginManagement>
+     <plugins>
+ 
+  <plugin>
+    <groupId>org.codehaus.mojo</groupId>
+    <artifactId>buildnumber-maven-plugin</artifactId>
+    <version>1.4</version>
+    <executions>
+      <execution>
+        <phase>validate</phase>
+        <goals>
+          <goal>create</goal>
+        </goals>
+      </execution>
+    </executions>
+    <configuration>
+      <doCheck>true</doCheck>
+      <doUpdate>true</doUpdate>
+    </configuration>
+  </plugin>
+
+  
+  <plugin>
+    <artifactId>maven-jar-plugin</artifactId>
+    <version>3.2.2</version>
+    <configuration>
+      <archive>
+        <manifestEntries>
+          <Implementation-Build>${buildNumber}</Implementation-Build>
+        </manifestEntries>
+      </archive>
+    </configuration>
+  </plugin>
+</plugins>
+
+
   </build>
 </project>


### PR DESCRIPTION
This pull request introduces the `buildnumber-maven-plugin` to the Apache Beam project to include the Git commit SHA in the `MANIFEST.MF` file of the generated artifacts. This update helps in identifying the commit associated with each build and ensures traceability.

The changes are made to the `pom.xml` file, where the plugin is configured to retrieve the Git commit SHA and include it in the artifact’s metadata.

This PR solves issue #18227 by adding a mechanism to automatically attach the Git commit SHA to the built artifact.
