### PR TITLE
Improve clarity of PTransformRunnerFactory in Java SDK harness

### DIFF
--- a/sdks/java/build-tools/src/main/resources/beam/checkstyle/checkstyle.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/checkstyle/checkstyle.xml
@@ -148,7 +148,7 @@ page at http://checkstyle.sourceforge.net/config.html -->
       <property name="id" value="ForbidGrpcVendoredGuava"/>
       <property name="format" value="(\sorg\.apache\.beam\.vendor\.grpc\.(.*)\.com\.google\.common\.(?!testing))|(\sorg\.apache\.beam\.vendor\.grpc\.(.*)\.com\.google\.thirdparty)"/>
       <property name="severity" value="error"/>
-      <property name="message" value="You are using raw guava, please use vendored guava classes."/>
+      <property name="message" value="You are using guava from within vendored grpc, please use Beam's vendored guava classes."/>
     </module>
 
     <!-- Forbid deprecated Assert.assertThat. -->

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/CombineRunners.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/CombineRunners.java
@@ -43,10 +43,8 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterab
 
 /** Executes different components of Combine PTransforms. */
 @SuppressWarnings({
-  "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
-  "nullness",
-  "keyfor"
-}) // TODO(https://github.com/apache/beam/issues/20497)
+  "nullness" // TODO(https://github.com/apache/beam/issues/20497)
+})
 public class CombineRunners {
 
   /** A registrar which provides a factory to handle combine component PTransforms. */
@@ -129,12 +127,14 @@ public class CombineRunners {
 
   /** A factory for {@link PrecombineRunner}s. */
   @VisibleForTesting
-  public static class PrecombineFactory<KeyT, InputT, AccumT>
-      implements PTransformRunnerFactory<PrecombineRunner<KeyT, InputT, AccumT>> {
+  public static class PrecombineFactory implements PTransformRunnerFactory {
 
     @Override
-    public PrecombineRunner<KeyT, InputT, AccumT> createRunnerForPTransform(Context context)
-        throws IOException {
+    public void addRunnerForPTransform(Context context) throws IOException {
+      addPrecombineRunner(context);
+    }
+
+    private <KeyT, InputT, AccumT> void addPrecombineRunner(Context context) throws IOException {
       // Get objects needed to create the runner.
       RehydratedComponents rehydratedComponents =
           RehydratedComponents.forComponents(context.getComponents());
@@ -193,8 +193,6 @@ public class CombineRunners {
           (FnDataReceiver)
               (FnDataReceiver<WindowedValue<KV<KeyT, InputT>>>) runner::processElement);
       context.addFinishBundleFunction(runner::finishBundle);
-
-      return runner;
     }
   }
 

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FlattenRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FlattenRunner.java
@@ -28,9 +28,6 @@ import org.apache.beam.sdk.util.construction.PTransformTranslation;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 
 /** Executes flatten PTransforms. */
-@SuppressWarnings({
-  "rawtypes" // TODO(https://github.com/apache/beam/issues/20447)
-})
 public class FlattenRunner<InputT> {
   /** A registrar which provides a factory to handle flatten PTransforms. */
   @AutoService(PTransformRunnerFactory.Registrar.class)
@@ -43,19 +40,20 @@ public class FlattenRunner<InputT> {
   }
 
   /** A factory for {@link FlattenRunner}. */
-  static class Factory<InputT> implements PTransformRunnerFactory<FlattenRunner<InputT>> {
+  static class Factory implements PTransformRunnerFactory {
     @Override
-    public FlattenRunner<InputT> createRunnerForPTransform(Context context) throws IOException {
+    public void addRunnerForPTransform(Context context) throws IOException {
+      addFlattenRunner(context);
+    }
+
+    private <T> void addFlattenRunner(Context context) throws IOException {
       // Give each input a MultiplexingFnDataReceiver to all outputs of the flatten.
       String output = getOnlyElement(context.getPTransform().getOutputsMap().values());
-      FnDataReceiver<WindowedValue<?>> receiver = context.getPCollectionConsumer(output);
+      FnDataReceiver<WindowedValue<T>> receiver = context.getPCollectionConsumer(output);
 
-      FlattenRunner<InputT> runner = new FlattenRunner<>();
       for (String pCollectionId : context.getPTransform().getInputsMap().values()) {
-        context.addPCollectionConsumer(pCollectionId, (FnDataReceiver) receiver);
+        context.addPCollectionConsumer(pCollectionId, receiver);
       }
-
-      return runner;
     }
   }
 }

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -161,12 +161,10 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
   }
 
   static class Factory<InputT, RestrictionT, PositionT, WatermarkEstimatorStateT, OutputT>
-      implements PTransformRunnerFactory<
-          FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimatorStateT, OutputT>> {
+      implements PTransformRunnerFactory {
 
     @Override
-    public final FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimatorStateT, OutputT>
-        createRunnerForPTransform(Context context) {
+    public final void addRunnerForPTransform(Context context) {
 
       FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimatorStateT, OutputT> runner =
           new FnApiDoFnRunner<>(
@@ -205,7 +203,6 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
               localName, coder, timer -> runner.processTimer(localName, timeDomain, timer));
         }
       }
-      return runner;
     }
   }
 

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/MapFnRunners.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/MapFnRunners.java
@@ -35,13 +35,10 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterab
  * <p>TODO: Add support for DoFns which are actually user supplied map/lambda functions instead of
  * using the {@link FnApiDoFnRunner} instance.
  */
-@SuppressWarnings({
-  "rawtypes" // TODO(https://github.com/apache/beam/issues/20447)
-})
 public abstract class MapFnRunners {
 
   /** Create a {@link MapFnRunners} where the map function consumes elements directly. */
-  public static <InputT, OutputT> PTransformRunnerFactory<?> forValueMapFnFactory(
+  public static <InputT, OutputT> PTransformRunnerFactory forValueMapFnFactory(
       ValueMapFnFactory<InputT, OutputT> fnFactory) {
     return new Factory<>(new CompressedValueOnlyMapperFactory<>(fnFactory));
   }
@@ -54,7 +51,7 @@ public abstract class MapFnRunners {
    * WindowedValueMapFnFactory} will be in exactly one {@link
    * org.apache.beam.sdk.transforms.windowing.BoundedWindow window}.
    */
-  public static <InputT, OutputT> PTransformRunnerFactory<?> forWindowedValueMapFnFactory(
+  public static <InputT, OutputT> PTransformRunnerFactory forWindowedValueMapFnFactory(
       WindowedValueMapFnFactory<InputT, OutputT> fnFactory) {
     return new Factory<>(new ExplodedWindowedValueMapperFactory<>(fnFactory));
   }
@@ -77,18 +74,17 @@ public abstract class MapFnRunners {
   }
 
   /** A factory for {@link MapFnRunners}s. */
-  private static class Factory<InputT, OutputT>
-      implements PTransformRunnerFactory<Mapper<InputT, OutputT>> {
+  private static class Factory<InputT, OutputT> implements PTransformRunnerFactory {
 
-    private final MapperFactory mapperFactory;
+    private final MapperFactory<InputT, OutputT> mapperFactory;
 
     private Factory(MapperFactory<InputT, OutputT> mapperFactory) {
       this.mapperFactory = mapperFactory;
     }
 
     @Override
-    public Mapper<InputT, OutputT> createRunnerForPTransform(Context context) throws IOException {
-      FnDataReceiver<WindowedValue<InputT>> consumer =
+    public void addRunnerForPTransform(Context context) throws IOException {
+      FnDataReceiver<WindowedValue<OutputT>> consumer =
           context.getPCollectionConsumer(
               getOnlyElement(context.getPTransform().getOutputsMap().values()));
 
@@ -98,7 +94,6 @@ public abstract class MapFnRunners {
       String pCollectionId =
           Iterables.getOnlyElement(context.getPTransform().getInputsMap().values());
       context.addPCollectionConsumer(pCollectionId, mapper::map);
-      return mapper;
     }
   }
 

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/PTransformRunnerFactory.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/PTransformRunnerFactory.java
@@ -40,10 +40,7 @@ import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.util.construction.Timer;
 
 /** A factory able to instantiate an appropriate handler for a given PTransform. */
-@SuppressWarnings({
-  "rawtypes" // TODO(https://github.com/apache/beam/issues/20447)
-})
-public interface PTransformRunnerFactory<T> {
+public interface PTransformRunnerFactory {
 
   /** A context used to instantiate and support the handler necessary to execute the PTransform. */
   interface Context {
@@ -122,6 +119,8 @@ public interface PTransformRunnerFactory<T> {
     <T> void addIncomingTimerEndpoint(
         String timerFamilyId, Coder<Timer<T>> coder, FnDataReceiver<Timer<T>> receiver);
 
+    <T> void addChannelRoot(BeamFnDataReadRunner<T> beamFnDataReadRunner);
+
     /**
      * Register any reset methods. This should not invoke any user code which should be done instead
      * using the {@link #addFinishBundleFunction}. The reset method is guaranteed to be invoked
@@ -164,12 +163,12 @@ public interface PTransformRunnerFactory<T> {
   }
 
   /**
-   * Creates and returns a handler for a given PTransform. Note that the handler must support
+   * Creates and registers a handler for a given PTransform. Note that the handler must support
    * processing multiple bundles. The handler will be discarded if bundle processing fails or
    * management of the handler between bundle processing fails. The handler may also be discarded
    * due to memory pressure.
    */
-  T createRunnerForPTransform(Context context) throws IOException;
+  void addRunnerForPTransform(Context context) throws IOException;
 
   /**
    * A registrar which can return a mapping from {@link RunnerApi.FunctionSpec#getUrn()} to a

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
@@ -121,10 +121,8 @@ import org.slf4j.LoggerFactory;
  * barrier</a> for further details.
  */
 @SuppressWarnings({
-  "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
-  "nullness",
-  "keyfor"
-}) // TODO(https://github.com/apache/beam/issues/20497)
+  "nullness" // TODO(https://github.com/apache/beam/issues/20497)
+})
 public class ProcessBundleHandler {
 
   // TODO: What should the initial set of URNs be?
@@ -224,7 +222,7 @@ public class ProcessBundleHandler {
     this.dataSampler = dataSampler;
   }
 
-  private void createRunnerAndConsumersForPTransformRecursively(
+  private void addRunnerAndConsumersForPTransformRecursively(
       BeamFnStateClient beamFnStateClient,
       BeamFnDataClient queueingClient,
       String pTransformId,
@@ -246,7 +244,7 @@ public class ProcessBundleHandler {
       Consumer<BundleProgressReporter> addBundleProgressReporter,
       BundleSplitListener splitListener,
       BundleFinalizer bundleFinalizer,
-      Collection<BeamFnDataReadRunner> channelRoots,
+      Collection<BeamFnDataReadRunner<?>> channelRoots,
       Map<ApiServiceDescriptor, BeamFnDataOutboundAggregator> outboundAggregatorMap,
       Set<String> runnerCapabilities)
       throws IOException {
@@ -257,7 +255,7 @@ public class ProcessBundleHandler {
     for (String pCollectionId : pTransform.getOutputsMap().values()) {
 
       for (String consumingPTransformId : pCollectionIdsToConsumingPTransforms.get(pCollectionId)) {
-        createRunnerAndConsumersForPTransformRecursively(
+        addRunnerAndConsumersForPTransformRecursively(
             beamFnStateClient,
             queueingClient,
             consumingPTransformId,
@@ -301,186 +299,187 @@ public class ProcessBundleHandler {
 
     // Skip reprocessing processed pTransforms.
     if (!processedPTransformIds.contains(pTransformId)) {
-      Object runner =
-          urnToPTransformRunnerFactoryMap
-              .getOrDefault(pTransform.getSpec().getUrn(), defaultPTransformRunnerFactory)
-              .createRunnerForPTransform(
-                  new Context() {
-                    @Override
-                    public PipelineOptions getPipelineOptions() {
-                      return options;
-                    }
+      urnToPTransformRunnerFactoryMap
+          .getOrDefault(pTransform.getSpec().getUrn(), defaultPTransformRunnerFactory)
+          .addRunnerForPTransform(
+              new Context() {
+                @Override
+                public PipelineOptions getPipelineOptions() {
+                  return options;
+                }
 
-                    @Override
-                    public ShortIdMap getShortIdMap() {
-                      return shortIds;
-                    }
+                @Override
+                public ShortIdMap getShortIdMap() {
+                  return shortIds;
+                }
 
-                    @Override
-                    public BeamFnDataClient getBeamFnDataClient() {
-                      return queueingClient;
-                    }
+                @Override
+                public BeamFnDataClient getBeamFnDataClient() {
+                  return queueingClient;
+                }
 
-                    @Override
-                    public BeamFnStateClient getBeamFnStateClient() {
-                      return beamFnStateClient;
-                    }
+                @Override
+                public BeamFnStateClient getBeamFnStateClient() {
+                  return beamFnStateClient;
+                }
 
-                    @Override
-                    public String getPTransformId() {
-                      return pTransformId;
-                    }
+                @Override
+                public String getPTransformId() {
+                  return pTransformId;
+                }
 
-                    @Override
-                    public PTransform getPTransform() {
-                      return pTransform;
-                    }
+                @Override
+                public PTransform getPTransform() {
+                  return pTransform;
+                }
 
-                    @Override
-                    public Supplier<String> getProcessBundleInstructionIdSupplier() {
-                      return processBundleInstructionId;
-                    }
+                @Override
+                public Supplier<String> getProcessBundleInstructionIdSupplier() {
+                  return processBundleInstructionId;
+                }
 
-                    @Override
-                    public Supplier<List<CacheToken>> getCacheTokensSupplier() {
-                      return cacheTokens;
-                    }
+                @Override
+                public Supplier<List<CacheToken>> getCacheTokensSupplier() {
+                  return cacheTokens;
+                }
 
-                    @Override
-                    public Supplier<Cache<?, ?>> getBundleCacheSupplier() {
-                      return bundleCache;
-                    }
+                @Override
+                public Supplier<Cache<?, ?>> getBundleCacheSupplier() {
+                  return bundleCache;
+                }
 
-                    @Override
-                    public Cache<?, ?> getProcessWideCache() {
-                      return processWideCache;
-                    }
+                @Override
+                public Cache<?, ?> getProcessWideCache() {
+                  return processWideCache;
+                }
 
-                    @Override
-                    public RunnerApi.Components getComponents() {
-                      return components;
-                    }
+                @Override
+                public RunnerApi.Components getComponents() {
+                  return components;
+                }
 
-                    @Override
-                    public Set<String> getRunnerCapabilities() {
-                      return runnerCapabilities;
-                    }
+                @Override
+                public Set<String> getRunnerCapabilities() {
+                  return runnerCapabilities;
+                }
 
-                    @Override
-                    public <T> void addPCollectionConsumer(
-                        String pCollectionId, FnDataReceiver<WindowedValue<T>> consumer) {
-                      pCollectionConsumerRegistry.register(
-                          pCollectionId, pTransformId, pTransform.getUniqueName(), consumer);
-                    }
+                @Override
+                public <T> void addPCollectionConsumer(
+                    String pCollectionId, FnDataReceiver<WindowedValue<T>> consumer) {
+                  pCollectionConsumerRegistry.register(
+                      pCollectionId, pTransformId, pTransform.getUniqueName(), consumer);
+                }
 
-                    @Override
-                    public <T> FnDataReceiver<T> addOutgoingDataEndpoint(
-                        ApiServiceDescriptor apiServiceDescriptor,
-                        org.apache.beam.sdk.coders.Coder<T> coder) {
-                      BeamFnDataOutboundAggregator aggregator =
-                          outboundAggregatorMap.computeIfAbsent(
-                              apiServiceDescriptor,
-                              asd ->
-                                  queueingClient.createOutboundAggregator(
-                                      asd,
-                                      processBundleInstructionId,
-                                      runnerCapabilities.contains(
-                                          BeamUrns.getUrn(
-                                              StandardRunnerProtocols.Enum
-                                                  .CONTROL_RESPONSE_ELEMENTS_EMBEDDING))));
-                      return aggregator.registerOutputDataLocation(pTransformId, coder);
-                    }
+                @Override
+                public <T> FnDataReceiver<T> addOutgoingDataEndpoint(
+                    ApiServiceDescriptor apiServiceDescriptor,
+                    org.apache.beam.sdk.coders.Coder<T> coder) {
+                  BeamFnDataOutboundAggregator aggregator =
+                      outboundAggregatorMap.computeIfAbsent(
+                          apiServiceDescriptor,
+                          asd ->
+                              queueingClient.createOutboundAggregator(
+                                  asd,
+                                  processBundleInstructionId,
+                                  runnerCapabilities.contains(
+                                      BeamUrns.getUrn(
+                                          StandardRunnerProtocols.Enum
+                                              .CONTROL_RESPONSE_ELEMENTS_EMBEDDING))));
+                  return aggregator.registerOutputDataLocation(pTransformId, coder);
+                }
 
-                    @Override
-                    public <T> FnDataReceiver<Timer<T>> addOutgoingTimersEndpoint(
-                        String timerFamilyId, org.apache.beam.sdk.coders.Coder<Timer<T>> coder) {
-                      BeamFnDataOutboundAggregator aggregator;
-                      if (!processBundleDescriptor.hasTimerApiServiceDescriptor()) {
-                        throw new IllegalStateException(
-                            String.format(
-                                "Timers are unsupported because the "
-                                    + "ProcessBundleRequest %s does not provide a timer ApiServiceDescriptor.",
-                                processBundleInstructionId.get()));
-                      }
-                      aggregator =
-                          outboundAggregatorMap.computeIfAbsent(
-                              processBundleDescriptor.getTimerApiServiceDescriptor(),
-                              asd ->
-                                  queueingClient.createOutboundAggregator(
-                                      asd,
-                                      processBundleInstructionId,
-                                      runnerCapabilities.contains(
-                                          BeamUrns.getUrn(
-                                              StandardRunnerProtocols.Enum
-                                                  .CONTROL_RESPONSE_ELEMENTS_EMBEDDING))));
-                      return aggregator.registerOutputTimersLocation(
-                          pTransformId, timerFamilyId, coder);
-                    }
+                @Override
+                public <T> FnDataReceiver<Timer<T>> addOutgoingTimersEndpoint(
+                    String timerFamilyId, org.apache.beam.sdk.coders.Coder<Timer<T>> coder) {
+                  BeamFnDataOutboundAggregator aggregator;
+                  if (!processBundleDescriptor.hasTimerApiServiceDescriptor()) {
+                    throw new IllegalStateException(
+                        String.format(
+                            "Timers are unsupported because the "
+                                + "ProcessBundleRequest %s does not provide a timer ApiServiceDescriptor.",
+                            processBundleInstructionId.get()));
+                  }
+                  aggregator =
+                      outboundAggregatorMap.computeIfAbsent(
+                          processBundleDescriptor.getTimerApiServiceDescriptor(),
+                          asd ->
+                              queueingClient.createOutboundAggregator(
+                                  asd,
+                                  processBundleInstructionId,
+                                  runnerCapabilities.contains(
+                                      BeamUrns.getUrn(
+                                          StandardRunnerProtocols.Enum
+                                              .CONTROL_RESPONSE_ELEMENTS_EMBEDDING))));
+                  return aggregator.registerOutputTimersLocation(
+                      pTransformId, timerFamilyId, coder);
+                }
 
-                    @Override
-                    public FnDataReceiver<?> getPCollectionConsumer(String pCollectionId) {
-                      return pCollectionConsumerRegistry.getMultiplexingConsumer(pCollectionId);
-                    }
+                @Override
+                public FnDataReceiver<?> getPCollectionConsumer(String pCollectionId) {
+                  return pCollectionConsumerRegistry.getMultiplexingConsumer(pCollectionId);
+                }
 
-                    @Override
-                    public void addStartBundleFunction(ThrowingRunnable startFunction) {
-                      startFunctionRegistry.register(
-                          pTransformId, pTransform.getUniqueName(), startFunction);
-                    }
+                @Override
+                public void addStartBundleFunction(ThrowingRunnable startFunction) {
+                  startFunctionRegistry.register(
+                      pTransformId, pTransform.getUniqueName(), startFunction);
+                }
 
-                    @Override
-                    public void addFinishBundleFunction(ThrowingRunnable finishFunction) {
-                      finishFunctionRegistry.register(
-                          pTransformId, pTransform.getUniqueName(), finishFunction);
-                    }
+                @Override
+                public void addFinishBundleFunction(ThrowingRunnable finishFunction) {
+                  finishFunctionRegistry.register(
+                      pTransformId, pTransform.getUniqueName(), finishFunction);
+                }
 
-                    @Override
-                    public <T> void addIncomingDataEndpoint(
-                        ApiServiceDescriptor apiServiceDescriptor,
-                        org.apache.beam.sdk.coders.Coder<T> coder,
-                        FnDataReceiver<T> receiver) {
-                      addDataEndpoint.accept(
-                          apiServiceDescriptor, DataEndpoint.create(pTransformId, coder, receiver));
-                    }
+                @Override
+                public <T> void addIncomingDataEndpoint(
+                    ApiServiceDescriptor apiServiceDescriptor,
+                    org.apache.beam.sdk.coders.Coder<T> coder,
+                    FnDataReceiver<T> receiver) {
+                  addDataEndpoint.accept(
+                      apiServiceDescriptor, DataEndpoint.create(pTransformId, coder, receiver));
+                }
 
-                    @Override
-                    public <T> void addIncomingTimerEndpoint(
-                        String timerFamilyId,
-                        org.apache.beam.sdk.coders.Coder<Timer<T>> coder,
-                        FnDataReceiver<Timer<T>> receiver) {
-                      addTimerEndpoint.accept(
-                          TimerEndpoint.create(pTransformId, timerFamilyId, coder, receiver));
-                    }
+                @Override
+                public <T> void addIncomingTimerEndpoint(
+                    String timerFamilyId,
+                    org.apache.beam.sdk.coders.Coder<Timer<T>> coder,
+                    FnDataReceiver<Timer<T>> receiver) {
+                  addTimerEndpoint.accept(
+                      TimerEndpoint.create(pTransformId, timerFamilyId, coder, receiver));
+                }
 
-                    @Override
-                    public void addResetFunction(ThrowingRunnable resetFunction) {
-                      addResetFunction.accept(resetFunction);
-                    }
+                @Override
+                public void addResetFunction(ThrowingRunnable resetFunction) {
+                  addResetFunction.accept(resetFunction);
+                }
 
-                    @Override
-                    public void addTearDownFunction(ThrowingRunnable tearDownFunction) {
-                      addTearDownFunction.accept(tearDownFunction);
-                    }
+                @Override
+                public <T> void addChannelRoot(BeamFnDataReadRunner<T> beamFnDataReadRunner) {
+                  channelRoots.add(beamFnDataReadRunner);
+                }
 
-                    @Override
-                    public void addBundleProgressReporter(
-                        BundleProgressReporter bundleProgressReporter) {
-                      addBundleProgressReporter.accept(bundleProgressReporter);
-                    }
+                @Override
+                public void addTearDownFunction(ThrowingRunnable tearDownFunction) {
+                  addTearDownFunction.accept(tearDownFunction);
+                }
 
-                    @Override
-                    public BundleSplitListener getSplitListener() {
-                      return splitListener;
-                    }
+                @Override
+                public void addBundleProgressReporter(
+                    BundleProgressReporter bundleProgressReporter) {
+                  addBundleProgressReporter.accept(bundleProgressReporter);
+                }
 
-                    @Override
-                    public BundleFinalizer getBundleFinalizer() {
-                      return bundleFinalizer;
-                    }
-                  });
-      if (runner instanceof BeamFnDataReadRunner) {
-        channelRoots.add((BeamFnDataReadRunner) runner);
-      }
+                @Override
+                public BundleSplitListener getSplitListener() {
+                  return splitListener;
+                }
+
+                @Override
+                public BundleFinalizer getBundleFinalizer() {
+                  return bundleFinalizer;
+                }
+              });
       processedPTransformIds.add(pTransformId);
     }
   }
@@ -739,7 +738,7 @@ public class ProcessBundleHandler {
           .setProcessBundleSplit(BeamFnApi.ProcessBundleSplitResponse.getDefaultInstance());
     }
 
-    for (BeamFnDataReadRunner channelRoot : bundleProcessor.getChannelRoots()) {
+    for (BeamFnDataReadRunner<?> channelRoot : bundleProcessor.getChannelRoots()) {
       channelRoot.trySplit(request.getProcessBundleSplit(), response);
     }
     return BeamFnApi.InstructionResponse.newBuilder().setProcessBundleSplit(response);
@@ -865,7 +864,7 @@ public class ProcessBundleHandler {
               .putAllWindowingStrategies(bundleDescriptor.getWindowingStrategiesMap())
               .build();
 
-      createRunnerAndConsumersForPTransformRecursively(
+      addRunnerAndConsumersForPTransformRecursively(
           beamFnStateClient,
           beamFnDataClient,
           entry.getKey(),
@@ -1025,7 +1024,6 @@ public class ProcessBundleHandler {
   /** A container for the reusable information used to process a bundle. */
   @AutoValue
   @AutoValue.CopyAnnotations
-  @SuppressWarnings({"rawtypes"})
   public abstract static class BundleProcessor {
     public static BundleProcessor create(
         Cache<Object, Object> processWideCache,
@@ -1102,7 +1100,7 @@ public class ProcessBundleHandler {
 
     abstract Collection<CallbackRegistration> getBundleFinalizationCallbackRegistrations();
 
-    abstract Collection<BeamFnDataReadRunner> getChannelRoots();
+    abstract Collection<BeamFnDataReadRunner<?>> getChannelRoots();
 
     abstract Map<ApiServiceDescriptor, BeamFnDataOutboundAggregator> getOutboundAggregators();
 
@@ -1279,7 +1277,7 @@ public class ProcessBundleHandler {
 
   abstract static class HandleStateCallsForBundle implements AutoCloseable, BeamFnStateClient {}
 
-  private static class UnknownPTransformRunnerFactory implements PTransformRunnerFactory<Object> {
+  private static class UnknownPTransformRunnerFactory implements PTransformRunnerFactory {
     private final Set<String> knownUrns;
 
     private UnknownPTransformRunnerFactory(Set<String> knownUrns) {
@@ -1287,7 +1285,7 @@ public class ProcessBundleHandler {
     }
 
     @Override
-    public Object createRunnerForPTransform(Context context) {
+    public void addRunnerForPTransform(Context context) {
       String message =
           String.format(
               "No factory registered for %s, known factories %s",

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/AssignWindowsRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/AssignWindowsRunnerTest.java
@@ -202,7 +202,7 @@ public class AssignWindowsRunnerTest implements Serializable {
     context.addPCollectionConsumer("output", outputs::add);
 
     MapFnRunners.forWindowedValueMapFnFactory(new AssignWindowsMapFnFactory<>())
-        .createRunnerForPTransform(context);
+        .addRunnerForPTransform(context);
 
     WindowedValue<Integer> value =
         WindowedValue.of(

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BeamFnDataReadRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BeamFnDataReadRunnerTest.java
@@ -163,7 +163,7 @@ public class BeamFnDataReadRunnerTest {
               .build();
       context.<String>addPCollectionConsumer(localOutputId, outputValues::add);
 
-      new BeamFnDataReadRunner.Factory<String>().createRunnerForPTransform(context);
+      new BeamFnDataReadRunner.Factory().addRunnerForPTransform(context);
 
       assertThat(context.getTearDownFunctions(), empty());
       assertThat(context.getStartBundleFunctions(), empty());
@@ -207,7 +207,7 @@ public class BeamFnDataReadRunnerTest {
       context.<String>addPCollectionConsumer(localOutputId, outputValues::add);
 
       BeamFnDataReadRunner<String> readRunner =
-          new BeamFnDataReadRunner.Factory<String>().createRunnerForPTransform(context);
+          new BeamFnDataReadRunner.Factory().addReadRunnerForPTransform(context);
       assertThat(context.getIncomingDataEndpoints().keySet(), hasSize(1));
       DataEndpoint<WindowedValue<String>> endpoint =
           (DataEndpoint<WindowedValue<String>>)
@@ -683,7 +683,7 @@ public class BeamFnDataReadRunnerTest {
             .build();
     context.addPCollectionConsumer(localOutputId, consumer);
 
-    return new BeamFnDataReadRunner.Factory<String>().createRunnerForPTransform(context);
+    return new BeamFnDataReadRunner.Factory().addReadRunnerForPTransform(context);
   }
 
   private static void assertIntermediateMonitoringDataDataChannelReadIndexEquals(

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BeamFnDataWriteRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BeamFnDataWriteRunnerTest.java
@@ -164,7 +164,7 @@ public class BeamFnDataWriteRunnerTest {
                     .build())
             .build();
 
-    new BeamFnDataWriteRunner.Factory<String>().createRunnerForPTransform(context);
+    new BeamFnDataWriteRunner.Factory().addRunnerForPTransform(context);
 
     assertThat(context.getPCollectionConsumers().keySet(), containsInAnyOrder(localInputId));
 

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/CombineRunnersTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/CombineRunnersTest.java
@@ -135,7 +135,7 @@ public class CombineRunnersTest {
             (FnDataReceiver<WindowedValue<KV<String, Integer>>>) mainOutputValues::add);
 
     // Create runner.
-    new CombineRunners.PrecombineFactory<>().createRunnerForPTransform(context);
+    new CombineRunners.PrecombineFactory().addRunnerForPTransform(context);
 
     Iterables.getOnlyElement(context.getStartBundleFunctions()).run();
 
@@ -219,7 +219,7 @@ public class CombineRunnersTest {
 
     // Create runner.
     MapFnRunners.forValueMapFnFactory(CombineRunners::createMergeAccumulatorsMapFunction)
-        .createRunnerForPTransform(context);
+        .addRunnerForPTransform(context);
 
     assertThat(context.getStartBundleFunctions(), empty());
     assertThat(context.getFinishBundleFunctions(), empty());
@@ -283,7 +283,7 @@ public class CombineRunnersTest {
 
     // Create runner.
     MapFnRunners.forValueMapFnFactory(CombineRunners::createExtractOutputsMapFunction)
-        .createRunnerForPTransform(context);
+        .addRunnerForPTransform(context);
 
     assertThat(context.getStartBundleFunctions(), empty());
     assertThat(context.getFinishBundleFunctions(), empty());
@@ -330,7 +330,7 @@ public class CombineRunnersTest {
 
     // Create runner.
     MapFnRunners.forValueMapFnFactory(CombineRunners::createConvertToAccumulatorsMapFunction)
-        .createRunnerForPTransform(context);
+        .addRunnerForPTransform(context);
 
     assertThat(context.getStartBundleFunctions(), empty());
     assertThat(context.getFinishBundleFunctions(), empty());
@@ -400,7 +400,7 @@ public class CombineRunnersTest {
 
     // Create runner.
     MapFnRunners.forValueMapFnFactory(CombineRunners::createCombineGroupedValuesMapFunction)
-        .createRunnerForPTransform(context);
+        .addRunnerForPTransform(context);
 
     assertThat(context.getStartBundleFunctions(), empty());
     assertThat(context.getFinishBundleFunctions(), empty());

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FlattenRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FlattenRunnerTest.java
@@ -101,7 +101,7 @@ public class FlattenRunnerTest {
         "mainOutputTarget",
         (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add);
 
-    new FlattenRunner.Factory<>().createRunnerForPTransform(context);
+    new FlattenRunner.Factory().addRunnerForPTransform(context);
 
     mainOutputValues.clear();
     assertThat(
@@ -164,7 +164,7 @@ public class FlattenRunnerTest {
         "mainOutputTarget",
         (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add);
 
-    new FlattenRunner.Factory<>().createRunnerForPTransform(context);
+    new FlattenRunner.Factory().addRunnerForPTransform(context);
 
     mainOutputValues.clear();
     assertThat(

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
@@ -280,7 +280,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
           outputPCollectionId,
           (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add);
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
 
       Iterables.getOnlyElement(context.getStartBundleFunctions()).run();
       mainOutputValues.clear();
@@ -448,7 +448,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
           additionalPCollectionId,
           (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) additionalOutputValues::add);
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
 
       Iterables.getOnlyElement(context.getStartBundleFunctions()).run();
       mainOutputValues.clear();
@@ -555,7 +555,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
           additionalPCollectionId,
           (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) additionalOutputValues::add);
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
 
       Iterables.getOnlyElement(context.getStartBundleFunctions()).run();
       mainOutputValues.clear();
@@ -694,7 +694,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
           Iterables.getOnlyElement(pTransform.getOutputsMap().values()),
           (FnDataReceiver) (FnDataReceiver<WindowedValue<Iterable<String>>>) mainOutputValues::add);
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
 
       Iterables.getOnlyElement(context.getStartBundleFunctions()).run();
       mainOutputValues.clear();
@@ -800,7 +800,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
           Iterables.getOnlyElement(pTransform.getOutputsMap().values()),
           (FnDataReceiver) (FnDataReceiver<WindowedValue<Iterable<String>>>) mainOutputValues::add);
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
 
       Iterables.getOnlyElement(context.getStartBundleFunctions()).run();
       mainOutputValues.clear();
@@ -976,7 +976,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
           outputPCollectionId,
           (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add);
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
 
       Iterables.getOnlyElement(context.getStartBundleFunctions()).run();
       mainOutputValues.clear();
@@ -1715,7 +1715,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
           outputPCollectionId,
           (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add);
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
 
       Iterables.getOnlyElement(context.getStartBundleFunctions()).run();
       mainOutputValues.clear();
@@ -2009,7 +2009,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
           outputPCollectionId,
           (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add);
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
 
       Iterables.getOnlyElement(context.getStartBundleFunctions()).run();
       mainOutputValues.clear();
@@ -2223,7 +2223,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
           outputPCollectionId,
           (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add);
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
 
       Iterables.getOnlyElement(context.getStartBundleFunctions()).run();
       mainOutputValues.clear();
@@ -2420,7 +2420,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
           outputPCollectionId,
           (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add);
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
 
       Iterables.getOnlyElement(context.getStartBundleFunctions()).run();
       mainOutputValues.clear();
@@ -2838,7 +2838,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
       List<WindowedValue<KV<String, OffsetRange>>> mainOutputValues = new ArrayList<>();
       context.addPCollectionConsumer(outputPCollectionId, ((List) mainOutputValues)::add);
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
 
       assertTrue(context.getStartBundleFunctions().isEmpty());
       mainOutputValues.clear();
@@ -2926,7 +2926,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
       List<WindowedValue<KV<String, OffsetRange>>> mainOutputValues = new ArrayList<>();
       context.addPCollectionConsumer(outputPCollectionId, ((List) mainOutputValues)::add);
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
 
       assertTrue(context.getStartBundleFunctions().isEmpty());
       mainOutputValues.clear();
@@ -3040,7 +3040,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
       List<WindowedValue<KV<String, OffsetRange>>> mainOutputValues = new ArrayList<>();
       context.addPCollectionConsumer(outputPCollectionId, ((List) mainOutputValues)::add);
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
 
       assertTrue(context.getStartBundleFunctions().isEmpty());
       mainOutputValues.clear();
@@ -3143,7 +3143,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
               DoubleCoder.of());
       context.addPCollectionConsumer(outputPCollectionId, ((List) mainOutputValues)::add);
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
 
       assertTrue(context.getStartBundleFunctions().isEmpty());
       mainOutputValues.clear();
@@ -3245,7 +3245,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
               DoubleCoder.of());
       context.addPCollectionConsumer(outputPCollectionId, ((List) mainOutputValues)::add);
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
 
       assertTrue(context.getStartBundleFunctions().isEmpty());
       mainOutputValues.clear();
@@ -3389,7 +3389,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
               DoubleCoder.of());
       context.addPCollectionConsumer(outputPCollectionId, ((List) mainOutputValues)::add);
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
 
       assertTrue(context.getStartBundleFunctions().isEmpty());
       mainOutputValues.clear();
@@ -3592,7 +3592,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
       context.addPCollectionConsumer(
           outputPCollectionId, (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues));
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
       FnDataReceiver<WindowedValue<?>> mainInput =
           context.getPCollectionConsumer(inputPCollectionId);
       assertThat(mainInput, instanceOf(HandlesSplits.class));
@@ -3743,7 +3743,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
       context.addPCollectionConsumer(
           outputPCollectionId, (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues));
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
       FnDataReceiver<WindowedValue<?>> mainInput =
           context.getPCollectionConsumer(inputPCollectionId);
       assertThat(mainInput, instanceOf(HandlesSplits.class));
@@ -3806,7 +3806,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
       context.addPCollectionConsumer(
           outputPCollectionId, (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues));
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
 
       assertTrue(context.getStartBundleFunctions().isEmpty());
       mainOutputValues.clear();
@@ -3908,7 +3908,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
       context.addPCollectionConsumer(
           outputPCollectionId, (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues));
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
 
       assertTrue(context.getStartBundleFunctions().isEmpty());
       mainOutputValues.clear();
@@ -4030,7 +4030,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
       context.addPCollectionConsumer(
           outputPCollectionId, (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues));
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
 
       assertTrue(context.getStartBundleFunctions().isEmpty());
       mainOutputValues.clear();
@@ -4158,7 +4158,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
       context.addPCollectionConsumer(
           outputPCollectionId, (FnDataReceiver) new OutputFnDataReceiver(mainOutputValues));
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
 
       mainOutputValues.clear();
       FnDataReceiver<WindowedValue<?>> mainInput =
@@ -4220,7 +4220,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
       context.addPCollectionConsumer(
           outputPCollectionId, (FnDataReceiver) new OutputFnDataReceiver(mainOutputValues));
 
-      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+      new FnApiDoFnRunner.Factory<>().addRunnerForPTransform(context);
 
       mainOutputValues.clear();
 

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/MapFnRunnersTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/MapFnRunnersTest.java
@@ -81,7 +81,7 @@ public class MapFnRunnersTest {
     context.addPCollectionConsumer("outputPC", outputConsumer::add);
 
     ValueMapFnFactory<String, String> factory = (ptId, pt) -> String::toUpperCase;
-    MapFnRunners.forValueMapFnFactory(factory).createRunnerForPTransform(context);
+    MapFnRunners.forValueMapFnFactory(factory).addRunnerForPTransform(context);
 
     assertThat(context.getStartBundleFunctions(), empty());
     assertThat(context.getFinishBundleFunctions(), empty());
@@ -109,7 +109,7 @@ public class MapFnRunnersTest {
     List<WindowedValue<?>> outputConsumer = new ArrayList<>();
     context.addPCollectionConsumer("outputPC", outputConsumer::add);
     MapFnRunners.forWindowedValueMapFnFactory(this::createMapFunctionForPTransform)
-        .createRunnerForPTransform(context);
+        .addRunnerForPTransform(context);
 
     assertThat(context.getStartBundleFunctions(), empty());
     assertThat(context.getFinishBundleFunctions(), empty());
@@ -138,7 +138,7 @@ public class MapFnRunnersTest {
     context.addPCollectionConsumer("outputPC", outputConsumer::add);
 
     MapFnRunners.forWindowedValueMapFnFactory(this::createMapFunctionForPTransform)
-        .createRunnerForPTransform(context);
+        .addRunnerForPTransform(context);
 
     assertThat(context.getStartBundleFunctions(), empty());
     assertThat(context.getFinishBundleFunctions(), empty());

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/PTransformRunnerFactoryTestContext.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/PTransformRunnerFactoryTestContext.java
@@ -277,6 +277,11 @@ public abstract class PTransformRunnerFactoryTestContext
         .add(TimerEndpoint.create(getPTransformId(), timerFamilyId, coder, receiver));
   }
 
+  @Override
+  public <T> void addChannelRoot(BeamFnDataReadRunner<T> beamFnDataReadRunner) {
+    // noop
+  }
+
   public abstract Map<ApiServiceDescriptor, BeamFnDataOutboundAggregator> getOutboundAggregators();
 
   public void addOutboundAggregator(


### PR DESCRIPTION
I am attempting to make it easier to comprehend and improve the Java SDK harness. This is a small initial step.

 - `PTransformRunnerFactory` did not use its type parameter and abused rawtypes significantly, so the type parameter was silly.
 - The return value was just barely used. It is clearer to just match the existing design of `addBlahBlah` in the one place it was used and eliminate all the extraneous returns. (I don't like the design of "pass a mutate-anything-you-want context to a visitor" pattern but at least it is consistent)
 - The `create` method was actually _not_ just creating things, but attaching them and registering them. Now I just renamed.

Eventually, `FnApiDoFnRunner` is basically 4 or 5 different runners with different types that abuse typing and every method has a `switch` statement, so I will tackle that later.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
