### PR TITLE
[IcebergIO] Support column pruning

### DIFF
--- a/.github/trigger_files/IO_Iceberg_Integration_Tests.json
+++ b/.github/trigger_files/IO_Iceberg_Integration_Tests.json
@@ -1,4 +1,4 @@
 {
     "comment": "Modify this file in a trivial way to cause this test suite to run.",
-    "modification": 2
+    "modification": 3
 }

--- a/.github/trigger_files/IO_Iceberg_Integration_Tests_Dataflow.json
+++ b/.github/trigger_files/IO_Iceberg_Integration_Tests_Dataflow.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run.",
-  "modification": 1
+  "modification": 2
 }

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/CreateReadTasksDoFn.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/CreateReadTasksDoFn.java
@@ -78,7 +78,11 @@ class CreateReadTasksDoFn
       }
 
       LOG.info("Planning to scan snapshot {}", toSnapshot);
-      IncrementalAppendScan scan = table.newIncrementalAppendScan().toSnapshot(toSnapshot);
+      IncrementalAppendScan scan =
+          table
+              .newIncrementalAppendScan()
+              .toSnapshot(toSnapshot)
+              .project(scanConfig.getProjectedSchema());
       if (fromSnapshot != null) {
         scan = scan.fromSnapshotExclusive(fromSnapshot);
       }

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergCdcReadSchemaTransformProvider.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergCdcReadSchemaTransformProvider.java
@@ -115,7 +115,9 @@ public class IcebergCdcReadSchemaTransformProvider
               .fromTimestamp(configuration.getFromTimestamp())
               .toTimestamp(configuration.getToTimestamp())
               .withStartingStrategy(strategy)
-              .streaming(configuration.getStreaming());
+              .streaming(configuration.getStreaming())
+              .keeping(configuration.getKeep())
+              .dropping(configuration.getDrop());
 
       @Nullable Integer pollIntervalSeconds = configuration.getPollIntervalSeconds();
       if (pollIntervalSeconds != null) {
@@ -177,6 +179,14 @@ public class IcebergCdcReadSchemaTransformProvider
         "The interval at which to poll for new snapshots. Defaults to 60 seconds.")
     abstract @Nullable Integer getPollIntervalSeconds();
 
+    @SchemaFieldDescription(
+        "A subset of column names to read exclusively. If null or empty, all columns will be read.")
+    abstract @Nullable List<String> getKeep();
+
+    @SchemaFieldDescription(
+        "A subset of column names to exclude from reading. If null or empty, all columns will be read.")
+    abstract @Nullable List<String> getDrop();
+
     @AutoValue.Builder
     abstract static class Builder {
       abstract Builder setTable(String table);
@@ -200,6 +210,10 @@ public class IcebergCdcReadSchemaTransformProvider
       abstract Builder setPollIntervalSeconds(Integer pollInterval);
 
       abstract Builder setStreaming(Boolean streaming);
+
+      abstract Builder setKeep(List<String> keep);
+
+      abstract Builder setDrop(List<String> drop);
 
       abstract Configuration build();
     }

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergIO.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergIO.java
@@ -603,6 +603,10 @@ public class IcebergIO {
 
     abstract @Nullable Duration getPollInterval();
 
+    abstract @Nullable List<String> getKeep();
+
+    abstract @Nullable List<String> getDrop();
+
     abstract Builder toBuilder();
 
     @AutoValue.Builder
@@ -626,6 +630,10 @@ public class IcebergIO {
       abstract Builder setStreaming(@Nullable Boolean streaming);
 
       abstract Builder setPollInterval(@Nullable Duration triggeringFrequency);
+
+      abstract Builder setKeep(@Nullable List<String> fields);
+
+      abstract Builder setDrop(@Nullable List<String> fields);
 
       abstract ReadRows build();
     }
@@ -666,6 +674,14 @@ public class IcebergIO {
       return toBuilder().setStartingStrategy(strategy).build();
     }
 
+    public ReadRows keeping(@Nullable List<String> keep) {
+      return toBuilder().setKeep(keep).build();
+    }
+
+    public ReadRows dropping(@Nullable List<String> drop) {
+      return toBuilder().setDrop(drop).build();
+    }
+
     @Override
     public PCollection<Row> expand(PBegin input) {
       TableIdentifier tableId =
@@ -687,6 +703,8 @@ public class IcebergIO {
               .setStreaming(getStreaming())
               .setPollInterval(getPollInterval())
               .setUseCdc(getUseCdc())
+              .setKeepFields(getKeep())
+              .setDropFields(getDrop())
               .build();
       scanConfig.validate(table);
 

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergReadSchemaTransformProvider.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergReadSchemaTransformProvider.java
@@ -93,7 +93,9 @@ public class IcebergReadSchemaTransformProvider
               .getPipeline()
               .apply(
                   IcebergIO.readRows(configuration.getIcebergCatalog())
-                      .from(TableIdentifier.parse(configuration.getTable())));
+                      .from(TableIdentifier.parse(configuration.getTable()))
+                      .keeping(configuration.getKeep())
+                      .dropping(configuration.getDrop()));
 
       return PCollectionRowTuple.of(OUTPUT_TAG, output);
     }
@@ -121,6 +123,14 @@ public class IcebergReadSchemaTransformProvider
     @Nullable
     abstract Map<String, String> getConfigProperties();
 
+    @SchemaFieldDescription(
+        "A subset of column names to read exclusively. If null or empty, all columns will be read.")
+    abstract @Nullable List<String> getKeep();
+
+    @SchemaFieldDescription(
+        "A subset of column names to exclude from reading. If null or empty, all columns will be read.")
+    abstract @Nullable List<String> getDrop();
+
     @AutoValue.Builder
     abstract static class Builder {
       abstract Builder setTable(String table);
@@ -130,6 +140,10 @@ public class IcebergReadSchemaTransformProvider
       abstract Builder setCatalogProperties(Map<String, String> catalogProperties);
 
       abstract Builder setConfigProperties(Map<String, String> confProperties);
+
+      abstract Builder setKeep(List<String> keep);
+
+      abstract Builder setDrop(List<String> drop);
 
       abstract Configuration build();
     }

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergScanConfig.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergScanConfig.java
@@ -18,11 +18,12 @@
 package org.apache.beam.sdk.io.iceberg;
 
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.hadoop.util.Sets.newHashSet;
 
 import com.google.auto.value.AutoValue;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -253,10 +254,10 @@ public abstract class IcebergScanConfig implements Serializable {
       String param;
       if (keep != null) {
         param = "keep";
-        fieldsSpecified = new HashSet<>(keep);
+        fieldsSpecified = newHashSet(checkNotNull(keep));
       } else { // drop != null
         param = "drop";
-        fieldsSpecified = new HashSet<>(drop);
+        fieldsSpecified = newHashSet(checkNotNull(drop));
       }
       table.schema().columns().forEach(nf -> fieldsSpecified.remove(nf.name()));
 

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergScanConfig.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergScanConfig.java
@@ -23,6 +23,8 @@ import com.google.auto.value.AutoValue;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.beam.sdk.io.iceberg.IcebergIO.ReadRows.StartingStrategy;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
@@ -31,6 +33,7 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Immuta
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.types.Types;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.qual.Pure;
@@ -65,6 +68,24 @@ public abstract class IcebergScanConfig implements Serializable {
 
   @Pure
   public abstract Schema getSchema();
+
+  @VisibleForTesting
+  static org.apache.iceberg.Schema resolveSchema(
+      org.apache.iceberg.Schema schema, @Nullable List<String> keep, @Nullable List<String> drop) {
+    if (keep != null && !keep.isEmpty()) {
+      schema = schema.select(keep);
+    } else if (drop != null && !drop.isEmpty()) {
+      Set<String> fields =
+          schema.columns().stream().map(Types.NestedField::name).collect(Collectors.toSet());
+      drop.forEach(fields::remove);
+      schema = schema.select(fields);
+    }
+    return schema;
+  }
+
+  public org.apache.iceberg.Schema getProjectedSchema() {
+    return resolveSchema(getTable().schema(), getKeepFields(), getDropFields());
+  }
 
   @Pure
   public abstract @Nullable Expression getFilter();
@@ -122,6 +143,12 @@ public abstract class IcebergScanConfig implements Serializable {
 
   @Pure
   public abstract @Nullable String getBranch();
+
+  @Pure
+  public abstract @Nullable List<String> getKeepFields();
+
+  @Pure
+  public abstract @Nullable List<String> getDropFields();
 
   @Pure
   public static Builder builder() {
@@ -204,6 +231,10 @@ public abstract class IcebergScanConfig implements Serializable {
 
     public abstract Builder setBranch(@Nullable String branch);
 
+    public abstract Builder setKeepFields(@Nullable List<String> fields);
+
+    public abstract Builder setDropFields(@Nullable List<String> fields);
+
     public abstract IcebergScanConfig build();
   }
 
@@ -211,6 +242,9 @@ public abstract class IcebergScanConfig implements Serializable {
   abstract Builder toBuilder();
 
   void validate(Table table) {
+    checkArgument(
+        getKeepFields() == null || getDropFields() == null,
+        error("only one of 'keep' or 'drop' can be set."));
     // TODO(#34168, ahmedabu98): fill these gaps for the existing batch source
     if (!getUseCdc()) {
       List<String> invalidOptions = new ArrayList<>();

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IncrementalScanSource.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IncrementalScanSource.java
@@ -70,7 +70,7 @@ class IncrementalScanSource extends PTransform<PBegin, PCollection<Row>> {
         .setCoder(KvCoder.of(ReadTaskDescriptor.getCoder(), ReadTask.getCoder()))
         .apply(Redistribute.arbitrarily())
         .apply("Read Rows From Tasks", ParDo.of(new ReadFromTasks(scanConfig)))
-        .setRowSchema(IcebergUtils.icebergSchemaToBeamSchema(table.schema()));
+        .setRowSchema(IcebergUtils.icebergSchemaToBeamSchema(scanConfig.getProjectedSchema()));
   }
 
   /** Continuously watches for new snapshots. */

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/ReadUtils.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/ReadUtils.java
@@ -34,6 +34,7 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Sets;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
@@ -67,7 +68,7 @@ public class ReadUtils {
           "parquet.read.support.class",
           "parquet.crypto.factory.class");
 
-  static ParquetReader<Record> createReader(FileScanTask task, Table table) {
+  static ParquetReader<Record> createReader(FileScanTask task, Table table, Schema schema) {
     String filePath = task.file().path().toString();
     InputFile inputFile;
     try (FileIO io = table.io()) {
@@ -100,11 +101,11 @@ public class ReadUtils {
 
     return new ParquetReader<>(
         inputFile,
-        table.schema(),
+        schema,
         optionsBuilder.build(),
         // TODO(ahmedabu98): Implement a Parquet-to-Beam Row reader, bypassing conversion to Iceberg
         // Record
-        fileSchema -> GenericParquetReaders.buildReader(table.schema(), fileSchema, idToConstants),
+        fileSchema -> GenericParquetReaders.buildReader(schema, fileSchema, idToConstants),
         mapping,
         task.residual(),
         false,

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/ScanSource.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/ScanSource.java
@@ -48,7 +48,7 @@ class ScanSource extends BoundedSource<Row> {
 
   private TableScan getTableScan() {
     Table table = scanConfig.getTable();
-    TableScan tableScan = table.newScan().project(table.schema());
+    TableScan tableScan = table.newScan().project(scanConfig.getProjectedSchema());
 
     if (scanConfig.getFilter() != null) {
       tableScan = tableScan.filter(scanConfig.getFilter());
@@ -115,7 +115,7 @@ class ScanSource extends BoundedSource<Row> {
 
   @Override
   public Coder<Row> getOutputCoder() {
-    return RowCoder.of(scanConfig.getSchema());
+    return RowCoder.of(IcebergUtils.icebergSchemaToBeamSchema(scanConfig.getProjectedSchema()));
   }
 
   @Override

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/ScanTaskReader.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/ScanTaskReader.java
@@ -70,7 +70,7 @@ class ScanTaskReader extends BoundedSource.BoundedReader<Row> {
   public ScanTaskReader(ScanTaskSource source) {
     this.source = source;
     this.project = source.getSchema();
-    this.beamSchema = icebergSchemaToBeamSchema(source.getSchema());
+    this.beamSchema = icebergSchemaToBeamSchema(project);
   }
 
   @Override

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/ScanTaskSource.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/ScanTaskSource.java
@@ -56,7 +56,7 @@ class ScanTaskSource extends BoundedSource<Row> {
 
   @Pure
   Schema getSchema() {
-    return getTable().schema();
+    return scanConfig.getProjectedSchema();
   }
 
   @Override

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/IcebergIOReadTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/IcebergIOReadTest.java
@@ -17,18 +17,20 @@
  */
 package org.apache.beam.sdk.io.iceberg;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.apache.beam.sdk.io.iceberg.IcebergScanConfig.resolveSchema;
 import static org.apache.beam.sdk.io.iceberg.IcebergUtils.icebergSchemaToBeamSchema;
 import static org.apache.beam.sdk.io.iceberg.TestFixtures.createRecord;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -43,6 +45,7 @@ import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.util.RowFilter;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
@@ -71,6 +74,8 @@ import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.mapping.NameMappingParser;
 import org.apache.iceberg.parquet.ParquetUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.StringType;
+import org.apache.iceberg.types.Types.StructType;
 import org.apache.parquet.avro.AvroParquetWriter;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -103,7 +108,7 @@ public class IcebergIOReadTest {
 
   @Parameters
   public static Iterable<Object[]> data() {
-    return Arrays.asList(new Object[][] {{false}, {true}});
+    return asList(new Object[][] {{false}, {true}});
   }
 
   // TODO(#34168, ahmedabu98): Update tests when we close feature gaps between regular and cdc
@@ -203,6 +208,29 @@ public class IcebergIOReadTest {
   }
 
   @Test
+  public void testProjectedSchema() {
+    org.apache.iceberg.Schema original =
+        new org.apache.iceberg.Schema(
+            required(1, "a", StringType.get()),
+            required(2, "b", StructType.of(required(5, "b.a", StringType.get()))),
+            required(3, "c", StringType.get()),
+            required(4, "d", StringType.get()));
+
+    org.apache.iceberg.Schema projectDrop = resolveSchema(original, null, asList("a", "c"));
+    org.apache.iceberg.Schema expectedDrop =
+        new org.apache.iceberg.Schema(
+            required(2, "b", StructType.of(required(5, "b.a", StringType.get()))),
+            required(4, "d", StringType.get()));
+    assertTrue(projectDrop.sameSchema(expectedDrop));
+
+    org.apache.iceberg.Schema projectKeep = resolveSchema(original, asList("a", "c"), null);
+    org.apache.iceberg.Schema expectedKeep =
+        new org.apache.iceberg.Schema(
+            required(1, "a", StringType.get()), required(3, "c", StringType.get()));
+    assertTrue(projectKeep.sameSchema(expectedKeep));
+  }
+
+  @Test
   public void testSimpleScan() throws Exception {
     TableIdentifier tableId =
         TableIdentifier.of("default", "table" + Long.toString(UUID.randomUUID().hashCode(), 16));
@@ -235,17 +263,62 @@ public class IcebergIOReadTest {
   }
 
   @Test
+  public void testScanSelectedFields() throws Exception {
+    TableIdentifier tableId =
+        TableIdentifier.of("default", "table" + Long.toString(UUID.randomUUID().hashCode(), 16));
+    Table simpleTable = warehouse.createTable(tableId, TestFixtures.SCHEMA);
+    final Schema schema = icebergSchemaToBeamSchema(TestFixtures.SCHEMA);
+
+    List<List<Record>> expectedRecords = warehouse.commitData(simpleTable);
+
+    IcebergIO.ReadRows read = IcebergIO.readRows(catalogConfig()).from(tableId);
+
+    if (useIncrementalScan) {
+      read = read.withCdc().toSnapshot(simpleTable.currentSnapshot().snapshotId());
+    }
+
+    final List<Row> originalRows =
+        expectedRecords.stream()
+            .flatMap(List::stream)
+            .map(record -> IcebergUtils.icebergRecordToBeamRow(schema, record))
+            .collect(Collectors.toList());
+
+    // test keep fields
+    read = read.keeping(singletonList("id"));
+    PCollection<Row> outputKeep = testPipeline.apply(read).apply(new PrintRow());
+    RowFilter keepFilter = new RowFilter(schema).keep(singletonList("id"));
+    PAssert.that(outputKeep)
+        .satisfies(
+            (Iterable<Row> rows) -> {
+              assertThat(rows, containsInAnyOrder(keepFilter.filter(originalRows)));
+              return null;
+            });
+
+    // test drop fields
+    read = read.keeping(null).dropping(singletonList("id"));
+    PCollection<Row> outputDrop = testPipeline.apply(read).apply(new PrintRow());
+    RowFilter dropFilter = new RowFilter(schema).drop(singletonList("id"));
+    PAssert.that(outputDrop)
+        .satisfies(
+            (Iterable<Row> rows) -> {
+              assertThat(rows, containsInAnyOrder(dropFilter.filter(originalRows)));
+              return null;
+            });
+
+    testPipeline.run();
+  }
+
+  @Test
   public void testReadSchemaWithRandomlyOrderedIds() throws IOException {
     TableIdentifier tableId = TableIdentifier.of("default", testName.getMethodName());
     org.apache.iceberg.Schema nestedSchema =
         new org.apache.iceberg.Schema(
-            required(3, "b.a", Types.IntegerType.get()),
-            required(4, "b.b", Types.StringType.get()));
+            required(3, "b.a", Types.IntegerType.get()), required(4, "b.b", StringType.get()));
     org.apache.iceberg.Schema schema =
         new org.apache.iceberg.Schema(
             required(1, "a", Types.IntegerType.get()),
-            required(2, "b", Types.StructType.of(nestedSchema.columns())),
-            required(5, "c", Types.StringType.get()));
+            required(2, "b", StructType.of(nestedSchema.columns())),
+            required(5, "c", StringType.get()));
 
     // hadoop catalog will re-order by breadth-first ordering
     Table simpleTable = warehouse.createTable(tableId, schema);
@@ -267,7 +340,7 @@ public class IcebergIOReadTest {
     Row expectedRow =
         Row.withSchema(icebergSchemaToBeamSchema(schema)).addValues(nestedRow, 1, "sss").build();
 
-    DataFile file = warehouse.writeRecords("file1.parquet", schema, Collections.singletonList(rec));
+    DataFile file = warehouse.writeRecords("file1.parquet", schema, singletonList(rec));
     simpleTable.newFastAppend().appendFile(file).commit();
 
     IcebergIO.ReadRows read = IcebergIO.readRows(catalogConfig()).from(tableId);
@@ -294,7 +367,7 @@ public class IcebergIOReadTest {
 
     String identityColumnName = "identity";
     String identityColumnValue = "some-value";
-    simpleTable.updateSchema().addColumn(identityColumnName, Types.StringType.get()).commit();
+    simpleTable.updateSchema().addColumn(identityColumnName, StringType.get()).commit();
     simpleTable.updateSpec().addField(identityColumnName).commit();
 
     PartitionSpec spec = simpleTable.spec();
@@ -591,7 +664,7 @@ public class IcebergIOReadTest {
   }
 
   @SuppressWarnings("unchecked")
-  public static Record icebergGenericRecord(Types.StructType type, Map<String, Object> values) {
+  public static Record icebergGenericRecord(StructType type, Map<String, Object> values) {
     org.apache.iceberg.data.GenericRecord record =
         org.apache.iceberg.data.GenericRecord.create(type);
     for (Types.NestedField field : type.fields()) {

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/ReadUtilsTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/ReadUtilsTest.java
@@ -81,7 +81,8 @@ public class ReadUtilsTest {
         for (FileScanTask fileScanTask : combinedScanTask.tasks()) {
           String fileName = Iterables.getLast(Splitter.on("/").split(fileScanTask.file().path()));
           List<Record> recordsRead = new ArrayList<>();
-          try (ParquetReader<Record> reader = ReadUtils.createReader(fileScanTask, simpleTable)) {
+          try (ParquetReader<Record> reader =
+              ReadUtils.createReader(fileScanTask, simpleTable, simpleTable.schema())) {
             reader.forEach(recordsRead::add);
           }
 

--- a/website/www/site/content/en/documentation/io/managed-io.md
+++ b/website/www/site/content/en/documentation/io/managed-io.md
@@ -50,8 +50,10 @@ manual updates or user intervention required!)
         catalog_name (<code style="color: green">str</code>)<br>
         catalog_properties (<code>map[<span style="color: green;">str</span>, <span style="color: green;">str</span>]</code>)<br>
         config_properties (<code>map[<span style="color: green;">str</span>, <span style="color: green;">str</span>]</code>)<br>
+        drop (<code>list[<span style="color: green;">str</span>]</code>)<br>
         from_snapshot (<code style="color: #f54251">int64</code>)<br>
         from_timestamp (<code style="color: #f54251">int64</code>)<br>
+        keep (<code>list[<span style="color: green;">str</span>]</code>)<br>
         poll_interval_seconds (<code style="color: #f54251">int32</code>)<br>
         starting_strategy (<code style="color: green">str</code>)<br>
         streaming (<code style="color: orange">boolean</code>)<br>
@@ -69,6 +71,8 @@ manual updates or user intervention required!)
         catalog_name (<code style="color: green">str</code>)<br>
         catalog_properties (<code>map[<span style="color: green;">str</span>, <span style="color: green;">str</span>]</code>)<br>
         config_properties (<code>map[<span style="color: green;">str</span>, <span style="color: green;">str</span>]</code>)<br>
+        drop (<code>list[<span style="color: green;">str</span>]</code>)<br>
+        keep (<code>list[<span style="color: green;">str</span>]</code>)<br>
       </td>
       <td>
         <strong>table</strong> (<code style="color: green">str</code>)<br>
@@ -182,6 +186,17 @@ manual updates or user intervention required!)
     </tr>
     <tr>
       <td>
+        drop
+      </td>
+      <td>
+        <code>list[<span style="color: green;">str</span>]</code>
+      </td>
+      <td>
+        A subset of column names to exclude from reading. If null or empty, all columns will be read.
+      </td>
+    </tr>
+    <tr>
+      <td>
         from_snapshot
       </td>
       <td>
@@ -200,6 +215,17 @@ manual updates or user intervention required!)
       </td>
       <td>
         Starts reading from the first snapshot (inclusive) that was created after this timestamp (in milliseconds).
+      </td>
+    </tr>
+    <tr>
+      <td>
+        keep
+      </td>
+      <td>
+        <code>list[<span style="color: green;">str</span>]</code>
+      </td>
+      <td>
+        A subset of column names to read exclusively. If null or empty, all columns will be read.
       </td>
     </tr>
     <tr>
@@ -411,6 +437,28 @@ manual updates or user intervention required!)
       </td>
       <td>
         Properties passed to the Hadoop Configuration.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        drop
+      </td>
+      <td>
+        <code>list[<span style="color: green;">str</span>]</code>
+      </td>
+      <td>
+        A subset of column names to exclude from reading. If null or empty, all columns will be read.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        keep
+      </td>
+      <td>
+        <code>list[<span style="color: green;">str</span>]</code>
+      </td>
+      <td>
+        A subset of column names to read exclusively. If null or empty, all columns will be read.
       </td>
     </tr>
   </table>


### PR DESCRIPTION
Part of #34789 

Allows users to pass a list of field names to either keep or drop when reading from an Iceberg table.

For example, say we have a table with columns `colA`, `colB`, `colC`, `colD`, `colE`. Either of the following will produce the same output:

- `keep: ["colA", "colE"]`
- `drop: ["colB", "colC", "colD"]`

`keep` and `drop` are mutually exclusive and an error will be thrown if both are specified