### PR TITLE
[WIP] Update Error Prone for ThreadSafe analysis

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -51,7 +51,7 @@ dependencies {
   runtimeOnly("gradle.plugin.com.github.johnrengelman:shadow:7.1.1")                                       // Enable shading Java dependencies
   runtimeOnly("net.linguica.gradle:maven-settings-plugin:0.5")
   runtimeOnly("gradle.plugin.io.pry.gradle.offline_dependencies:gradle-offline-dependencies-plugin:0.5.0") // Enable creating an offline repository
-  runtimeOnly("net.ltgt.gradle:gradle-errorprone-plugin:3.1.0")                                            // Enable errorprone Java static analysis
+  runtimeOnly("net.ltgt.gradle:gradle-errorprone-plugin:4.2.0")                                            // Enable errorprone Java static analysis
   runtimeOnly("org.ajoberstar.grgit:grgit-gradle:4.1.1")                                                   // Enable website git publish to asf-site branch
   runtimeOnly("com.avast.gradle:gradle-docker-compose-plugin:0.16.12")                                     // Enable docker compose tasks
   runtimeOnly("ca.cutterslade.gradle:gradle-dependency-analyze:1.8.3")                                     // Enable dep analysis

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -600,7 +600,7 @@ class BeamModulePlugin implements Plugin<Project> {
     def checkerframework_version = "3.42.0"
     def classgraph_version = "4.8.162"
     def dbcp2_version = "2.9.0"
-    def errorprone_version = "2.10.0"
+    def errorprone_version = "2.38.0"
     // [bomupgrader] determined by: com.google.api:gax, consistent with: google_cloud_platform_libraries_bom
     def gax_version = "2.63.1"
     def google_ads_version = "33.0.0"
@@ -1485,7 +1485,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
         project.dependencies {
           errorprone("com.google.errorprone:error_prone_core:$errorprone_version")
-          errorprone("jp.skypencil.errorprone.slf4j:errorprone-slf4j:0.1.2")
+          errorprone("jp.skypencil.errorprone.slf4j:errorprone-slf4j:0.1.28")
           // At least JDk 9 compiler is required, however JDK 8 still can be used but with additional errorproneJavac
           // configuration. For more details please see https://github.com/tbroyer/gradle-errorprone-plugin#jdk-8-support
           if (JavaVersion.VERSION_1_8.compareTo(JavaVersion.current()) == 0) {

--- a/sdks/java/io/cassandra/build.gradle
+++ b/sdks/java/io/cassandra/build.gradle
@@ -60,11 +60,6 @@ dependencies {
 
 // Cassandra dependencies require old version of Guava (BEAM-11626)
 configurations.all (Configuration it) -> {
-  // error-prone requires newer guava, don't override for annotation processing
-  // https://github.com/google/error-prone/issues/2745
-  if (it.name == "annotationProcessor" || it.name =="testAnnotationProcessor") {
-    return
-  }
   resolutionStrategy {
     force 'com.google.guava:guava:25.1-jre'
   }

--- a/sdks/java/io/hadoop-file-system/build.gradle
+++ b/sdks/java/io/hadoop-file-system/build.gradle
@@ -83,11 +83,6 @@ hadoopVersions.each {kv ->
 
 // Hadoop dependencies require old version of Guava (BEAM-11626)
 configurations.all (Configuration it) -> {
-  // error-prone requires newer guava, don't override for annotation processing
-  // https://github.com/google/error-prone/issues/2745
-  if (it.name == "annotationProcessor" || it.name =="testAnnotationProcessor") {
-    return
-  }
   resolutionStrategy {
     force 'com.google.guava:guava:25.1-jre'
   }

--- a/sdks/java/io/hadoop-format/build.gradle
+++ b/sdks/java/io/hadoop-format/build.gradle
@@ -123,11 +123,6 @@ hadoopVersions.each {kv ->
 
 // Hadoop dependencies require old version of Guava (BEAM-11626)
 configurations.all (Configuration it) -> {
-  // error-prone requires newer guava, don't override for annotation processing
-  // https://github.com/google/error-prone/issues/2745
-  if (it.name == "annotationProcessor" || it.name =="testAnnotationProcessor") {
-    return
-  }
   resolutionStrategy {
     force 'com.google.guava:guava:25.1-jre'
   }


### PR DESCRIPTION
Update the Error Prone and Error Prone Gradle plugin versions. Error Prone 2.19.0 introduced a thread safety checker (compatible with Error Prone's `@ThreadSafe` annotation) which provides a few automated checks based on e.g. `@GuardedBy` annotations.

This should help catch obvious thread safety issues in annotated code undergoing maintenance/refactoring.

Error Prone's minimum supported compiler release was bumped from 8 to 11 between 2.10.0 and 2.19.0 and from 11 to 17 between 2.19.0 and 2.38.0. Additionally, Beam now fails to build because of new, updated and fixed checkers. This PR should address compiler (17+) and target release (8+) versioning requirements (e.g. using Gradle toolchains or `--release` flag) and silence new Error Prone warnings (e.g. by temporarily disabling or fixing issues). Note that `ThreadSafeChecker` is published, but not supported in any current release of Error Prone (https://github.com/google/error-prone/issues/4833).

This PR might take a while, but hopefully makes these changes easier to manage going forward.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
