### PR TITLE
34749 added cache for avro coder to reduce memory footprint

### DIFF
--- a/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/coders/AvroGenericCoder.java
+++ b/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/coders/AvroGenericCoder.java
@@ -17,17 +17,27 @@
  */
 package org.apache.beam.sdk.extensions.avro.coders;
 
+import java.util.concurrent.ExecutionException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.extensions.avro.io.AvroDatumFactory;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.cache.Cache;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.cache.CacheBuilder;
 
 /** AvroCoder specialisation for GenericRecord, needed for cross-language transforms. */
 public class AvroGenericCoder extends AvroCoder<GenericRecord> {
+  private static final Cache<Schema, AvroGenericCoder> AVRO_GENERIC_CODER_CACHE =
+      CacheBuilder.newBuilder().build();
+
   AvroGenericCoder(Schema schema) {
     super(AvroDatumFactory.GenericDatumFactory.INSTANCE, schema);
   }
 
   public static AvroGenericCoder of(Schema schema) {
-    return new AvroGenericCoder(schema);
+    try {
+      return AVRO_GENERIC_CODER_CACHE.get(schema, () -> new AvroGenericCoder(schema));
+    } catch (ExecutionException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/coders/AvroGenericCoder.java
+++ b/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/coders/AvroGenericCoder.java
@@ -27,7 +27,7 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.cache.CacheBui
 /** AvroCoder specialisation for GenericRecord, needed for cross-language transforms. */
 public class AvroGenericCoder extends AvroCoder<GenericRecord> {
   private static final Cache<Schema, AvroGenericCoder> AVRO_GENERIC_CODER_CACHE =
-      CacheBuilder.newBuilder().build();
+      CacheBuilder.newBuilder().weakValues().build();
 
   AvroGenericCoder(Schema schema) {
     super(AvroDatumFactory.GenericDatumFactory.INSTANCE, schema);

--- a/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/coders/AvroCoderTest.java
+++ b/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/coders/AvroCoderTest.java
@@ -494,11 +494,11 @@ public class AvroCoderTest {
     AvroCoder<TestAvro> deserializedCoder1 = SerializableUtils.clone(coder);
     AvroCoder<TestAvro> deserializedCoder2 = SerializableUtils.clone(coder);
 
-    assertSame(coder.reader, deserializedCoder1.reader);
-    assertSame(coder.writer, deserializedCoder1.writer);
+    assertSame(coder.getReader(), deserializedCoder1.getReader());
+    assertSame(coder.getWriter(), deserializedCoder1.getWriter());
 
-    assertSame(coder.reader, deserializedCoder2.reader);
-    assertSame(coder.writer, deserializedCoder2.writer);
+    assertSame(coder.getReader(), deserializedCoder2.getReader());
+    assertSame(coder.getWriter(), deserializedCoder2.getWriter());
   }
 
   @Test

--- a/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/coders/AvroCoderTest.java
+++ b/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/coders/AvroCoderTest.java
@@ -421,14 +421,16 @@ public class AvroCoderTest {
 
   @Test
   public void testCoderCached() {
-    Schema schema = AVRO_SPECIFIC_RECORD.getSchema();
-    TypeDescriptor<TestAvro> typeDescriptor = TypeDescriptor.of(TestAvro.class);
-    Class<TestAvro> clazz = TestAvro.class;
-    boolean useReflectApi = false;
-    AvroDatumFactory<TestAvro> reflectFactory1 = new AvroDatumFactory.ReflectDatumFactory<>(clazz);
-    AvroDatumFactory<TestAvro> reflectFactory2 = new AvroDatumFactory.ReflectDatumFactory<>(clazz);
+    final Schema avroSchema = AVRO_SPECIFIC_RECORD.getSchema();
+    final TypeDescriptor<TestAvro> typeDescriptor = TypeDescriptor.of(TestAvro.class);
+    final Class<TestAvro> testAvroClass = TestAvro.class;
+
+    AvroDatumFactory<TestAvro> reflectFactory1 =
+        new AvroDatumFactory.ReflectDatumFactory<>(testAvroClass);
+    AvroDatumFactory<TestAvro> reflectFactory2 =
+        new AvroDatumFactory.ReflectDatumFactory<>(testAvroClass);
     AvroDatumFactory<TestAvro> specificDatumFactory =
-        new AvroDatumFactory.SpecificDatumFactory<>(clazz);
+        new AvroDatumFactory.SpecificDatumFactory<>(testAvroClass);
     AvroDatumFactory<TestAvro> customDatumFactory =
         new AvroDatumFactory<TestAvro>(TestAvro.class) {
           @Override
@@ -444,41 +446,46 @@ public class AvroCoderTest {
 
     // Test that the AvroCoder caches the coder for the same class/type descriptor/schema/datum
     // factory/useReflectApi
-    assertSame(AvroCoder.of(clazz), AvroCoder.of(clazz));
-    assertSame(AvroCoder.of(clazz, useReflectApi), AvroCoder.of(clazz, useReflectApi));
-    assertNotSame(AvroCoder.of(clazz, useReflectApi), AvroCoder.of(clazz, !useReflectApi));
+    assertSame(AvroCoder.of(testAvroClass), AvroCoder.of(testAvroClass));
+    assertSame(AvroCoder.of(testAvroClass, false), AvroCoder.of(testAvroClass, false));
+    assertNotSame(AvroCoder.of(testAvroClass, false), AvroCoder.of(testAvroClass, true));
     assertSame(AvroCoder.of(typeDescriptor), AvroCoder.of(typeDescriptor));
+    assertSame(AvroCoder.of(typeDescriptor, false), AvroCoder.of(typeDescriptor, false));
+    assertSame(AvroCoder.of(testAvroClass, avroSchema), AvroCoder.of(testAvroClass, avroSchema));
     assertSame(
-        AvroCoder.of(typeDescriptor, useReflectApi), AvroCoder.of(typeDescriptor, useReflectApi));
-    assertSame(AvroCoder.of(clazz, schema), AvroCoder.of(clazz, schema));
-    assertSame(
-        AvroCoder.of(clazz, schema, useReflectApi), AvroCoder.of(clazz, schema, useReflectApi));
+        AvroCoder.of(testAvroClass, avroSchema, false),
+        AvroCoder.of(testAvroClass, avroSchema, false));
 
     // Test that the AvroCoder caches the coder when providing a datum factory
-    assertSame(AvroCoder.of(reflectFactory1, schema), AvroCoder.of(reflectFactory1, schema));
-    assertSame(AvroCoder.of(reflectFactory1, schema), AvroCoder.of(reflectFactory2, schema));
+    assertSame(
+        AvroCoder.of(reflectFactory1, avroSchema), AvroCoder.of(reflectFactory1, avroSchema));
+    assertSame(
+        AvroCoder.of(reflectFactory1, avroSchema), AvroCoder.of(reflectFactory2, avroSchema));
 
     // ensure that when providing datum factories of different types,
     // the previously cached coder is not used
     assertNotSame(
-        AvroCoder.of(reflectFactory1, schema), AvroCoder.of(specificDatumFactory, schema));
+        AvroCoder.of(reflectFactory1, avroSchema), AvroCoder.of(specificDatumFactory, avroSchema));
 
     // for custom datum factories (neither specific nor reflect) we don't use the cache
     assertNotSame(
-        AvroCoder.of(customDatumFactory, schema), AvroCoder.of(customDatumFactory, schema));
+        AvroCoder.of(customDatumFactory, avroSchema), AvroCoder.of(customDatumFactory, avroSchema));
 
     // Test that the AvroCoder caches the coder when using a specific datum factory
-    assertSame(AvroCoder.specific(clazz), AvroCoder.specific(clazz));
+    assertSame(AvroCoder.specific(testAvroClass), AvroCoder.specific(testAvroClass));
     assertSame(AvroCoder.specific(typeDescriptor), AvroCoder.specific(typeDescriptor));
-    assertSame(AvroCoder.specific(clazz, schema), AvroCoder.specific(clazz, schema));
+    assertSame(
+        AvroCoder.specific(testAvroClass, avroSchema),
+        AvroCoder.specific(testAvroClass, avroSchema));
 
     // Test that the AvroCoder caches the coder when using a reflect datum factory
-    assertSame(AvroCoder.reflect(clazz), AvroCoder.reflect(clazz));
+    assertSame(AvroCoder.reflect(testAvroClass), AvroCoder.reflect(testAvroClass));
     assertSame(AvroCoder.reflect(typeDescriptor), AvroCoder.reflect(typeDescriptor));
-    assertSame(AvroCoder.reflect(clazz, schema), AvroCoder.reflect(clazz, schema));
+    assertSame(
+        AvroCoder.reflect(testAvroClass, avroSchema), AvroCoder.reflect(testAvroClass, avroSchema));
 
     // Test that the AvroCoder does not cache the coder when using different datum factories
-    assertNotSame(AvroCoder.specific(clazz), AvroCoder.reflect(clazz));
+    assertNotSame(AvroCoder.specific(testAvroClass), AvroCoder.reflect(testAvroClass));
   }
 
   @Test

--- a/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/coders/AvroCoderTest.java
+++ b/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/coders/AvroCoderTest.java
@@ -494,11 +494,11 @@ public class AvroCoderTest {
     AvroCoder<TestAvro> deserializedCoder1 = SerializableUtils.clone(coder);
     AvroCoder<TestAvro> deserializedCoder2 = SerializableUtils.clone(coder);
 
-    assertSame(coder.getReader(), deserializedCoder1.getReader());
-    assertSame(coder.getWriter(), deserializedCoder1.getWriter());
+    assertSame(coder.getDatumReader(), deserializedCoder1.getDatumReader());
+    assertSame(coder.getDatumWriter(), deserializedCoder1.getDatumWriter());
 
-    assertSame(coder.getReader(), deserializedCoder2.getReader());
-    assertSame(coder.getWriter(), deserializedCoder2.getWriter());
+    assertSame(coder.getDatumReader(), deserializedCoder2.getDatumReader());
+    assertSame(coder.getDatumWriter(), deserializedCoder2.getDatumWriter());
   }
 
   @Test

--- a/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/coders/AvroCoderTest.java
+++ b/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/coders/AvroCoderTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -414,6 +415,40 @@ public class AvroCoderTest {
 
     CoderProperties.coderDecodeEncodeEqual(coder, AVRO_SPECIFIC_RECORD);
     CoderProperties.coderDecodeEncodeEqual(coderWithSchema, AVRO_SPECIFIC_RECORD);
+  }
+
+  @Test
+  public void testCoderCached() {
+    Schema schema = AVRO_SPECIFIC_RECORD.getSchema();
+    TypeDescriptor<TestAvro> typeDescriptor = TypeDescriptor.of(TestAvro.class);
+    Class<TestAvro> clazz = TestAvro.class;
+    boolean useReflectApi = false;
+    AvroDatumFactory<TestAvro> datumFactory = new AvroDatumFactory.ReflectDatumFactory<>(clazz);
+
+    assertSame(AvroCoder.of(clazz), AvroCoder.of(clazz));
+    assertSame(AvroCoder.of(clazz, useReflectApi), AvroCoder.of(clazz, useReflectApi));
+    assertSame(AvroCoder.of(typeDescriptor), AvroCoder.of(typeDescriptor));
+    assertSame(
+        AvroCoder.of(typeDescriptor, useReflectApi), AvroCoder.of(typeDescriptor, useReflectApi));
+    assertSame(AvroCoder.of(clazz, schema), AvroCoder.of(clazz, schema));
+    assertSame(
+        AvroCoder.of(clazz, schema, useReflectApi), AvroCoder.of(clazz, schema, useReflectApi));
+    assertSame(AvroCoder.of(datumFactory, schema), AvroCoder.of(datumFactory, schema));
+
+    assertSame(AvroCoder.specific(clazz), AvroCoder.specific(clazz));
+    assertSame(AvroCoder.specific(typeDescriptor), AvroCoder.specific(typeDescriptor));
+    assertSame(AvroCoder.specific(clazz, schema), AvroCoder.specific(clazz, schema));
+
+    assertSame(AvroCoder.reflect(clazz), AvroCoder.reflect(clazz));
+    assertSame(AvroCoder.reflect(typeDescriptor), AvroCoder.reflect(typeDescriptor));
+    assertSame(AvroCoder.reflect(clazz, schema), AvroCoder.reflect(clazz, schema));
+  }
+
+  @Test
+  public void testAvroGenericCoderSame() {
+    Schema schema = AVRO_SPECIFIC_RECORD.getSchema();
+    assertSame(AvroCoder.of(schema), AvroCoder.of(schema));
+    assertSame(AvroCoder.generic(schema), AvroCoder.generic(schema));
   }
 
   @Test


### PR DESCRIPTION
This addresses issue https://github.com/apache/beam/issues/34749.

Results on heap allocation:

**AvroDatumFactory**
before: 32%
after: 0.036%

**AvroCoder**
before: 69%
after: 11%


As we thought, this improves not only user code, but also sdk performance.
Example taken from another pipeline:
**org.apache.beam.runners.dataflow.worker.StreamingModeExecutionContext.flushState()**
before: 43%
after: 10%


**Before**

<img width="600" alt="image" src="https://github.com/user-attachments/assets/b121e360-79c9-4fbd-b9d9-079ed9ad50c3" />
<img width="600" alt="image" src="https://github.com/user-attachments/assets/3a0e3651-c5f3-4d0b-a2ef-87ec61733bfe" />
<img width="600" alt="image" src="https://github.com/user-attachments/assets/6173ea0e-a9b6-4a23-9653-d62df14ef61e" />





**After**

<img width="600" alt="image" src="https://github.com/user-attachments/assets/a33c71f6-af23-481e-a721-5fb272161e67" />
<img width="600" alt="image" src="https://github.com/user-attachments/assets/31ee28a8-637c-4bd6-a95e-7eca0b19040b" />
<img width="600" alt="image" src="https://github.com/user-attachments/assets/ae1516dc-d23a-4857-ae09-e2c28e4977a0" />


See also PR https://github.com/apache/beam/pull/34750 for more details
