### PR TITLE
Refactor how to run connector forever

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -1792,8 +1792,7 @@ public class SpannerIO {
               .orElse(PartitionMetadataTableNames.generateRandom(partitionMetadataDatabaseId));
       final String changeStreamName = getChangeStreamName();
       final Timestamp startTimestamp = getInclusiveStartAt();
-      // Uses (Timestamp.MAX - 1ns) at max for end timestamp, because we add 1ns to transform the
-      // interval into a closed-open in the read change stream restriction (prevents overflow)
+      // MAX_INCLUSIVE_END_AT means the connector is expected to run forever.
       final Timestamp endTimestamp =
           getInclusiveEndAt().compareTo(MAX_INCLUSIVE_END_AT) > 0
               ? MAX_INCLUSIVE_END_AT

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/action/QueryChangeStreamAction.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/action/QueryChangeStreamAction.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.sdk.io.gcp.spanner.changestreams.action;
 
+import static org.apache.beam.sdk.io.gcp.spanner.changestreams.ChangeStreamsConstants.MAX_INCLUSIVE_END_AT;
+
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.SpannerException;
@@ -160,7 +162,10 @@ public class QueryChangeStreamAction {
       BundleFinalizer bundleFinalizer) {
     final String token = partition.getPartitionToken();
     final Timestamp startTimestamp = tracker.currentRestriction().getFrom();
-    final Timestamp endTimestamp = partition.getEndTimestamp();
+    final Timestamp changeStreamQueryEndTimestamp =
+        partition.getEndTimestamp().equals(MAX_INCLUSIVE_END_AT)
+            ? getNextReadChangeStreamEndTimestamp()
+            : partition.getEndTimestamp();
 
     // TODO: Potentially we can avoid this fetch, by enriching the runningAt timestamp when the
     // ReadChangeStreamPartitionDoFn#processElement is called
@@ -178,7 +183,7 @@ public class QueryChangeStreamAction {
 
     try (ChangeStreamResultSet resultSet =
         changeStreamDao.changeStreamQuery(
-            token, startTimestamp, endTimestamp, partition.getHeartbeatMillis())) {
+            token, startTimestamp, changeStreamQueryEndTimestamp, partition.getHeartbeatMillis())) {
 
       metrics.incQueryCounter();
       while (resultSet.next()) {
@@ -243,7 +248,7 @@ public class QueryChangeStreamAction {
             "[{}] query change stream is out of range for {} to {}, finishing stream.",
             token,
             startTimestamp,
-            endTimestamp,
+            changeStreamQueryEndTimestamp,
             e);
       } else {
         throw e;
@@ -253,13 +258,13 @@ public class QueryChangeStreamAction {
           "[{}] query change stream had exception processing range {} to {}.",
           token,
           startTimestamp,
-          endTimestamp,
+          changeStreamQueryEndTimestamp,
           e);
       throw e;
     }
 
     LOG.debug("[{}] change stream completed successfully", token);
-    if (tracker.tryClaim(endTimestamp)) {
+    if (tracker.tryClaim(changeStreamQueryEndTimestamp)) {
       LOG.debug("[{}] Finishing partition", token);
       partitionMetadataDao.updateToFinished(token);
       metrics.decActivePartitionReadCounter();
@@ -291,5 +296,13 @@ public class QueryChangeStreamAction {
             || e.getErrorCode() == ErrorCode.OUT_OF_RANGE)
         && e.getMessage() != null
         && e.getMessage().contains(OUT_OF_RANGE_ERROR_MESSAGE);
+  }
+
+  // Return (now + 2 mins) as the end timestamp for reading change streams. This is only used if
+  // users want to run the connector for ever. This approach works because Apache beam checkpoints
+  // every 5s or 5MB output provided and the change stream query has deadline for 1 min.
+  private Timestamp getNextReadChangeStreamEndTimestamp() {
+    final Timestamp current = Timestamp.now();
+    return Timestamp.ofTimeSecondsAndNanos(current.getSeconds() + 2 * 60, current.getNanos());
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dao/PartitionMetadataAdminDao.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dao/PartitionMetadataAdminDao.java
@@ -128,7 +128,7 @@ public class PartitionMetadataAdminDao {
               + COLUMN_PARTITION_TOKEN
               + "\" text NOT NULL,\""
               + COLUMN_PARENT_TOKENS
-              + "\" text[] NOT NULL,\""
+              + "\" text[],\""
               + COLUMN_START_TIMESTAMP
               + "\" timestamptz NOT NULL,\""
               + COLUMN_END_TIMESTAMP
@@ -184,7 +184,7 @@ public class PartitionMetadataAdminDao {
               + COLUMN_PARTITION_TOKEN
               + " STRING(MAX) NOT NULL,"
               + COLUMN_PARENT_TOKENS
-              + " ARRAY<STRING(MAX)> NOT NULL,"
+              + " ARRAY<STRING(MAX)>,"
               + COLUMN_START_TIMESTAMP
               + " TIMESTAMP NOT NULL,"
               + COLUMN_END_TIMESTAMP

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/InitializeDoFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/InitializeDoFn.java
@@ -86,7 +86,6 @@ public class InitializeDoFn extends DoFn<byte[], PartitionMetadata> implements S
     PartitionMetadata parentPartition =
         PartitionMetadata.newBuilder()
             .setPartitionToken(InitialPartition.PARTITION_TOKEN)
-            .setParentTokens(InitialPartition.PARENT_TOKENS)
             .setStartTimestamp(startTimestamp)
             .setEndTimestamp(endTimestamp)
             .setHeartbeatMillis(DEFAULT_HEARTBEAT_MILLIS)

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/mapper/PartitionMetadataMapper.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/mapper/PartitionMetadataMapper.java
@@ -80,7 +80,10 @@ public class PartitionMetadataMapper {
   public PartitionMetadata from(Struct row) {
     return PartitionMetadata.newBuilder()
         .setPartitionToken(row.getString(COLUMN_PARTITION_TOKEN))
-        .setParentTokens(Sets.newHashSet(row.getStringList(COLUMN_PARENT_TOKENS)))
+        .setParentTokens(
+            !row.isNull(COLUMN_PARENT_TOKENS)
+                ? Sets.newHashSet(row.getStringList(COLUMN_PARENT_TOKENS))
+                : null)
         .setStartTimestamp(row.getTimestamp(COLUMN_START_TIMESTAMP))
         .setEndTimestamp(row.getTimestamp(COLUMN_END_TIMESTAMP))
         .setHeartbeatMillis(row.getLong(COLUMN_HEARTBEAT_MILLIS))

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/model/InitialPartition.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/model/InitialPartition.java
@@ -17,9 +17,6 @@
  */
 package org.apache.beam.sdk.io.gcp.spanner.changestreams.model;
 
-import java.util.HashSet;
-import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Sets;
-
 /**
  * Utility class to determine initial partition constants and methods.
  *
@@ -33,8 +30,6 @@ public class InitialPartition {
    * recognised by Cloud Spanner.
    */
   public static final String PARTITION_TOKEN = "Parent0";
-  /** The empty set representing the initial partition parent tokens. */
-  public static final HashSet<String> PARENT_TOKENS = Sets.newHashSet();
 
   /**
    * Verifies if the given partition token is the initial partition.

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/model/PartitionMetadata.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/model/PartitionMetadata.java
@@ -61,7 +61,7 @@ public class PartitionMetadata implements Serializable {
   }
 
   private String partitionToken;
-  private HashSet<String> parentTokens;
+  @Nullable @org.apache.avro.reflect.Nullable private HashSet<String> parentTokens;
 
   @AvroEncode(using = TimestampEncoding.class)
   private Timestamp startTimestamp;
@@ -98,7 +98,7 @@ public class PartitionMetadata implements Serializable {
 
   public PartitionMetadata(
       String partitionToken,
-      HashSet<String> parentTokens,
+      @Nullable HashSet<String> parentTokens,
       Timestamp startTimestamp,
       Timestamp endTimestamp,
       long heartbeatMillis,
@@ -130,7 +130,7 @@ public class PartitionMetadata implements Serializable {
    * The unique partition identifiers of the parent partitions where this child partition originated
    * from.
    */
-  public HashSet<String> getParentTokens() {
+  public @Nullable HashSet<String> getParentTokens() {
     return parentTokens;
   }
 
@@ -269,7 +269,7 @@ public class PartitionMetadata implements Serializable {
   public static class Builder {
 
     private String partitionToken;
-    private HashSet<String> parentTokens;
+    @Nullable private HashSet<String> parentTokens;
     private Timestamp startTimestamp;
     private Timestamp endTimestamp;
     private Long heartbeatMillis;
@@ -303,7 +303,7 @@ public class PartitionMetadata implements Serializable {
     }
 
     /** Sets the collection of parent partition identifiers. */
-    public Builder setParentTokens(HashSet<String> parentTokens) {
+    public Builder setParentTokens(@Nullable HashSet<String> parentTokens) {
       this.parentTokens = parentTokens;
       return this;
     }
@@ -376,7 +376,6 @@ public class PartitionMetadata implements Serializable {
      */
     public PartitionMetadata build() {
       Preconditions.checkState(partitionToken != null, "partitionToken");
-      Preconditions.checkState(parentTokens != null, "parentTokens");
       Preconditions.checkState(startTimestamp != null, "startTimestamp");
       Preconditions.checkState(heartbeatMillis != null, "heartbeatMillis");
       Preconditions.checkState(state != null, "state");

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/model/PartitionMetadataTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/model/PartitionMetadataTest.java
@@ -125,23 +125,6 @@ public class PartitionMetadataTest {
   }
 
   @Test
-  public void testBuilderThrowsExceptionWhenParentTokenMissing() {
-    assertThrows(
-        "parentToken",
-        IllegalStateException.class,
-        () ->
-            PartitionMetadata.newBuilder()
-                .setPartitionToken(PARTITION_TOKEN)
-                .setStartTimestamp(START_TIMESTAMP)
-                .setEndTimestamp(END_TIMESTAMP)
-                .setHeartbeatMillis(10)
-                .setState(State.CREATED)
-                .setWatermark(WATERMARK)
-                .setCreatedAt(CREATED_AT)
-                .build());
-  }
-
-  @Test
   public void testBuilderThrowsExceptionWhenStartTimestampMissing() {
     assertThrows(
         "startTimestamp",


### PR DESCRIPTION
For the V2 connector,  in the change Stream query the end timestamp is set to 
now() + 2 mins.
This can also achieve the same goal of running queries forever. Because the apache beam the ReadChangeStreamPartition execution every 5s or 5MB of output data produced.

