### PR TITLE
Get min unfinished watermark improve

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/cache/NoOpWatermarkCache.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/cache/NoOpWatermarkCache.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.io.gcp.spanner.changestreams.cache;
 
 import com.google.cloud.Timestamp;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.dao.PartitionMetadataDao;
 
@@ -35,6 +36,6 @@ public class NoOpWatermarkCache implements WatermarkCache {
 
   @Override
   public @Nullable Timestamp getUnfinishedMinWatermark() {
-    return dao.getUnfinishedMinWatermark();
+    return dao.getUnfinishedMinWatermark(Optional.empty());
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dao/PartitionMetadataAdminDao.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dao/PartitionMetadataAdminDao.java
@@ -128,7 +128,7 @@ public class PartitionMetadataAdminDao {
               + COLUMN_PARTITION_TOKEN
               + "\" text NOT NULL,\""
               + COLUMN_PARENT_TOKENS
-              + "\" text[] NOT NULL,\""
+              + "\" text[],\""
               + COLUMN_START_TIMESTAMP
               + "\" timestamptz NOT NULL,\""
               + COLUMN_END_TIMESTAMP
@@ -184,7 +184,7 @@ public class PartitionMetadataAdminDao {
               + COLUMN_PARTITION_TOKEN
               + " STRING(MAX) NOT NULL,"
               + COLUMN_PARENT_TOKENS
-              + " ARRAY<STRING(MAX)> NOT NULL,"
+              + " ARRAY<STRING(MAX)>,"
               + COLUMN_START_TIMESTAMP
               + " TIMESTAMP NOT NULL,"
               + COLUMN_END_TIMESTAMP

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/InitializeDoFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/InitializeDoFn.java
@@ -86,7 +86,6 @@ public class InitializeDoFn extends DoFn<byte[], PartitionMetadata> implements S
     PartitionMetadata parentPartition =
         PartitionMetadata.newBuilder()
             .setPartitionToken(InitialPartition.PARTITION_TOKEN)
-            .setParentTokens(InitialPartition.PARENT_TOKENS)
             .setStartTimestamp(startTimestamp)
             .setEndTimestamp(endTimestamp)
             .setHeartbeatMillis(DEFAULT_HEARTBEAT_MILLIS)

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/mapper/PartitionMetadataMapper.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/mapper/PartitionMetadataMapper.java
@@ -80,7 +80,10 @@ public class PartitionMetadataMapper {
   public PartitionMetadata from(Struct row) {
     return PartitionMetadata.newBuilder()
         .setPartitionToken(row.getString(COLUMN_PARTITION_TOKEN))
-        .setParentTokens(Sets.newHashSet(row.getStringList(COLUMN_PARENT_TOKENS)))
+        .setParentTokens(
+            !row.isNull(COLUMN_PARENT_TOKENS)
+                ? Sets.newHashSet(row.getStringList(COLUMN_PARENT_TOKENS))
+                : null)
         .setStartTimestamp(row.getTimestamp(COLUMN_START_TIMESTAMP))
         .setEndTimestamp(row.getTimestamp(COLUMN_END_TIMESTAMP))
         .setHeartbeatMillis(row.getLong(COLUMN_HEARTBEAT_MILLIS))

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/model/InitialPartition.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/model/InitialPartition.java
@@ -17,9 +17,6 @@
  */
 package org.apache.beam.sdk.io.gcp.spanner.changestreams.model;
 
-import java.util.HashSet;
-import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Sets;
-
 /**
  * Utility class to determine initial partition constants and methods.
  *
@@ -33,8 +30,6 @@ public class InitialPartition {
    * recognised by Cloud Spanner.
    */
   public static final String PARTITION_TOKEN = "Parent0";
-  /** The empty set representing the initial partition parent tokens. */
-  public static final HashSet<String> PARENT_TOKENS = Sets.newHashSet();
 
   /**
    * Verifies if the given partition token is the initial partition.

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/model/PartitionMetadata.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/model/PartitionMetadata.java
@@ -61,7 +61,7 @@ public class PartitionMetadata implements Serializable {
   }
 
   private String partitionToken;
-  private HashSet<String> parentTokens;
+  @Nullable @org.apache.avro.reflect.Nullable private HashSet<String> parentTokens;
 
   @AvroEncode(using = TimestampEncoding.class)
   private Timestamp startTimestamp;
@@ -98,7 +98,7 @@ public class PartitionMetadata implements Serializable {
 
   public PartitionMetadata(
       String partitionToken,
-      HashSet<String> parentTokens,
+      @Nullable HashSet<String> parentTokens,
       Timestamp startTimestamp,
       Timestamp endTimestamp,
       long heartbeatMillis,
@@ -130,7 +130,7 @@ public class PartitionMetadata implements Serializable {
    * The unique partition identifiers of the parent partitions where this child partition originated
    * from.
    */
-  public HashSet<String> getParentTokens() {
+  public @Nullable HashSet<String> getParentTokens() {
     return parentTokens;
   }
 
@@ -269,7 +269,7 @@ public class PartitionMetadata implements Serializable {
   public static class Builder {
 
     private String partitionToken;
-    private HashSet<String> parentTokens;
+    @Nullable private HashSet<String> parentTokens;
     private Timestamp startTimestamp;
     private Timestamp endTimestamp;
     private Long heartbeatMillis;
@@ -303,7 +303,7 @@ public class PartitionMetadata implements Serializable {
     }
 
     /** Sets the collection of parent partition identifiers. */
-    public Builder setParentTokens(HashSet<String> parentTokens) {
+    public Builder setParentTokens(@Nullable HashSet<String> parentTokens) {
       this.parentTokens = parentTokens;
       return this;
     }
@@ -376,7 +376,6 @@ public class PartitionMetadata implements Serializable {
      */
     public PartitionMetadata build() {
       Preconditions.checkState(partitionToken != null, "partitionToken");
-      Preconditions.checkState(parentTokens != null, "parentTokens");
       Preconditions.checkState(startTimestamp != null, "startTimestamp");
       Preconditions.checkState(heartbeatMillis != null, "heartbeatMillis");
       Preconditions.checkState(state != null, "state");

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/SpannerChangeStreamErrorTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/SpannerChangeStreamErrorTest.java
@@ -460,11 +460,19 @@ public class SpannerChangeStreamErrorTest implements Serializable {
   }
 
   private void mockGetWatermark(Timestamp watermark) {
+    final String MIN_WATERMARK = "min_watermark";
+    // The query needs to sync with getUnfinishedMinWatermark() in PartitionMetadataDao file.
     Statement watermarkStatement =
         Statement.newBuilder(
-                "SELECT Watermark FROM my-metadata-table WHERE State != @state ORDER BY Watermark ASC LIMIT 1")
+                "SELECT min(Watermark) as "
+                    + MIN_WATERMARK
+                    + " FROM my-metadata-table "
+                    + "WHERE State != @state "
+                    + "AND Watermark >= @since;")
             .bind("state")
             .to(State.FINISHED.name())
+            .bind("since")
+            .to(Timestamp.MIN_VALUE)
             .build();
     ResultSetMetadata watermarkResultSetMetadata =
         ResultSetMetadata.newBuilder()
@@ -472,7 +480,7 @@ public class SpannerChangeStreamErrorTest implements Serializable {
                 StructType.newBuilder()
                     .addFields(
                         Field.newBuilder()
-                            .setName("Watermark")
+                            .setName(MIN_WATERMARK)
                             .setType(Type.newBuilder().setCode(TypeCode.TIMESTAMP).build())
                             .build())
                     .build())

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/model/PartitionMetadataTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/model/PartitionMetadataTest.java
@@ -125,23 +125,6 @@ public class PartitionMetadataTest {
   }
 
   @Test
-  public void testBuilderThrowsExceptionWhenParentTokenMissing() {
-    assertThrows(
-        "parentToken",
-        IllegalStateException.class,
-        () ->
-            PartitionMetadata.newBuilder()
-                .setPartitionToken(PARTITION_TOKEN)
-                .setStartTimestamp(START_TIMESTAMP)
-                .setEndTimestamp(END_TIMESTAMP)
-                .setHeartbeatMillis(10)
-                .setState(State.CREATED)
-                .setWatermark(WATERMARK)
-                .setCreatedAt(CREATED_AT)
-                .build());
-  }
-
-  @Test
   public void testBuilderThrowsExceptionWhenStartTimestampMissing() {
     assertThrows(
         "startTimestamp",


### PR DESCRIPTION
To improve the performance of the query for GetUnfinishedMinWatermark, we can add a filter to the query.
Note that the query run on a cache to refresh every 1s. We can remember the cached value every time and use the value as a filter in the next time query.
