### PR TITLE
Added Postgres vector embedding type support

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerSchema.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerSchema.java
@@ -237,10 +237,12 @@ public abstract class SpannerSchema implements Serializable {
           }
           throw new IllegalArgumentException("Unknown spanner type " + spannerType);
         case POSTGRESQL:
-          if (spannerType.endsWith("[]")) {
-            // Substring "xxx[]"
+          Pattern pattern = Pattern.compile("([^\\[]+)\\[\\]");
+          Matcher m = pattern.matcher(spannerType);
+          if (m.find()) {
+            // Substring "xxx[]" or "xxx[] vector length yyy"
             // Must check array type first
-            String spannerArrayType = spannerType.substring(0, spannerType.length() - 2);
+            String spannerArrayType = m.group(1);
             Type itemType = parseSpannerType(spannerArrayType, dialect);
             return Type.array(itemType);
           }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/SpannerSchemaTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/SpannerSchemaTest.java
@@ -99,14 +99,18 @@ public class SpannerSchemaTest {
             .addColumn("test", "jsonbCol", "jsonb")
             .addColumn("test", "tokens", "spanner.tokenlist")
             .addColumn("test", "uuidCol", "uuid")
+            .addColumn("test", "arrayCol", "DOUBLE PRECISION[]")
+            .addColumn("test", "embeddingVectorCol", "DOUBLE PRECISION[] VECTOR LENGTH 16")
             .build();
 
     assertEquals(1, schema.getTables().size());
-    assertEquals(7, schema.getColumns("test").size());
+    assertEquals(9, schema.getColumns("test").size());
     assertEquals(1, schema.getKeyParts("test").size());
     assertEquals(Type.timestamp(), schema.getColumns("test").get(3).getType());
     assertEquals(Type.bytes(), schema.getColumns("test").get(5).getType());
     assertEquals(Type.string(), schema.getColumns("test").get(6).getType());
+    assertEquals(Type.array(Type.float64()), schema.getColumns("test").get(7).getType());
+    assertEquals(Type.array(Type.float64()), schema.getColumns("test").get(8).getType());
   }
 
   @Test


### PR DESCRIPTION
Added support for the "vector length" attribute for Postgres arrays. This is needed to support vector indexes in the Postgres dialect. Also extended the tests to validate both regular and vector arrays.