### PR TITLE
fix arbitrary file access during archive extraction ("Zip Slip") 

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/download_test.go
+++ b/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/download_test.go
@@ -80,7 +80,6 @@ func TestGetAndSetRepositoryURL_bad(t *testing.T) {
 			if err == nil {
 				t.Errorf("setRepositoryURL(%v) succeeded when it should have failed", test.newRepo)
 			}
-			// Check that the failed Set call did not change the URL.
 			if got, want := j.getRepositoryURL(), string(apacheRepository); got != want {
 				t.Errorf("getRepositoryURL() got %v, want %v", got, want)
 			}
@@ -139,17 +138,8 @@ func TestNewJarGetter(t *testing.T) {
 	}
 }
 
-func makeTempDir(t *testing.T) string {
-	d, err := os.MkdirTemp(os.Getenv("TEST_TMPDIR"), "expansionx-*")
-	if err != nil {
-		t.Fatalf("failed to make temp directory, got %v", err)
-	}
-	t.Cleanup(func() { os.RemoveAll(d) })
-	return d
-}
-
 func TestJarExists(t *testing.T) {
-	d := makeTempDir(t)
+	d := t.TempDir()
 
 	tmpFile, err := os.CreateTemp(d, "expansion-*.jar")
 	if err != nil {
@@ -162,7 +152,7 @@ func TestJarExists(t *testing.T) {
 }
 
 func TestJarExists_bad(t *testing.T) {
-	d := makeTempDir(t)
+	d := t.TempDir()
 
 	fakePath := filepath.Join(d, "not-a-file.jar")
 
@@ -179,13 +169,12 @@ func getGeneratedNumberInFile(fileName, jarPrefix string) string {
 }
 
 func TestGetJar_present(t *testing.T) {
-	d := makeTempDir(t)
+	d := t.TempDir()
 
 	j := newJarGetter()
 	j.jarCache = d
 
 	gradleTarget := ":sdks:java:fake:fakeJar"
-
 	jarName := "beam-sdks-java-fake-"
 
 	tmpFile, err := os.CreateTemp(d, jarName+"*.jar")
@@ -194,7 +183,6 @@ func TestGetJar_present(t *testing.T) {
 	}
 
 	genNumber := getGeneratedNumberInFile(tmpFile.Name(), jarName)
-
 	fullJarName := jarName + genNumber + ".jar"
 	expJarPath := filepath.Join(d, fullJarName)
 


### PR DESCRIPTION
https://github.com/apache/beam/blob/75cf7e182c9af656db147050f2cab1b7b374ee97/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/download.go#L142-L164

To fix the issue, we need to validate the file paths extracted from the zip archive to ensure they do not contain directory traversal elements (`..`) and are confined to the intended destination directory. This can be achieved by resolving the absolute path of the constructed `fileName` and ensuring it is a subpath of the `dest` directory. If the validation fails, the file should be skipped or an error should be raised.

The fix involves:
1. Resolving the absolute path of `fileName` using `filepath.Abs`.
2. Ensuring that the resolved path starts with the absolute path of the `dest` directory.
3. Skipping or rejecting files that fail this validation.

---

Extracting files from a malicious zip file, or similar type of archive, is at risk of directory traversal attacks if filenames from the archive are not properly validated. archive paths.

Zip archives contain archive entries representing each file in the archive. These entries include a file path for the entry, but these file paths are not restricted and may contain unexpected special elements such as the directory traversal element (`..`). If these file paths are used to create a filesystem path, then a file operation may happen in an unexpected location. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.

For example, if a zip file contains a file entry `..\beam-file`, and the zip file is extracted to the directory `c:\output`, then naively combining the paths would result in an output file path of `c:\output\..\beam-file`, which would cause the file to be written to `c:\beam-file`.


In this an archive is extracted without validating file paths. If archive.zip contained relative paths (for instance, if it were created by something like zip archive.zip ../file.txt) then executing this code could write to locations outside the destination directory.
```go
package main

import (
	"archive/zip"
	"io/ioutil"
	"path/filepath"
)

func unzip(f string) {
	r, _ := zip.OpenReader(f)
	for _, f := range r.File {
		p, _ := filepath.Abs(f.Name)
		// BAD: This could overwrite any file on the file system
		ioutil.WriteFile(p, []byte("present"), 0666)
	}
}
```
To fix this vulnerability, we need to check that the path does not contain any "`..`" elements in it.
```go
package main

import (
	"archive/zip"
	"io/ioutil"
	"path/filepath"
	"strings"
)

func unzipGood(f string) {
	r, _ := zip.OpenReader(f)
	for _, f := range r.File {
		p, _ := filepath.Abs(f.Name)
		// GOOD: Check that path does not contain ".." before using it
		if !strings.Contains(f.Name, "..") {
			ioutil.WriteFile(p, []byte("present"), 0666)
		}
	}
}
```
## References
[Zip Slip Vulnerability](https://snyk.io/research/zip-slip-vulnerability)
[Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)
[CWE-22](https://cwe.mitre.org/data/definitions/22.html)
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
