### PR TITLE
Add Kafka to Kafka RAW example pipeline configuration

### DIFF
--- a/sdks/python/apache_beam/yaml/examples/kafka-to-kafka.yaml
+++ b/sdks/python/apache_beam/yaml/examples/kafka-to-kafka.yaml
@@ -1,0 +1,22 @@
+pipeline:
+  type: chain
+  transforms:
+    - type: ReadFromKafka
+      name: KafkaSource
+      config:
+        topic: "i-topic"
+        bootstrap_servers: "localhost:9092"
+        format: RAW
+        consumer_config:
+          group.id: beam-mirror-001
+          auto.offset.reset: earliest
+
+    - type: WriteToKafka
+      name: MirrorToNTopic
+      config:
+        topic: "o-topic"
+        bootstrap_servers: "localhost:9092"
+        format: RAW
+        producer_config_update:
+          key.serializer:   org.apache.kafka.common.serialization.ByteArraySerializer
+          value.serializer: org.apache.kafka.common.serialization.ByteArraySerializer


### PR DESCRIPTION

This Apache Beam YAML pipeline demonstrates a basic Kafka-to-Kafka message mirroring use case. It reads raw byte messages from a source Kafka topic (i-topic) and writes them directly to a target Kafka topic (o-topic) without any transformation or decoding.

The pipeline is defined using Beam’s YAML DSL and leverages the ReadFromKafka and WriteToKafka transforms. It is configured to use the RAW data format, making it suitable for scenarios where the message structure is opaque or processing is deferred downstream.

This example serves as a minimal reference for validating Kafka I/O configurations and can be extended for more complex streaming dataflows. It is compatible with runners that support Kafka I/O, including Direct Runner and Flink Runner.
