### PR TITLE
Refactor: separate SplittableTruncateSizedRestrictions

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/fn/splittabledofn/RestrictionTrackers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/fn/splittabledofn/RestrictionTrackers.java
@@ -119,4 +119,25 @@ public class RestrictionTrackers {
       return new RestrictionTrackerObserver<>(restrictionTracker, claimObserver);
     }
   }
+
+  public static <RestrictionT, PositionT> RestrictionTracker<RestrictionT, PositionT> synchronize(
+      RestrictionTracker<RestrictionT, PositionT> restrictionTracker) {
+    if (restrictionTracker instanceof RestrictionTracker.HasProgress) {
+      return new RestrictionTrackerObserverWithProgress<>(
+          restrictionTracker, (ClaimObserver<PositionT>) NOOP_CLAIM_OBSERVER);
+    } else {
+      return new RestrictionTrackerObserver<>(
+          restrictionTracker, (ClaimObserver<PositionT>) NOOP_CLAIM_OBSERVER);
+    }
+  }
+
+  static class NoopClaimObserver<PositionT> implements ClaimObserver<PositionT> {
+    @Override
+    public void onClaimed(PositionT position) {}
+
+    @Override
+    public void onClaimFailed(PositionT position) {}
+  }
+
+  private static final NoopClaimObserver<Object> NOOP_CLAIM_OBSERVER = new NoopClaimObserver<>();
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
@@ -211,6 +211,6 @@ public abstract class RestrictionTracker<RestrictionT, PositionT> {
       return new AutoValue_RestrictionTracker_TruncateResult(restriction);
     }
 
-    public abstract @Nullable RestrictionT getTruncatedRestriction();
+    public abstract RestrictionT getTruncatedRestriction();
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/Holder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/Holder.java
@@ -15,31 +15,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.fn.harness;
+package org.apache.beam.sdk.util;
 
-import com.google.auto.value.AutoValue;
 import org.apache.beam.sdk.annotations.Internal;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.dataflow.qual.Pure;
 
-@AutoValue
-@AutoValue.CopyAnnotations
+/**
+ * A trivial boxing of a value, used when nullability needs to be added to a generic type. (Optional
+ * does not work for this)
+ *
+ * <p>Example: For a generic type `T` the actual parameter may be nullable or not. So you cannot
+ * check values for null to determine presence/absence. Instead you can store a {@code @Nullable
+ * Holder<T>}.
+ */
 @Internal
-abstract class SplitResultsWithStopIndex {
-  public static SplitResultsWithStopIndex of(
-      WindowedSplitResult windowSplit,
-      HandlesSplits.@Nullable SplitResult downstreamSplit,
-      int newWindowStopIndex) {
-    return new AutoValue_SplitResultsWithStopIndex(
-        windowSplit, downstreamSplit, newWindowStopIndex);
+public class Holder<T> {
+  private T value;
+
+  private Holder(T value) {
+    this.value = value;
   }
 
-  @Pure
-  public abstract WindowedSplitResult getWindowSplit();
+  public static <ValueT> Holder<ValueT> of(ValueT value) {
+    return new Holder<>(value);
+  }
 
-  @Pure
-  public abstract HandlesSplits.@Nullable SplitResult getDownstreamSplit();
-
-  @Pure
-  public abstract int getNewWindowStopIndex();
+  public T get() {
+    return value;
+  };
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/KV.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/KV.java
@@ -40,6 +40,7 @@ import org.checkerframework.dataflow.qual.Pure;
  */
 public class KV<K, V> implements Serializable {
   /** Returns a {@link KV} with the given key and value. */
+  @Pure
   public static <K, V> KV<K, V> of(K key, V value) {
     return new KV<>(key, value);
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/WindowedValue.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/WindowedValue.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.values;
 import java.util.Collection;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
+import org.checkerframework.dataflow.qual.Pure;
 import org.joda.time.Instant;
 
 /**
@@ -29,26 +30,32 @@ import org.joda.time.Instant;
  */
 public interface WindowedValue<T> {
   /** The primary data for this value. */
+  @Pure
   T getValue();
 
   /** The timestamp of this value in event time. */
+  @Pure
   Instant getTimestamp();
 
   /** Returns the windows of this {@code WindowedValue}. */
+  @Pure
   Collection<? extends BoundedWindow> getWindows();
 
   /** The {@link PaneInfo} associated with this WindowedValue. */
+  @Pure
   PaneInfo getPaneInfo();
 
   /**
    * A representation of each of the actual values represented by this compressed {@link
    * WindowedValue}, one per window.
    */
+  @Pure
   Iterable<WindowedValue<T>> explodeWindows();
 
   /**
    * A {@link WindowedValue} with identical metadata to the current one, but with the provided
    * value.
    */
+  @Pure
   <OtherT> WindowedValue<OtherT> withValue(OtherT value);
 }

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -90,7 +90,6 @@ import org.apache.beam.sdk.transforms.reflect.DoFnSignatures;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.HasProgress;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.Progress;
-import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.TruncateResult;
 import org.apache.beam.sdk.transforms.splittabledofn.SplitResult;
 import org.apache.beam.sdk.transforms.splittabledofn.TimestampObservingWatermarkEstimator;
 import org.apache.beam.sdk.transforms.splittabledofn.WatermarkEstimator;
@@ -146,7 +145,6 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
       Factory factory = new Factory();
       return ImmutableMap.<String, PTransformRunnerFactory>builder()
           .put(PTransformTranslation.PAR_DO_TRANSFORM_URN, factory)
-          .put(PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN, factory)
           .put(
               PTransformTranslation.SPLITTABLE_PROCESS_SIZED_ELEMENTS_AND_RESTRICTIONS_URN, factory)
           .build();
@@ -251,8 +249,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
 
   /**
    * Only valid during {@link
-   * #processElementForWindowObservingSizedElementAndRestriction(WindowedValue)} and {@link
-   * #processElementForWindowObservingTruncateRestriction(WindowedValue)}.
+   * #processElementForWindowObservingSizedElementAndRestriction(WindowedValue)}.
    */
   private List<BoundedWindow> currentWindows;
 
@@ -261,8 +258,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
    * processed.
    *
    * <p>Only valid during {@link
-   * #processElementForWindowObservingSizedElementAndRestriction(WindowedValue)} and {@link
-   * #processElementForWindowObservingTruncateRestriction(WindowedValue)}.
+   * #processElementForWindowObservingSizedElementAndRestriction(WindowedValue)}.
    */
   private int windowStopIndex;
 
@@ -271,28 +267,17 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
    * windowStopIndex.
    *
    * <p>Only valid during {@link
-   * #processElementForWindowObservingSizedElementAndRestriction(WindowedValue)} and {@link
-   * #processElementForWindowObservingTruncateRestriction(WindowedValue)}.
+   * #processElementForWindowObservingSizedElementAndRestriction(WindowedValue)}.
    */
   private int windowCurrentIndex;
 
-  /**
-   * Only valid during {@link #processElementForPairWithRestriction}, {@link
-   * #processElementForSplitRestriction}, and {@link
-   * #processElementForWindowObservingSizedElementAndRestriction}, null otherwise.
-   */
+  /** Only valid during #processElementForWindowObservingSizedElementAndRestriction}. */
   private RestrictionT currentRestriction;
 
-  /**
-   * Only valid during {@link #processElementForSplitRestriction}, and {@link
-   * #processElementForWindowObservingSizedElementAndRestriction}, null otherwise.
-   */
+  /** Only valid during {@link #processElementForWindowObservingSizedElementAndRestriction}. */
   private WatermarkEstimatorStateT currentWatermarkEstimatorState;
 
-  /**
-   * Only valid during {@link #processElementForWindowObservingSizedElementAndRestriction} and
-   * {@link #processElementForWindowObservingTruncateRestriction}.
-   */
+  /** Only valid during {@link #processElementForWindowObservingSizedElementAndRestriction}. */
   private Instant initialWatermark;
 
   /**
@@ -361,7 +346,6 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
           mainOutputTag = (TupleTag) ParDoTranslation.getMainOutputTag(parDoPayload);
           break;
         case PTransformTranslation.SPLITTABLE_SPLIT_AND_SIZE_RESTRICTIONS_URN:
-        case PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN:
           mainOutputTag =
               new TupleTag(Iterables.getOnlyElement(pTransform.getOutputsMap().keySet()));
           break;
@@ -463,8 +447,6 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
         break;
       case PTransformTranslation.SPLITTABLE_SPLIT_AND_SIZE_RESTRICTIONS_URN:
         // startBundle should not be invoked
-      case PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN:
-        // startBundle should not be invoked
       default:
         // no-op
     }
@@ -484,79 +466,6 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
         } else {
           mainInputConsumer = this::processElementForParDo;
           this.processContext = new NonWindowObservingProcessBundleContext();
-        }
-        break;
-      case PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN:
-        if ((doFnSignature.truncateRestriction() != null
-                && doFnSignature.truncateRestriction().observesWindow())
-            || (doFnSignature.newTracker() != null && doFnSignature.newTracker().observesWindow())
-            || (doFnSignature.getSize() != null && doFnSignature.getSize().observesWindow())
-            || !sideInputMapping.isEmpty()) {
-          // Only forward split/progress when the only consumer is splittable.
-          if (mainOutputConsumer instanceof HandlesSplits) {
-            mainInputConsumer =
-                new SplittableFnDataReceiver() {
-                  private final HandlesSplits splitDelegate = (HandlesSplits) mainOutputConsumer;
-
-                  @Override
-                  public void accept(WindowedValue input) throws Exception {
-                    processElementForWindowObservingTruncateRestriction(input);
-                  }
-
-                  @Override
-                  public HandlesSplits.SplitResult trySplit(double fractionOfRemainder) {
-                    return trySplitForWindowObservingTruncateRestriction(
-                        fractionOfRemainder, splitDelegate);
-                  }
-
-                  @Override
-                  public double getProgress() {
-                    Progress progress =
-                        FnApiDoFnRunner.this.getProgressFromWindowObservingTruncate(
-                            splitDelegate.getProgress());
-                    if (progress != null) {
-                      double totalWork = progress.getWorkCompleted() + progress.getWorkRemaining();
-                      if (totalWork > 0) {
-                        return progress.getWorkCompleted() / totalWork;
-                      }
-                    }
-                    return 0;
-                  }
-                };
-          } else {
-            mainInputConsumer = this::processElementForWindowObservingTruncateRestriction;
-          }
-          this.processContext =
-              new SizedRestrictionWindowObservingProcessBundleContext(
-                  PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN);
-        } else {
-          // Only forward split/progress when the only consumer is splittable.
-          if (mainOutputConsumer instanceof HandlesSplits) {
-            mainInputConsumer =
-                new SplittableFnDataReceiver() {
-                  private final HandlesSplits splitDelegate = (HandlesSplits) mainOutputConsumer;
-
-                  @Override
-                  public void accept(WindowedValue input) throws Exception {
-                    processElementForTruncateRestriction(input);
-                  }
-
-                  @Override
-                  public HandlesSplits.SplitResult trySplit(double fractionOfRemainder) {
-                    return splitDelegate.trySplit(fractionOfRemainder);
-                  }
-
-                  @Override
-                  public double getProgress() {
-                    return splitDelegate.getProgress();
-                  }
-                };
-          } else {
-            mainInputConsumer = this::processElementForTruncateRestriction;
-          }
-          this.processContext =
-              new SizedRestrictionNonWindowObservingProcessBundleContext(
-                  PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN);
         }
         break;
       case PTransformTranslation.SPLITTABLE_PROCESS_SIZED_ELEMENTS_AND_RESTRICTIONS_URN:
@@ -599,8 +508,6 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
         addFinishFunction.accept(this::finishBundle);
         break;
       case PTransformTranslation.SPLITTABLE_SPLIT_AND_SIZE_RESTRICTIONS_URN:
-        // finishBundle should not be invoked
-      case PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN:
         // finishBundle should not be invoked
       default:
         // no-op
@@ -736,90 +643,6 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
     }
   }
 
-  private void processElementForTruncateRestriction(
-      WindowedValue<KV<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>, Double>> elem) {
-    currentElement = elem.withValue(elem.getValue().getKey().getKey());
-    currentRestriction = elem.getValue().getKey().getValue().getKey();
-    currentWatermarkEstimatorState = elem.getValue().getKey().getValue().getValue();
-    // For truncation, we don't set currentTrackerClaimed so that we enable checkpointing even if no
-    // progress is made.
-    currentTracker =
-        RestrictionTrackers.observe(
-            doFnInvoker.invokeNewTracker(processContext),
-            new ClaimObserver<PositionT>() {
-              @Override
-              public void onClaimed(PositionT position) {}
-
-              @Override
-              public void onClaimFailed(PositionT position) {}
-            });
-    try {
-      TruncateResult<OutputT> truncatedRestriction =
-          doFnInvoker.invokeTruncateRestriction(processContext);
-      if (truncatedRestriction != null) {
-        processContext.output(truncatedRestriction.getTruncatedRestriction());
-      }
-    } finally {
-      currentTracker = null;
-      currentElement = null;
-      currentRestriction = null;
-      currentWatermarkEstimatorState = null;
-    }
-
-    this.stateAccessor.finalizeState();
-  }
-
-  private void processElementForWindowObservingTruncateRestriction(
-      WindowedValue<KV<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>, Double>> elem) {
-    currentElement = elem.withValue(elem.getValue().getKey().getKey());
-    windowCurrentIndex = -1;
-    windowStopIndex = currentElement.getWindows().size();
-    currentWindows = ImmutableList.copyOf(currentElement.getWindows());
-    while (true) {
-      synchronized (splitLock) {
-        windowCurrentIndex++;
-        if (windowCurrentIndex >= windowStopIndex) {
-          // Careful to reset the split state under the same synchronized block.
-          windowCurrentIndex = -1;
-          windowStopIndex = 0;
-          currentElement = null;
-          currentWindows = null;
-          currentRestriction = null;
-          currentWatermarkEstimatorState = null;
-          currentWindow = null;
-          currentTracker = null;
-          currentWatermarkEstimator = null;
-          initialWatermark = null;
-          break;
-        }
-        currentRestriction = elem.getValue().getKey().getValue().getKey();
-        currentWatermarkEstimatorState = elem.getValue().getKey().getValue().getValue();
-        currentWindow = currentWindows.get(windowCurrentIndex);
-        // We leave currentTrackerClaimed unset as we want to split regardless of if tryClaim is
-        // called.
-        currentTracker =
-            RestrictionTrackers.observe(
-                doFnInvoker.invokeNewTracker(processContext),
-                new ClaimObserver<PositionT>() {
-                  @Override
-                  public void onClaimed(PositionT position) {}
-
-                  @Override
-                  public void onClaimFailed(PositionT position) {}
-                });
-        currentWatermarkEstimator =
-            WatermarkEstimators.threadSafe(doFnInvoker.invokeNewWatermarkEstimator(processContext));
-        initialWatermark = currentWatermarkEstimator.getWatermarkAndState().getKey();
-      }
-      TruncateResult<OutputT> truncatedRestriction =
-          doFnInvoker.invokeTruncateRestriction(processContext);
-      if (truncatedRestriction != null) {
-        processContext.output(truncatedRestriction.getTruncatedRestriction());
-      }
-    }
-    this.stateAccessor.finalizeState();
-  }
-
   private void processElementForWindowObservingSizedElementAndRestriction(
       WindowedValue<KV<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>, Double>> elem) {
     currentElement = elem.withValue(elem.getValue().getKey().getKey());
@@ -922,39 +745,11 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
   private Progress getProgress() {
     synchronized (splitLock) {
       if (currentTracker instanceof RestrictionTracker.HasProgress && currentWindow != null) {
-        return scaleProgress(
+        return ProgressUtils.scaleProgress(
             ((HasProgress) currentTracker).getProgress(), windowCurrentIndex, windowStopIndex);
       }
     }
     return null;
-  }
-
-  private Progress getProgressFromWindowObservingTruncate(double elementCompleted) {
-    synchronized (splitLock) {
-      if (currentWindow != null) {
-        return scaleProgress(
-            Progress.from(elementCompleted, 1 - elementCompleted),
-            windowCurrentIndex,
-            windowStopIndex);
-      }
-    }
-    return null;
-  }
-
-  @VisibleForTesting
-  static Progress scaleProgress(Progress progress, int currentWindowIndex, int stopWindowIndex) {
-    checkArgument(
-        currentWindowIndex < stopWindowIndex,
-        "Current window index (%s) must be less than stop window index (%s)",
-        currentWindowIndex,
-        stopWindowIndex);
-
-    double totalWorkPerWindow = progress.getWorkCompleted() + progress.getWorkRemaining();
-    double completed = totalWorkPerWindow * currentWindowIndex + progress.getWorkCompleted();
-    double remaining =
-        totalWorkPerWindow * (stopWindowIndex - currentWindowIndex - 1)
-            + progress.getWorkRemaining();
-    return Progress.from(completed, remaining);
   }
 
   private WindowedSplitResult calculateRestrictionSize(
@@ -1040,61 +835,6 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                 splitResult.getResidualInUnprocessedWindowsRoot().getPaneInfo()));
   }
 
-  private HandlesSplits.SplitResult trySplitForWindowObservingTruncateRestriction(
-      double fractionOfRemainder, HandlesSplits splitDelegate) {
-    WindowedSplitResult windowedSplitResult = null;
-    HandlesSplits.SplitResult downstreamSplitResult = null;
-    synchronized (splitLock) {
-      // There is nothing to split if we are between truncate processing calls.
-      if (currentWindow == null) {
-        return null;
-      }
-      // We are requesting a checkpoint but have not yet progressed on the restriction, skip
-      // request.
-      if (fractionOfRemainder == 0
-          && currentTrackerClaimed != null
-          && !currentTrackerClaimed.get()) {
-        return null;
-      }
-
-      SplitResultsWithStopIndex splitResult =
-          computeSplitForProcessOrTruncate(
-              currentElement,
-              currentRestriction,
-              currentWindow,
-              currentWindows,
-              currentWatermarkEstimatorState,
-              fractionOfRemainder,
-              null,
-              splitDelegate,
-              null,
-              windowCurrentIndex,
-              windowStopIndex);
-      if (splitResult == null) {
-        return null;
-      }
-      windowStopIndex = splitResult.getNewWindowStopIndex();
-      windowedSplitResult =
-          calculateRestrictionSize(
-              splitResult.getWindowSplit(),
-              PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN + "/GetSize");
-      downstreamSplitResult = splitResult.getDownstreamSplit();
-    }
-    // Note that the assumption here is the fullInputCoder of the Truncate transform should be the
-    // the same as the SDF/Process transform.
-    Coder fullInputCoder = WindowedValues.getFullCoder(inputCoder, windowCoder);
-    return constructSplitResult(
-        windowedSplitResult,
-        downstreamSplitResult,
-        fullInputCoder,
-        initialWatermark,
-        null,
-        pTransformId,
-        mainInputId,
-        pTransform.getOutputsMap().keySet(),
-        null);
-  }
-
   private static <WatermarkEstimatorStateT> WindowedSplitResult computeWindowSplitResult(
       WindowedValue currentElement,
       Object currentRestriction,
@@ -1152,7 +892,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
   }
 
   @VisibleForTesting
-  static <WatermarkEstimatorStateT> SplitResultsWithStopIndex computeSplitForProcessOrTruncate(
+  static <WatermarkEstimatorStateT> SplitResultsWithStopIndex computeSplitForProcess(
       WindowedValue currentElement,
       Object currentRestriction,
       BoundedWindow currentWindow,
@@ -1189,7 +929,8 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
         double elementCompleted = splitDelegate.getProgress();
         elementProgress = Progress.from(elementCompleted, 1 - elementCompleted);
       }
-      Progress scaledProgress = scaleProgress(elementProgress, currentWindowIndex, stopWindowIndex);
+      Progress scaledProgress =
+          ProgressUtils.scaleProgress(elementProgress, currentWindowIndex, stopWindowIndex);
       double scaledFractionOfRemainder = scaledProgress.getWorkRemaining() * fractionOfRemainder;
 
       // The fraction is out of the current window and hence we will split at the closest window
@@ -1417,7 +1158,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
       // applies to the residual.
       watermarkAndState = currentWatermarkEstimator.getWatermarkAndState();
       SplitResultsWithStopIndex splitResult =
-          computeSplitForProcessOrTruncate(
+          computeSplitForProcess(
               currentElement,
               currentRestriction,
               currentWindow,
@@ -2098,327 +1839,6 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
           currentElement.getTimestamp(),
           currentElement.getTimestamp(),
           currentElement.getPaneInfo());
-    }
-  }
-
-  /** This context outputs KV<KV<Element, KV<Restriction, WatemarkEstimatorState>>, Size>. */
-  private class SizedRestrictionWindowObservingProcessBundleContext
-      extends WindowObservingProcessBundleContextBase {
-    private final String errorContextPrefix;
-
-    SizedRestrictionWindowObservingProcessBundleContext(String errorContextPrefix) {
-      this.errorContextPrefix = errorContextPrefix;
-    }
-
-    @Override
-    // OutputT == RestrictionT
-    public void output(OutputT output) {
-      double size =
-          doFnInvoker.invokeGetSize(
-              new DelegatingArgumentProvider<InputT, OutputT>(
-                  this, this.errorContextPrefix + "/GetSize") {
-                @Override
-                public Object restriction() {
-                  return output;
-                }
-
-                @Override
-                public Instant timestamp(DoFn<InputT, OutputT> doFn) {
-                  return currentElement.getTimestamp();
-                }
-
-                @Override
-                public RestrictionTracker<?, ?> restrictionTracker() {
-                  return doFnInvoker.invokeNewTracker(this);
-                }
-              });
-
-      // Don't need to check timestamp since we can always output using the input timestamp.
-      outputTo(
-          mainOutputConsumer,
-          (WindowedValue<OutputT>)
-              WindowedValues.of(
-                  KV.of(
-                      KV.of(
-                          currentElement.getValue(), KV.of(output, currentWatermarkEstimatorState)),
-                      size),
-                  currentElement.getTimestamp(),
-                  currentWindow,
-                  currentElement.getPaneInfo()));
-    }
-
-    @Override
-    public <T> void output(TupleTag<T> tag, T output) {
-      // Note that the OutputReceiver/RowOutputReceiver specifically will use the non-tag versions
-      // of these methods when producing output.
-      throw new UnsupportedOperationException(
-          String.format("Non-main output %s unsupported in %s", tag, errorContextPrefix));
-    }
-
-    @Override
-    // OutputT == RestrictionT
-    public void outputWithTimestamp(OutputT output, Instant timestamp) {
-      checkTimestamp(timestamp);
-      double size =
-          doFnInvoker.invokeGetSize(
-              new DelegatingArgumentProvider<InputT, OutputT>(
-                  this, this.errorContextPrefix + "/GetSize") {
-                @Override
-                public Object restriction() {
-                  return output;
-                }
-
-                @Override
-                public Instant timestamp(DoFn<InputT, OutputT> doFn) {
-                  return timestamp;
-                }
-
-                @Override
-                public RestrictionTracker<?, ?> restrictionTracker() {
-                  return doFnInvoker.invokeNewTracker(this);
-                }
-              });
-
-      outputTo(
-          mainOutputConsumer,
-          (WindowedValue<OutputT>)
-              WindowedValues.of(
-                  KV.of(
-                      KV.of(
-                          currentElement.getValue(), KV.of(output, currentWatermarkEstimatorState)),
-                      size),
-                  timestamp,
-                  currentWindow,
-                  currentElement.getPaneInfo()));
-    }
-
-    @Override
-    public void outputWindowedValue(
-        OutputT output,
-        Instant timestamp,
-        Collection<? extends BoundedWindow> windows,
-        PaneInfo paneInfo) {
-      checkTimestamp(timestamp);
-      double size =
-          doFnInvoker.invokeGetSize(
-              new DelegatingArgumentProvider<InputT, OutputT>(
-                  this, this.errorContextPrefix + "/GetSize") {
-                @Override
-                public Object restriction() {
-                  return output;
-                }
-
-                @Override
-                public Instant timestamp(DoFn<InputT, OutputT> doFn) {
-                  return timestamp;
-                }
-
-                @Override
-                public RestrictionTracker<?, ?> restrictionTracker() {
-                  return doFnInvoker.invokeNewTracker(this);
-                }
-              });
-
-      outputTo(
-          mainOutputConsumer,
-          (WindowedValue<OutputT>)
-              WindowedValues.of(
-                  KV.of(
-                      KV.of(
-                          currentElement.getValue(), KV.of(output, currentWatermarkEstimatorState)),
-                      size),
-                  timestamp,
-                  windows,
-                  paneInfo));
-    }
-
-    @Override
-    public <T> void outputWithTimestamp(TupleTag<T> tag, T output, Instant timestamp) {
-      // Note that the OutputReceiver/RowOutputReceiver specifically will use the non-tag versions
-      // of these methods when producing output.
-      throw new UnsupportedOperationException(
-          String.format("Non-main output %s unsupported in %s", tag, errorContextPrefix));
-    }
-
-    @Override
-    public <T> void outputWindowedValue(
-        TupleTag<T> tag,
-        T output,
-        Instant timestamp,
-        Collection<? extends BoundedWindow> windows,
-        PaneInfo paneInfo) {
-      // Note that the OutputReceiver/RowOutputReceiver specifically will use the non-tag versions
-      // of these methods when producing output.
-      throw new UnsupportedOperationException(
-          String.format("Non-main output %s unsupported in %s", tag, errorContextPrefix));
-    }
-
-    @Override
-    public State state(String stateId, boolean alwaysFetched) {
-      throw new UnsupportedOperationException(
-          String.format("State unsupported in %s", errorContextPrefix));
-    }
-
-    @Override
-    public org.apache.beam.sdk.state.Timer timer(String timerId) {
-      throw new UnsupportedOperationException(
-          String.format("Timer unsupported in %s", errorContextPrefix));
-    }
-
-    @Override
-    public TimerMap timerFamily(String tagId) {
-      throw new UnsupportedOperationException(
-          String.format("Timer unsupported in %s", errorContextPrefix));
-    }
-  }
-
-  /** This context outputs KV<KV<Element, KV<Restriction, WatermarkEstimatorState>>, Size>. */
-  private class SizedRestrictionNonWindowObservingProcessBundleContext
-      extends NonWindowObservingProcessBundleContextBase {
-    private final String errorContextPrefix;
-
-    SizedRestrictionNonWindowObservingProcessBundleContext(String errorContextPrefix) {
-      this.errorContextPrefix = errorContextPrefix;
-    }
-
-    @Override
-    // OutputT == RestrictionT
-    public void output(OutputT output) {
-      double size =
-          doFnInvoker.invokeGetSize(
-              new DelegatingArgumentProvider<InputT, OutputT>(
-                  this, errorContextPrefix + "/GetSize") {
-                @Override
-                public Object restriction() {
-                  return output;
-                }
-
-                @Override
-                public Instant timestamp(DoFn<InputT, OutputT> doFn) {
-                  return currentElement.getTimestamp();
-                }
-
-                @Override
-                public RestrictionTracker<?, ?> restrictionTracker() {
-                  return doFnInvoker.invokeNewTracker(this);
-                }
-              });
-
-      // Don't need to check timestamp since we can always output using the input timestamp.
-      outputTo(
-          mainOutputConsumer,
-          (WindowedValue<OutputT>)
-              currentElement.withValue(
-                  KV.of(
-                      KV.of(
-                          currentElement.getValue(), KV.of(output, currentWatermarkEstimatorState)),
-                      size)));
-    }
-
-    @Override
-    public <T> void output(TupleTag<T> tag, T output) {
-      // Note that the OutputReceiver/RowOutputReceiver specifically will use the non-tag versions
-      // of these methods when producing output.
-      throw new UnsupportedOperationException(
-          String.format("Non-main output %s unsupported in %s", tag, errorContextPrefix));
-    }
-
-    @Override
-    // OutputT == RestrictionT
-    public void outputWithTimestamp(OutputT output, Instant timestamp) {
-      checkTimestamp(timestamp);
-      double size =
-          doFnInvoker.invokeGetSize(
-              new DelegatingArgumentProvider<InputT, OutputT>(
-                  this, errorContextPrefix + "/GetSize") {
-                @Override
-                public Object restriction() {
-                  return output;
-                }
-
-                @Override
-                public Instant timestamp(DoFn<InputT, OutputT> doFn) {
-                  return timestamp;
-                }
-
-                @Override
-                public RestrictionTracker<?, ?> restrictionTracker() {
-                  return doFnInvoker.invokeNewTracker(this);
-                }
-              });
-
-      outputTo(
-          mainOutputConsumer,
-          (WindowedValue<OutputT>)
-              WindowedValues.of(
-                  KV.of(
-                      KV.of(
-                          currentElement.getValue(), KV.of(output, currentWatermarkEstimatorState)),
-                      size),
-                  timestamp,
-                  currentElement.getWindows(),
-                  currentElement.getPaneInfo()));
-    }
-
-    @Override
-    public void outputWindowedValue(
-        OutputT output,
-        Instant timestamp,
-        Collection<? extends BoundedWindow> windows,
-        PaneInfo paneInfo) {
-      checkTimestamp(timestamp);
-      double size =
-          doFnInvoker.invokeGetSize(
-              new DelegatingArgumentProvider<InputT, OutputT>(
-                  this, errorContextPrefix + "/GetSize") {
-                @Override
-                public Object restriction() {
-                  return output;
-                }
-
-                @Override
-                public Instant timestamp(DoFn<InputT, OutputT> doFn) {
-                  return timestamp;
-                }
-
-                @Override
-                public RestrictionTracker<?, ?> restrictionTracker() {
-                  return doFnInvoker.invokeNewTracker(this);
-                }
-              });
-
-      outputTo(
-          mainOutputConsumer,
-          (WindowedValue<OutputT>)
-              WindowedValues.of(
-                  KV.of(
-                      KV.of(
-                          currentElement.getValue(), KV.of(output, currentWatermarkEstimatorState)),
-                      size),
-                  timestamp,
-                  windows,
-                  paneInfo));
-    }
-
-    @Override
-    public <T> void outputWithTimestamp(TupleTag<T> tag, T output, Instant timestamp) {
-      // Note that the OutputReceiver/RowOutputReceiver specifically will use the non-tag versions
-      // of these methods when producing output.
-      throw new UnsupportedOperationException(
-          String.format("Non-main output %s unsupported in %s", tag, errorContextPrefix));
-    }
-
-    @Override
-    public <T> void outputWindowedValue(
-        TupleTag<T> tag,
-        T output,
-        Instant timestamp,
-        Collection<? extends BoundedWindow> windows,
-        PaneInfo paneInfo) {
-      // Note that the OutputReceiver/RowOutputReceiver specifically will use the non-tag versions
-      // of these methods when producing output.
-      throw new UnsupportedOperationException(
-          String.format("Non-main output %s unsupported in %s", tag, errorContextPrefix));
     }
   }
 

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/HandlesSplits.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/HandlesSplits.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.BundleApplication;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * An interface that may be used to extend a {@link FnDataReceiver} signalling that the downstream
@@ -30,6 +31,7 @@ import org.apache.beam.sdk.fn.data.FnDataReceiver;
 public interface HandlesSplits {
 
   /** Returns null if the split was unsuccessful. */
+  @Nullable
   SplitResult trySplit(double fractionOfRemainder);
 
   /** Returns the current progress of the active element as a fraction between 0.0 and 1.0. */

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/ProgressUtils.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/ProgressUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.fn.harness;
+
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
+
+import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
+
+/** Miscellaneous methods for working with progress. */
+@Internal
+public abstract class ProgressUtils {
+  static RestrictionTracker.Progress scaleProgress(
+      RestrictionTracker.Progress progress, int currentWindowIndex, int stopWindowIndex) {
+    checkArgument(
+        currentWindowIndex < stopWindowIndex,
+        "Current window index (%s) must be less than stop window index (%s)",
+        currentWindowIndex,
+        stopWindowIndex);
+
+    double totalWorkPerWindow = progress.getWorkCompleted() + progress.getWorkRemaining();
+    double completed = totalWorkPerWindow * currentWindowIndex + progress.getWorkCompleted();
+    double remaining =
+        totalWorkPerWindow * (stopWindowIndex - currentWindowIndex - 1)
+            + progress.getWorkRemaining();
+    return RestrictionTracker.Progress.from(completed, remaining);
+  }
+}

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/SplittableSplitAndSizeRestrictionsDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/SplittableSplitAndSizeRestrictionsDoFnRunner.java
@@ -359,7 +359,7 @@ public class SplittableSplitAndSizeRestrictionsDoFnRunner<
 
   /** This context outputs KV<KV<Element, KV<Restriction, WatermarkEstimatorState>>, Size>. */
   private class SizedRestrictionNonWindowObservingArgumentProvider
-      extends SplitRestrictionArgumentProvider implements OutputReceiver<RestrictionT> {
+      extends SplitRestrictionArgumentProvider {
     @Override
     public void output(RestrictionT subrestriction) {
       double size = getSize(subrestriction);

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/SplittableTruncateSizedRestrictionsDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/SplittableTruncateSizedRestrictionsDoFnRunner.java
@@ -1,0 +1,968 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.fn.harness;
+
+import static org.apache.beam.sdk.util.Preconditions.checkStateNotNull;
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
+
+import com.google.auto.service.AutoService;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.fn.harness.state.FnApiStateAccessor;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.BundleApplication;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.DelayedBundleApplication;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
+import org.apache.beam.model.pipeline.v1.RunnerApi.ParDoPayload;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.fn.data.FnDataReceiver;
+import org.apache.beam.sdk.fn.splittabledofn.RestrictionTrackers;
+import org.apache.beam.sdk.fn.splittabledofn.WatermarkEstimators;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
+import org.apache.beam.sdk.transforms.DoFnSchemaInformation;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.reflect.DoFnInvoker;
+import org.apache.beam.sdk.transforms.reflect.DoFnInvoker.DelegatingArgumentProvider;
+import org.apache.beam.sdk.transforms.reflect.DoFnInvokers;
+import org.apache.beam.sdk.transforms.reflect.DoFnSignature;
+import org.apache.beam.sdk.transforms.reflect.DoFnSignatures;
+import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
+import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.Progress;
+import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.TruncateResult;
+import org.apache.beam.sdk.transforms.splittabledofn.TimestampObservingWatermarkEstimator;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.transforms.windowing.PaneInfo;
+import org.apache.beam.sdk.util.ByteStringOutputStream;
+import org.apache.beam.sdk.util.Holder;
+import org.apache.beam.sdk.util.UserCodeException;
+import org.apache.beam.sdk.util.construction.PTransformTranslation;
+import org.apache.beam.sdk.util.construction.ParDoTranslation;
+import org.apache.beam.sdk.util.construction.RehydratedComponents;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.WindowedValue;
+import org.apache.beam.sdk.values.WindowedValues;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.joda.time.Instant;
+
+/**
+ * A runner for the PTransform that truncates sized restrictions, for the case of draining a
+ * pipeline.
+ *
+ * <p>The input and output types for this transform are
+ * <li>{@code WindowedValue<KV<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>, Double>>}
+ */
+public class SplittableTruncateSizedRestrictionsDoFnRunner<
+        InputT, RestrictionT extends @NonNull Object, PositionT, WatermarkEstimatorStateT, OutputT>
+    implements FnApiStateAccessor.MutatingStateContext<Void, BoundedWindow> {
+
+  /** A registrar which provides a factory to handle Java {@link DoFn}s. */
+  @AutoService(PTransformRunnerFactory.Registrar.class)
+  public static class Registrar implements PTransformRunnerFactory.Registrar {
+    @Override
+    public Map<String, PTransformRunnerFactory> getPTransformRunnerFactories() {
+      Factory factory = new Factory();
+      return ImmutableMap.<String, PTransformRunnerFactory>builder()
+          .put(PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN, factory)
+          .build();
+    }
+  }
+
+  static class Factory implements PTransformRunnerFactory {
+    @Override
+    public final void addRunnerForPTransform(Context context) throws IOException {
+      addRunnerForTruncateSizedRestrictions(context);
+    }
+
+    private <
+            InputT,
+            RestrictionT extends @NonNull Object,
+            PositionT,
+            WatermarkEstimatorStateT,
+            OutputT>
+        void addRunnerForTruncateSizedRestrictions(Context context) throws IOException {
+
+      FnApiStateAccessor<Void> stateAccessor =
+          FnApiStateAccessor.Factory.<Void>factoryForPTransformContext(context).create();
+
+      // Main output
+      checkArgument(
+          context.getPTransform().getOutputsMap().size() == 1,
+          "TruncateSizedRestrictions expects exact one output, but got: ",
+          context.getPTransform().getOutputsMap().size());
+      TupleTag<KV<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>, Double>> mainOutputTag =
+          new TupleTag<>(
+              Iterables.getOnlyElement(context.getPTransform().getOutputsMap().keySet()));
+
+      FnDataReceiver<
+              WindowedValue<KV<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>, Double>>>
+          mainOutputConsumer =
+              context.getPCollectionConsumer(
+                  context.getPTransform().getOutputsOrThrow(mainOutputTag.getId()));
+
+      SplittableTruncateSizedRestrictionsDoFnRunner<
+              InputT, RestrictionT, PositionT, WatermarkEstimatorStateT, OutputT>
+          runner =
+              new SplittableTruncateSizedRestrictionsDoFnRunner<>(
+                  context.getPipelineOptions(),
+                  context.getPTransformId(),
+                  context.getPTransform(),
+                  context.getComponents(),
+                  mainOutputConsumer,
+                  stateAccessor);
+
+      // Register input consumer that delegates splitting
+      FnDataReceiver<
+              WindowedValue<KV<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>, Double>>>
+          mainInputConsumer;
+
+      if (mainOutputConsumer instanceof HandlesSplits) {
+        mainInputConsumer =
+            new SplitDelegatingFnDataReceiver<>(runner, (HandlesSplits) mainOutputConsumer);
+      } else {
+        mainInputConsumer = runner::processElement;
+      }
+
+      context.addPCollectionConsumer(
+          context
+              .getPTransform()
+              .getInputsOrThrow(ParDoTranslation.getMainInputName(context.getPTransform())),
+          mainInputConsumer);
+      context.addTearDownFunction(runner::tearDown);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+
+  private final boolean observesWindow;
+  private final PipelineOptions pipelineOptions;
+
+  private final DoFnInvoker<InputT, OutputT> doFnInvoker;
+
+  private final FnDataReceiver<
+          WindowedValue<KV<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>, Double>>>
+      mainOutputConsumer;
+
+  private final FnApiStateAccessor<?> stateAccessor;
+
+  private final TruncateSizedRestrictionArgumentProvider mutableArgumentProvider;
+
+  private final String pTransformId;
+  private final RunnerApi.PTransform pTransform;
+  private final String mainInputId;
+  private final Coder<WindowedValue<?>> fullInputCoder;
+
+  /**
+   * Used to guarantee a consistent view of this {@link
+   * SplittableTruncateSizedRestrictionsDoFnRunner} while setting up for {@link
+   * DoFnInvoker#invokeProcessElement} since {@link #trySplit} may access internal {@link
+   * SplittableTruncateSizedRestrictionsDoFnRunner} state concurrently.
+   */
+  // TODO: explicitly mark guarded fields with @GuardedBy
+  private final Object splitLock = new Object();
+
+  private final DoFnSchemaInformation doFnSchemaInformation;
+  private final Map<String, PCollectionView<?>> sideInputMapping;
+
+  ///
+  // Mutating fields that change with the element and window being processed
+  //
+  private int windowCurrentIndex;
+  private @Nullable List<BoundedWindow> currentWindows;
+  private @Nullable RestrictionT currentRestriction;
+  private @Nullable Holder<WatermarkEstimatorStateT> currentWatermarkEstimatorState;
+  private @Nullable Instant initialWatermark;
+  private WatermarkEstimators.@Nullable WatermarkAndStateObserver<WatermarkEstimatorStateT>
+      currentWatermarkEstimator;
+  private @Nullable BoundedWindow currentWindow;
+  private @Nullable RestrictionTracker<RestrictionT, PositionT> currentTracker;
+  private @Nullable WindowedValue<InputT> currentElement;
+
+  /**
+   * The window index at which processing should stop. The window with this index should not be
+   * processed.
+   */
+  private int windowStopIndex;
+
+  /**
+   * The window index which is currently being processed. This should always be less than
+   * windowStopIndex.
+   */
+  SplittableTruncateSizedRestrictionsDoFnRunner(
+      PipelineOptions pipelineOptions,
+      String pTransformId,
+      PTransform pTransform,
+      RunnerApi.Components components,
+      FnDataReceiver<
+              WindowedValue<KV<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>, Double>>>
+          mainOutputConsumer,
+      FnApiStateAccessor<Void> stateAccessor)
+      throws IOException {
+    this.pipelineOptions = pipelineOptions;
+    this.stateAccessor = stateAccessor;
+    this.pTransformId = pTransformId;
+    this.pTransform = pTransform;
+
+    ParDoPayload parDoPayload = ParDoPayload.parseFrom(pTransform.getSpec().getPayload());
+
+    // DoFn and metadata
+    DoFn<InputT, OutputT> doFn = (DoFn<InputT, OutputT>) ParDoTranslation.getDoFn(parDoPayload);
+    DoFnSignature doFnSignature = DoFnSignatures.signatureForDoFn(doFn);
+    this.doFnInvoker = DoFnInvokers.tryInvokeSetupFor(doFn, pipelineOptions);
+    this.doFnSchemaInformation = ParDoTranslation.getSchemaInformation(parDoPayload);
+
+    this.mainOutputConsumer = mainOutputConsumer;
+
+    // Side inputs
+    this.sideInputMapping = ParDoTranslation.getSideInputMapping(parDoPayload);
+
+    // Register processing methods
+    this.observesWindow =
+        (doFnSignature.splitRestriction() != null
+                && doFnSignature.splitRestriction().observesWindow())
+            || (doFnSignature.newTracker() != null && doFnSignature.newTracker().observesWindow())
+            || (doFnSignature.getSize() != null && doFnSignature.getSize().observesWindow())
+            || !sideInputMapping.isEmpty();
+
+    if (observesWindow) {
+      this.mutableArgumentProvider = new TruncateSizedRestrictionWindowObservingArgumentProvider();
+    } else {
+      this.mutableArgumentProvider =
+          new TruncateSizedRestrictionNonWindowObservingArgumentProvider();
+    }
+
+    // Main Input
+    this.mainInputId = ParDoTranslation.getMainInputName(pTransform);
+    RunnerApi.PCollection mainInput =
+        components.getPcollectionsOrThrow(pTransform.getInputsOrThrow(mainInputId));
+    RehydratedComponents rehydratedComponents =
+        RehydratedComponents.forComponents(components).withPipeline(Pipeline.create());
+    Coder<KV<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>, Double>> inputCoder =
+        (Coder<KV<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>, Double>>)
+            rehydratedComponents.getCoder(mainInput.getCoderId());
+    Coder<BoundedWindow> windowCoder =
+        (Coder<BoundedWindow>)
+            rehydratedComponents
+                .getWindowingStrategy(mainInput.getWindowingStrategyId())
+                .getWindowFn()
+                .windowCoder();
+    this.fullInputCoder =
+        (Coder<WindowedValue<?>>) (Object) WindowedValues.getFullCoder(inputCoder, windowCoder);
+  }
+
+  @Override
+  public Void getCurrentKey() {
+    return null;
+  }
+
+  @Override
+  public BoundedWindow getCurrentWindow() {
+    return checkStateNotNull(
+        currentWindow, "Attempt to access window outside windowed element processing context.");
+  }
+
+  public List<BoundedWindow> getCurrentWindows() {
+    return checkStateNotNull(
+        currentWindows,
+        "Attempt to access window collection outside windowed element processing context.");
+  }
+
+  public WindowedValue<InputT> getCurrentElement() {
+    return checkStateNotNull(
+        currentElement, "Attempt to access element outside element processing context.");
+  }
+
+  private RestrictionT getCurrentRestriction() {
+    return checkStateNotNull(
+        this.currentRestriction,
+        "Attempt to access restriction outside element processing context.");
+  }
+
+  private RestrictionTracker<RestrictionT, ?> getCurrentTracker() {
+    return checkStateNotNull(
+        this.currentTracker,
+        "Attempt to access restriction tracker state outside element processing context.");
+  }
+
+  private WatermarkEstimatorStateT getCurrentWatermarkEstimatorState() {
+    checkStateNotNull(
+        this.currentWatermarkEstimatorState,
+        "Attempt to access watermark estimator state outside element processing context.");
+    return this.currentWatermarkEstimatorState.get();
+  }
+
+  void processElement(
+      WindowedValue<KV<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>, Double>> elem) {
+    if (observesWindow) {
+      processElementForWindowObservingTruncateRestriction(elem);
+    } else {
+      processElementForTruncateRestriction(elem);
+    }
+  }
+
+  HandlesSplits.@Nullable SplitResult trySplit(
+      double fractionOfRemainder, HandlesSplits splitDelegate) {
+    if (observesWindow) {
+      return trySplitForWindowObservingTruncateRestriction(fractionOfRemainder, splitDelegate);
+    } else {
+      return splitDelegate.trySplit(fractionOfRemainder);
+    }
+  }
+
+  private void processElementForTruncateRestriction(
+      WindowedValue<KV<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>, Double>> elem) {
+    currentElement = elem.withValue(elem.getValue().getKey().getKey());
+    currentRestriction = elem.getValue().getKey().getValue().getKey();
+    currentWatermarkEstimatorState = Holder.of(elem.getValue().getKey().getValue().getValue());
+    currentTracker =
+        RestrictionTrackers.synchronize(doFnInvoker.invokeNewTracker(mutableArgumentProvider));
+    try {
+      TruncateResult<RestrictionT> truncatedRestriction =
+          doFnInvoker.invokeTruncateRestriction(mutableArgumentProvider);
+      if (truncatedRestriction != null) {
+        mutableArgumentProvider.output(truncatedRestriction.getTruncatedRestriction());
+      }
+    } finally {
+      currentTracker = null;
+      currentElement = null;
+      currentRestriction = null;
+      currentWatermarkEstimatorState = null;
+    }
+
+    this.stateAccessor.finalizeState();
+  }
+
+  private void processElementForWindowObservingTruncateRestriction(
+      WindowedValue<KV<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>, Double>> elem) {
+    currentElement = elem.withValue(elem.getValue().getKey().getKey());
+    windowCurrentIndex = -1;
+    windowStopIndex = elem.getWindows().size();
+    currentWindows = ImmutableList.copyOf(elem.getWindows());
+    while (true) {
+      synchronized (splitLock) {
+        windowCurrentIndex++;
+        if (windowCurrentIndex >= windowStopIndex) {
+          // Careful to reset the split state under the same synchronized block.
+          windowCurrentIndex = -1;
+          windowStopIndex = 0;
+          currentElement = null;
+          currentWindows = null;
+          currentRestriction = null;
+          currentWatermarkEstimatorState = null;
+          currentWindow = null;
+          currentTracker = null;
+          currentWatermarkEstimator = null;
+          initialWatermark = null;
+          break;
+        }
+        currentRestriction = elem.getValue().getKey().getValue().getKey();
+        currentWatermarkEstimatorState = Holder.of(elem.getValue().getKey().getValue().getValue());
+        currentWindow =
+            checkStateNotNull(
+                    currentWindows,
+                    "internal error: currentWindows is null during element processing")
+                .get(windowCurrentIndex);
+        currentTracker =
+            RestrictionTrackers.synchronize(doFnInvoker.invokeNewTracker(mutableArgumentProvider));
+        currentWatermarkEstimator =
+            WatermarkEstimators.threadSafe(
+                doFnInvoker.invokeNewWatermarkEstimator(mutableArgumentProvider));
+        initialWatermark = currentWatermarkEstimator.getWatermarkAndState().getKey();
+      }
+      TruncateResult<RestrictionT> truncatedRestriction =
+          doFnInvoker.invokeTruncateRestriction(mutableArgumentProvider);
+      if (truncatedRestriction != null) {
+        mutableArgumentProvider.output(truncatedRestriction.getTruncatedRestriction());
+      }
+    }
+    this.stateAccessor.finalizeState();
+  }
+
+  private @Nullable Progress getProgressFromWindowObservingTruncate(double elementCompleted) {
+    synchronized (splitLock) {
+      if (currentWindow != null) {
+        return ProgressUtils.scaleProgress(
+            Progress.from(elementCompleted, 1 - elementCompleted),
+            windowCurrentIndex,
+            windowStopIndex);
+      }
+    }
+    return null;
+  }
+
+  private WindowedSplitResult calculateRestrictionSize(
+      WindowedSplitResult splitResult, String errorContext) {
+    double fullSize =
+        splitResult.getResidualInUnprocessedWindowsRoot() == null
+                && splitResult.getPrimaryInFullyProcessedWindowsRoot() == null
+            ? 0
+            : doFnInvoker.invokeGetSize(
+                new DelegatingArgumentProvider<InputT, OutputT>(
+                    mutableArgumentProvider, errorContext) {
+                  @Override
+                  public Object restriction() {
+                    return getCurrentRestriction();
+                  }
+
+                  @Override
+                  public RestrictionTracker<?, ?> restrictionTracker() {
+                    return doFnInvoker.invokeNewTracker(this);
+                  }
+                });
+    double primarySize =
+        splitResult.getPrimarySplitRoot() == null
+            ? 0
+            : doFnInvoker.invokeGetSize(
+                new DelegatingArgumentProvider<InputT, OutputT>(
+                    mutableArgumentProvider, errorContext) {
+                  @Override
+                  public Object restriction() {
+                    WindowedValue<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>>
+                        splitRoot =
+                            (WindowedValue<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>>)
+                                splitResult.getPrimarySplitRoot();
+
+                    return splitRoot.getValue().getValue().getKey();
+                  }
+
+                  @Override
+                  public RestrictionTracker<?, ?> restrictionTracker() {
+                    return doFnInvoker.invokeNewTracker(this);
+                  }
+                });
+    double residualSize =
+        splitResult.getResidualSplitRoot() == null
+            ? 0
+            : doFnInvoker.invokeGetSize(
+                new DelegatingArgumentProvider<InputT, OutputT>(
+                    mutableArgumentProvider, errorContext) {
+                  @Override
+                  public Object restriction() {
+                    WindowedValue<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>>
+                        splitRoot =
+                            (WindowedValue<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>>)
+                                splitResult.getResidualSplitRoot();
+
+                    return splitRoot.getValue().getValue().getKey();
+                  }
+
+                  @Override
+                  public RestrictionTracker<?, ?> restrictionTracker() {
+                    return doFnInvoker.invokeNewTracker(this);
+                  }
+                });
+    return WindowedSplitResult.forRoots(
+        splitResult.getPrimaryInFullyProcessedWindowsRoot() == null
+            ? null
+            : WindowedValues.of(
+                KV.of(splitResult.getPrimaryInFullyProcessedWindowsRoot().getValue(), fullSize),
+                splitResult.getPrimaryInFullyProcessedWindowsRoot().getTimestamp(),
+                splitResult.getPrimaryInFullyProcessedWindowsRoot().getWindows(),
+                splitResult.getPrimaryInFullyProcessedWindowsRoot().getPaneInfo()),
+        splitResult.getPrimarySplitRoot() == null
+            ? null
+            : WindowedValues.of(
+                KV.of(splitResult.getPrimarySplitRoot().getValue(), primarySize),
+                splitResult.getPrimarySplitRoot().getTimestamp(),
+                splitResult.getPrimarySplitRoot().getWindows(),
+                splitResult.getPrimarySplitRoot().getPaneInfo()),
+        splitResult.getResidualSplitRoot() == null
+            ? null
+            : WindowedValues.of(
+                KV.of(splitResult.getResidualSplitRoot().getValue(), residualSize),
+                splitResult.getResidualSplitRoot().getTimestamp(),
+                splitResult.getResidualSplitRoot().getWindows(),
+                splitResult.getResidualSplitRoot().getPaneInfo()),
+        splitResult.getResidualInUnprocessedWindowsRoot() == null
+            ? null
+            : WindowedValues.of(
+                KV.of(splitResult.getResidualInUnprocessedWindowsRoot().getValue(), fullSize),
+                splitResult.getResidualInUnprocessedWindowsRoot().getTimestamp(),
+                splitResult.getResidualInUnprocessedWindowsRoot().getWindows(),
+                splitResult.getResidualInUnprocessedWindowsRoot().getPaneInfo()));
+  }
+
+  private HandlesSplits.@Nullable SplitResult trySplitForWindowObservingTruncateRestriction(
+      double fractionOfRemainder, HandlesSplits splitDelegate) {
+    WindowedSplitResult windowedSplitResult;
+    HandlesSplits.SplitResult downstreamSplitResult;
+    synchronized (splitLock) {
+      // There is nothing to split if we are between truncate processing calls.
+      if (currentWindow == null) {
+        return null;
+      }
+
+      SplitResultsWithStopIndex splitResult =
+          computeSplitForTruncate(
+              getCurrentElement(),
+              getCurrentRestriction(),
+              getCurrentWindow(),
+              getCurrentWindows(),
+              getCurrentWatermarkEstimatorState(),
+              fractionOfRemainder,
+              splitDelegate,
+              windowCurrentIndex,
+              windowStopIndex);
+      if (splitResult == null) {
+        return null;
+      }
+      windowStopIndex = splitResult.getNewWindowStopIndex();
+      windowedSplitResult =
+          calculateRestrictionSize(
+              splitResult.getWindowSplit(),
+              PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN + "/GetSize");
+      downstreamSplitResult = splitResult.getDownstreamSplit();
+    }
+    return constructSplitResult(
+        windowedSplitResult,
+        downstreamSplitResult,
+        fullInputCoder,
+        checkStateNotNull(
+            initialWatermark, "Attempt to construct split result without initial watermark"),
+        pTransformId,
+        mainInputId,
+        pTransform.getOutputsMap().keySet());
+  }
+
+  private static <WatermarkEstimatorStateT> WindowedSplitResult computeWindowSplitResult(
+      WindowedValue<?> currentElement,
+      Object currentRestriction,
+      List<BoundedWindow> windows,
+      WatermarkEstimatorStateT currentWatermarkEstimatorState,
+      int toIndex,
+      int fromIndex,
+      int stopWindowIndex) {
+    List<BoundedWindow> primaryFullyProcessedWindows = windows.subList(0, toIndex);
+    List<BoundedWindow> residualUnprocessedWindows = windows.subList(fromIndex, stopWindowIndex);
+    WindowedSplitResult windowedSplitResult;
+
+    windowedSplitResult =
+        WindowedSplitResult.forRoots(
+            primaryFullyProcessedWindows.isEmpty()
+                ? null
+                : WindowedValues.of(
+                    KV.of(
+                        currentElement.getValue(),
+                        KV.of(currentRestriction, currentWatermarkEstimatorState)),
+                    currentElement.getTimestamp(),
+                    primaryFullyProcessedWindows,
+                    currentElement.getPaneInfo()),
+            null,
+            null,
+            residualUnprocessedWindows.isEmpty()
+                ? null
+                : WindowedValues.of(
+                    KV.of(
+                        currentElement.getValue(),
+                        KV.of(currentRestriction, currentWatermarkEstimatorState)),
+                    currentElement.getTimestamp(),
+                    residualUnprocessedWindows,
+                    currentElement.getPaneInfo()));
+    return windowedSplitResult;
+  }
+
+  @VisibleForTesting
+  static <WatermarkEstimatorStateT> @Nullable SplitResultsWithStopIndex computeSplitForTruncate(
+      WindowedValue<?> element,
+      Object restriction,
+      BoundedWindow window,
+      List<BoundedWindow> windows,
+      WatermarkEstimatorStateT watermarkEstimatorState,
+      double fractionOfRemainder,
+      HandlesSplits splitDelegate,
+      int currentWindowIndex,
+      int stopWindowIndex) {
+    checkArgument(splitDelegate != null);
+
+    WindowedSplitResult windowedSplitResult;
+    HandlesSplits.@Nullable SplitResult downstreamSplitResult = null;
+    int newWindowStopIndex;
+    // If we are not on the last window, try to compute the split which is on the current window or
+    // on a future window.
+    if (currentWindowIndex != stopWindowIndex - 1) {
+      // Compute the fraction of the remainder relative to the scaled progress.
+      Progress elementProgress;
+      double elementCompleted = splitDelegate.getProgress();
+      elementProgress = Progress.from(elementCompleted, 1 - elementCompleted);
+      Progress scaledProgress =
+          ProgressUtils.scaleProgress(elementProgress, currentWindowIndex, stopWindowIndex);
+      double scaledFractionOfRemainder = scaledProgress.getWorkRemaining() * fractionOfRemainder;
+
+      // The fraction is out of the current window and hence we will split at the closest window
+      // boundary.
+      if (scaledFractionOfRemainder >= elementProgress.getWorkRemaining()) {
+        newWindowStopIndex =
+            (int)
+                Math.min(
+                    stopWindowIndex - 1,
+                    currentWindowIndex
+                        + Math.max(
+                            1,
+                            Math.round(
+                                (elementProgress.getWorkCompleted() + scaledFractionOfRemainder)
+                                    / (elementProgress.getWorkCompleted()
+                                        + elementProgress.getWorkRemaining()))));
+        windowedSplitResult =
+            computeWindowSplitResult(
+                element,
+                restriction,
+                windows,
+                watermarkEstimatorState,
+                newWindowStopIndex,
+                newWindowStopIndex,
+                stopWindowIndex);
+      } else {
+        // Compute the element split with the scaled fraction.
+        downstreamSplitResult = splitDelegate.trySplit(scaledFractionOfRemainder);
+        newWindowStopIndex = currentWindowIndex + 1;
+        int toIndex = (downstreamSplitResult == null) ? newWindowStopIndex : currentWindowIndex;
+        windowedSplitResult =
+            computeWindowSplitResult(
+                element,
+                restriction,
+                windows,
+                watermarkEstimatorState,
+                toIndex,
+                newWindowStopIndex,
+                stopWindowIndex);
+      }
+    } else {
+      // We are on the last window then compute the element split with given fraction.
+      newWindowStopIndex = stopWindowIndex;
+      downstreamSplitResult = splitDelegate.trySplit(fractionOfRemainder);
+      if (downstreamSplitResult == null) {
+        return null;
+      }
+      windowedSplitResult =
+          computeWindowSplitResult(
+              element,
+              restriction,
+              windows,
+              watermarkEstimatorState,
+              currentWindowIndex,
+              stopWindowIndex,
+              stopWindowIndex);
+    }
+    return SplitResultsWithStopIndex.of(
+        windowedSplitResult, downstreamSplitResult, newWindowStopIndex);
+  }
+
+  @VisibleForTesting
+  static <WatermarkEstimatorStateT> HandlesSplits.SplitResult constructSplitResult(
+      @Nullable WindowedSplitResult windowedSplitResult,
+      HandlesSplits.@Nullable SplitResult downstreamElementSplit,
+      Coder<WindowedValue<?>> fullInputCoder,
+      Instant initialWatermark,
+      String pTransformId,
+      String mainInputId,
+      Collection<String> outputIds) {
+    // The element split cannot from both windowedSplitResult and downstreamElementSplit.
+    checkArgument(
+        (windowedSplitResult == null || windowedSplitResult.getResidualSplitRoot() == null)
+            || downstreamElementSplit == null);
+    List<BundleApplication> primaryRoots = new ArrayList<>();
+    List<DelayedBundleApplication> residualRoots = new ArrayList<>();
+
+    // Encode window splits.
+    if (windowedSplitResult != null
+        && windowedSplitResult.getPrimaryInFullyProcessedWindowsRoot() != null) {
+      ByteStringOutputStream primaryInOtherWindowsBytes = new ByteStringOutputStream();
+      try {
+        fullInputCoder.encode(
+            windowedSplitResult.getPrimaryInFullyProcessedWindowsRoot(),
+            primaryInOtherWindowsBytes);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      BundleApplication.Builder primaryApplicationInOtherWindows =
+          BundleApplication.newBuilder()
+              .setTransformId(pTransformId)
+              .setInputId(mainInputId)
+              .setElement(primaryInOtherWindowsBytes.toByteString());
+      primaryRoots.add(primaryApplicationInOtherWindows.build());
+    }
+    if (windowedSplitResult != null
+        && windowedSplitResult.getResidualInUnprocessedWindowsRoot() != null) {
+      ByteStringOutputStream bytesOut = new ByteStringOutputStream();
+      try {
+        fullInputCoder.encode(windowedSplitResult.getResidualInUnprocessedWindowsRoot(), bytesOut);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      BundleApplication.Builder residualInUnprocessedWindowsRoot =
+          BundleApplication.newBuilder()
+              .setTransformId(pTransformId)
+              .setInputId(mainInputId)
+              .setElement(bytesOut.toByteString());
+      // We don't want to change the output watermarks or set the checkpoint resume time since
+      // that applies to the current window.
+      Map<String, org.apache.beam.vendor.grpc.v1p69p0.com.google.protobuf.Timestamp>
+          outputWatermarkMapForUnprocessedWindows = new HashMap<>();
+      if (!initialWatermark.equals(GlobalWindow.TIMESTAMP_MIN_VALUE)) {
+        org.apache.beam.vendor.grpc.v1p69p0.com.google.protobuf.Timestamp outputWatermark =
+            org.apache.beam.vendor.grpc.v1p69p0.com.google.protobuf.Timestamp.newBuilder()
+                .setSeconds(initialWatermark.getMillis() / 1000)
+                .setNanos((int) (initialWatermark.getMillis() % 1000) * 1000000)
+                .build();
+        for (String outputId : outputIds) {
+          outputWatermarkMapForUnprocessedWindows.put(outputId, outputWatermark);
+        }
+      }
+      residualInUnprocessedWindowsRoot.putAllOutputWatermarks(
+          outputWatermarkMapForUnprocessedWindows);
+      residualRoots.add(
+          DelayedBundleApplication.newBuilder()
+              .setApplication(residualInUnprocessedWindowsRoot)
+              .build());
+    }
+
+    // Encode element split from windowedSplitResult or from downstream element split. It's possible
+    // that there is no element split.
+    if (downstreamElementSplit != null) {
+      primaryRoots.add(Iterables.getOnlyElement(downstreamElementSplit.getPrimaryRoots()));
+      residualRoots.add(Iterables.getOnlyElement(downstreamElementSplit.getResidualRoots()));
+    }
+
+    return HandlesSplits.SplitResult.of(primaryRoots, residualRoots);
+  }
+
+  /** Outputs the given element to the specified set of consumers wrapping any exceptions. */
+  private <T> void outputTo(FnDataReceiver<WindowedValue<T>> consumer, WindowedValue<T> output) {
+    if (currentWatermarkEstimator instanceof TimestampObservingWatermarkEstimator) {
+      ((TimestampObservingWatermarkEstimator) currentWatermarkEstimator)
+          .observeTimestamp(output.getTimestamp());
+    }
+    try {
+      consumer.accept(output);
+    } catch (Throwable t) {
+      throw UserCodeException.wrap(t);
+    }
+  }
+
+  private void tearDown() {
+    doFnInvoker.invokeTeardown();
+  }
+
+  /** This context outputs KV<KV<Element, KV<Restriction, WatemarkEstimatorState>>, Size>. */
+  private class TruncateSizedRestrictionWindowObservingArgumentProvider
+      extends TruncateSizedRestrictionArgumentProvider {
+
+    @Override
+    public void output(RestrictionT output) {
+      double size = getSize(output);
+      outputTo(
+          mainOutputConsumer,
+          WindowedValues.of(
+              KV.of(
+                  KV.of(
+                      getCurrentElement().getValue(),
+                      KV.of(output, getCurrentWatermarkEstimatorState())),
+                  size),
+              getCurrentElement().getTimestamp(),
+              getCurrentWindow(),
+              getCurrentElement().getPaneInfo()));
+    }
+
+    @Override
+    public BoundedWindow window() {
+      return getCurrentWindow();
+    }
+
+    @Override
+    public Object sideInput(String tagId) {
+      PCollectionView<Object> pCollectionView =
+          (PCollectionView<Object>)
+              checkStateNotNull(sideInputMapping.get(tagId), "Side input tag not found: %s", tagId);
+
+      return stateAccessor.get(pCollectionView, getCurrentWindow());
+    }
+  }
+
+  /** This context outputs KV<KV<Element, KV<Restriction, WatermarkEstimatorState>>, Size>. */
+  private class TruncateSizedRestrictionNonWindowObservingArgumentProvider
+      extends TruncateSizedRestrictionArgumentProvider {
+
+    @Override
+    public void output(RestrictionT truncatedRestriction) {
+      double size = getSize(truncatedRestriction);
+      outputTo(
+          mainOutputConsumer,
+          getCurrentElement()
+              .withValue(
+                  KV.of(
+                      KV.of(
+                          getCurrentElement().getValue(),
+                          KV.of(truncatedRestriction, getCurrentWatermarkEstimatorState())),
+                      size)));
+    }
+  }
+
+  /** Base implementation that does not override methods which need to be window aware. */
+  private abstract class TruncateSizedRestrictionArgumentProvider
+      extends DoFnInvoker.BaseArgumentProvider<InputT, OutputT>
+      implements OutputReceiver<RestrictionT> {
+
+    protected double getSize(RestrictionT subrestriction) {
+      return doFnInvoker.invokeGetSize(
+          new DelegatingArgumentProvider<InputT, OutputT>(this, getErrorContext() + "/GetSize") {
+            @Override
+            public Object restriction() {
+              return subrestriction;
+            }
+
+            @Override
+            public Instant timestamp(DoFn<InputT, OutputT> doFn) {
+              return getCurrentElement().getTimestamp();
+            }
+
+            @Override
+            public RestrictionTracker<?, ?> restrictionTracker() {
+              return doFnInvoker.invokeNewTracker(this);
+            }
+          });
+    }
+
+    @Override
+    public String getErrorContext() {
+      return "TruncateRestriction";
+    }
+
+    @Override
+    public PaneInfo paneInfo(DoFn<InputT, OutputT> doFn) {
+      return getCurrentElement().getPaneInfo();
+    }
+
+    @Override
+    public InputT element(DoFn<InputT, OutputT> doFn) {
+      return getCurrentElement().getValue();
+    }
+
+    @Override
+    public Object schemaElement(int index) {
+      SerializableFunction<InputT, Object> converter =
+          (SerializableFunction<InputT, Object>)
+              doFnSchemaInformation.getElementConverters().get(index);
+      return converter.apply(getCurrentElement().getValue());
+    }
+
+    @Override
+    public Instant timestamp(DoFn<InputT, OutputT> doFn) {
+      return getCurrentElement().getTimestamp();
+    }
+
+    @Override
+    public OutputReceiver<OutputT> outputReceiver(DoFn<InputT, OutputT> doFn) {
+      // OutputT == RestrictionT
+      return (OutputReceiver<OutputT>) this;
+    }
+
+    @Override
+    public Object restriction() {
+      return getCurrentRestriction();
+    }
+
+    @Override
+    @SuppressWarnings("nullness")
+    public Object watermarkEstimatorState() {
+      return getCurrentWatermarkEstimatorState();
+    }
+
+    @Override
+    public RestrictionTracker<?, ?> restrictionTracker() {
+      return getCurrentTracker();
+    }
+
+    @Override
+    public PipelineOptions pipelineOptions() {
+      return pipelineOptions;
+    }
+
+    @Override
+    public void outputWithTimestamp(RestrictionT output, Instant timestamp) {
+      throw new UnsupportedOperationException(
+          "Cannot outputWithTimestamp from TruncateRestriction");
+    }
+  }
+
+  /**
+   * Passes split requests downstream, by way of trySplit on the overall runner, which will split
+   * per window if needed.
+   */
+  private static class SplitDelegatingFnDataReceiver<
+          InputT, RestrictionT extends @NonNull Object, WatermarkEstimatorStateT>
+      implements FnDataReceiver<
+              WindowedValue<KV<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>, Double>>>,
+          HandlesSplits {
+
+    private final HandlesSplits splitDelegate;
+    private final SplittableTruncateSizedRestrictionsDoFnRunner<
+            InputT, RestrictionT, ?, WatermarkEstimatorStateT, ?>
+        runner;
+
+    public SplitDelegatingFnDataReceiver(
+        SplittableTruncateSizedRestrictionsDoFnRunner<
+                InputT, RestrictionT, ?, WatermarkEstimatorStateT, ?>
+            runner,
+        HandlesSplits splitDelegate) {
+      this.runner = runner;
+      this.splitDelegate = splitDelegate;
+    }
+
+    @Override
+    public void accept(
+        WindowedValue<KV<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>, Double>> input) {
+      runner.processElement(input);
+    }
+
+    @Override
+    public @Nullable SplitResult trySplit(double fractionOfRemainder) {
+      return runner.trySplit(fractionOfRemainder, splitDelegate);
+    }
+
+    @Override
+    public double getProgress() {
+      double delegateProgress = splitDelegate.getProgress();
+      if (!runner.observesWindow) {
+        return delegateProgress;
+      } else {
+        Progress progress = runner.getProgressFromWindowObservingTruncate(delegateProgress);
+        if (progress != null) {
+          double totalWork = progress.getWorkCompleted() + progress.getWorkRemaining();
+          if (totalWork > 0) {
+            return progress.getWorkCompleted() / totalWork;
+          }
+        }
+        return 0;
+      }
+    }
+  }
+}

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/WindowedSplitResult.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/WindowedSplitResult.java
@@ -21,6 +21,7 @@ import com.google.auto.value.AutoValue;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.values.WindowedValue;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.dataflow.qual.Pure;
 
 /** Internal class to hold the primary and residual roots when converted to an input element. */
 @AutoValue
@@ -28,10 +29,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 @Internal
 abstract class WindowedSplitResult {
   public static WindowedSplitResult forRoots(
-      WindowedValue<?> primaryInFullyProcessedWindowsRoot,
-      WindowedValue<?> primarySplitRoot,
-      WindowedValue<?> residualSplitRoot,
-      WindowedValue<?> residualInUnprocessedWindowsRoot) {
+      @Nullable WindowedValue<?> primaryInFullyProcessedWindowsRoot,
+      @Nullable WindowedValue<?> primarySplitRoot,
+      @Nullable WindowedValue<?> residualSplitRoot,
+      @Nullable WindowedValue<?> residualInUnprocessedWindowsRoot) {
     return new AutoValue_WindowedSplitResult(
         primaryInFullyProcessedWindowsRoot,
         primarySplitRoot,
@@ -39,11 +40,15 @@ abstract class WindowedSplitResult {
         residualInUnprocessedWindowsRoot);
   }
 
+  @Pure
   public abstract @Nullable WindowedValue<?> getPrimaryInFullyProcessedWindowsRoot();
 
+  @Pure
   public abstract @Nullable WindowedValue<?> getPrimarySplitRoot();
 
+  @Pure
   public abstract @Nullable WindowedValue<?> getResidualSplitRoot();
 
+  @Pure
   public abstract @Nullable WindowedValue<?> getResidualInUnprocessedWindowsRoot();
 }

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/ProgressUtilsTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/ProgressUtilsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.fn.harness;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.Serializable;
+import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.Progress;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link ProgressUtils}. */
+@RunWith(JUnit4.class)
+public class ProgressUtilsTest implements Serializable {
+  @Test
+  public void testScaledProgress() throws Exception {
+    Progress elementProgress = Progress.from(2, 8);
+    // There is only one window.
+    Progress scaledResult = ProgressUtils.scaleProgress(elementProgress, 0, 1);
+    assertEquals(2, scaledResult.getWorkCompleted(), 0.0);
+    assertEquals(8, scaledResult.getWorkRemaining(), 0.0);
+
+    // We are at the first window of 3 in total.
+    scaledResult = ProgressUtils.scaleProgress(elementProgress, 0, 3);
+    assertEquals(2, scaledResult.getWorkCompleted(), 0.0);
+    assertEquals(28, scaledResult.getWorkRemaining(), 0.0);
+
+    // We are at the second window of 3 in total.
+    scaledResult = ProgressUtils.scaleProgress(elementProgress, 1, 3);
+    assertEquals(12, scaledResult.getWorkCompleted(), 0.0);
+    assertEquals(18, scaledResult.getWorkRemaining(), 0.0);
+
+    // We are at the last window of 3 in total.
+    scaledResult = ProgressUtils.scaleProgress(elementProgress, 2, 3);
+    assertEquals(22, scaledResult.getWorkCompleted(), 0.0);
+    assertEquals(8, scaledResult.getWorkRemaining(), 0.0);
+  }
+}

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/SplittableTruncateSizedRestrictionsDoFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/SplittableTruncateSizedRestrictionsDoFnRunnerTest.java
@@ -1,0 +1,1191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.fn.harness;
+
+import static org.apache.beam.sdk.values.WindowedValues.valueInGlobalWindow;
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.apache.beam.fn.harness.HandlesSplits.SplitResult;
+import org.apache.beam.fn.harness.state.FakeBeamFnStateClient;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.BundleApplication;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.DelayedBundleApplication;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.runners.core.metrics.MetricUpdates.MetricUpdate;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.DoubleCoder;
+import org.apache.beam.sdk.coders.InstantCoder;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.fn.data.FnDataReceiver;
+import org.apache.beam.sdk.io.range.OffsetRange;
+import org.apache.beam.sdk.metrics.MetricKey;
+import org.apache.beam.sdk.metrics.MetricName;
+import org.apache.beam.sdk.testing.ResetDateTimeProvider;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.View;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.windowing.PaneInfo;
+import org.apache.beam.sdk.transforms.windowing.SlidingWindows;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.util.ByteStringOutputStream;
+import org.apache.beam.sdk.util.construction.CoderTranslation;
+import org.apache.beam.sdk.util.construction.CoderTranslation.TranslationContext;
+import org.apache.beam.sdk.util.construction.PTransformTranslation;
+import org.apache.beam.sdk.util.construction.ParDoTranslation;
+import org.apache.beam.sdk.util.construction.PipelineTranslation;
+import org.apache.beam.sdk.util.construction.RehydratedComponents;
+import org.apache.beam.sdk.util.construction.SdkComponents;
+import org.apache.beam.sdk.util.construction.graph.ProtoOverrides;
+import org.apache.beam.sdk.util.construction.graph.SplittableParDoExpander;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.WindowedValue;
+import org.apache.beam.sdk.values.WindowedValues;
+import org.apache.beam.vendor.grpc.v1p69p0.com.google.protobuf.util.Durations;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
+import org.hamcrest.collection.IsMapContaining;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link SplittableTruncateSizedRestrictionsDoFnRunner}. */
+@RunWith(Enclosed.class)
+@SuppressWarnings({
+  "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
+  // TODO(https://github.com/apache/beam/issues/21230): Remove when new version of
+  // errorprone is released (2.11.0)
+  "unused"
+})
+public class SplittableTruncateSizedRestrictionsDoFnRunnerTest implements Serializable {
+
+  @RunWith(JUnit4.class)
+  public static class ExecutionTest implements Serializable {
+    @Rule public transient ResetDateTimeProvider dateTimeProvider = new ResetDateTimeProvider();
+
+    public static final String TEST_TRANSFORM_ID = "pTransformId";
+
+    /** @return a test MetricUpdate for expected metrics to compare against */
+    public MetricUpdate create(String stepName, MetricName name, long value) {
+      return MetricUpdate.create(MetricKey.create(stepName, name), value);
+    }
+
+    private <T> WindowedValue<T> valueInWindows(
+        T value, BoundedWindow window, BoundedWindow... windows) {
+      return WindowedValues.of(
+          value,
+          window.maxTimestamp(),
+          ImmutableList.<BoundedWindow>builder().add(window).add(windows).build(),
+          PaneInfo.NO_FIRING);
+    }
+
+    @Test
+    public void testRegistration() {
+      for (PTransformRunnerFactory.Registrar registrar :
+          ServiceLoader.load(PTransformRunnerFactory.Registrar.class)) {
+        if (registrar instanceof SplittableTruncateSizedRestrictionsDoFnRunner.Registrar) {
+          assertThat(
+              registrar.getPTransformRunnerFactories(),
+              IsMapContaining.hasKey(
+                  PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN));
+          return;
+        }
+      }
+      fail("Expected registrar not found.");
+    }
+
+    private static SplitResult createSplitResult(double fractionOfRemainder) {
+      ByteStringOutputStream primaryBytes = new ByteStringOutputStream();
+      ByteStringOutputStream residualBytes = new ByteStringOutputStream();
+      try {
+        DoubleCoder.of().encode(fractionOfRemainder, primaryBytes);
+        DoubleCoder.of().encode(1 - fractionOfRemainder, residualBytes);
+      } catch (Exception e) {
+        // No-op.
+      }
+      return SplitResult.of(
+          ImmutableList.of(
+              BundleApplication.newBuilder()
+                  .setElement(primaryBytes.toByteString())
+                  .setInputId("mainInputId-process")
+                  .setTransformId("processPTransfromId")
+                  .build()),
+          ImmutableList.of(
+              DelayedBundleApplication.newBuilder()
+                  .setApplication(
+                      BundleApplication.newBuilder()
+                          .setElement(residualBytes.toByteString())
+                          .setInputId("mainInputId-process")
+                          .setTransformId("processPTransfromId")
+                          .build())
+                  .build()));
+    }
+
+    private static class SplittableFnDataReceiver
+        implements HandlesSplits, FnDataReceiver<WindowedValue> {
+      SplittableFnDataReceiver(
+          List<WindowedValue<KV<KV<String, OffsetRange>, Double>>> mainOutputValues) {
+        this.mainOutputValues = mainOutputValues;
+      }
+
+      private final List<WindowedValue<KV<KV<String, OffsetRange>, Double>>> mainOutputValues;
+
+      @Override
+      public SplitResult trySplit(double fractionOfRemainder) {
+        return createSplitResult(fractionOfRemainder);
+      }
+
+      @Override
+      public double getProgress() {
+        return 0.7;
+      }
+
+      @Override
+      public void accept(WindowedValue input) throws Exception {
+        mainOutputValues.add(input);
+      }
+    }
+
+    @Test
+    public void testProcessElementForTruncateAndSizeRestrictionForwardSplitWhenObservingWindows()
+        throws Exception {
+      Pipeline p = Pipeline.create();
+      PCollection<String> valuePCollection = p.apply(Create.of("unused"));
+      PCollectionView<String> singletonSideInputView = valuePCollection.apply(View.asSingleton());
+      WindowObservingTestSplittableDoFn doFn =
+          WindowObservingTestSplittableDoFn.forSplitAtTruncate(singletonSideInputView);
+      valuePCollection
+          .apply(Window.into(SlidingWindows.of(Duration.standardSeconds(1))))
+          .apply(TEST_TRANSFORM_ID, ParDo.of(doFn).withSideInputs(singletonSideInputView));
+
+      RunnerApi.Pipeline pProto =
+          ProtoOverrides.updateTransform(
+              PTransformTranslation.PAR_DO_TRANSFORM_URN,
+              PipelineTranslation.toProto(p, SdkComponents.create(p.getOptions()), true),
+              SplittableParDoExpander.createTruncateReplacement());
+      String expandedTransformId =
+          Iterables.find(
+                  pProto.getComponents().getTransformsMap().entrySet(),
+                  entry ->
+                      entry
+                              .getValue()
+                              .getSpec()
+                              .getUrn()
+                              .equals(
+                                  PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN)
+                          && entry.getValue().getUniqueName().contains(TEST_TRANSFORM_ID))
+              .getKey();
+      RunnerApi.PTransform pTransform =
+          pProto.getComponents().getTransformsOrThrow(expandedTransformId);
+      String inputPCollectionId =
+          pTransform.getInputsOrThrow(ParDoTranslation.getMainInputName(pTransform));
+      RunnerApi.PCollection inputPCollection =
+          pProto.getComponents().getPcollectionsOrThrow(inputPCollectionId);
+      RehydratedComponents rehydratedComponents =
+          RehydratedComponents.forComponents(pProto.getComponents());
+      Coder<WindowedValue> inputCoder =
+          WindowedValues.getFullCoder(
+              CoderTranslation.fromProto(
+                  pProto.getComponents().getCodersOrThrow(inputPCollection.getCoderId()),
+                  rehydratedComponents,
+                  TranslationContext.DEFAULT),
+              (Coder)
+                  CoderTranslation.fromProto(
+                      pProto
+                          .getComponents()
+                          .getCodersOrThrow(
+                              pProto
+                                  .getComponents()
+                                  .getWindowingStrategiesOrThrow(
+                                      inputPCollection.getWindowingStrategyId())
+                                  .getWindowCoderId()),
+                      rehydratedComponents,
+                      TranslationContext.DEFAULT));
+
+      String outputPCollectionId = Iterables.getOnlyElement(pTransform.getOutputsMap().values());
+
+      FakeBeamFnStateClient fakeClient =
+          new FakeBeamFnStateClient(StringUtf8Coder.of(), ImmutableMap.of());
+
+      PTransformRunnerFactoryTestContext context =
+          PTransformRunnerFactoryTestContext.builder(TEST_TRANSFORM_ID, pTransform)
+              .beamFnStateClient(fakeClient)
+              .processBundleInstructionId("57")
+              // .pCollections(pProto.getComponentsOrBuilder().getPcollectionsMap())
+              .components(
+                  RunnerApi.Components.newBuilder()
+                      .putAllCoders(pProto.getComponents().getCodersMap())
+                      .putAllWindowingStrategies(pProto.getComponents().getWindowingStrategiesMap())
+                      .putAllEnvironments(Collections.emptyMap())
+                      .putAllPcollections(pProto.getComponentsOrBuilder().getPcollectionsMap())
+                      .build())
+              // .coders(pProto.getComponents().getCodersMap())
+              // .windowingStrategies(pProto.getComponents().getWindowingStrategiesMap())
+              .build();
+      List<WindowedValue<KV<KV<String, OffsetRange>, Double>>> mainOutputValues = new ArrayList<>();
+      context.addPCollectionConsumer(
+          outputPCollectionId, (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues));
+
+      new SplittableTruncateSizedRestrictionsDoFnRunner.Factory().addRunnerForPTransform(context);
+      FnDataReceiver<WindowedValue<?>> mainInput =
+          context.getPCollectionConsumer(inputPCollectionId);
+      assertThat(mainInput, instanceOf(HandlesSplits.class));
+
+      mainOutputValues.clear();
+      BoundedWindow window1 = new IntervalWindow(new Instant(5), new Instant(10));
+      BoundedWindow window2 = new IntervalWindow(new Instant(6), new Instant(11));
+      BoundedWindow window3 = new IntervalWindow(new Instant(7), new Instant(12));
+      // Setup and launch the trySplit thread.
+      ExecutorService executorService = Executors.newSingleThreadExecutor();
+      Future<SplitResult> trySplitFuture =
+          executorService.submit(
+              () -> {
+                try {
+                  doFn.waitForSplitElementToBeProcessed();
+                  SplitResult result = ((HandlesSplits) mainInput).trySplit(0);
+                  Assert.assertNotNull(result);
+                  return result;
+                } finally {
+                  doFn.trySplitPerformed();
+                }
+              });
+
+      WindowedValue<?> splitValue =
+          valueInWindows(
+              KV.of(
+                  KV.of("7", KV.of(new OffsetRange(0, 6), GlobalWindow.TIMESTAMP_MIN_VALUE)), 6.0),
+              window1,
+              window2,
+              window3);
+      mainInput.accept(splitValue);
+      SplitResult trySplitResult = trySplitFuture.get();
+
+      // We expect that there are outputs from window1 and window2
+      assertThat(
+          mainOutputValues,
+          contains(
+              WindowedValues.of(
+                  KV.of(
+                      KV.of("7", KV.of(new OffsetRange(0, 3), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                      3.0),
+                  splitValue.getTimestamp(),
+                  window1,
+                  splitValue.getPaneInfo()),
+              WindowedValues.of(
+                  KV.of(
+                      KV.of("7", KV.of(new OffsetRange(0, 3), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                      3.0),
+                  splitValue.getTimestamp(),
+                  window2,
+                  splitValue.getPaneInfo())));
+
+      SplitResult expectedElementSplit = createSplitResult(0);
+      BundleApplication expectedElementSplitPrimary =
+          Iterables.getOnlyElement(expectedElementSplit.getPrimaryRoots());
+      ByteStringOutputStream primaryBytes = new ByteStringOutputStream();
+      inputCoder.encode(
+          WindowedValues.of(
+              KV.of(
+                  KV.of("7", KV.of(new OffsetRange(0, 6), GlobalWindow.TIMESTAMP_MIN_VALUE)), 6.0),
+              splitValue.getTimestamp(),
+              window1,
+              splitValue.getPaneInfo()),
+          primaryBytes);
+      BundleApplication expectedWindowedPrimary =
+          BundleApplication.newBuilder()
+              .setElement(primaryBytes.toByteString())
+              .setInputId(ParDoTranslation.getMainInputName(pTransform))
+              .setTransformId(TEST_TRANSFORM_ID)
+              .build();
+      DelayedBundleApplication expectedElementSplitResidual =
+          Iterables.getOnlyElement(expectedElementSplit.getResidualRoots());
+      ByteStringOutputStream residualBytes = new ByteStringOutputStream();
+      inputCoder.encode(
+          WindowedValues.of(
+              KV.of(
+                  KV.of("7", KV.of(new OffsetRange(0, 6), GlobalWindow.TIMESTAMP_MIN_VALUE)), 6.0),
+              splitValue.getTimestamp(),
+              window3,
+              splitValue.getPaneInfo()),
+          residualBytes);
+      DelayedBundleApplication expectedWindowedResidual =
+          DelayedBundleApplication.newBuilder()
+              .setApplication(
+                  BundleApplication.newBuilder()
+                      .setElement(residualBytes.toByteString())
+                      .setInputId(ParDoTranslation.getMainInputName(pTransform))
+                      .setTransformId(TEST_TRANSFORM_ID)
+                      .build())
+              .build();
+      assertThat(
+          trySplitResult.getPrimaryRoots(),
+          containsInAnyOrder(expectedWindowedPrimary, expectedElementSplitPrimary));
+      assertThat(
+          trySplitResult.getResidualRoots(),
+          containsInAnyOrder(expectedWindowedResidual, expectedElementSplitResidual));
+    }
+
+    @Test
+    public void testProcessElementForTruncateAndSizeRestrictionForwardSplitWithoutObservingWindow()
+        throws Exception {
+      Pipeline p = Pipeline.create();
+      PCollection<String> valuePCollection = p.apply(Create.of("unused"));
+      valuePCollection.apply(
+          TEST_TRANSFORM_ID, ParDo.of(new NonWindowObservingTestSplittableDoFn()));
+
+      RunnerApi.Pipeline pProto =
+          ProtoOverrides.updateTransform(
+              PTransformTranslation.PAR_DO_TRANSFORM_URN,
+              PipelineTranslation.toProto(p, SdkComponents.create(p.getOptions()), true),
+              SplittableParDoExpander.createTruncateReplacement());
+      String expandedTransformId =
+          Iterables.find(
+                  pProto.getComponents().getTransformsMap().entrySet(),
+                  entry ->
+                      entry
+                              .getValue()
+                              .getSpec()
+                              .getUrn()
+                              .equals(
+                                  PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN)
+                          && entry.getValue().getUniqueName().contains(TEST_TRANSFORM_ID))
+              .getKey();
+      RunnerApi.PTransform pTransform =
+          pProto.getComponents().getTransformsOrThrow(expandedTransformId);
+      String inputPCollectionId =
+          pTransform.getInputsOrThrow(ParDoTranslation.getMainInputName(pTransform));
+      String outputPCollectionId = Iterables.getOnlyElement(pTransform.getOutputsMap().values());
+
+      FakeBeamFnStateClient fakeClient =
+          new FakeBeamFnStateClient(StringUtf8Coder.of(), ImmutableMap.of());
+
+      PTransformRunnerFactoryTestContext context =
+          PTransformRunnerFactoryTestContext.builder(TEST_TRANSFORM_ID, pTransform)
+              .beamFnStateClient(fakeClient)
+              .processBundleInstructionId("57")
+              .components(
+                  RunnerApi.Components.newBuilder()
+                      .putAllCoders(pProto.getComponents().getCodersMap())
+                      .putAllEnvironments(Collections.emptyMap())
+                      .putAllWindowingStrategies(pProto.getComponents().getWindowingStrategiesMap())
+                      .putAllPcollections(pProto.getComponentsOrBuilder().getPcollectionsMap())
+                      .build())
+              .build();
+      List<WindowedValue<KV<KV<String, OffsetRange>, Double>>> mainOutputValues = new ArrayList<>();
+      context.addPCollectionConsumer(
+          outputPCollectionId, (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues));
+
+      new SplittableTruncateSizedRestrictionsDoFnRunner.Factory().addRunnerForPTransform(context);
+      FnDataReceiver<WindowedValue<?>> mainInput =
+          context.getPCollectionConsumer(inputPCollectionId);
+      assertThat(mainInput, instanceOf(HandlesSplits.class));
+
+      assertEquals(0.7, ((HandlesSplits) mainInput).getProgress(), 0.0);
+      assertEquals(createSplitResult(0.4), ((HandlesSplits) mainInput).trySplit(0.4));
+    }
+
+    @Test
+    public void testProcessElementForTruncateAndSizeRestriction() throws Exception {
+      Pipeline p = Pipeline.create();
+      PCollection<String> valuePCollection = p.apply(Create.of("unused"));
+      valuePCollection.apply(
+          TEST_TRANSFORM_ID, ParDo.of(new NonWindowObservingTestSplittableDoFn()));
+
+      RunnerApi.Pipeline pProto =
+          ProtoOverrides.updateTransform(
+              PTransformTranslation.PAR_DO_TRANSFORM_URN,
+              PipelineTranslation.toProto(p, SdkComponents.create(p.getOptions()), true),
+              SplittableParDoExpander.createTruncateReplacement());
+      String expandedTransformId =
+          Iterables.find(
+                  pProto.getComponents().getTransformsMap().entrySet(),
+                  entry ->
+                      entry
+                              .getValue()
+                              .getSpec()
+                              .getUrn()
+                              .equals(
+                                  PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN)
+                          && entry.getValue().getUniqueName().contains(TEST_TRANSFORM_ID))
+              .getKey();
+      RunnerApi.PTransform pTransform =
+          pProto.getComponents().getTransformsOrThrow(expandedTransformId);
+      String inputPCollectionId =
+          pTransform.getInputsOrThrow(ParDoTranslation.getMainInputName(pTransform));
+      String outputPCollectionId = Iterables.getOnlyElement(pTransform.getOutputsMap().values());
+
+      FakeBeamFnStateClient fakeClient =
+          new FakeBeamFnStateClient(StringUtf8Coder.of(), ImmutableMap.of());
+
+      PTransformRunnerFactoryTestContext context =
+          PTransformRunnerFactoryTestContext.builder(TEST_TRANSFORM_ID, pTransform)
+              .beamFnStateClient(fakeClient)
+              .processBundleInstructionId("57")
+              .components(
+                  RunnerApi.Components.newBuilder()
+                      .putAllCoders(pProto.getComponents().getCodersMap())
+                      .putAllEnvironments(Collections.emptyMap())
+                      .putAllWindowingStrategies(pProto.getComponents().getWindowingStrategiesMap())
+                      .putAllPcollections(pProto.getComponentsOrBuilder().getPcollectionsMap())
+                      .build())
+              .build();
+      List<WindowedValue<KV<KV<String, OffsetRange>, Double>>> mainOutputValues = new ArrayList<>();
+      context.addPCollectionConsumer(
+          outputPCollectionId, (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues));
+
+      new SplittableTruncateSizedRestrictionsDoFnRunner.Factory().addRunnerForPTransform(context);
+
+      assertTrue(context.getStartBundleFunctions().isEmpty());
+      mainOutputValues.clear();
+
+      assertThat(
+          context.getPCollectionConsumers().keySet(),
+          containsInAnyOrder(inputPCollectionId, outputPCollectionId));
+
+      FnDataReceiver<WindowedValue<?>> mainInput =
+          context.getPCollectionConsumer(inputPCollectionId);
+      assertThat(mainInput, instanceOf(HandlesSplits.class));
+
+      mainInput.accept(
+          valueInGlobalWindow(
+              KV.of(
+                  KV.of("5", KV.of(new OffsetRange(0, 5), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                  5.0)));
+      mainInput.accept(
+          valueInGlobalWindow(
+              KV.of(
+                  KV.of("2", KV.of(new OffsetRange(0, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                  2.0)));
+      assertThat(
+          mainOutputValues,
+          contains(
+              valueInGlobalWindow(
+                  KV.of(
+                      KV.of("5", KV.of(new OffsetRange(0, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                      2.0)),
+              valueInGlobalWindow(
+                  KV.of(
+                      KV.of("2", KV.of(new OffsetRange(0, 1), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                      1.0))));
+      mainOutputValues.clear();
+
+      assertTrue(context.getFinishBundleFunctions().isEmpty());
+      assertThat(mainOutputValues, empty());
+
+      Iterables.getOnlyElement(context.getTearDownFunctions()).run();
+      assertThat(mainOutputValues, empty());
+    }
+
+    @Test
+    public void testProcessElementForWindowedTruncateAndSizeRestriction() throws Exception {
+      Pipeline p = Pipeline.create();
+      PCollection<String> valuePCollection = p.apply(Create.of("unused"));
+      PCollectionView<String> singletonSideInputView = valuePCollection.apply(View.asSingleton());
+      valuePCollection
+          .apply(Window.into(SlidingWindows.of(Duration.standardSeconds(1))))
+          .apply(
+              TEST_TRANSFORM_ID,
+              ParDo.of(new WindowObservingTestSplittableDoFn(singletonSideInputView))
+                  .withSideInputs(singletonSideInputView));
+
+      RunnerApi.Pipeline pProto =
+          ProtoOverrides.updateTransform(
+              PTransformTranslation.PAR_DO_TRANSFORM_URN,
+              PipelineTranslation.toProto(p, SdkComponents.create(p.getOptions()), true),
+              SplittableParDoExpander.createTruncateReplacement());
+      String expandedTransformId =
+          Iterables.find(
+                  pProto.getComponents().getTransformsMap().entrySet(),
+                  entry ->
+                      entry
+                              .getValue()
+                              .getSpec()
+                              .getUrn()
+                              .equals(
+                                  PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN)
+                          && entry.getValue().getUniqueName().contains(TEST_TRANSFORM_ID))
+              .getKey();
+      RunnerApi.PTransform pTransform =
+          pProto.getComponents().getTransformsOrThrow(expandedTransformId);
+      String inputPCollectionId =
+          pTransform.getInputsOrThrow(ParDoTranslation.getMainInputName(pTransform));
+      String outputPCollectionId = Iterables.getOnlyElement(pTransform.getOutputsMap().values());
+
+      FakeBeamFnStateClient fakeClient =
+          new FakeBeamFnStateClient(StringUtf8Coder.of(), ImmutableMap.of());
+
+      PTransformRunnerFactoryTestContext context =
+          PTransformRunnerFactoryTestContext.builder(TEST_TRANSFORM_ID, pTransform)
+              .beamFnStateClient(fakeClient)
+              .processBundleInstructionId("57")
+              .components(
+                  RunnerApi.Components.newBuilder()
+                      .putAllCoders(pProto.getComponents().getCodersMap())
+                      .putAllEnvironments(Collections.emptyMap())
+                      .putAllWindowingStrategies(pProto.getComponents().getWindowingStrategiesMap())
+                      .putAllPcollections(pProto.getComponentsOrBuilder().getPcollectionsMap())
+                      .build())
+              .build();
+      List<WindowedValue<KV<KV<String, OffsetRange>, Double>>> mainOutputValues = new ArrayList<>();
+      context.addPCollectionConsumer(
+          outputPCollectionId, (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues));
+
+      new SplittableTruncateSizedRestrictionsDoFnRunner.Factory().addRunnerForPTransform(context);
+
+      assertTrue(context.getStartBundleFunctions().isEmpty());
+      mainOutputValues.clear();
+
+      assertThat(
+          context.getPCollectionConsumers().keySet(),
+          containsInAnyOrder(inputPCollectionId, outputPCollectionId));
+
+      FnDataReceiver<WindowedValue<?>> mainInput =
+          context.getPCollectionConsumer(inputPCollectionId);
+      assertThat(mainInput, instanceOf(HandlesSplits.class));
+
+      IntervalWindow window1 = new IntervalWindow(new Instant(5), new Instant(10));
+      IntervalWindow window2 = new IntervalWindow(new Instant(6), new Instant(11));
+      WindowedValue<?> firstValue =
+          valueInWindows(
+              KV.of(
+                  KV.of("5", KV.of(new OffsetRange(0, 5), GlobalWindow.TIMESTAMP_MIN_VALUE)), 5.0),
+              window1,
+              window2);
+      WindowedValue<?> secondValue =
+          valueInWindows(
+              KV.of(
+                  KV.of("2", KV.of(new OffsetRange(0, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)), 2.0),
+              window1,
+              window2);
+      mainInput.accept(firstValue);
+      mainInput.accept(secondValue);
+      assertThat(
+          mainOutputValues,
+          contains(
+              WindowedValues.of(
+                  KV.of(
+                      KV.of("5", KV.of(new OffsetRange(0, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                      2.0),
+                  firstValue.getTimestamp(),
+                  window1,
+                  firstValue.getPaneInfo()),
+              WindowedValues.of(
+                  KV.of(
+                      KV.of("5", KV.of(new OffsetRange(0, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                      2.0),
+                  firstValue.getTimestamp(),
+                  window2,
+                  firstValue.getPaneInfo()),
+              WindowedValues.of(
+                  KV.of(
+                      KV.of("2", KV.of(new OffsetRange(0, 1), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                      1.0),
+                  firstValue.getTimestamp(),
+                  window1,
+                  firstValue.getPaneInfo()),
+              WindowedValues.of(
+                  KV.of(
+                      KV.of("2", KV.of(new OffsetRange(0, 1), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                      1.0),
+                  firstValue.getTimestamp(),
+                  window2,
+                  firstValue.getPaneInfo())));
+      mainOutputValues.clear();
+
+      assertTrue(context.getFinishBundleFunctions().isEmpty());
+      assertThat(mainOutputValues, empty());
+
+      Iterables.getOnlyElement(context.getTearDownFunctions()).run();
+      assertThat(mainOutputValues, empty());
+    }
+
+    @Test
+    public void
+        testProcessElementForWindowedTruncateAndSizeRestrictionWithNonWindowObservingOptimization()
+            throws Exception {
+      Pipeline p = Pipeline.create();
+      PCollection<String> valuePCollection = p.apply(Create.of("unused"));
+      valuePCollection
+          .apply(Window.into(SlidingWindows.of(Duration.standardSeconds(1))))
+          .apply(TEST_TRANSFORM_ID, ParDo.of(new NonWindowObservingTestSplittableDoFn()));
+
+      RunnerApi.Pipeline pProto =
+          ProtoOverrides.updateTransform(
+              PTransformTranslation.PAR_DO_TRANSFORM_URN,
+              PipelineTranslation.toProto(p, SdkComponents.create(p.getOptions()), true),
+              SplittableParDoExpander.createTruncateReplacement());
+      String expandedTransformId =
+          Iterables.find(
+                  pProto.getComponents().getTransformsMap().entrySet(),
+                  entry ->
+                      entry
+                              .getValue()
+                              .getSpec()
+                              .getUrn()
+                              .equals(
+                                  PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN)
+                          && entry.getValue().getUniqueName().contains(TEST_TRANSFORM_ID))
+              .getKey();
+      RunnerApi.PTransform pTransform =
+          pProto.getComponents().getTransformsOrThrow(expandedTransformId);
+      String inputPCollectionId =
+          pTransform.getInputsOrThrow(ParDoTranslation.getMainInputName(pTransform));
+      String outputPCollectionId = Iterables.getOnlyElement(pTransform.getOutputsMap().values());
+
+      PTransformRunnerFactoryTestContext context =
+          PTransformRunnerFactoryTestContext.builder(TEST_TRANSFORM_ID, pTransform)
+              .processBundleInstructionId("57")
+              .components(
+                  RunnerApi.Components.newBuilder()
+                      .putAllCoders(pProto.getComponents().getCodersMap())
+                      .putAllEnvironments(Collections.emptyMap())
+                      .putAllWindowingStrategies(pProto.getComponents().getWindowingStrategiesMap())
+                      .putAllPcollections(pProto.getComponentsOrBuilder().getPcollectionsMap())
+                      .build())
+              .build();
+      List<WindowedValue<KV<KV<String, OffsetRange>, Double>>> mainOutputValues = new ArrayList<>();
+      context.addPCollectionConsumer(
+          outputPCollectionId, (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues));
+
+      new SplittableTruncateSizedRestrictionsDoFnRunner.Factory().addRunnerForPTransform(context);
+
+      assertTrue(context.getStartBundleFunctions().isEmpty());
+      mainOutputValues.clear();
+
+      assertThat(
+          context.getPCollectionConsumers().keySet(),
+          containsInAnyOrder(inputPCollectionId, outputPCollectionId));
+
+      FnDataReceiver<WindowedValue<?>> mainInput =
+          context.getPCollectionConsumer(inputPCollectionId);
+      assertThat(mainInput, instanceOf(HandlesSplits.class));
+
+      IntervalWindow window1 = new IntervalWindow(new Instant(5), new Instant(10));
+      IntervalWindow window2 = new IntervalWindow(new Instant(6), new Instant(11));
+      WindowedValue<?> firstValue =
+          valueInWindows(
+              KV.of(
+                  KV.of("5", KV.of(new OffsetRange(0, 5), GlobalWindow.TIMESTAMP_MIN_VALUE)), 5.0),
+              window1,
+              window2);
+      WindowedValue<?> secondValue =
+          valueInWindows(
+              KV.of(
+                  KV.of("2", KV.of(new OffsetRange(0, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)), 2.0),
+              window1,
+              window2);
+      mainInput.accept(firstValue);
+      mainInput.accept(secondValue);
+      // Ensure that each output element is in all the windows and not one per window.
+      assertThat(
+          mainOutputValues,
+          contains(
+              WindowedValues.of(
+                  KV.of(
+                      KV.of("5", KV.of(new OffsetRange(0, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                      2.0),
+                  firstValue.getTimestamp(),
+                  ImmutableList.of(window1, window2),
+                  firstValue.getPaneInfo()),
+              WindowedValues.of(
+                  KV.of(
+                      KV.of("2", KV.of(new OffsetRange(0, 1), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                      1.0),
+                  firstValue.getTimestamp(),
+                  ImmutableList.of(window1, window2),
+                  firstValue.getPaneInfo())));
+      mainOutputValues.clear();
+
+      assertTrue(context.getFinishBundleFunctions().isEmpty());
+      assertThat(mainOutputValues, empty());
+
+      Iterables.getOnlyElement(context.getTearDownFunctions()).run();
+      assertThat(mainOutputValues, empty());
+    }
+  }
+
+  @RunWith(JUnit4.class)
+  public static class SplitTest {
+    @Rule public final ExpectedException expected = ExpectedException.none();
+    private IntervalWindow window1;
+    private IntervalWindow window2;
+    private IntervalWindow window3;
+    private WindowedValue<String> currentElement;
+    private OffsetRange currentRestriction;
+    private Instant currentWatermarkEstimatorState;
+    KV<Instant, Instant> watermarkAndState;
+
+    private KV<WindowedValue, WindowedValue> createSplitAcrossWindows(
+        List<BoundedWindow> primaryWindows, List<BoundedWindow> residualWindows) {
+      return KV.of(
+          primaryWindows.isEmpty()
+              ? null
+              : WindowedValues.of(
+                  KV.of(
+                      currentElement.getValue(),
+                      KV.of(currentRestriction, currentWatermarkEstimatorState)),
+                  currentElement.getTimestamp(),
+                  primaryWindows,
+                  currentElement.getPaneInfo()),
+          residualWindows.isEmpty()
+              ? null
+              : WindowedValues.of(
+                  KV.of(
+                      currentElement.getValue(),
+                      KV.of(currentRestriction, currentWatermarkEstimatorState)),
+                  currentElement.getTimestamp(),
+                  residualWindows,
+                  currentElement.getPaneInfo()));
+    }
+
+    @Before
+    public void setUp() {
+      window1 = new IntervalWindow(Instant.ofEpochMilli(0), Instant.ofEpochMilli(10));
+      window2 = new IntervalWindow(Instant.ofEpochMilli(10), Instant.ofEpochMilli(20));
+      window3 = new IntervalWindow(Instant.ofEpochMilli(20), Instant.ofEpochMilli(30));
+      currentElement =
+          WindowedValues.of(
+              "a",
+              Instant.ofEpochMilli(57),
+              ImmutableList.of(window1, window2, window3),
+              PaneInfo.NO_FIRING);
+      currentRestriction = new OffsetRange(0L, 100L);
+      currentWatermarkEstimatorState = Instant.ofEpochMilli(21);
+      watermarkAndState = KV.of(Instant.ofEpochMilli(42), Instant.ofEpochMilli(42));
+    }
+
+    private static final String PROCESS_TRANSFORM_ID = "processPTransformId";
+    private static final String TRUNCATE_TRANSFORM_ID = "truncatePTransformId";
+    private static final String PROCESS_INPUT_ID = "processInputId";
+    private static final String TRUNCATE_INPUT_ID = "truncateInputId";
+    private static final String TRUNCATE_OUTPUT_ID = "truncateOutputId";
+
+    private HandlesSplits.SplitResult getProcessElementSplit(String transformId, String inputId) {
+      return SplitResult.of(
+          ImmutableList.of(
+              BundleApplication.newBuilder()
+                  .setTransformId(transformId)
+                  .setInputId(inputId)
+                  .build()),
+          ImmutableList.of(
+              DelayedBundleApplication.newBuilder()
+                  .setApplication(
+                      BundleApplication.newBuilder()
+                          .setTransformId(transformId)
+                          .setInputId(inputId)
+                          .build())
+                  .setRequestedTimeDelay(Durations.fromMillis(1000L))
+                  .build()));
+    }
+
+    @Test
+    public void testConstructSplitResultWithElementSplitFromDelegate() throws Exception {
+      Coder fullInputCoder =
+          getFullInputCoder(
+              StringUtf8Coder.of(),
+              OffsetRange.Coder.of(),
+              InstantCoder.of(),
+              IntervalWindow.getCoder());
+      HandlesSplits.SplitResult elementSplit =
+          getProcessElementSplit(PROCESS_TRANSFORM_ID, PROCESS_INPUT_ID);
+      HandlesSplits.SplitResult result =
+          FnApiDoFnRunner.constructSplitResult(
+              null,
+              elementSplit,
+              fullInputCoder,
+              null,
+              null,
+              TRUNCATE_TRANSFORM_ID,
+              TRUNCATE_INPUT_ID,
+              ImmutableList.of(TRUNCATE_OUTPUT_ID),
+              null);
+      assertEquals(elementSplit.getPrimaryRoots(), result.getPrimaryRoots());
+      assertEquals(elementSplit.getResidualRoots(), result.getResidualRoots());
+    }
+
+    private HandlesSplits createSplitDelegate(
+        double progress, double expectedFraction, SplitResult result) {
+      return new HandlesSplits() {
+        @Override
+        public SplitResult trySplit(double fractionOfRemainder) {
+          checkArgument(fractionOfRemainder == expectedFraction);
+          return result;
+        }
+
+        @Override
+        public double getProgress() {
+          return progress;
+        }
+      };
+    }
+
+    @Test
+    public void testTrySplitForTruncateCheckpointOnFirstWindow() throws Exception {
+      List<BoundedWindow> windows = ImmutableList.copyOf(currentElement.getWindows());
+      SplitResult splitResult =
+          SplitResult.of(
+              ImmutableList.of(BundleApplication.getDefaultInstance()),
+              ImmutableList.of(DelayedBundleApplication.getDefaultInstance()));
+      HandlesSplits splitDelegate = createSplitDelegate(0.3, 0.0, splitResult);
+      SplitResultsWithStopIndex result =
+          SplittableTruncateSizedRestrictionsDoFnRunner.computeSplitForTruncate(
+              currentElement,
+              currentRestriction,
+              window1,
+              windows,
+              currentWatermarkEstimatorState,
+              0.0,
+              splitDelegate,
+              0,
+              3);
+      assertEquals(1, result.getNewWindowStopIndex());
+      KV<WindowedValue, WindowedValue> expectedWindowSplit =
+          createSplitAcrossWindows(ImmutableList.of(), ImmutableList.of(window2, window3));
+      assertEquals(splitResult, result.getDownstreamSplit());
+      assertNull(result.getWindowSplit().getPrimarySplitRoot());
+      assertNull(result.getWindowSplit().getResidualSplitRoot());
+      assertEquals(
+          expectedWindowSplit.getKey(),
+          result.getWindowSplit().getPrimaryInFullyProcessedWindowsRoot());
+      assertEquals(
+          expectedWindowSplit.getValue(),
+          result.getWindowSplit().getResidualInUnprocessedWindowsRoot());
+    }
+
+    @Test
+    public void testTrySplitForTruncateCheckpointOnFirstWindowAfterOneSplit() throws Exception {
+      List<BoundedWindow> windows = ImmutableList.copyOf(currentElement.getWindows());
+      SplitResult splitResult =
+          SplitResult.of(
+              ImmutableList.of(BundleApplication.getDefaultInstance()),
+              ImmutableList.of(DelayedBundleApplication.getDefaultInstance()));
+      HandlesSplits splitDelegate = createSplitDelegate(0.3, 0.0, splitResult);
+      SplitResultsWithStopIndex result =
+          SplittableTruncateSizedRestrictionsDoFnRunner.computeSplitForTruncate(
+              currentElement,
+              currentRestriction,
+              window1,
+              windows,
+              currentWatermarkEstimatorState,
+              0.0,
+              splitDelegate,
+              0,
+              2);
+      assertEquals(1, result.getNewWindowStopIndex());
+      KV<WindowedValue, WindowedValue> expectedWindowSplit =
+          createSplitAcrossWindows(ImmutableList.of(), ImmutableList.of(window2));
+      assertEquals(splitResult, result.getDownstreamSplit());
+      assertNull(result.getWindowSplit().getPrimarySplitRoot());
+      assertNull(result.getWindowSplit().getResidualSplitRoot());
+      assertEquals(
+          expectedWindowSplit.getKey(),
+          result.getWindowSplit().getPrimaryInFullyProcessedWindowsRoot());
+      assertEquals(
+          expectedWindowSplit.getValue(),
+          result.getWindowSplit().getResidualInUnprocessedWindowsRoot());
+    }
+
+    @Test
+    public void testTrySplitForTruncateSplitOnFirstWindow() throws Exception {
+      List<BoundedWindow> windows = ImmutableList.copyOf(currentElement.getWindows());
+      SplitResult splitResult =
+          SplitResult.of(
+              ImmutableList.of(BundleApplication.getDefaultInstance()),
+              ImmutableList.of(DelayedBundleApplication.getDefaultInstance()));
+      HandlesSplits splitDelegate = createSplitDelegate(0.3, 0.54, splitResult);
+      SplitResultsWithStopIndex result =
+          SplittableTruncateSizedRestrictionsDoFnRunner.computeSplitForTruncate(
+              currentElement,
+              currentRestriction,
+              window1,
+              windows,
+              currentWatermarkEstimatorState,
+              0.2,
+              splitDelegate,
+              0,
+              3);
+      assertEquals(1, result.getNewWindowStopIndex());
+      KV<WindowedValue, WindowedValue> expectedWindowSplit =
+          createSplitAcrossWindows(ImmutableList.of(), ImmutableList.of(window2, window3));
+      assertEquals(splitResult, result.getDownstreamSplit());
+      assertNull(result.getWindowSplit().getPrimarySplitRoot());
+      assertNull(result.getWindowSplit().getResidualSplitRoot());
+      assertEquals(
+          expectedWindowSplit.getKey(),
+          result.getWindowSplit().getPrimaryInFullyProcessedWindowsRoot());
+      assertEquals(
+          expectedWindowSplit.getValue(),
+          result.getWindowSplit().getResidualInUnprocessedWindowsRoot());
+    }
+
+    @Test
+    public void testTrySplitForTruncateSplitOnMiddleWindow() throws Exception {
+      List<BoundedWindow> windows = ImmutableList.copyOf(currentElement.getWindows());
+      SplitResult splitResult =
+          SplitResult.of(
+              ImmutableList.of(BundleApplication.getDefaultInstance()),
+              ImmutableList.of(DelayedBundleApplication.getDefaultInstance()));
+      HandlesSplits splitDelegate = createSplitDelegate(0.3, 0.34, splitResult);
+      SplitResultsWithStopIndex result =
+          SplittableTruncateSizedRestrictionsDoFnRunner.computeSplitForTruncate(
+              currentElement,
+              currentRestriction,
+              window1,
+              windows,
+              currentWatermarkEstimatorState,
+              0.2,
+              splitDelegate,
+              1,
+              3);
+      assertEquals(2, result.getNewWindowStopIndex());
+      KV<WindowedValue, WindowedValue> expectedWindowSplit =
+          createSplitAcrossWindows(ImmutableList.of(window1), ImmutableList.of(window3));
+      assertEquals(splitResult, result.getDownstreamSplit());
+      assertNull(result.getWindowSplit().getPrimarySplitRoot());
+      assertNull(result.getWindowSplit().getResidualSplitRoot());
+      assertEquals(
+          expectedWindowSplit.getKey(),
+          result.getWindowSplit().getPrimaryInFullyProcessedWindowsRoot());
+      assertEquals(
+          expectedWindowSplit.getValue(),
+          result.getWindowSplit().getResidualInUnprocessedWindowsRoot());
+    }
+
+    @Test
+    public void testTrySplitForTruncateSplitOnLastWindow() throws Exception {
+      List<BoundedWindow> windows = ImmutableList.copyOf(currentElement.getWindows());
+      SplitResult splitResult =
+          SplitResult.of(
+              ImmutableList.of(BundleApplication.getDefaultInstance()),
+              ImmutableList.of(DelayedBundleApplication.getDefaultInstance()));
+      HandlesSplits splitDelegate = createSplitDelegate(0.3, 0.2, splitResult);
+      SplitResultsWithStopIndex result =
+          SplittableTruncateSizedRestrictionsDoFnRunner.computeSplitForTruncate(
+              currentElement,
+              currentRestriction,
+              window1,
+              windows,
+              currentWatermarkEstimatorState,
+              0.2,
+              splitDelegate,
+              2,
+              3);
+      assertEquals(3, result.getNewWindowStopIndex());
+      KV<WindowedValue, WindowedValue> expectedWindowSplit =
+          createSplitAcrossWindows(ImmutableList.of(window1, window2), ImmutableList.of());
+      assertEquals(splitResult, result.getDownstreamSplit());
+      assertNull(result.getWindowSplit().getPrimarySplitRoot());
+      assertNull(result.getWindowSplit().getResidualSplitRoot());
+      assertEquals(
+          expectedWindowSplit.getKey(),
+          result.getWindowSplit().getPrimaryInFullyProcessedWindowsRoot());
+      assertEquals(
+          expectedWindowSplit.getValue(),
+          result.getWindowSplit().getResidualInUnprocessedWindowsRoot());
+    }
+
+    @Test
+    public void testTrySplitForTruncateSplitOnFirstWindowFallback() throws Exception {
+      List<BoundedWindow> windows = ImmutableList.copyOf(currentElement.getWindows());
+      SplitResult unusedSplitResult =
+          SplitResult.of(
+              ImmutableList.of(BundleApplication.getDefaultInstance()),
+              ImmutableList.of(DelayedBundleApplication.getDefaultInstance()));
+      HandlesSplits splitDelegate = createSplitDelegate(1.0, 0.0, unusedSplitResult);
+      SplitResultsWithStopIndex result =
+          SplittableTruncateSizedRestrictionsDoFnRunner.computeSplitForTruncate(
+              currentElement,
+              currentRestriction,
+              window1,
+              windows,
+              currentWatermarkEstimatorState,
+              0.0,
+              splitDelegate,
+              0,
+              3);
+      assertEquals(1, result.getNewWindowStopIndex());
+      KV<WindowedValue, WindowedValue> expectedWindowSplit =
+          createSplitAcrossWindows(ImmutableList.of(window1), ImmutableList.of(window2, window3));
+      assertNull(result.getDownstreamSplit());
+      assertNull(result.getWindowSplit().getPrimarySplitRoot());
+      assertNull(result.getWindowSplit().getResidualSplitRoot());
+      assertEquals(
+          expectedWindowSplit.getKey(),
+          result.getWindowSplit().getPrimaryInFullyProcessedWindowsRoot());
+      assertEquals(
+          expectedWindowSplit.getValue(),
+          result.getWindowSplit().getResidualInUnprocessedWindowsRoot());
+    }
+
+    @Test
+    public void testTrySplitForTruncateSplitOnLastWindowWhenNoElementSplit() throws Exception {
+      List<BoundedWindow> windows = ImmutableList.copyOf(currentElement.getWindows());
+      HandlesSplits splitDelegate = createSplitDelegate(1.0, 0.0, null);
+      SplitResultsWithStopIndex result =
+          SplittableTruncateSizedRestrictionsDoFnRunner.computeSplitForTruncate(
+              currentElement,
+              currentRestriction,
+              window1,
+              windows,
+              currentWatermarkEstimatorState,
+              0.0,
+              splitDelegate,
+              2,
+              3);
+      assertNull(result);
+    }
+
+    @Test
+    public void testTrySplitForTruncateOnWindowBoundaryRoundUp() throws Exception {
+      List<BoundedWindow> windows = ImmutableList.copyOf(currentElement.getWindows());
+      SplitResult unusedSplitResult =
+          SplitResult.of(
+              ImmutableList.of(BundleApplication.getDefaultInstance()),
+              ImmutableList.of(DelayedBundleApplication.getDefaultInstance()));
+      HandlesSplits splitDelegate = createSplitDelegate(0.3, 0.0, unusedSplitResult);
+      SplitResultsWithStopIndex result =
+          SplittableTruncateSizedRestrictionsDoFnRunner.computeSplitForTruncate(
+              currentElement,
+              currentRestriction,
+              window1,
+              windows,
+              currentWatermarkEstimatorState,
+              0.6,
+              splitDelegate,
+              0,
+              3);
+      assertEquals(2, result.getNewWindowStopIndex());
+      KV<WindowedValue, WindowedValue> expectedWindowSplit =
+          createSplitAcrossWindows(ImmutableList.of(window1, window2), ImmutableList.of(window3));
+      assertNull(result.getDownstreamSplit());
+      assertNull(result.getWindowSplit().getPrimarySplitRoot());
+      assertNull(result.getWindowSplit().getResidualSplitRoot());
+      assertEquals(
+          expectedWindowSplit.getKey(),
+          result.getWindowSplit().getPrimaryInFullyProcessedWindowsRoot());
+      assertEquals(
+          expectedWindowSplit.getValue(),
+          result.getWindowSplit().getResidualInUnprocessedWindowsRoot());
+    }
+
+    @Test
+    public void testTrySplitForTruncateOnWindowBoundaryRoundDown() throws Exception {
+      List<BoundedWindow> windows = ImmutableList.copyOf(currentElement.getWindows());
+      SplitResult unusedSplitResult =
+          SplitResult.of(
+              ImmutableList.of(BundleApplication.getDefaultInstance()),
+              ImmutableList.of(DelayedBundleApplication.getDefaultInstance()));
+      HandlesSplits splitDelegate = createSplitDelegate(0.3, 0.0, unusedSplitResult);
+      SplitResultsWithStopIndex result =
+          SplittableTruncateSizedRestrictionsDoFnRunner.computeSplitForTruncate(
+              currentElement,
+              currentRestriction,
+              window1,
+              windows,
+              currentWatermarkEstimatorState,
+              0.3,
+              splitDelegate,
+              0,
+              3);
+      assertEquals(1, result.getNewWindowStopIndex());
+      KV<WindowedValue, WindowedValue> expectedWindowSplit =
+          createSplitAcrossWindows(ImmutableList.of(window1), ImmutableList.of(window2, window3));
+      assertNull(result.getDownstreamSplit());
+      assertNull(result.getWindowSplit().getPrimarySplitRoot());
+      assertNull(result.getWindowSplit().getResidualSplitRoot());
+      assertEquals(
+          expectedWindowSplit.getKey(),
+          result.getWindowSplit().getPrimaryInFullyProcessedWindowsRoot());
+      assertEquals(
+          expectedWindowSplit.getValue(),
+          result.getWindowSplit().getResidualInUnprocessedWindowsRoot());
+    }
+
+    @Test
+    public void testTrySplitForTruncateOnWindowBoundaryRoundDownOnLastWindow() throws Exception {
+      List<BoundedWindow> windows = ImmutableList.copyOf(currentElement.getWindows());
+      SplitResult unusedSplitResult =
+          SplitResult.of(
+              ImmutableList.of(BundleApplication.getDefaultInstance()),
+              ImmutableList.of(DelayedBundleApplication.getDefaultInstance()));
+      HandlesSplits splitDelegate = createSplitDelegate(0.3, 0.0, unusedSplitResult);
+      SplitResultsWithStopIndex result =
+          SplittableTruncateSizedRestrictionsDoFnRunner.computeSplitForTruncate(
+              currentElement,
+              currentRestriction,
+              window1,
+              windows,
+              currentWatermarkEstimatorState,
+              0.6,
+              splitDelegate,
+              0,
+              3);
+      assertEquals(2, result.getNewWindowStopIndex());
+      KV<WindowedValue, WindowedValue> expectedWindowSplit =
+          createSplitAcrossWindows(ImmutableList.of(window1, window2), ImmutableList.of(window3));
+      assertNull(result.getDownstreamSplit());
+      assertNull(result.getWindowSplit().getPrimarySplitRoot());
+      assertNull(result.getWindowSplit().getResidualSplitRoot());
+      assertEquals(
+          expectedWindowSplit.getKey(),
+          result.getWindowSplit().getPrimaryInFullyProcessedWindowsRoot());
+      assertEquals(
+          expectedWindowSplit.getValue(),
+          result.getWindowSplit().getResidualInUnprocessedWindowsRoot());
+    }
+
+    private Coder getFullInputCoder(
+        Coder elementCoder, Coder restrictionCoder, Coder watermarkStateCoder, Coder windowCoder) {
+      Coder inputCoder =
+          KvCoder.of(
+              KvCoder.of(elementCoder, KvCoder.of(restrictionCoder, watermarkStateCoder)),
+              DoubleCoder.of());
+      return WindowedValues.getFullCoder(inputCoder, windowCoder);
+    }
+  }
+}


### PR DESCRIPTION
This follows #34919, splis out calls to `@TruncateRestriction`. This is the first Fn API transform that deals with responding to splits so it is a bit more complex than the prior refactors that only touched `@GetSize` and `@GetInitialRestriction` and `@SplitRestriction` that do not respond to split requests.

As I understand it, this responds to split requests by delegating them downstream, as it is expected to be fused with final element+restriction processing.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
