### PR TITLE
Add filter to GetMinUnfinishedWatermark queryAdd filter tester

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/cache/NoOpWatermarkCache.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/cache/NoOpWatermarkCache.java
@@ -35,6 +35,6 @@ public class NoOpWatermarkCache implements WatermarkCache {
 
   @Override
   public @Nullable Timestamp getUnfinishedMinWatermark() {
-    return dao.getUnfinishedMinWatermark();
+    return dao.getUnfinishedMinWatermarkFrom(Timestamp.MIN_VALUE);
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamIT.java
@@ -60,6 +60,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -81,6 +82,8 @@ public class SpannerChangeStreamIT {
   private static String changeStreamTableName;
   private static String changeStreamName;
   private static DatabaseClient databaseClient;
+
+  @Rule public transient Timeout globalTimeout = Timeout.seconds(3600);
 
   @BeforeClass
   public static void beforeClass() throws Exception {

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamOrderedByTimestampAndTransactionIdIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamOrderedByTimestampAndTransactionIdIT.java
@@ -58,6 +58,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
@@ -82,6 +83,8 @@ public class SpannerChangeStreamOrderedByTimestampAndTransactionIdIT {
   private static String tableName;
   private static String changeStreamName;
   private static DatabaseClient databaseClient;
+
+  @Rule public transient Timeout globalTimeout = Timeout.seconds(3600);
 
   @BeforeClass
   public static void setup() throws InterruptedException, ExecutionException, TimeoutException {

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamOrderedWithinKeyGloballyIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamOrderedWithinKeyGloballyIT.java
@@ -55,6 +55,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
@@ -66,6 +67,8 @@ public class SpannerChangeStreamOrderedWithinKeyGloballyIT {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(SpannerChangeStreamOrderedWithinKeyGloballyIT.class);
+
+  @Rule public transient Timeout globalTimeout = Timeout.seconds(3600);
 
   @ClassRule public static final IntegrationTestEnv ENV = new IntegrationTestEnv();
   @Rule public final transient TestPipeline pipeline = TestPipeline.create();

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamOrderedWithinKeyIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamOrderedWithinKeyIT.java
@@ -49,6 +49,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
@@ -70,6 +71,8 @@ public class SpannerChangeStreamOrderedWithinKeyIT {
   private static String tableName;
   private static String changeStreamName;
   private static DatabaseClient databaseClient;
+
+  @Rule public transient Timeout globalTimeout = Timeout.seconds(3600);
 
   @BeforeClass
   public static void setup() throws InterruptedException, ExecutionException, TimeoutException {

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamPostgresIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamPostgresIT.java
@@ -51,12 +51,15 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** End-to-end test of Cloud Spanner CDC Source. */
 @RunWith(JUnit4.class)
 public class SpannerChangeStreamPostgresIT {
+
+  @Rule public transient Timeout globalTimeout = Timeout.seconds(3600);
 
   @ClassRule
   public static final IntegrationTestEnv ENV = new IntegrationTestEnv(/*isPostgres=*/ true);

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamTransactionBoundariesIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamTransactionBoundariesIT.java
@@ -51,6 +51,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
@@ -59,6 +60,8 @@ import org.slf4j.LoggerFactory;
 /** End-to-end test of Cloud Spanner Change Streams Transaction Boundaries. */
 @RunWith(JUnit4.class)
 public class SpannerChangeStreamTransactionBoundariesIT {
+
+  @Rule public transient Timeout globalTimeout = Timeout.seconds(3600);
 
   private static final Logger LOG =
       LoggerFactory.getLogger(SpannerChangeStreamTransactionBoundariesIT.class);

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamsSchemaTransformIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamsSchemaTransformIT.java
@@ -48,6 +48,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -65,6 +66,8 @@ public class SpannerChangeStreamsSchemaTransformIT {
   private static String changeStreamTableName;
   private static String changeStreamName;
   private static DatabaseClient databaseClient;
+
+  @Rule public transient Timeout globalTimeout = Timeout.seconds(3600);
 
   @BeforeClass
   public static void beforeClass() throws Exception {


### PR DESCRIPTION
To improve the performance of the query for GetUnfinishedMinWatermark, we can add a filter to the query.
Note that the query run on a cache to refresh every 1s. We can remember the cached value every time and use the value as a filter in the next time query.

Also add class level timeout for all change stream integration tests.

Note that, the CacheLoader's refresh function cannot return null, because that will be deemed invalid, then the cache will not be updated. As the result, the connector will run forever. Hence we still keep the return type optional.