### PR TITLE
Resolve default project ID for Storage API table access

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java
@@ -674,12 +674,36 @@ public class BigQueryServicesImpl implements BigQueryServices {
         Sleeper sleeper)
         throws IOException, InterruptedException {
       TableReference updatedRef = ref.clone();
-      if (updatedRef.getProjectId() == null) {
+      if (Strings.isNullOrEmpty(updatedRef.getProjectId())) { // Check for null or empty string
         BigQueryOptions bqOptions = options.as(BigQueryOptions.class);
-        updatedRef.setProjectId(
-            bqOptions.getBigQueryProject() == null
-                ? bqOptions.getProject()
-                : bqOptions.getBigQueryProject());
+        String projectId = bqOptions.getBigQueryProject();
+        if (Strings.isNullOrEmpty(projectId)) {
+          // Fallback to GcpOptions.getProject() if BigQueryOptions.getBigQueryProject() is also null/empty
+          projectId = bqOptions.as(GcpOptions.class).getProject();
+        }
+        // It's crucial that 'projectId' is guaranteed to be non-null here.
+        // The Preconditions.checkNotNull in Bigquery$Tables$Get.<init> implies it must be set.
+        // If 'projectId' can still be null after these checks, the fundamental assumption of
+        // how default project IDs are handled in Beam needs re-evaluation, but for now,
+        // we trust that one of these options will provide a valid project ID.
+        // If projectId is still null, it would mean no project is configured anywhere,
+        // which is a larger configuration issue.
+        if (Strings.isNullOrEmpty(projectId)) {
+          // This case should ideally not happen in a correctly configured pipeline.
+          // However, to prevent the NPE, we might have to throw a more informative error here,
+          // or ensure that the calling code (e.g. StorageApiDynamicDestinationsTableRow)
+          // has already validated that a project ID can be obtained.
+          // For now, let the Preconditions.checkNotNull in the Google API client catch it,
+          // but the problem originates from lack of a configured project ID.
+          // The most direct fix for the NPE is to ensure a project ID is set if available.
+          // If 'projectId' is still null here, the original NPE will occur, but we've
+          // tried our best with the available options.
+          // A more robust solution might involve ensuring 'options.getProject()' or
+          // 'bqOptions.getBigQueryProject()' cannot be null if no project is in the table spec.
+          // However, altering those getters is outside this scope.
+          // The issue seems to be about *using* the available default, not that a default is *always* missing.
+        }
+        updatedRef.setProjectId(projectId); // Set the resolved project ID
       }
       Tables.Get get =
           client

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java
@@ -678,30 +678,13 @@ public class BigQueryServicesImpl implements BigQueryServices {
         BigQueryOptions bqOptions = options.as(BigQueryOptions.class);
         String projectId = bqOptions.getBigQueryProject();
         if (Strings.isNullOrEmpty(projectId)) {
-          // Fallback to GcpOptions.getProject() if BigQueryOptions.getBigQueryProject() is also null/empty
+          // Fallback to GcpOptions.getProject() if BigQueryOptions.getBigQueryProject() is also
+          // null/empty
           projectId = bqOptions.as(GcpOptions.class).getProject();
         }
-        // It's crucial that 'projectId' is guaranteed to be non-null here.
-        // The Preconditions.checkNotNull in Bigquery$Tables$Get.<init> implies it must be set.
-        // If 'projectId' can still be null after these checks, the fundamental assumption of
-        // how default project IDs are handled in Beam needs re-evaluation, but for now,
-        // we trust that one of these options will provide a valid project ID.
-        // If projectId is still null, it would mean no project is configured anywhere,
-        // which is a larger configuration issue.
         if (Strings.isNullOrEmpty(projectId)) {
-          // This case should ideally not happen in a correctly configured pipeline.
-          // However, to prevent the NPE, we might have to throw a more informative error here,
-          // or ensure that the calling code (e.g. StorageApiDynamicDestinationsTableRow)
-          // has already validated that a project ID can be obtained.
-          // For now, let the Preconditions.checkNotNull in the Google API client catch it,
-          // but the problem originates from lack of a configured project ID.
-          // The most direct fix for the NPE is to ensure a project ID is set if available.
-          // If 'projectId' is still null here, the original NPE will occur, but we've
-          // tried our best with the available options.
-          // A more robust solution might involve ensuring 'options.getProject()' or
-          // 'bqOptions.getBigQueryProject()' cannot be null if no project is in the table spec.
-          // However, altering those getters is outside this scope.
-          // The issue seems to be about *using* the available default, not that a default is *always* missing.
+          throw new IllegalArgumentException(
+              "Project ID is null and could not be inferred from options. Please ensure a project ID is configured.");
         }
         updatedRef.setProjectId(projectId); // Set the resolved project ID
       }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImplTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImplTest.java
@@ -2128,6 +2128,8 @@ public class BigQueryServicesImplTest {
   @Test
   public void testGetTableWithDefaultProjectFromOptions() throws Exception {
     BigQueryOptions mockOptions = mock(BigQueryOptions.class);
+    when(mockOptions.as(BigQueryOptions.class)).thenReturn(mockOptions);
+    when(mockOptions.as(GcpOptions.class)).thenReturn(mockOptions);
     when(mockOptions.getBigQueryProject()).thenReturn("test-project-bqoptions");
     // Mock fallback project ID, though it shouldn't be used in this test
     when(mockOptions.getProject()).thenReturn("test-project-gcpopts");
@@ -2166,10 +2168,13 @@ public class BigQueryServicesImplTest {
   @Test
   public void testGetTableWithDefaultProjectFromGcpOptions() throws Exception {
     BigQueryOptions mockOptions = mock(BigQueryOptions.class);
+    when(mockOptions.as(BigQueryOptions.class)).thenReturn(mockOptions);
+    // when(mockOptions.as(GcpOptions.class)).thenReturn(mockOptions); // This will be set up below
     when(mockOptions.getBigQueryProject()).thenReturn(null); // Primary is null
     // Mock GcpOptions specifically for getProject()
     GcpOptions mockGcpOptions = mock(GcpOptions.class);
-    when(mockOptions.as(GcpOptions.class)).thenReturn(mockGcpOptions);
+    when(mockOptions.as(GcpOptions.class))
+        .thenReturn(mockGcpOptions); // Correctly stubbed for the test's logic path
     when(mockGcpOptions.getProject()).thenReturn("test-project-gcpopts"); // Fallback
 
     Bigquery mockBigqueryClient = mock(Bigquery.class);
@@ -2205,11 +2210,15 @@ public class BigQueryServicesImplTest {
   @Test
   public void testGetTableWithProjectIdInTableReference() throws Exception {
     BigQueryOptions mockOptions = mock(BigQueryOptions.class);
+    when(mockOptions.as(BigQueryOptions.class)).thenReturn(mockOptions);
+    when(mockOptions.as(GcpOptions.class)).thenReturn(mockOptions);
     // These shouldn't be used, but set them for completeness
     when(mockOptions.getBigQueryProject()).thenReturn("test-project-bqoptions");
-    GcpOptions mockGcpOptions = mock(GcpOptions.class);
-    when(mockOptions.as(GcpOptions.class)).thenReturn(mockGcpOptions);
-    when(mockGcpOptions.getProject()).thenReturn("test-project-gcpopts");
+    // GcpOptions mockGcpOptions = mock(GcpOptions.class); // Not strictly needed if BQO.as(GcpO)
+    // returns BQO itself
+    // when(mockOptions.as(GcpOptions.class)).thenReturn(mockGcpOptions); // Now returns mockOptions
+    when(mockOptions.getProject())
+        .thenReturn("test-project-gcpopts"); // Call on mockOptions directly
 
     Bigquery mockBigqueryClient = mock(Bigquery.class);
     Bigquery.Tables mockTables = mock(Bigquery.Tables.class);

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImplTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImplTest.java
@@ -95,6 +95,7 @@ import org.apache.beam.runners.core.metrics.GcpResourceIdentifiers;
 import org.apache.beam.runners.core.metrics.MetricsContainerImpl;
 import org.apache.beam.runners.core.metrics.MonitoringInfoConstants;
 import org.apache.beam.runners.core.metrics.MonitoringInfoMetricName;
+import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
 import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
 import org.apache.beam.sdk.extensions.gcp.util.BackOffAdapter;
 import org.apache.beam.sdk.extensions.gcp.util.RetryHttpRequestInitializer;

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImplTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImplTest.java
@@ -30,6 +30,9 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -121,8 +124,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.MockitoAnnotations;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockitoAnnotations;
 
 /** Tests for {@link BigQueryServicesImpl}. */
 @RunWith(JUnit4.class)
@@ -2139,7 +2142,6 @@ public class BigQueryServicesImplTest {
     when(mockGet.setSelectedFields(anyString())).thenReturn(mockGet);
     when(mockGet.set(anyString(), any())).thenReturn(mockGet);
 
-
     Table mockResultTable =
         new Table()
             .setTableReference(
@@ -2207,7 +2209,6 @@ public class BigQueryServicesImplTest {
     GcpOptions mockGcpOptions = mock(GcpOptions.class);
     when(mockOptions.as(GcpOptions.class)).thenReturn(mockGcpOptions);
     when(mockGcpOptions.getProject()).thenReturn("test-project-gcpopts");
-
 
     Bigquery mockBigqueryClient = mock(Bigquery.class);
     Bigquery.Tables mockTables = mock(Bigquery.Tables.class);


### PR DESCRIPTION
**Testing Jules.**

Fixes https://github.com/apache/beam/issues/21405

When using BigQueryIO's STORAGE_API_AT_LEAST_ONCE write method, if the TableReference provided (e.g., through a dynamic destination) did not explicitly contain a project ID, the underlying call to fetch table metadata (schema) would result in a NullPointerException. This occurred because the default project ID from BigQueryOptions or GcpOptions was not being consistently applied at the point of the API call in BigQueryServicesImpl.DatasetServiceImpl.getTable().

This commit modifies the getTable() method in DatasetServiceImpl to more robustly resolve the project ID. If the input TableReference lacks a project ID, the method now attempts to use the project ID from BigQueryOptions.getBigQueryProject(), and if that is also unavailable, it falls back to GcpOptions.getProject().

Unit tests have been added to BigQueryServicesImplTest to verify:
- Resolution of project ID from BigQueryOptions.getBigQueryProject().
- Fallback resolution from GcpOptions.getProject() when BigQueryOptions.getBigQueryProject() is null.
- Preservation of an existing project ID if already present in the TableReference.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
