### PR TITLE
[BigQueryIO] support MicrosInstant for long type

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
@@ -754,7 +754,14 @@ public class BigQueryUtils {
       } else if (fieldType.isLogicalType(SqlTypes.TIME.getIdentifier())) {
         return LocalTime.parse(jsonBQString);
       } else if (fieldType.isLogicalType(SqlTypes.TIMESTAMP.getIdentifier())) {
-        return java.time.Instant.parse(jsonBQString);
+        try {
+          long micros = Long.parseLong(jsonBQString);
+          long seconds = micros / 1_000_000;
+          long nanos = (micros % 1_000_000) * 1_000;
+          return java.time.Instant.ofEpochSecond(seconds, nanos);
+        } catch (NumberFormatException e) {
+          return java.time.Instant.parse(jsonBQString);
+        }
       }
     }
 


### PR DESCRIPTION
Extension of #34707, adds support for `long` type representing micros