### PR TITLE
Prism: Fix event-time timer firing earlier than the time set.

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
@@ -1647,11 +1647,13 @@ keysPerBundle:
 					timerCleared = true
 					continue
 				}
-				holdsInBundle[e.holdTimestamp]++
 				if e.timestamp > watermark {
-					// we don't trigger a timer when its firing timestamp is over watermark
+					// We don't trigger a timer when its firing timestamp is over watermark.
+					// Push the timer back so we won't lose it.
+					heap.Push(&dnt.elements, e)
 					break
 				}
+				holdsInBundle[e.holdTimestamp]++
 				// Clear the "fired" timer so subsequent matches can be ignored.
 				delete(dnt.timers, timerKey{family: e.family, tag: e.tag, window: e.window})
 			}

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
@@ -1648,6 +1648,10 @@ keysPerBundle:
 					continue
 				}
 				holdsInBundle[e.holdTimestamp]++
+				if e.timestamp > watermark {
+					// we don't trigger a timer when its firing timestamp is over watermark
+					break
+				}
 				// Clear the "fired" timer so subsequent matches can be ignored.
 				delete(dnt.timers, timerKey{family: e.family, tag: e.tag, window: e.window})
 			}

--- a/sdks/go/pkg/beam/runners/prism/internal/stage.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/stage.go
@@ -180,9 +180,9 @@ func (s *stage) Execute(ctx context.Context, j *jobservices.Job, wk *worker.W, c
 	progTick := time.NewTicker(baseTick)
 	defer progTick.Stop()
 	var dataFinished, bundleFinished bool
-	// If we have no data outputs, we still need to have progress & splits
+	// If we have no data outputs and timers, we still need to have progress & splits
 	// while waiting for bundle completion.
-	if b.OutputCount == 0 {
+	if b.OutputCount+len(b.HasTimers) == 0 {
 		dataFinished = true
 	}
 	var resp *fnpb.ProcessBundleResponse


### PR DESCRIPTION
Fixes #35090.

Running the same test code from https://github.com/apache/beam/issues/35090#issue-3102012585, we no longer see timer callback being invoked.

Furthermore, if we change the test code to set firing timestamp of a timer to be the timestamp of first element + 2 (rather than 10 in the original test), we will see the timer callback is actually called.

```
set timer to Timestamp(1748577640.693000)
timer callback start (timestamp=Timestamp(1748577640.693000))
timer callback elements: [1748577638.693265, 1748577639.693265, 1748577640.693265]
timer callback end
batch process start
1748577638.693265
1748577639.693265
1748577640.693265
1748577641.693265
1748577642.693265
batch process end
clear timer
set timer to Timestamp(1748577645.693000)
timer callback start (timestamp=Timestamp(1748577645.693000))
timer callback elements: [1748577643.693265, 1748577644.693265, 1748577645.693265]
timer callback end
batch process start
1748577643.693265
1748577644.693265
1748577645.693265
1748577646.693265
1748577647.693265
batch process end
clear timer
set timer to Timestamp(1748577650.693000)
timer callback start (timestamp=Timestamp(1748577650.693000))
timer callback elements: [1748577648.693265, 1748577649.693265]
timer callback end
batch process start
1748577648.693265
1748577649.693265
1748577650.693265
1748577651.693265
1748577652.693265
batch process end
clear timer
set timer to Timestamp(1748577655.693000)
timer callback start (timestamp=Timestamp(1748577655.693000))
timer callback elements: [1748577653.693265, 1748577654.693265, 1748577655.693265]
timer callback end
batch process start
1748577653.693265
1748577654.693265
1748577655.693265
1748577656.693265
1748577657.693265
batch process end
...
```