### PR TITLE
Pass max_writers_per_bundle=0 in textio.writeToJson

### DIFF
--- a/sdks/python/apache_beam/dataframe/io.py
+++ b/sdks/python/apache_beam/dataframe/io.py
@@ -53,6 +53,7 @@ import apache_beam as beam
 from apache_beam import io
 from apache_beam.dataframe import frame_base
 from apache_beam.io import fileio
+from apache_beam.io.fileio import WriteToFiles
 
 _DEFAULT_LINES_CHUNKSIZE = 10_000
 _DEFAULT_BYTES_CHUNKSIZE = 1 << 20
@@ -668,6 +669,7 @@ class _WriteToPandas(beam.PTransform):
     return pcoll | fileio.WriteToFiles(
         path=dir,
         shards=self.kwargs.pop('num_shards', None),
+        max_writers_per_bundle=self.kwargs.pop('max_writers_per_bundle', WriteToFiles.MAX_NUM_WRITERS_PER_BUNDLE),
         file_naming=self.kwargs.pop(
             'file_naming', fileio.default_file_naming(name)),
         sink=lambda _: _WriteToPandasFileSink(

--- a/sdks/python/apache_beam/dataframe/io.py
+++ b/sdks/python/apache_beam/dataframe/io.py
@@ -53,7 +53,6 @@ import apache_beam as beam
 from apache_beam import io
 from apache_beam.dataframe import frame_base
 from apache_beam.io import fileio
-from apache_beam.io.fileio import WriteToFiles
 
 _DEFAULT_LINES_CHUNKSIZE = 10_000
 _DEFAULT_BYTES_CHUNKSIZE = 1 << 20
@@ -669,7 +668,7 @@ class _WriteToPandas(beam.PTransform):
     return pcoll | fileio.WriteToFiles(
         path=dir,
         shards=self.kwargs.pop('num_shards', None),
-        max_writers_per_bundle=self.kwargs.pop('max_writers_per_bundle', WriteToFiles.MAX_NUM_WRITERS_PER_BUNDLE),
+        max_writers_per_bundle=self.kwargs.pop('max_writers_per_bundle', fileio.WriteToFiles.MAX_NUM_WRITERS_PER_BUNDLE),
         file_naming=self.kwargs.pop(
             'file_naming', fileio.default_file_naming(name)),
         sink=lambda _: _WriteToPandasFileSink(

--- a/sdks/python/apache_beam/dataframe/io.py
+++ b/sdks/python/apache_beam/dataframe/io.py
@@ -668,7 +668,9 @@ class _WriteToPandas(beam.PTransform):
     return pcoll | fileio.WriteToFiles(
         path=dir,
         shards=self.kwargs.pop('num_shards', None),
-        max_writers_per_bundle=self.kwargs.pop('max_writers_per_bundle', fileio.WriteToFiles.MAX_NUM_WRITERS_PER_BUNDLE),
+        max_writers_per_bundle=self.kwargs.pop(
+            'max_writers_per_bundle',
+            fileio.WriteToFiles.MAX_NUM_WRITERS_PER_BUNDLE),
         file_naming=self.kwargs.pop(
             'file_naming', fileio.default_file_naming(name)),
         sink=lambda _: _WriteToPandasFileSink(

--- a/sdks/python/apache_beam/io/textio.py
+++ b/sdks/python/apache_beam/io/textio.py
@@ -1056,7 +1056,8 @@ try:
       kwargs['num_shards'] = num_shards
     if file_naming is not None:
       kwargs['file_naming'] = file_naming
-    kwargs['max_writers_per_bundle'] = 0
+    if 'max_writers_per_bundle' not in kwargs:
+        kwargs['max_writers_per_bundle'] = 0
     if lines is None:
       lines = orient == 'records'
     return 'WriteToJson' >> WriteViaPandas(

--- a/sdks/python/apache_beam/io/textio.py
+++ b/sdks/python/apache_beam/io/textio.py
@@ -1057,7 +1057,7 @@ try:
     if file_naming is not None:
       kwargs['file_naming'] = file_naming
     if 'max_writers_per_bundle' not in kwargs:
-        kwargs['max_writers_per_bundle'] = 0
+      kwargs['max_writers_per_bundle'] = 0
     if lines is None:
       lines = orient == 'records'
     return 'WriteToJson' >> WriteViaPandas(

--- a/sdks/python/apache_beam/io/textio.py
+++ b/sdks/python/apache_beam/io/textio.py
@@ -1056,6 +1056,7 @@ try:
       kwargs['num_shards'] = num_shards
     if file_naming is not None:
       kwargs['file_naming'] = file_naming
+    kwargs['max_writers_per_bundle'] = 0
     if lines is None:
       lines = orient == 'records'
     return 'WriteToJson' >> WriteViaPandas(


### PR DESCRIPTION
Setting max_writers_per_bundle=0 in writeToJson() so that it is passed to WriteToFiles transform. This allows the PCollections to be processed as part of [WriteShardedRecordsFn](https://github.com/apache/beam/blob/82ef9d81066226833aaf8c1b30aae11e46e62771/sdks/python/apache_beam/io/fileio.py#L621) step which allows sharding based on the user specified num_shards or default shards. It can create larger files and increase parallelism. 

Currently, writes happen via [WriteUnshardedRecordsFn](https://github.com/apache/beam/blob/82ef9d81066226833aaf8c1b30aae11e46e62771/sdks/python/apache_beam/io/fileio.py#L609) step which creates a single key because the sharding is dependent on destination and destination is not available to pass via writeToJson. 

fixes - https://github.com/apache/beam/issues/35111