### PR TITLE
rename WindowedValue.getPane() to WindowedValue.getPaneInfo() in preparation for making it public

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/LateDataDroppingDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/LateDataDroppingDoFnRunner.java
@@ -141,7 +141,7 @@ public class LateDataDroppingDoFnRunner<K, InputT, OutputT, W extends BoundedWin
           } else {
             nonLateElements.add(
                 WindowedValue.of(
-                    element.getValue(), element.getTimestamp(), window, element.getPane()));
+                    element.getValue(), element.getTimestamp(), window, element.getPaneInfo()));
           }
         }
       }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvoker.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvoker.java
@@ -375,7 +375,7 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
 
     @Override
     public PaneInfo pane() {
-      return element.getPane();
+      return element.getPaneInfo();
     }
 
     @Override
@@ -390,7 +390,7 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
 
     @Override
     public void outputWithTimestamp(OutputT value, Instant timestamp) {
-      outputWindowedValue(value, timestamp, element.getWindows(), element.getPane());
+      outputWindowedValue(value, timestamp, element.getWindows(), element.getPaneInfo());
     }
 
     @Override
@@ -413,7 +413,7 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
 
     @Override
     public <T> void outputWithTimestamp(TupleTag<T> tag, T value, Instant timestamp) {
-      outputWindowedValue(tag, value, timestamp, element.getWindows(), element.getPane());
+      outputWindowedValue(tag, value, timestamp, element.getWindows(), element.getPaneInfo());
     }
 
     @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
@@ -404,7 +404,7 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
 
     @Override
     public PaneInfo pane() {
-      return elem.getPane();
+      return elem.getPaneInfo();
     }
 
     @Override
@@ -436,7 +436,7 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     public <T> void outputWithTimestamp(TupleTag<T> tag, T output, Instant timestamp) {
       checkNotNull(tag, "Tag passed to outputWithTimestamp cannot be null");
       checkTimestamp(elem.getTimestamp(), timestamp);
-      outputWindowedValue(tag, output, timestamp, elem.getWindows(), elem.getPane());
+      outputWindowedValue(tag, output, timestamp, elem.getWindows(), elem.getPaneInfo());
     }
 
     @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SplittableParDoViaKeyedWorkItems.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SplittableParDoViaKeyedWorkItems.java
@@ -430,7 +430,7 @@ public class SplittableParDoViaKeyedWorkItems {
 
                   @Override
                   public PaneInfo paneInfo(DoFn<InputT, OutputT> doFn) {
-                    return elementAndRestriction.getKey().getPane();
+                    return elementAndRestriction.getKey().getPaneInfo();
                   }
 
                   @Override
@@ -490,7 +490,7 @@ public class SplittableParDoViaKeyedWorkItems {
 
                 @Override
                 public PaneInfo paneInfo(DoFn<InputT, OutputT> doFn) {
-                  return elementAndRestriction.getKey().getPane();
+                  return elementAndRestriction.getKey().getPaneInfo();
                 }
 
                 @Override
@@ -544,7 +544,7 @@ public class SplittableParDoViaKeyedWorkItems {
 
                 @Override
                 public PaneInfo paneInfo(DoFn<InputT, OutputT> doFn) {
-                  return elementAndRestriction.getKey().getPane();
+                  return elementAndRestriction.getKey().getPaneInfo();
                 }
 
                 @Override

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/ReduceFnRunnerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/ReduceFnRunnerTest.java
@@ -759,7 +759,8 @@ public class ReduceFnRunnerTest {
                 equalTo(new Instant(1)),
                 equalTo((BoundedWindow) expectedWindow))));
     assertThat(
-        output.get(0).getPane(), equalTo(PaneInfo.createPane(true, false, Timing.EARLY, 0, -1)));
+        output.get(0).getPaneInfo(),
+        equalTo(PaneInfo.createPane(true, false, Timing.EARLY, 0, -1)));
 
     // There is no end-of-window hold, but the timer set by the trigger holds the watermark
     assertThat(tester.getWatermarkHold(), nullValue());
@@ -805,7 +806,8 @@ public class ReduceFnRunnerTest {
                 0, // window start
                 10))); // window end
     assertThat(
-        output.get(0).getPane(), equalTo(PaneInfo.createPane(false, false, Timing.EARLY, 1, -1)));
+        output.get(0).getPaneInfo(),
+        equalTo(PaneInfo.createPane(false, false, Timing.EARLY, 1, -1)));
 
     // Since the element hold is cleared, there is no hold remaining
     assertThat(tester.getWatermarkHold(), nullValue());
@@ -846,7 +848,8 @@ public class ReduceFnRunnerTest {
                 0, // window start
                 10))); // window end
     assertThat(
-        output.get(0).getPane(), equalTo(PaneInfo.createPane(false, false, Timing.ON_TIME, 2, 0)));
+        output.get(0).getPaneInfo(),
+        equalTo(PaneInfo.createPane(false, false, Timing.ON_TIME, 2, 0)));
 
     tester.setAutoAdvanceOutputWatermark(true);
 
@@ -879,7 +882,7 @@ public class ReduceFnRunnerTest {
                 0, // window start
                 10))); // window end
     assertThat(
-        output.get(0).getPane(), equalTo(PaneInfo.createPane(false, true, Timing.LATE, 3, 1)));
+        output.get(0).getPaneInfo(), equalTo(PaneInfo.createPane(false, true, Timing.LATE, 3, 1)));
     assertEquals(new Instant(50), tester.getOutputWatermark());
     assertEquals(null, tester.getWatermarkHold());
 
@@ -1486,7 +1489,8 @@ public class ReduceFnRunnerTest {
             1, // window start
             20)); // window end
     assertThat(
-        output.get(0).getPane(), equalTo(PaneInfo.createPane(true, true, Timing.ON_TIME, 0, 0)));
+        output.get(0).getPaneInfo(),
+        equalTo(PaneInfo.createPane(true, true, Timing.ON_TIME, 0, 0)));
   }
 
   /**
@@ -1527,7 +1531,8 @@ public class ReduceFnRunnerTest {
             1, // window start
             20)); // window end
     assertThat(
-        output.get(0).getPane(), equalTo(PaneInfo.createPane(true, true, Timing.ON_TIME, 0, 0)));
+        output.get(0).getPaneInfo(),
+        equalTo(PaneInfo.createPane(true, true, Timing.ON_TIME, 0, 0)));
   }
 
   /** Ensure a closed trigger has its state recorded in the merge result window. */
@@ -1614,7 +1619,8 @@ public class ReduceFnRunnerTest {
             equalTo((BoundedWindow) mergedWindow)));
 
     assertThat(
-        output.get(0).getPane(), equalTo(PaneInfo.createPane(true, true, Timing.ON_TIME, 0, 0)));
+        output.get(0).getPaneInfo(),
+        equalTo(PaneInfo.createPane(true, true, Timing.ON_TIME, 0, 0)));
   }
 
   /**
@@ -1661,7 +1667,7 @@ public class ReduceFnRunnerTest {
             1, // window start
             18)); // window end
     assertThat(
-        output.get(0).getPane(), equalTo(PaneInfo.createPane(true, true, Timing.EARLY, 0, 0)));
+        output.get(0).getPaneInfo(), equalTo(PaneInfo.createPane(true, true, Timing.EARLY, 0, 0)));
   }
 
   /**
@@ -1702,7 +1708,7 @@ public class ReduceFnRunnerTest {
             2, // window start
             12)); // window end
     assertThat(
-        output.get(0).getPane(), equalTo(PaneInfo.createPane(true, true, Timing.EARLY, 0, 0)));
+        output.get(0).getPaneInfo(), equalTo(PaneInfo.createPane(true, true, Timing.EARLY, 0, 0)));
     assertThat(
         output.get(1),
         isSingleWindowedValue(
@@ -1711,7 +1717,8 @@ public class ReduceFnRunnerTest {
             1, // window start
             13)); // window end
     assertThat(
-        output.get(1).getPane(), equalTo(PaneInfo.createPane(true, true, Timing.ON_TIME, 0, 0)));
+        output.get(1).getPaneInfo(),
+        equalTo(PaneInfo.createPane(true, true, Timing.ON_TIME, 0, 0)));
   }
 
   /**
@@ -1811,7 +1818,7 @@ public class ReduceFnRunnerTest {
     // The late pane has the correct indices.
     assertThat(output.get(1).getValue(), contains(3));
     assertThat(
-        output.get(1).getPane(), equalTo(PaneInfo.createPane(false, true, Timing.LATE, 1, 1)));
+        output.get(1).getPaneInfo(), equalTo(PaneInfo.createPane(false, true, Timing.LATE, 1, 1)));
 
     assertTrue(tester.isMarkedFinished(firstWindow));
     tester.assertHasOnlyGlobalAndFinishedSetsFor(firstWindow);
@@ -1850,7 +1857,8 @@ public class ReduceFnRunnerTest {
     assertThat(output.size(), equalTo(1));
     assertThat(output.get(0), isSingleWindowedValue(containsInAnyOrder(1, 2), 1, 0, 10));
     assertThat(
-        output.get(0).getPane(), equalTo(PaneInfo.createPane(true, false, Timing.ON_TIME, 0, 0)));
+        output.get(0).getPaneInfo(),
+        equalTo(PaneInfo.createPane(true, false, Timing.ON_TIME, 0, 0)));
 
     // Fire another timer with no data; the empty pane should not be output even though the
     // trigger is ready to fire
@@ -1868,7 +1876,7 @@ public class ReduceFnRunnerTest {
     // The late pane has the correct indices.
     assertThat(output.get(0).getValue(), containsInAnyOrder(1, 2, 3));
     assertThat(
-        output.get(0).getPane(), equalTo(PaneInfo.createPane(false, true, Timing.LATE, 1, 1)));
+        output.get(0).getPaneInfo(), equalTo(PaneInfo.createPane(false, true, Timing.LATE, 1, 1)));
 
     assertTrue(tester.isMarkedFinished(firstWindow));
     tester.assertHasOnlyGlobalAndFinishedSetsFor(firstWindow);
@@ -2193,8 +2201,8 @@ public class ReduceFnRunnerTest {
     List<WindowedValue<Iterable<Integer>>> output = tester.extractOutput();
     assertEquals(n / 3, output.size());
     for (int i = 0; i < output.size(); i++) {
-      assertEquals(Timing.EARLY, output.get(i).getPane().getTiming());
-      assertEquals(i, output.get(i).getPane().getIndex());
+      assertEquals(Timing.EARLY, output.get(i).getPaneInfo().getTiming());
+      assertEquals(i, output.get(i).getPaneInfo().getIndex());
       assertEquals(3, Iterables.size(output.get(i).getValue()));
     }
 
@@ -2202,8 +2210,8 @@ public class ReduceFnRunnerTest {
 
     output = tester.extractOutput();
     assertEquals(1, output.size());
-    assertEquals(Timing.ON_TIME, output.get(0).getPane().getTiming());
-    assertEquals(n / 3, output.get(0).getPane().getIndex());
+    assertEquals(Timing.ON_TIME, output.get(0).getPaneInfo().getTiming());
+    assertEquals(n / 3, output.get(0).getPaneInfo().getIndex());
     assertEquals(n - ((n / 3) * 3), Iterables.size(output.get(0).getValue()));
   }
 
@@ -2231,8 +2239,8 @@ public class ReduceFnRunnerTest {
     List<WindowedValue<Iterable<Integer>>> output = tester.extractOutput();
     assertEquals((n + 3) / 4, output.size());
     for (int i = 0; i < output.size(); i++) {
-      assertEquals(Timing.EARLY, output.get(i).getPane().getTiming());
-      assertEquals(i, output.get(i).getPane().getIndex());
+      assertEquals(Timing.EARLY, output.get(i).getPaneInfo().getTiming());
+      assertEquals(i, output.get(i).getPaneInfo().getIndex());
       assertEquals(4, Iterables.size(output.get(i).getValue()));
     }
 
@@ -2240,8 +2248,8 @@ public class ReduceFnRunnerTest {
 
     output = tester.extractOutput();
     assertEquals(1, output.size());
-    assertEquals(Timing.ON_TIME, output.get(0).getPane().getTiming());
-    assertEquals((n + 3) / 4, output.get(0).getPane().getIndex());
+    assertEquals(Timing.ON_TIME, output.get(0).getPaneInfo().getTiming());
+    assertEquals((n + 3) / 4, output.get(0).getPaneInfo().getIndex());
     assertEquals(0, Iterables.size(output.get(0).getValue()));
   }
 

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/WindowMatchers.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/WindowMatchers.java
@@ -155,13 +155,13 @@ public class WindowMatchers {
 
       @Override
       protected boolean matchesSafely(WindowedValue<? extends T> item) {
-        return Objects.equals(item.getPane(), paneInfo);
+        return Objects.equals(item.getPaneInfo(), paneInfo);
       }
 
       @Override
       protected void describeMismatchSafely(
           WindowedValue<? extends T> item, Description mismatchDescription) {
-        mismatchDescription.appendValue(item.getPane());
+        mismatchDescription.appendValue(item.getPaneInfo());
       }
     };
   }
@@ -212,7 +212,7 @@ public class WindowMatchers {
       return valueMatcher.matches(windowedValue.getValue())
           && timestampMatcher.matches(windowedValue.getTimestamp())
           && windowsMatcher.matches(windowedValue.getWindows())
-          && paneInfoMatcher.matches(windowedValue.getPane());
+          && paneInfoMatcher.matches(windowedValue.getPaneInfo());
     }
   }
 }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/SideInputContainer.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/SideInputContainer.java
@@ -159,7 +159,7 @@ class SideInputContainer {
       // the value had never been set, so we set it and are done.
       return;
     }
-    PaneInfo newPane = windowValues.iterator().next().getPane();
+    PaneInfo newPane = windowValues.iterator().next().getPaneInfo();
 
     Iterable<? extends WindowedValue<?>> existingValues;
     long existingPane;
@@ -168,7 +168,7 @@ class SideInputContainer {
       existingPane =
           Iterables.isEmpty(existingValues)
               ? -1L
-              : existingValues.iterator().next().getPane().getIndex();
+              : existingValues.iterator().next().getPaneInfo().getIndex();
     } while (newPane.getIndex() > existingPane
         && !contents.compareAndSet(existingValues, windowValues));
   }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WindowEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WindowEvaluatorFactory.java
@@ -91,7 +91,7 @@ class WindowEvaluatorFactory implements TransformEvaluatorFactory {
         Collection<? extends BoundedWindow> windows = assignWindows(windowFn, element);
         outputBundle.add(
             WindowedValue.of(
-                element.getValue(), element.getTimestamp(), windows, element.getPane()));
+                element.getValue(), element.getTimestamp(), windows, element.getPaneInfo()));
       }
     }
 

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WindowEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WindowEvaluatorFactoryTest.java
@@ -176,24 +176,24 @@ public class WindowEvaluatorFactoryTest {
                 valueInIntervalWindow.getValue(),
                 valueInIntervalWindow.getTimestamp(),
                 ImmutableSet.of(wMinus1, wMinusSlide),
-                valueInIntervalWindow.getPane()),
+                valueInIntervalWindow.getPaneInfo()),
 
             // Value in three windows mapped to three windowed values in the same multiple windows
             isWindowedValue(
                 valueInGlobalAndTwoIntervalWindows.getValue(),
                 valueInGlobalAndTwoIntervalWindows.getTimestamp(),
                 ImmutableSet.of(w1, w2),
-                valueInGlobalAndTwoIntervalWindows.getPane()),
+                valueInGlobalAndTwoIntervalWindows.getPaneInfo()),
             isWindowedValue(
                 valueInGlobalAndTwoIntervalWindows.getValue(),
                 valueInGlobalAndTwoIntervalWindows.getTimestamp(),
                 ImmutableSet.of(w1, w2),
-                valueInGlobalAndTwoIntervalWindows.getPane()),
+                valueInGlobalAndTwoIntervalWindows.getPaneInfo()),
             isWindowedValue(
                 valueInGlobalAndTwoIntervalWindows.getValue(),
                 valueInGlobalAndTwoIntervalWindows.getTimestamp(),
                 ImmutableSet.of(w1, w2),
-                valueInGlobalAndTwoIntervalWindows.getPane())));
+                valueInGlobalAndTwoIntervalWindows.getPaneInfo())));
   }
 
   @Test
@@ -219,14 +219,14 @@ public class WindowEvaluatorFactoryTest {
                 new IntervalWindow(
                     valueInGlobalWindow.getTimestamp(),
                     valueInGlobalWindow.getTimestamp().plus(Duration.millis(1L))),
-                valueInGlobalWindow.getPane()),
+                valueInGlobalWindow.getPaneInfo()),
 
             // Value in interval window mapped to the same window
             isWindowedValue(
                 valueInIntervalWindow.getValue(),
                 valueInIntervalWindow.getTimestamp(),
                 valueInIntervalWindow.getWindows(),
-                valueInIntervalWindow.getPane()),
+                valueInIntervalWindow.getPaneInfo()),
 
             // Value in global window and two interval windows exploded and mapped in both ways
             isSingleWindowedValue(
@@ -235,17 +235,17 @@ public class WindowEvaluatorFactoryTest {
                 new IntervalWindow(
                     valueInGlobalAndTwoIntervalWindows.getTimestamp(),
                     valueInGlobalAndTwoIntervalWindows.getTimestamp().plus(Duration.millis(1L))),
-                valueInGlobalAndTwoIntervalWindows.getPane()),
+                valueInGlobalAndTwoIntervalWindows.getPaneInfo()),
             isSingleWindowedValue(
                 valueInGlobalAndTwoIntervalWindows.getValue(),
                 valueInGlobalAndTwoIntervalWindows.getTimestamp(),
                 intervalWindow1,
-                valueInGlobalAndTwoIntervalWindows.getPane()),
+                valueInGlobalAndTwoIntervalWindows.getPaneInfo()),
             isSingleWindowedValue(
                 valueInGlobalAndTwoIntervalWindows.getValue(),
                 valueInGlobalAndTwoIntervalWindows.getTimestamp(),
                 intervalWindow2,
-                valueInGlobalAndTwoIntervalWindows.getPane())));
+                valueInGlobalAndTwoIntervalWindows.getPaneInfo())));
   }
 
   private CommittedBundle<Long> createInputBundle() {

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
@@ -1404,7 +1404,7 @@ class FlinkStreamingTransformTranslators {
         OutputT originalValue = element.getValue().getValue();
         WindowedValue<OutputT> output =
             WindowedValue.of(
-                originalValue, element.getTimestamp(), element.getWindows(), element.getPane());
+                originalValue, element.getTimestamp(), element.getWindows(), element.getPaneInfo());
         ctx.collect(output);
       }
 
@@ -1414,7 +1414,7 @@ class FlinkStreamingTransformTranslators {
         OutputT originalValue = element.getValue().getValue();
         WindowedValue<OutputT> output =
             WindowedValue.of(
-                originalValue, element.getTimestamp(), element.getWindows(), element.getPane());
+                originalValue, element.getTimestamp(), element.getWindows(), element.getPaneInfo());
         ctx.collectWithTimestamp(output, timestamp);
       }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkAssignWindows.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkAssignWindows.java
@@ -43,7 +43,7 @@ public class FlinkAssignWindows<T, W extends BoundedWindow>
     Collection<W> windows = windowFn.assignWindows(new FlinkAssignContext<>(windowFn, input));
     for (W window : windows) {
       collector.collect(
-          WindowedValue.of(input.getValue(), input.getTimestamp(), window, input.getPane()));
+          WindowedValue.of(input.getValue(), input.getTimestamp(), window, input.getPaneInfo()));
     }
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkDoFnFunction.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkDoFnFunction.java
@@ -223,7 +223,7 @@ public class FlinkDoFnFunction<InputT, OutputT> extends AbstractRichFunction
                   new RawUnionValue(0 /* single output */, output.getValue()),
                   output.getTimestamp(),
                   output.getWindows(),
-                  output.getPane()));
+                  output.getPaneInfo()));
     }
   }
 
@@ -256,7 +256,7 @@ public class FlinkDoFnFunction<InputT, OutputT> extends AbstractRichFunction
                   new RawUnionValue(outputMap.get(tag), output.getValue()),
                   output.getTimestamp(),
                   output.getWindows(),
-                  output.getPane()));
+                  output.getPaneInfo()));
     }
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/SortingFlinkCombineRunner.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/SortingFlinkCombineRunner.java
@@ -162,7 +162,7 @@ public class SortingFlinkCombineRunner<K, InputT, AccumT, OutputT, W extends Bou
           elements.set(
               j,
               WindowedValue.of(
-                  value.getValue(), value.getTimestamp(), currentWindow, value.getPane()));
+                  value.getValue(), value.getTimestamp(), currentWindow, value.getPaneInfo()));
         }
         currentStart = i;
         currentWindow = nextWindow;
@@ -175,7 +175,7 @@ public class SortingFlinkCombineRunner<K, InputT, AccumT, OutputT, W extends Bou
         elements.set(
             j,
             WindowedValue.of(
-                value.getValue(), value.getTimestamp(), currentWindow, value.getPane()));
+                value.getValue(), value.getTimestamp(), currentWindow, value.getPaneInfo()));
       }
     }
   }

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/BatchViewOverrides.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/BatchViewOverrides.java
@@ -1390,7 +1390,7 @@ class BatchViewOverrides {
     }
 
     @Override
-    public PaneInfo getPane() {
+    public PaneInfo getPaneInfo() {
       return PaneInfo.NO_FIRING;
     }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/AssignWindowsParDoFnFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/AssignWindowsParDoFnFactory.java
@@ -111,7 +111,7 @@ class AssignWindowsParDoFnFactory implements ParDoFnFactory {
               });
 
       WindowedValue<T> res =
-          WindowedValue.of(elem.getValue(), elem.getTimestamp(), windows, elem.getPane());
+          WindowedValue.of(elem.getValue(), elem.getTimestamp(), windows, elem.getPaneInfo());
       receiver.process(res);
     }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/PartialGroupByKeyParDoFns.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/PartialGroupByKeyParDoFns.java
@@ -243,7 +243,7 @@ public class PartialGroupByKeyParDoFns {
       // Ignore timestamp for grouping purposes.
       // The PGBK output will inherit the timestamp of one of its inputs.
       return WindowedValue.of(
-          coder.structuralValue(key.getValue()), ignored, key.getWindows(), key.getPane());
+          coder.structuralValue(key.getValue()), ignored, key.getWindows(), key.getPaneInfo());
     }
   }
 
@@ -304,7 +304,7 @@ public class PartialGroupByKeyParDoFns {
       WindowedValue<KV<K, InputT>> input = (WindowedValue<KV<K, InputT>>) elem;
       for (BoundedWindow w : input.getWindows()) {
         WindowedValue<KV<K, InputT>> windowsExpandedInput =
-            WindowedValue.of(input.getValue(), input.getTimestamp(), w, input.getPane());
+            WindowedValue.of(input.getValue(), input.getTimestamp(), w, input.getPaneInfo());
         groupingTable.put(windowsExpandedInput, receiver);
       }
     }
@@ -361,7 +361,7 @@ public class PartialGroupByKeyParDoFns {
       WindowedValue<KV<K, InputT>> input = (WindowedValue<KV<K, InputT>>) elem;
       for (BoundedWindow w : input.getWindows()) {
         WindowedValue<KV<K, InputT>> windowsExpandedInput =
-            WindowedValue.of(input.getValue(), input.getTimestamp(), w, input.getPane());
+            WindowedValue.of(input.getValue(), input.getTimestamp(), w, input.getPaneInfo());
 
         if (!sideInputFetcher.storeIfBlocked(windowsExpandedInput)) {
           groupingTable.put(windowsExpandedInput, receiver);

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ReifyTimestampAndWindowsParDoFnFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ReifyTimestampAndWindowsParDoFnFactory.java
@@ -77,10 +77,10 @@ class ReifyTimestampAndWindowsParDoFnFactory implements ParDoFnFactory {
                       typedElem.getValue().getValue(),
                       typedElem.getTimestamp(),
                       typedElem.getWindows(),
-                      typedElem.getPane())),
+                      typedElem.getPaneInfo())),
               typedElem.getTimestamp(),
               typedElem.getWindows(),
-              typedElem.getPane()));
+              typedElem.getPaneInfo()));
     }
 
     @Override

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingGroupAlsoByWindowReshuffleFn.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingGroupAlsoByWindowReshuffleFn.java
@@ -58,7 +58,7 @@ public class StreamingGroupAlsoByWindowReshuffleFn<K, T>
           KV.of(key, Collections.singletonList(item.getValue())),
           item.getTimestamp(),
           item.getWindows(),
-          item.getPane());
+          item.getPaneInfo());
     }
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WindmillSink.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WindmillSink.java
@@ -155,7 +155,7 @@ class WindmillSink<T> extends Sink<WindowedValue<T>> {
     public long add(WindowedValue<T> data) throws IOException {
       ByteString key, value;
       ByteString id = ByteString.EMPTY;
-      ByteString metadata = encodeMetadata(windowsCoder, data.getWindows(), data.getPane());
+      ByteString metadata = encodeMetadata(windowsCoder, data.getWindows(), data.getPaneInfo());
       if (valueCoder instanceof KvCoder) {
         KvCoder kvCoder = (KvCoder) valueCoder;
         KV kv = (KV) data.getValue();

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/BatchGroupAlsoByWindowReshuffleFn.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/BatchGroupAlsoByWindowReshuffleFn.java
@@ -57,7 +57,7 @@ public class BatchGroupAlsoByWindowReshuffleFn<K, V, W extends BoundedWindow>
           KV.<K, Iterable<V>>of(key, Collections.singletonList(item.getValue())),
           item.getTimestamp(),
           item.getWindows(),
-          item.getPane());
+          item.getPaneInfo());
     }
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/ValueInEmptyWindows.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/ValueInEmptyWindows.java
@@ -45,7 +45,7 @@ public class ValueInEmptyWindows<T> extends WindowedValue<T> {
   }
 
   @Override
-  public PaneInfo getPane() {
+  public PaneInfo getPaneInfo() {
     return PaneInfo.NO_FIRING;
   }
 
@@ -88,7 +88,7 @@ public class ValueInEmptyWindows<T> extends WindowedValue<T> {
   public String toString() {
     return MoreObjects.toStringHelper(getClass())
         .add("value", getValue())
-        .add("pane", getPane())
+        .add("pane", getPaneInfo())
         .toString();
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/ReifyTimestampAndWindowsParDoFnFactoryTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/ReifyTimestampAndWindowsParDoFnFactoryTest.java
@@ -55,7 +55,7 @@ public class ReifyTimestampAndWindowsParDoFnFactoryTest {
         receiver.reified.getValue().getValue().getValue(), equalTo(elem.getValue().getValue()));
     assertThat(receiver.reified.getValue().getValue().getTimestamp(), equalTo(elem.getTimestamp()));
     assertThat(receiver.reified.getValue().getValue().getWindows(), equalTo(elem.getWindows()));
-    assertThat(receiver.reified.getValue().getValue().getPane(), equalTo(elem.getPane()));
+    assertThat(receiver.reified.getValue().getValue().getPaneInfo(), equalTo(elem.getPaneInfo()));
   }
 
   @Test

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/BundleCheckpointHandlers.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/BundleCheckpointHandlers.java
@@ -131,7 +131,7 @@ public class BundleCheckpointHandlers {
                         stateValue.getValue(),
                         stateValue.getTimestamp(),
                         ImmutableList.of(window),
-                        stateValue.getPane()));
+                        stateValue.getPaneInfo()));
           }
         } catch (Exception e) {
           throw new RuntimeException("Failed to set timer/state for the residual", e);

--- a/runners/jet/src/main/java/org/apache/beam/runners/jet/processors/AssignWindowP.java
+++ b/runners/jet/src/main/java/org/apache/beam/runners/jet/processors/AssignWindowP.java
@@ -77,7 +77,7 @@ public class AssignWindowP<T> extends AbstractProcessor {
                       inputValue.getValue(),
                       inputValue.getTimestamp(),
                       windows,
-                      inputValue.getPane());
+                      inputValue.getPaneInfo());
               traverser.accept(Utils.encode(outputValue, outputCoder));
               return traverser;
             });

--- a/runners/jet/src/main/java/org/apache/beam/runners/jet/processors/ViewP.java
+++ b/runners/jet/src/main/java/org/apache/beam/runners/jet/processors/ViewP.java
@@ -74,7 +74,7 @@ public class ViewP extends AbstractProcessor {
       values.merge(
           window,
           new TimestampAndValues(
-              windowedValue.getPane(), windowedValue.getTimestamp(), windowedValue.getValue()),
+              windowedValue.getPaneInfo(), windowedValue.getTimestamp(), windowedValue.getValue()),
           (o, n) -> o.merge(timestampCombiner, n));
     }
 

--- a/runners/jet/src/main/java/org/apache/beam/runners/jet/processors/WindowGroupP.java
+++ b/runners/jet/src/main/java/org/apache/beam/runners/jet/processors/WindowGroupP.java
@@ -134,7 +134,7 @@ public class WindowGroupP<K, V> extends AbstractProcessor {
                         value,
                         windowedValue.getTimestamp(),
                         windowedValue.getWindows(),
-                        windowedValue.getPane());
+                        windowedValue.getPaneInfo());
                 keyManagers
                     .computeIfAbsent(keyBytes, x -> new KeyManager(key))
                     .processElement(updatedWindowedValue);

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/DoFnOp.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/DoFnOp.java
@@ -485,7 +485,7 @@ public class DoFnOp<InT, FnOutT, OutT> implements Op<InT, OutT, Void> {
                 valueMapper.apply(res),
                 windowedValue.getTimestamp(),
                 windowedValue.getWindows(),
-                windowedValue.getPane()));
+                windowedValue.getPaneInfo()));
   }
 
   /**

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/WindowAssignOp.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/WindowAssignOp.java
@@ -46,7 +46,7 @@ public class WindowAssignOp<T, W extends BoundedWindow> implements Op<T, T, Void
                     inputElement.getValue(),
                     inputElement.getTimestamp(),
                     window,
-                    inputElement.getPane()))
+                    inputElement.getPaneInfo()))
         .forEach(outputElement -> emitter.emitElement(outputElement));
   }
 }

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/WindowAssignTranslatorBatch.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/WindowAssignTranslatorBatch.java
@@ -93,7 +93,7 @@ class WindowAssignTranslatorBatch<T>
                   return window;
                 }
               });
-      return WindowedValue.of(element, timestamp, windows, value.getPane());
+      return WindowedValue.of(element, timestamp, windows, value.getPaneInfo());
     };
   }
 

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/GroupNonMergingWindowsFunctions.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/GroupNonMergingWindowsFunctions.java
@@ -131,7 +131,8 @@ public class GroupNonMergingWindowsFunctions {
                 final W window = (W) Iterables.getOnlyElement(item.getWindows());
                 final byte[] windowBytes = CoderHelpers.toByteArray(window, windowCoder);
                 WindowedValue<KV<K, V>> valueOut =
-                    WindowedValue.of(item.getValue(), item.getTimestamp(), window, item.getPane());
+                    WindowedValue.of(
+                        item.getValue(), item.getTimestamp(), window, item.getPaneInfo());
                 final ByteArray windowedKey = new ByteArray(Bytes.concat(keyBytes, windowBytes));
                 return new Tuple2<>(windowedKey, mappingFn.apply(valueOut));
               });

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/ReifyTimestampsAndWindowsFunction.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/ReifyTimestampsAndWindowsFunction.java
@@ -33,6 +33,9 @@ public class ReifyTimestampsAndWindowsFunction<K, V>
     return KV.of(
         elem.getValue().getKey(),
         WindowedValue.of(
-            elem.getValue().getValue(), elem.getTimestamp(), elem.getWindows(), elem.getPane()));
+            elem.getValue().getValue(),
+            elem.getTimestamp(),
+            elem.getWindows(),
+            elem.getPaneInfo()));
   }
 }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TransformTranslator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TransformTranslator.java
@@ -231,7 +231,7 @@ public final class TransformTranslator {
                                 in.getValue().getValue(), sparkCombineFn.ctxtForValue(in))),
                         in.getTimestamp(),
                         in.getWindows(),
-                        in.getPane()));
+                        in.getPaneInfo()));
         context.putDataset(transform, new BoundedDataset<>(outRDD));
       }
 
@@ -698,7 +698,10 @@ public final class TransformTranslator {
                 WindowedValue<V> wv = CoderHelpers.fromByteArray(read._2(), wvCoder);
                 consumed();
                 return WindowedValue.of(
-                    KV.of(key, wv.getValue()), wv.getTimestamp(), wv.getWindows(), wv.getPane());
+                    KV.of(key, wv.getValue()),
+                    wv.getTimestamp(),
+                    wv.getWindows(),
+                    wv.getPaneInfo());
               }
             }
             return endOfData();

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TranslationUtils.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TranslationUtils.java
@@ -109,7 +109,7 @@ public final class TranslationUtils {
                   .apply(windowedKv.getValue().getValue(), fn.ctxtForValue(windowedKv))),
           windowedKv.getTimestamp(),
           windowedKv.getWindows(),
-          windowedKv.getPane());
+          windowedKv.getPaneInfo());
     }
   }
 

--- a/runners/twister2/src/main/java/org/apache/beam/runners/twister2/translators/functions/AssignWindowsFunction.java
+++ b/runners/twister2/src/main/java/org/apache/beam/runners/twister2/translators/functions/AssignWindowsFunction.java
@@ -70,7 +70,7 @@ public class AssignWindowsFunction<T>
         for (BoundedWindow window : windows) {
           output.collect(
               WindowedValue.of(
-                  element.getValue(), element.getTimestamp(), window, element.getPane()));
+                  element.getValue(), element.getTimestamp(), window, element.getPaneInfo()));
         }
       }
     } catch (Exception e) {

--- a/runners/twister2/src/main/java/org/apache/beam/runners/twister2/translators/functions/ByteToWindowFunctionPrimitive.java
+++ b/runners/twister2/src/main/java/org/apache/beam/runners/twister2/translators/functions/ByteToWindowFunctionPrimitive.java
@@ -80,7 +80,7 @@ public class ByteToWindowFunctionPrimitive<K, V>
             KV.of(key, value.getValue()),
             value.getTimestamp(),
             value.getWindows(),
-            value.getPane());
+            value.getPaneInfo());
 
     return element;
   }

--- a/runners/twister2/src/main/java/org/apache/beam/runners/twister2/translators/functions/MapToTupleFunction.java
+++ b/runners/twister2/src/main/java/org/apache/beam/runners/twister2/translators/functions/MapToTupleFunction.java
@@ -68,10 +68,10 @@ public class MapToTupleFunction<K, V>
                     input.getValue().getValue(),
                     input.getTimestamp(),
                     input.getWindows(),
-                    input.getPane())),
+                    input.getPaneInfo())),
             input.getTimestamp(),
             input.getWindows(),
-            input.getPane());
+            input.getPaneInfo());
     try {
       element =
           new Tuple<>(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Create.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Create.java
@@ -913,7 +913,10 @@ public class Create<T> {
       @ProcessElement
       public void processElement(@Element WindowedValue<T> element, OutputReceiver<T> r) {
         r.outputWindowedValue(
-            element.getValue(), element.getTimestamp(), element.getWindows(), element.getPane());
+            element.getValue(),
+            element.getTimestamp(),
+            element.getWindows(),
+            element.getPaneInfo());
       }
     }
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/WindowedValue.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/WindowedValue.java
@@ -155,7 +155,7 @@ public abstract class WindowedValue<T> {
   public abstract Collection<? extends BoundedWindow> getWindows();
 
   /** Returns the pane of this {@code WindowedValue} in its window. */
-  public abstract PaneInfo getPane();
+  public abstract PaneInfo getPaneInfo();
 
   /** Returns {@code true} if this WindowedValue has exactly one window. */
   public boolean isSingleWindowedValue() {
@@ -172,7 +172,7 @@ public abstract class WindowedValue<T> {
     }
     ImmutableList.Builder<WindowedValue<T>> windowedValues = ImmutableList.builder();
     for (BoundedWindow w : getWindows()) {
-      windowedValues.add(of(getValue(), getTimestamp(), w, getPane()));
+      windowedValues.add(of(getValue(), getTimestamp(), w, getPaneInfo()));
     }
     return windowedValues.build();
   }
@@ -190,14 +190,14 @@ public abstract class WindowedValue<T> {
       return this.getTimestamp().isEqual(that.getTimestamp())
           && Objects.equals(this.getValue(), that.getValue())
           && Objects.equals(this.getWindows(), that.getWindows())
-          && Objects.equals(this.getPane(), that.getPane());
+          && Objects.equals(this.getPaneInfo(), that.getPaneInfo());
     }
   }
 
   @Override
   public int hashCode() {
     // Hash only the millis of the timestamp to be consistent with equals
-    return Objects.hash(getValue(), getTimestamp().getMillis(), getWindows(), getPane());
+    return Objects.hash(getValue(), getTimestamp().getMillis(), getWindows(), getPaneInfo());
   }
 
   @Override
@@ -228,7 +228,7 @@ public abstract class WindowedValue<T> {
     }
 
     @Override
-    public PaneInfo getPane() {
+    public PaneInfo getPaneInfo() {
       return pane;
     }
 
@@ -260,7 +260,7 @@ public abstract class WindowedValue<T> {
 
     @Override
     public <NewT> WindowedValue<NewT> withValue(NewT newValue) {
-      return new ValueInGlobalWindow<>(newValue, getPane());
+      return new ValueInGlobalWindow<>(newValue, getPaneInfo());
     }
 
     @Override
@@ -282,7 +282,7 @@ public abstract class WindowedValue<T> {
     public boolean equals(@Nullable Object o) {
       if (o instanceof ValueInGlobalWindow) {
         ValueInGlobalWindow<?> that = (ValueInGlobalWindow<?>) o;
-        return Objects.equals(that.getPane(), this.getPane())
+        return Objects.equals(that.getPaneInfo(), this.getPaneInfo())
             && Objects.equals(that.getValue(), this.getValue());
       } else {
         return super.equals(o);
@@ -291,14 +291,14 @@ public abstract class WindowedValue<T> {
 
     @Override
     public int hashCode() {
-      return Objects.hash(getValue(), getPane());
+      return Objects.hash(getValue(), getPaneInfo());
     }
 
     @Override
     public String toString() {
       return MoreObjects.toStringHelper(getClass())
           .add("value", getValue())
-          .add("pane", getPane())
+          .add("pane", getPaneInfo())
           .toString();
     }
   }
@@ -331,7 +331,7 @@ public abstract class WindowedValue<T> {
 
     @Override
     public <NewT> WindowedValue<NewT> withValue(NewT newValue) {
-      return new TimestampedValueInGlobalWindow<>(newValue, getTimestamp(), getPane());
+      return new TimestampedValueInGlobalWindow<>(newValue, getTimestamp(), getPaneInfo());
     }
 
     @Override
@@ -357,7 +357,7 @@ public abstract class WindowedValue<T> {
         // Also compare timestamps according to millis-since-epoch because otherwise expensive
         // comparisons are made on their Chronology objects.
         return this.getTimestamp().isEqual(that.getTimestamp())
-            && Objects.equals(that.getPane(), this.getPane())
+            && Objects.equals(that.getPaneInfo(), this.getPaneInfo())
             && Objects.equals(that.getValue(), this.getValue());
       } else {
         return super.equals(o);
@@ -367,7 +367,7 @@ public abstract class WindowedValue<T> {
     @Override
     public int hashCode() {
       // Hash only the millis of the timestamp to be consistent with equals
-      return Objects.hash(getValue(), getPane(), getTimestamp().getMillis());
+      return Objects.hash(getValue(), getPaneInfo(), getTimestamp().getMillis());
     }
 
     @Override
@@ -375,7 +375,7 @@ public abstract class WindowedValue<T> {
       return MoreObjects.toStringHelper(getClass())
           .add("value", getValue())
           .add("timestamp", getTimestamp())
-          .add("pane", getPane())
+          .add("pane", getPaneInfo())
           .toString();
     }
   }
@@ -397,7 +397,7 @@ public abstract class WindowedValue<T> {
 
     @Override
     public <NewT> WindowedValue<NewT> withValue(NewT newValue) {
-      return new TimestampedValueInSingleWindow<>(newValue, getTimestamp(), window, getPane());
+      return new TimestampedValueInSingleWindow<>(newValue, getTimestamp(), window, getPaneInfo());
     }
 
     @Override
@@ -424,7 +424,7 @@ public abstract class WindowedValue<T> {
         // comparisons are made on their Chronology objects.
         return this.getTimestamp().isEqual(that.getTimestamp())
             && Objects.equals(that.getValue(), this.getValue())
-            && Objects.equals(that.getPane(), this.getPane())
+            && Objects.equals(that.getPaneInfo(), this.getPaneInfo())
             && Objects.equals(that.window, this.window);
       } else {
         return super.equals(o);
@@ -434,7 +434,7 @@ public abstract class WindowedValue<T> {
     @Override
     public int hashCode() {
       // Hash only the millis of the timestamp to be consistent with equals
-      return Objects.hash(getValue(), getTimestamp().getMillis(), getPane(), window);
+      return Objects.hash(getValue(), getTimestamp().getMillis(), getPaneInfo(), window);
     }
 
     @Override
@@ -443,7 +443,7 @@ public abstract class WindowedValue<T> {
           .add("value", getValue())
           .add("timestamp", getTimestamp())
           .add("window", window)
-          .add("pane", getPane())
+          .add("pane", getPaneInfo())
           .toString();
     }
   }
@@ -460,7 +460,8 @@ public abstract class WindowedValue<T> {
 
     @Override
     public <NewT> WindowedValue<NewT> withValue(NewT newValue) {
-      return new TimestampedValueInMultipleWindows<>(newValue, getTimestamp(), windows, getPane());
+      return new TimestampedValueInMultipleWindows<>(
+          newValue, getTimestamp(), windows, getPaneInfo());
     }
 
     @Override
@@ -477,7 +478,7 @@ public abstract class WindowedValue<T> {
         // comparisons are made on their Chronology objects.
         if (this.getTimestamp().isEqual(that.getTimestamp())
             && Objects.equals(that.getValue(), this.getValue())
-            && Objects.equals(that.getPane(), this.getPane())) {
+            && Objects.equals(that.getPaneInfo(), this.getPaneInfo())) {
           ensureWindowsAreASet();
           that.ensureWindowsAreASet();
           return that.windows.equals(this.windows);
@@ -493,7 +494,7 @@ public abstract class WindowedValue<T> {
     public int hashCode() {
       // Hash only the millis of the timestamp to be consistent with equals
       ensureWindowsAreASet();
-      return Objects.hash(getValue(), getTimestamp().getMillis(), getPane(), windows);
+      return Objects.hash(getValue(), getTimestamp().getMillis(), getPaneInfo(), windows);
     }
 
     @Override
@@ -502,7 +503,7 @@ public abstract class WindowedValue<T> {
           .add("value", getValue())
           .add("timestamp", getTimestamp())
           .add("windows", windows)
-          .add("pane", getPane())
+          .add("pane", getPaneInfo())
           .toString();
     }
 
@@ -603,7 +604,7 @@ public abstract class WindowedValue<T> {
         throws CoderException, IOException {
       InstantCoder.of().encode(windowedElem.getTimestamp(), outStream);
       windowsCoder.encode(windowedElem.getWindows(), outStream);
-      PaneInfoCoder.INSTANCE.encode(windowedElem.getPane(), outStream);
+      PaneInfoCoder.INSTANCE.encode(windowedElem.getPaneInfo(), outStream);
       valueCoder.encode(windowedElem.getValue(), outStream, context);
     }
 
@@ -638,7 +639,7 @@ public abstract class WindowedValue<T> {
         throws Exception {
       InstantCoder.of().registerByteSizeObserver(value.getTimestamp(), observer);
       windowsCoder.registerByteSizeObserver(value.getWindows(), observer);
-      PaneInfoCoder.INSTANCE.registerByteSizeObserver(value.getPane(), observer);
+      PaneInfoCoder.INSTANCE.registerByteSizeObserver(value.getPaneInfo(), observer);
       valueCoder.registerByteSizeObserver(value.getValue(), observer);
     }
 
@@ -840,7 +841,7 @@ public abstract class WindowedValue<T> {
     }
 
     public PaneInfo getPane() {
-      return windowedValuePrototype.getPane();
+      return windowedValuePrototype.getPaneInfo();
     }
 
     /** Returns the serialized payload that will be provided when deserializing this coder. */
@@ -877,7 +878,7 @@ public abstract class WindowedValue<T> {
             windowCoder,
             windowedValue.getTimestamp(),
             windowedValue.getWindows(),
-            windowedValue.getPane());
+            windowedValue.getPaneInfo());
       } catch (IOException e) {
         throw new RuntimeException(
             "Unable to decode constant members from payload for ParamWindowedValueCoder: ", e);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CreateTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CreateTest.java
@@ -366,7 +366,7 @@ public class CreateTest {
                                     windowedValue.getValue(),
                                     windowedValue.getTimestamp(),
                                     w,
-                                    windowedValue.getPane())))
+                                    windowedValue.getPaneInfo())))
             .collect(Collectors.toList());
 
     PCollection<String> output =

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/AssignWindowsRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/AssignWindowsRunner.java
@@ -109,6 +109,6 @@ class AssignWindowsRunner<T, W extends BoundedWindow> {
           }
         };
     Collection<W> windows = windowFn.assignWindows(ctxt);
-    return WindowedValue.of(input.getValue(), input.getTimestamp(), windows, input.getPane());
+    return WindowedValue.of(input.getValue(), input.getTimestamp(), windows, input.getPaneInfo());
   }
 }

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -1015,28 +1015,28 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                 KV.of(splitResult.getPrimaryInFullyProcessedWindowsRoot().getValue(), fullSize),
                 splitResult.getPrimaryInFullyProcessedWindowsRoot().getTimestamp(),
                 splitResult.getPrimaryInFullyProcessedWindowsRoot().getWindows(),
-                splitResult.getPrimaryInFullyProcessedWindowsRoot().getPane()),
+                splitResult.getPrimaryInFullyProcessedWindowsRoot().getPaneInfo()),
         splitResult.getPrimarySplitRoot() == null
             ? null
             : WindowedValue.of(
                 KV.of(splitResult.getPrimarySplitRoot().getValue(), primarySize),
                 splitResult.getPrimarySplitRoot().getTimestamp(),
                 splitResult.getPrimarySplitRoot().getWindows(),
-                splitResult.getPrimarySplitRoot().getPane()),
+                splitResult.getPrimarySplitRoot().getPaneInfo()),
         splitResult.getResidualSplitRoot() == null
             ? null
             : WindowedValue.of(
                 KV.of(splitResult.getResidualSplitRoot().getValue(), residualSize),
                 splitResult.getResidualSplitRoot().getTimestamp(),
                 splitResult.getResidualSplitRoot().getWindows(),
-                splitResult.getResidualSplitRoot().getPane()),
+                splitResult.getResidualSplitRoot().getPaneInfo()),
         splitResult.getResidualInUnprocessedWindowsRoot() == null
             ? null
             : WindowedValue.of(
                 KV.of(splitResult.getResidualInUnprocessedWindowsRoot().getValue(), fullSize),
                 splitResult.getResidualInUnprocessedWindowsRoot().getTimestamp(),
                 splitResult.getResidualInUnprocessedWindowsRoot().getWindows(),
-                splitResult.getResidualInUnprocessedWindowsRoot().getPane()));
+                splitResult.getResidualInUnprocessedWindowsRoot().getPaneInfo()));
   }
 
   private HandlesSplits.SplitResult trySplitForWindowObservingTruncateRestriction(
@@ -1119,7 +1119,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                         KV.of(currentRestriction, currentWatermarkEstimatorState)),
                     currentElement.getTimestamp(),
                     primaryFullyProcessedWindows,
-                    currentElement.getPane()),
+                    currentElement.getPaneInfo()),
             splitResult == null
                 ? null
                 : WindowedValue.of(
@@ -1128,7 +1128,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                         KV.of(splitResult.getPrimary(), currentWatermarkEstimatorState)),
                     currentElement.getTimestamp(),
                     currentWindow,
-                    currentElement.getPane()),
+                    currentElement.getPaneInfo()),
             splitResult == null
                 ? null
                 : WindowedValue.of(
@@ -1137,7 +1137,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                         KV.of(splitResult.getResidual(), watermarkAndState.getValue())),
                     currentElement.getTimestamp(),
                     currentWindow,
-                    currentElement.getPane()),
+                    currentElement.getPaneInfo()),
             residualUnprocessedWindows.isEmpty()
                 ? null
                 : WindowedValue.of(
@@ -1146,7 +1146,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                         KV.of(currentRestriction, currentWatermarkEstimatorState)),
                     currentElement.getTimestamp(),
                     residualUnprocessedWindows,
-                    currentElement.getPane()));
+                    currentElement.getPaneInfo()));
     return windowedSplitResult;
   }
 
@@ -1979,7 +1979,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
       outputTo(
           mainOutputConsumer,
           WindowedValue.of(
-              output, currentElement.getTimestamp(), currentWindow, currentElement.getPane()));
+              output, currentElement.getTimestamp(), currentWindow, currentElement.getPaneInfo()));
     }
 
     @Override
@@ -1993,7 +1993,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
       outputTo(
           consumer,
           WindowedValue.of(
-              output, currentElement.getTimestamp(), currentWindow, currentElement.getPane()));
+              output, currentElement.getTimestamp(), currentWindow, currentElement.getPaneInfo()));
     }
 
     @Override
@@ -2002,7 +2002,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
       // runners can provide proper timestamps.
       outputTo(
           mainOutputConsumer,
-          WindowedValue.of(output, timestamp, currentWindow, currentElement.getPane()));
+          WindowedValue.of(output, timestamp, currentWindow, currentElement.getPaneInfo()));
     }
 
     @Override
@@ -2026,7 +2026,8 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
         throw new IllegalArgumentException(String.format("Unknown output tag %s", tag));
       }
       outputTo(
-          consumer, WindowedValue.of(output, timestamp, currentWindow, currentElement.getPane()));
+          consumer,
+          WindowedValue.of(output, timestamp, currentWindow, currentElement.getPaneInfo()));
     }
 
     @Override
@@ -2083,7 +2084,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
           currentWindow,
           currentElement.getTimestamp(),
           currentElement.getTimestamp(),
-          currentElement.getPane(),
+          currentElement.getPaneInfo(),
           timeDomain);
     }
 
@@ -2095,7 +2096,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
           currentWindow,
           currentElement.getTimestamp(),
           currentElement.getTimestamp(),
-          currentElement.getPane());
+          currentElement.getPaneInfo());
     }
   }
 
@@ -2142,7 +2143,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                       size),
                   currentElement.getTimestamp(),
                   currentWindow,
-                  currentElement.getPane()));
+                  currentElement.getPaneInfo()));
     }
 
     @Override
@@ -2187,7 +2188,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                       size),
                   timestamp,
                   currentWindow,
-                  currentElement.getPane()));
+                  currentElement.getPaneInfo()));
     }
 
     @Override
@@ -2355,7 +2356,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                       size),
                   timestamp,
                   currentElement.getWindows(),
-                  currentElement.getPane()));
+                  currentElement.getPaneInfo()));
     }
 
     @Override
@@ -2451,7 +2452,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
       outputTo(
           mainOutputConsumer,
           WindowedValue.of(
-              output, timestamp, currentElement.getWindows(), currentElement.getPane()));
+              output, timestamp, currentElement.getWindows(), currentElement.getPaneInfo()));
     }
 
     @Override
@@ -2475,7 +2476,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
       outputTo(
           consumer,
           WindowedValue.of(
-              output, timestamp, currentElement.getWindows(), currentElement.getPane()));
+              output, timestamp, currentElement.getWindows(), currentElement.getPaneInfo()));
     }
 
     @Override
@@ -2785,7 +2786,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
 
     @Override
     public PaneInfo pane() {
-      return currentElement.getPane();
+      return currentElement.getPaneInfo();
     }
 
     @Override

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/SplittablePairWithRestrictionDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/SplittablePairWithRestrictionDoFnRunner.java
@@ -207,7 +207,7 @@ public class SplittablePairWithRestrictionDoFnRunner<
                 KV.of(elem.getValue(), KV.of(currentRestriction, watermarkEstimatorState)),
                 elem.getTimestamp(),
                 boundedWindow,
-                elem.getPane()));
+                elem.getPaneInfo()));
       }
     } finally {
       mutableArgumentProvider.currentElement = null;
@@ -272,7 +272,7 @@ public class SplittablePairWithRestrictionDoFnRunner<
 
     @Override
     public PaneInfo paneInfo(DoFn<InputT, OutputT> doFn) {
-      return getCurrentElementOrFail().getPane();
+      return getCurrentElementOrFail().getPaneInfo();
     }
 
     @Override

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/SplittableSplitAndSizeRestrictionsDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/SplittableSplitAndSizeRestrictionsDoFnRunner.java
@@ -352,7 +352,7 @@ public class SplittableSplitAndSizeRestrictionsDoFnRunner<
                   size),
               getCurrentElement().getTimestamp(),
               getCurrentWindow(),
-              getCurrentElement().getPane()));
+              getCurrentElement().getPaneInfo()));
     }
   }
 
@@ -411,7 +411,7 @@ public class SplittableSplitAndSizeRestrictionsDoFnRunner<
 
     @Override
     public PaneInfo paneInfo(DoFn<InputT, OutputT> doFn) {
-      return getCurrentElement().getPane();
+      return getCurrentElement().getPaneInfo();
     }
 
     @Override

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/AssignWindowsRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/AssignWindowsRunnerTest.java
@@ -120,7 +120,7 @@ public class AssignWindowsRunnerTest implements Serializable {
                 -3,
                 new Instant(-12),
                 ImmutableSet.of(firstWindow, secondWindow),
-                firstValue.getPane())));
+                firstValue.getPaneInfo())));
     WindowedValue<Integer> secondValue =
         WindowedValue.of(
             3,
@@ -135,7 +135,7 @@ public class AssignWindowsRunnerTest implements Serializable {
                 3,
                 new Instant(12),
                 ImmutableSet.of(secondWindow, thirdWindow),
-                secondValue.getPane())));
+                secondValue.getPaneInfo())));
   }
 
   @Test

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
@@ -2266,7 +2266,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
                     3.0),
                 firstValue.getTimestamp(),
                 window1,
-                firstValue.getPane()));
+                firstValue.getPaneInfo()));
         assertEquals(
             decode(inputCoder, residualRoot.getApplication().getElement()),
             WindowedValue.of(
@@ -2279,7 +2279,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
                     2.0),
                 firstValue.getTimestamp(),
                 window1,
-                firstValue.getPane()));
+                firstValue.getPaneInfo()));
         assertEquals(
             decode(inputCoder, residualRootForUnprocessedWindows.getApplication().getElement()),
             WindowedValue.of(
@@ -2292,7 +2292,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
                     5.0),
                 firstValue.getTimestamp(),
                 window2,
-                firstValue.getPane()));
+                firstValue.getPaneInfo()));
         splitListener.clear();
 
         // Check that before processing an element we don't report progress
@@ -2319,37 +2319,37 @@ public class FnApiDoFnRunnerTest implements Serializable {
                     "5:5",
                     GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(5)),
                     window1,
-                    firstValue.getPane()),
+                    firstValue.getPaneInfo()),
                 WindowedValue.of(
                     "5:6",
                     GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(6)),
                     window1,
-                    firstValue.getPane()),
+                    firstValue.getPaneInfo()),
                 WindowedValue.of(
                     "5:7",
                     GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(7)),
                     window1,
-                    firstValue.getPane()),
+                    firstValue.getPaneInfo()),
                 WindowedValue.of(
                     "2:0",
                     GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(0)),
                     window1,
-                    firstValue.getPane()),
+                    firstValue.getPaneInfo()),
                 WindowedValue.of(
                     "2:1",
                     GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(1)),
                     window1,
-                    firstValue.getPane()),
+                    firstValue.getPaneInfo()),
                 WindowedValue.of(
                     "2:0",
                     GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(0)),
                     window2,
-                    firstValue.getPane()),
+                    firstValue.getPaneInfo()),
                 WindowedValue.of(
                     "2:1",
                     GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(1)),
                     window2,
-                    firstValue.getPane())));
+                    firstValue.getPaneInfo())));
         assertTrue(splitListener.getPrimaryRoots().isEmpty());
         assertTrue(splitListener.getResidualRoots().isEmpty());
         mainOutputValues.clear();
@@ -2411,22 +2411,22 @@ public class FnApiDoFnRunnerTest implements Serializable {
                     "7:0",
                     GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(0)),
                     window1,
-                    splitValue.getPane()),
+                    splitValue.getPaneInfo()),
                 WindowedValue.of(
                     "7:1",
                     GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(1)),
                     window1,
-                    splitValue.getPane()),
+                    splitValue.getPaneInfo()),
                 WindowedValue.of(
                     "7:2",
                     GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(2)),
                     window1,
-                    splitValue.getPane()),
+                    splitValue.getPaneInfo()),
                 WindowedValue.of(
                     "7:3",
                     GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(3)),
                     window1,
-                    splitValue.getPane())));
+                    splitValue.getPaneInfo())));
 
         BundleApplication primaryRoot = Iterables.getOnlyElement(trySplitResult.getPrimaryRoots());
         assertEquals(2, trySplitResult.getResidualRoots().size());
@@ -2500,7 +2500,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
                     5.0),
                 splitValue.getTimestamp(),
                 window2,
-                splitValue.getPane()),
+                splitValue.getPaneInfo()),
             inputCoder.decode(
                 residualRootInUnprocessedWindows.getApplication().getElement().newInput()));
 
@@ -2716,14 +2716,14 @@ public class FnApiDoFnRunnerTest implements Serializable {
                       3.0),
                   splitValue.getTimestamp(),
                   window1,
-                  splitValue.getPane()),
+                  splitValue.getPaneInfo()),
               WindowedValue.of(
                   KV.of(
                       KV.of("7", KV.of(new OffsetRange(0, 3), GlobalWindow.TIMESTAMP_MIN_VALUE)),
                       3.0),
                   splitValue.getTimestamp(),
                   window2,
-                  splitValue.getPane())));
+                  splitValue.getPaneInfo())));
 
       SplitResult expectedElementSplit = createSplitResult(0);
       BundleApplication expectedElementSplitPrimary =
@@ -2735,7 +2735,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
                   KV.of("7", KV.of(new OffsetRange(0, 6), GlobalWindow.TIMESTAMP_MIN_VALUE)), 6.0),
               splitValue.getTimestamp(),
               window1,
-              splitValue.getPane()),
+              splitValue.getPaneInfo()),
           primaryBytes);
       BundleApplication expectedWindowedPrimary =
           BundleApplication.newBuilder()
@@ -2752,7 +2752,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
                   KV.of("7", KV.of(new OffsetRange(0, 6), GlobalWindow.TIMESTAMP_MIN_VALUE)), 6.0),
               splitValue.getTimestamp(),
               window3,
-              splitValue.getPane()),
+              splitValue.getPaneInfo()),
           residualBytes);
       DelayedBundleApplication expectedWindowedResidual =
           DelayedBundleApplication.newBuilder()
@@ -3026,28 +3026,28 @@ public class FnApiDoFnRunnerTest implements Serializable {
                       2.0),
                   firstValue.getTimestamp(),
                   window1,
-                  firstValue.getPane()),
+                  firstValue.getPaneInfo()),
               WindowedValue.of(
                   KV.of(
                       KV.of("5", KV.of(new OffsetRange(0, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)),
                       2.0),
                   firstValue.getTimestamp(),
                   window2,
-                  firstValue.getPane()),
+                  firstValue.getPaneInfo()),
               WindowedValue.of(
                   KV.of(
                       KV.of("2", KV.of(new OffsetRange(0, 1), GlobalWindow.TIMESTAMP_MIN_VALUE)),
                       1.0),
                   firstValue.getTimestamp(),
                   window1,
-                  firstValue.getPane()),
+                  firstValue.getPaneInfo()),
               WindowedValue.of(
                   KV.of(
                       KV.of("2", KV.of(new OffsetRange(0, 1), GlobalWindow.TIMESTAMP_MIN_VALUE)),
                       1.0),
                   firstValue.getTimestamp(),
                   window2,
-                  firstValue.getPane())));
+                  firstValue.getPaneInfo())));
       mainOutputValues.clear();
 
       assertTrue(context.getFinishBundleFunctions().isEmpty());
@@ -3149,14 +3149,14 @@ public class FnApiDoFnRunnerTest implements Serializable {
                       2.0),
                   firstValue.getTimestamp(),
                   ImmutableList.of(window1, window2),
-                  firstValue.getPane()),
+                  firstValue.getPaneInfo()),
               WindowedValue.of(
                   KV.of(
                       KV.of("2", KV.of(new OffsetRange(0, 1), GlobalWindow.TIMESTAMP_MIN_VALUE)),
                       1.0),
                   firstValue.getTimestamp(),
                   ImmutableList.of(window1, window2),
-                  firstValue.getPane())));
+                  firstValue.getPaneInfo())));
       mainOutputValues.clear();
 
       assertTrue(context.getFinishBundleFunctions().isEmpty());
@@ -3339,14 +3339,14 @@ public class FnApiDoFnRunnerTest implements Serializable {
                   KV.of(primaryRestriction, currentWatermarkEstimatorState)),
               currentElement.getTimestamp(),
               window,
-              currentElement.getPane()),
+              currentElement.getPaneInfo()),
           WindowedValue.of(
               KV.of(
                   currentElement.getValue(),
                   KV.of(residualRestriction, watermarkAndState.getValue())),
               currentElement.getTimestamp(),
               window,
-              currentElement.getPane()));
+              currentElement.getPaneInfo()));
     }
 
     private KV<WindowedValue, WindowedValue> createSplitAcrossWindows(
@@ -3360,7 +3360,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
                       KV.of(currentRestriction, currentWatermarkEstimatorState)),
                   currentElement.getTimestamp(),
                   primaryWindows,
-                  currentElement.getPane()),
+                  currentElement.getPaneInfo()),
           residualWindows.isEmpty()
               ? null
               : WindowedValue.of(
@@ -3369,7 +3369,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
                       KV.of(currentRestriction, currentWatermarkEstimatorState)),
                   currentElement.getTimestamp(),
                   residualWindows,
-                  currentElement.getPane()));
+                  currentElement.getPaneInfo()));
     }
 
     private KV<WindowedValue, WindowedValue> createSplitWithSizeInWindow(
@@ -3383,7 +3383,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
                   (double) (primaryRestriction.getTo() - primaryRestriction.getFrom())),
               currentElement.getTimestamp(),
               window,
-              currentElement.getPane()),
+              currentElement.getPaneInfo()),
           WindowedValue.of(
               KV.of(
                   KV.of(
@@ -3392,7 +3392,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
                   (double) (residualRestriction.getTo() - residualRestriction.getFrom())),
               currentElement.getTimestamp(),
               window,
-              currentElement.getPane()));
+              currentElement.getPaneInfo()));
     }
 
     private KV<WindowedValue, WindowedValue> createSplitWithSizeAcrossWindows(
@@ -3408,7 +3408,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
                       (double) (currentRestriction.getTo() - currentRestriction.getFrom())),
                   currentElement.getTimestamp(),
                   primaryWindows,
-                  currentElement.getPane()),
+                  currentElement.getPaneInfo()),
           residualWindows.isEmpty()
               ? null
               : WindowedValue.of(
@@ -3419,7 +3419,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
                       (double) (currentRestriction.getTo() - currentRestriction.getFrom())),
                   currentElement.getTimestamp(),
                   residualWindows,
-                  currentElement.getPane()));
+                  currentElement.getPaneInfo()));
     }
 
     @Before

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/SplittablePairWithRestrictionDoFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/SplittablePairWithRestrictionDoFnRunnerTest.java
@@ -361,7 +361,7 @@ public class SplittablePairWithRestrictionDoFnRunnerTest implements Serializable
                           GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(1)))),
                   firstValue.getTimestamp(),
                   window1,
-                  firstValue.getPane()),
+                  firstValue.getPaneInfo()),
               WindowedValue.of(
                   KV.of(
                       "5",
@@ -370,7 +370,7 @@ public class SplittablePairWithRestrictionDoFnRunnerTest implements Serializable
                           GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(1)))),
                   firstValue.getTimestamp(),
                   window2,
-                  firstValue.getPane()),
+                  firstValue.getPaneInfo()),
               WindowedValue.of(
                   KV.of(
                       "2",
@@ -379,7 +379,7 @@ public class SplittablePairWithRestrictionDoFnRunnerTest implements Serializable
                           GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(1)))),
                   secondValue.getTimestamp(),
                   window1,
-                  secondValue.getPane()),
+                  secondValue.getPaneInfo()),
               WindowedValue.of(
                   KV.of(
                       "2",
@@ -388,7 +388,7 @@ public class SplittablePairWithRestrictionDoFnRunnerTest implements Serializable
                           GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(1)))),
                   secondValue.getTimestamp(),
                   window2,
-                  secondValue.getPane())));
+                  secondValue.getPaneInfo())));
       mainOutputValues.clear();
 
       assertTrue(context.getFinishBundleFunctions().isEmpty());
@@ -476,7 +476,7 @@ public class SplittablePairWithRestrictionDoFnRunnerTest implements Serializable
                           GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(1)))),
                   firstValue.getTimestamp(),
                   ImmutableList.of(window1, window2),
-                  firstValue.getPane()),
+                  firstValue.getPaneInfo()),
               WindowedValue.of(
                   KV.of(
                       "2",
@@ -485,7 +485,7 @@ public class SplittablePairWithRestrictionDoFnRunnerTest implements Serializable
                           GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(1)))),
                   secondValue.getTimestamp(),
                   ImmutableList.of(window1, window2),
-                  secondValue.getPane())));
+                  secondValue.getPaneInfo())));
       mainOutputValues.clear();
 
       assertTrue(context.getFinishBundleFunctions().isEmpty());

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/SplittableSplitAndSizeRestrictionsDoFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/SplittableSplitAndSizeRestrictionsDoFnRunnerTest.java
@@ -333,56 +333,56 @@ public class SplittableSplitAndSizeRestrictionsDoFnRunnerTest implements Seriali
                     2.0),
                 firstValue.getTimestamp(),
                 window1,
-                firstValue.getPane()),
+                firstValue.getPaneInfo()),
             WindowedValue.of(
                 KV.of(
                     KV.of("5", KV.of(new OffsetRange(2, 5), GlobalWindow.TIMESTAMP_MIN_VALUE)),
                     3.0),
                 firstValue.getTimestamp(),
                 window1,
-                firstValue.getPane()),
+                firstValue.getPaneInfo()),
             WindowedValue.of(
                 KV.of(
                     KV.of("5", KV.of(new OffsetRange(0, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)),
                     2.0),
                 firstValue.getTimestamp(),
                 window2,
-                firstValue.getPane()),
+                firstValue.getPaneInfo()),
             WindowedValue.of(
                 KV.of(
                     KV.of("5", KV.of(new OffsetRange(2, 5), GlobalWindow.TIMESTAMP_MIN_VALUE)),
                     3.0),
                 firstValue.getTimestamp(),
                 window2,
-                firstValue.getPane()),
+                firstValue.getPaneInfo()),
             WindowedValue.of(
                 KV.of(
                     KV.of("2", KV.of(new OffsetRange(0, 1), GlobalWindow.TIMESTAMP_MIN_VALUE)),
                     1.0),
                 secondValue.getTimestamp(),
                 window1,
-                secondValue.getPane()),
+                secondValue.getPaneInfo()),
             WindowedValue.of(
                 KV.of(
                     KV.of("2", KV.of(new OffsetRange(1, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)),
                     1.0),
                 secondValue.getTimestamp(),
                 window1,
-                secondValue.getPane()),
+                secondValue.getPaneInfo()),
             WindowedValue.of(
                 KV.of(
                     KV.of("2", KV.of(new OffsetRange(0, 1), GlobalWindow.TIMESTAMP_MIN_VALUE)),
                     1.0),
                 secondValue.getTimestamp(),
                 window2,
-                secondValue.getPane()),
+                secondValue.getPaneInfo()),
             WindowedValue.of(
                 KV.of(
                     KV.of("2", KV.of(new OffsetRange(1, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)),
                     1.0),
                 secondValue.getTimestamp(),
                 window2,
-                secondValue.getPane())));
+                secondValue.getPaneInfo())));
     mainOutputValues.clear();
 
     assertTrue(context.getFinishBundleFunctions().isEmpty());
@@ -476,28 +476,28 @@ public class SplittableSplitAndSizeRestrictionsDoFnRunnerTest implements Seriali
                     2.0),
                 firstValue.getTimestamp(),
                 ImmutableList.of(window1, window2),
-                firstValue.getPane()),
+                firstValue.getPaneInfo()),
             WindowedValue.of(
                 KV.of(
                     KV.of("5", KV.of(new OffsetRange(2, 5), GlobalWindow.TIMESTAMP_MIN_VALUE)),
                     3.0),
                 firstValue.getTimestamp(),
                 ImmutableList.of(window1, window2),
-                firstValue.getPane()),
+                firstValue.getPaneInfo()),
             WindowedValue.of(
                 KV.of(
                     KV.of("2", KV.of(new OffsetRange(0, 1), GlobalWindow.TIMESTAMP_MIN_VALUE)),
                     1.0),
                 firstValue.getTimestamp(),
                 ImmutableList.of(window1, window2),
-                firstValue.getPane()),
+                firstValue.getPaneInfo()),
             WindowedValue.of(
                 KV.of(
                     KV.of("2", KV.of(new OffsetRange(1, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)),
                     1.0),
                 firstValue.getTimestamp(),
                 ImmutableList.of(window1, window2),
-                firstValue.getPane())));
+                firstValue.getPaneInfo())));
     mainOutputValues.clear();
 
     assertTrue(context.getFinishBundleFunctions().isEmpty());


### PR DESCRIPTION
This is a preliminary change to reduce the number of files to review in #34902 

For the user-facing API I think we would like `getPaneInfo` to be appropriately named. Notably, a `PaneInfo` record is _not_ the same as a "pane". A "pane" is a name for a single triggered output of a window (probably we tried to be too clever with names) but the `PaneInfo` does not uniquely identify the pane. In Python SDK this is the public field `WindowedVAlue.pane_info` so it also makes the SDKs match better. In Go SDK it is `pane` but it is not blocking the current change.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
