### PR TITLE
Allow Dofn Input/Output Typing

### DIFF
--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -30,6 +30,7 @@ import traceback
 import types
 import typing
 from itertools import dropwhile
+from typing import Generic
 
 from apache_beam import coders
 from apache_beam import pvalue
@@ -114,6 +115,8 @@ __all__ = [
 T = typing.TypeVar('T')
 K = typing.TypeVar('K')
 V = typing.TypeVar('V')
+InputT = typing.TypeVar('InputT')
+OutputT = typing.TypeVar('OutputT')
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -590,7 +593,7 @@ class _SetupContextParam(_ContextParam):
   """
 
 
-class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
+class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn, Generic[InputT, OutputT]):
   """A function object used by a transform with custom processing.
 
   The ParDo transform is such a transform. The ParDo.apply
@@ -692,7 +695,7 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
   def default_label(self):
     return self.__class__.__name__
 
-  def process(self, element, *args, **kwargs):
+  def process(self, element:InputT, *args, **kwargs) -> OutputT:
     """Method to use for processing elements.
 
     This is invoked by ``DoFnRunner`` for each element of a input


### PR DESCRIPTION
Adds Generic Type hints to Dofn input output.  Process should take an InputT and produce an Iterable[OutputT].

Adding so that I can use type hints to ensure that an async Function takes (K, V) pairs.

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
