### PR TITLE
Replace usages of deprecated pkg_resources package

### DIFF
--- a/sdks/python/gen_protos.py
+++ b/sdks/python/gen_protos.py
@@ -21,6 +21,7 @@ Generates Python proto modules and grpc stubs for Beam protos.
 import argparse
 import contextlib
 import glob
+import importlib.resources
 import inspect
 import logging
 import os
@@ -30,8 +31,6 @@ import shutil
 import sys
 from collections import defaultdict
 from importlib import import_module
-
-import importlib.resources
 
 LOG = logging.getLogger()
 LOG.setLevel(logging.INFO)

--- a/sdks/python/gen_protos.py
+++ b/sdks/python/gen_protos.py
@@ -31,7 +31,7 @@ import sys
 from collections import defaultdict
 from importlib import import_module
 
-import pkg_resources
+import importlib_resources
 
 LOG = logging.getLogger()
 LOG.setLevel(logging.INFO)
@@ -474,7 +474,7 @@ def generate_proto_files(force=False):
 
   protoc_gen_mypy = _find_protoc_gen_mypy()
   from grpc_tools import protoc
-  builtin_protos = pkg_resources.resource_filename('grpc_tools', '_proto')
+  builtin_protos = importlib_resources.files('grpc_tools') / '_proto'
   args = (
       [sys.executable] +  # expecting to be called from command line
       ['--proto_path=%s' % builtin_protos] +

--- a/sdks/python/gen_protos.py
+++ b/sdks/python/gen_protos.py
@@ -31,7 +31,7 @@ import sys
 from collections import defaultdict
 from importlib import import_module
 
-import importlib_resources
+import importlib.resources
 
 LOG = logging.getLogger()
 LOG.setLevel(logging.INFO)
@@ -474,7 +474,7 @@ def generate_proto_files(force=False):
 
   protoc_gen_mypy = _find_protoc_gen_mypy()
   from grpc_tools import protoc
-  builtin_protos = importlib_resources.files('grpc_tools') / '_proto'
+  builtin_protos = importlib.resources.files('grpc_tools') / '_proto'
   args = (
       [sys.executable] +  # expecting to be called from command line
       ['--proto_path=%s' % builtin_protos] +

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -35,7 +35,7 @@ requires = [
     'pyyaml>=3.12,<7.0.0',
     # also update Jinja2 bounds in test-suites/xlang/build.gradle (look for xlangWrapperValidation task)
     "jinja2>=2.7.1,<4.0.0",
-    'yapf==0.43.0',
+    'yapf==0.43.0'
 ]
 
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -35,7 +35,8 @@ requires = [
     'pyyaml>=3.12,<7.0.0',
     # also update Jinja2 bounds in test-suites/xlang/build.gradle (look for xlangWrapperValidation task)
     "jinja2>=2.7.1,<4.0.0",
-    'yapf==0.43.0'
+    'yapf==0.43.0',
+    'importlib-resources==6.5.2'
 ]
 
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -36,7 +36,6 @@ requires = [
     # also update Jinja2 bounds in test-suites/xlang/build.gradle (look for xlangWrapperValidation task)
     "jinja2>=2.7.1,<4.0.0",
     'yapf==0.43.0',
-    'importlib-resources==6.5.2'
 ]
 
 

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -46,7 +46,7 @@ def to_filename(name: str) -> str:
 
 
 def normalize_path(filename):
-    return os.path.normcase(os.path.realpath(os.path.normpath(filename)))
+  return os.path.normcase(os.path.realpath(os.path.normpath(filename)))
 
 
 class mypy(Command):
@@ -361,7 +361,7 @@ if __name__ == '__main__':
           'fasteners>=0.3,<1.0',
           # TODO(https://github.com/grpc/grpc/issues/37710): Unpin grpc
           'grpcio>=1.33.1,<2,!=1.48.0,!=1.59.*,!=1.60.*,!=1.61.*,!=1.62.0,!=1.62.1,<1.66.0; python_version <= "3.12"',  # pylint: disable=line-too-long
-          'grpcio>=1.67.0; python_version >= "3.13"', 
+          'grpcio>=1.67.0; python_version >= "3.13"',
           'hdfs>=2.1.0,<3.0.0',
           'httplib2>=0.8,<0.23.0',
           'jsonschema>=4.0.0,<5.0.0',

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -31,9 +31,7 @@ from pathlib import Path
 
 # pylint: disable=ungrouped-imports
 import setuptools
-from pkg_resources import normalize_path
-from pkg_resources import parse_version
-from pkg_resources import to_filename
+from packaging.version import parse
 from setuptools import Command
 
 # pylint: disable=wrong-import-order
@@ -41,6 +39,14 @@ from setuptools import Command
 # using legacy behavior from distutils.
 # https://setuptools.readthedocs.io/en/latest/history.html#v48-0-0
 from distutils.errors import DistutilsError  # isort:skip
+
+
+def to_filename(name: str) -> str:
+  return name.replace('-', '_')
+
+
+def normalize_path(filename):
+    return os.path.normcase(os.path.realpath(os.path.normpath(filename)))
 
 
 class mypy(Command):
@@ -101,7 +107,7 @@ different technologies and user communities.
 RECOMMENDED_MIN_PIP_VERSION = '19.3.0'
 try:
   _PIP_VERSION = distribution('pip').version
-  if parse_version(_PIP_VERSION) < parse_version(RECOMMENDED_MIN_PIP_VERSION):
+  if parse(_PIP_VERSION) < parse(RECOMMENDED_MIN_PIP_VERSION):
     warnings.warn(
         "You are using version {0} of pip. " \
         "However, the recommended min version is {1}.".format(
@@ -116,7 +122,7 @@ except PackageNotFoundError:
 REQUIRED_CYTHON_VERSION = '3.0.0'
 try:
   _CYTHON_VERSION = distribution('cython').version
-  if parse_version(_CYTHON_VERSION) < parse_version(REQUIRED_CYTHON_VERSION):
+  if parse(_CYTHON_VERSION) < parse(REQUIRED_CYTHON_VERSION):
     warnings.warn(
         "You are using version {0} of cython. " \
         "However, version {1} is recommended.".format(


### PR DESCRIPTION
Migrates `pkg_resources` usage in the Python SDK to `packaging` and `importlib.resources` equivalents and re-defines utility functions (`to_filename()` and `normalize_path()` which were small string utilities from `pkg_resources`.) `pkg_resources` is deprecated and these changes are the suggested migration path.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
