### PR TITLE
Fix incorrect typehints generated by FlatMap with default identity function

### DIFF
--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -2016,7 +2016,7 @@ class StatelessDoFnInfo(DoFnInfo):
     return beam_runner_api_pb2.FunctionSpec(urn=self._urn)
 
 
-def identity(x: T) -> T:
+def identity(x):
   return x
 
 
@@ -2053,6 +2053,7 @@ def FlatMap(fn=identity, *args, **kwargs):  # pylint: disable=invalid-name
 
   pardo = ParDo(CallableWrapperDoFn(fn), *args, **kwargs)
   pardo.label = label
+
   return pardo
 
 

--- a/sdks/python/apache_beam/transforms/core_test.py
+++ b/sdks/python/apache_beam/transforms/core_test.py
@@ -21,7 +21,6 @@
 import logging
 import os
 import tempfile
-import typing
 import unittest
 from typing import TypeVar
 
@@ -31,6 +30,7 @@ import apache_beam as beam
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
 from apache_beam.transforms.window import FixedWindows
+from apache_beam.typehints import typehints
 
 RETURN_NONE_PARTIAL_WARNING = "No iterator is returned"
 
@@ -298,8 +298,7 @@ class FlatMapTest(unittest.TestCase):
       return x
 
     dofn = beam.core.CallableWrapperDoFn(identity)
-    assert dofn.get_type_hints() is None
-    assert dofn.get_type_hints().strip_iterable()[1][0][0] is typing.Any
+    assert dofn.get_type_hints().strip_iterable()[1][0][0] == typehints.Any
 
   def test_default_with_typehint(self):
     with beam.Pipeline() as pipeline:

--- a/sdks/python/apache_beam/transforms/core_test.py
+++ b/sdks/python/apache_beam/transforms/core_test.py
@@ -20,17 +20,17 @@
 
 import logging
 import os
+import pytest
 import tempfile
 import unittest
 from typing import TypeVar
-
-import pytest
 
 import apache_beam as beam
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
 from apache_beam.transforms.window import FixedWindows
-from apache_beam.typehints import typehints, TypeCheckError
+from apache_beam.typehints import TypeCheckError
+from apache_beam.typehints import typehints
 
 RETURN_NONE_PARTIAL_WARNING = "No iterator is returned"
 

--- a/sdks/python/apache_beam/transforms/core_test.py
+++ b/sdks/python/apache_beam/transforms/core_test.py
@@ -281,6 +281,16 @@ class ExceptionHandlingTest(unittest.TestCase):
       self.assertFalse(os.path.isfile(tmp_path))
 
 
+def test_callablewrapper_typehint():
+  T = TypeVar("T")
+
+  def identity(x: T) -> T:
+    return x
+
+  dofn = beam.core.CallableWrapperDoFn(identity)
+  assert dofn.get_type_hints().strip_iterable()[1][0][0] == typehints.Any
+
+
 class FlatMapTest(unittest.TestCase):
   def test_default(self):
 
@@ -290,15 +300,6 @@ class FlatMapTest(unittest.TestCase):
           | beam.Create(['abc', 'def'], reshuffle=False)
           | beam.FlatMap())
       assert_that(letters, equal_to(['a', 'b', 'c', 'd', 'e', 'f']))
-
-  def test_callablewrapper_typehint(self):
-    T = TypeVar("T")
-
-    def identity(x: T) -> T:
-      return x
-
-    dofn = beam.core.CallableWrapperDoFn(identity)
-    assert dofn.get_type_hints().strip_iterable()[1][0][0] == typehints.Any
 
   def test_default_identity_function_with_typehint(self):
     with beam.Pipeline() as pipeline:

--- a/sdks/python/apache_beam/transforms/core_test.py
+++ b/sdks/python/apache_beam/transforms/core_test.py
@@ -21,7 +21,9 @@
 import logging
 import os
 import tempfile
+import typing
 import unittest
+from typing import TypeVar
 
 import pytest
 
@@ -288,6 +290,16 @@ class FlatMapTest(unittest.TestCase):
           | beam.Create(['abc', 'def'], reshuffle=False)
           | beam.FlatMap())
       assert_that(letters, equal_to(['a', 'b', 'c', 'd', 'e', 'f']))
+
+  def test_callablewrapper_typehint(self):
+    T = TypeVar("T")
+
+    def identity(x: T) -> T:
+      return x
+
+    dofn = beam.core.CallableWrapperDoFn(identity)
+    assert dofn.get_type_hints() is None
+    assert dofn.get_type_hints().strip_iterable()[1][0][0] is typing.Any
 
   def test_default_with_typehint(self):
     with beam.Pipeline() as pipeline:

--- a/sdks/python/apache_beam/transforms/core_test.py
+++ b/sdks/python/apache_beam/transforms/core_test.py
@@ -289,6 +289,16 @@ class FlatMapTest(unittest.TestCase):
           | beam.FlatMap())
       assert_that(letters, equal_to(['a', 'b', 'c', 'd', 'e', 'f']))
 
+  def test_default_with_typehint(self):
+    with beam.Pipeline() as pipeline:
+      letters = (
+          pipeline
+          | beam.Create([["abc"]], reshuffle=False)
+          | beam.FlatMap()
+          | beam.Map(lambda s: s.upper()).with_input_types(str))
+
+      assert_that(letters, equal_to(["ABC"]))
+
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)

--- a/sdks/python/apache_beam/transforms/core_test.py
+++ b/sdks/python/apache_beam/transforms/core_test.py
@@ -20,10 +20,11 @@
 
 import logging
 import os
-import pytest
 import tempfile
 import unittest
 from typing import TypeVar
+
+import pytest
 
 import apache_beam as beam
 from apache_beam.testing.util import assert_that

--- a/sdks/python/apache_beam/typehints/decorators.py
+++ b/sdks/python/apache_beam/typehints/decorators.py
@@ -424,6 +424,13 @@ class IOTypeHints(NamedTuple):
           output_type = types[0]
         except ValueError:
           pass
+    # if output_type == T, we can't strip it.
+    print(
+        'output_type:',
+        output_type,
+        f"{isinstance(output_type, typehints.TypeVariable) = }")
+    if isinstance(output_type, typehints.TypeVariable):
+      return self
 
     yielded_type = typehints.get_yielded_type(output_type)
     return self._replace(

--- a/sdks/python/apache_beam/typehints/decorators.py
+++ b/sdks/python/apache_beam/typehints/decorators.py
@@ -424,13 +424,11 @@ class IOTypeHints(NamedTuple):
           output_type = types[0]
         except ValueError:
           pass
-    # if output_type == T, we can't strip it.
-    print(
-        'output_type:',
-        output_type,
-        f"{isinstance(output_type, typehints.TypeVariable) = }")
     if isinstance(output_type, typehints.TypeVariable):
-      return self
+      # We don't know what T yields, so we just assume Any.
+      return self._replace(
+          output_types=((typehints.Any, ), {}),
+          origin=self._make_origin([self], tb=False, msg=['strip_iterable()']))
 
     yielded_type = typehints.get_yielded_type(output_type)
     return self._replace(

--- a/sdks/python/apache_beam/typehints/decorators_test.py
+++ b/sdks/python/apache_beam/typehints/decorators_test.py
@@ -131,7 +131,6 @@ class IOTypeHintsTest(unittest.TestCase):
   def test_strip_iterable(self):
     self._test_strip_iterable(None, None)
     self._test_strip_iterable(typehints.Any, typehints.Any)
-    self._test_strip_iterable(T, None)
     self._test_strip_iterable(typehints.Iterable[str], str)
     self._test_strip_iterable(typehints.List[str], str)
     self._test_strip_iterable(typehints.Iterator[str], str)
@@ -144,6 +143,7 @@ class IOTypeHintsTest(unittest.TestCase):
     self._test_strip_iterable(typehints.Set[str], str)
     self._test_strip_iterable(typehints.FrozenSet[str], str)
 
+    #self._test_strip_iterable_fail(T)
     self._test_strip_iterable_fail(typehints.Union[str, int])
     self._test_strip_iterable_fail(typehints.Optional[str])
     self._test_strip_iterable_fail(

--- a/sdks/python/apache_beam/typehints/decorators_test.py
+++ b/sdks/python/apache_beam/typehints/decorators_test.py
@@ -131,6 +131,7 @@ class IOTypeHintsTest(unittest.TestCase):
   def test_strip_iterable(self):
     self._test_strip_iterable(None, None)
     self._test_strip_iterable(typehints.Any, typehints.Any)
+    self._test_strip_iterable(T, typehints.Any)
     self._test_strip_iterable(typehints.Iterable[str], str)
     self._test_strip_iterable(typehints.List[str], str)
     self._test_strip_iterable(typehints.Iterator[str], str)
@@ -143,7 +144,6 @@ class IOTypeHintsTest(unittest.TestCase):
     self._test_strip_iterable(typehints.Set[str], str)
     self._test_strip_iterable(typehints.FrozenSet[str], str)
 
-    #self._test_strip_iterable_fail(T)
     self._test_strip_iterable_fail(typehints.Union[str, int])
     self._test_strip_iterable_fail(typehints.Optional[str])
     self._test_strip_iterable_fail(

--- a/sdks/python/apache_beam/typehints/decorators_test.py
+++ b/sdks/python/apache_beam/typehints/decorators_test.py
@@ -131,6 +131,7 @@ class IOTypeHintsTest(unittest.TestCase):
   def test_strip_iterable(self):
     self._test_strip_iterable(None, None)
     self._test_strip_iterable(typehints.Any, typehints.Any)
+    self._test_strip_iterable(T, None)
     self._test_strip_iterable(typehints.Iterable[str], str)
     self._test_strip_iterable(typehints.List[str], str)
     self._test_strip_iterable(typehints.Iterator[str], str)

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -1566,7 +1566,6 @@ def get_yielded_type(type_hint):
   if isinstance(type_hint, TypeVariable):
     raise ValueError('%s is not iterable' % type_hint)
   if isinstance(type_hint, AnyTypeConstraint):
-    print(f"{type_hint} is considered a AnyTypeConstraint")
     return type_hint
   if is_consistent_with(type_hint, Iterator[Any]):
     return type_hint.yielded_type

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -1563,7 +1563,10 @@ def get_yielded_type(type_hint):
   Raises:
     ValueError if not iterable.
   """
+  if isinstance(type_hint, TypeVariable):
+    raise ValueError('%s is not iterable' % type_hint)
   if isinstance(type_hint, AnyTypeConstraint):
+    print(f"{type_hint} is considered a AnyTypeConstraint")
     return type_hint
   if is_consistent_with(type_hint, Iterator[Any]):
     return type_hint.yielded_type

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -1563,8 +1563,8 @@ def get_yielded_type(type_hint):
   Raises:
     ValueError if not iterable.
   """
-  if isinstance(type_hint, TypeVariable):
-    raise ValueError('%s is not iterable' % type_hint)
+  if isinstance(type_hint, typing.TypeVar):
+    return typing.Any
   if isinstance(type_hint, AnyTypeConstraint):
     return type_hint
   if is_consistent_with(type_hint, Iterator[Any]):

--- a/sdks/python/apache_beam/typehints/typehints_test.py
+++ b/sdks/python/apache_beam/typehints/typehints_test.py
@@ -1654,6 +1654,7 @@ class TestGetYieldedType(unittest.TestCase):
         typehints.get_yielded_type(typehints.Tuple[int, str]))
     self.assertEqual(int, typehints.get_yielded_type(typehints.Set[int]))
     self.assertEqual(int, typehints.get_yielded_type(typehints.FrozenSet[int]))
+    self.assertEqual(typing.Any, typehints.get_yielded_type(T))
     self.assertEqual(
         typehints.Union[int, str],
         typehints.get_yielded_type(
@@ -1662,10 +1663,6 @@ class TestGetYieldedType(unittest.TestCase):
   def test_not_iterable(self):
     with self.assertRaisesRegex(ValueError, r'not iterable'):
       typehints.get_yielded_type(int)
-    with self.assertRaisesRegex(ValueError, r'not iterable'):
-      typehints.get_yielded_type(T)
-    with self.assertRaisesRegex(ValueError, r'not iterable'):
-      typehints.get_yielded_type(typehints.TypeVariable("T"))
 
   def test_union_not_iterable(self):
     with self.assertRaisesRegex(ValueError, r'not iterable'):

--- a/sdks/python/apache_beam/typehints/typehints_test.py
+++ b/sdks/python/apache_beam/typehints/typehints_test.py
@@ -1664,6 +1664,8 @@ class TestGetYieldedType(unittest.TestCase):
       typehints.get_yielded_type(int)
     with self.assertRaisesRegex(ValueError, r'not iterable'):
       typehints.get_yielded_type(T)
+    with self.assertRaisesRegex(ValueError, r'not iterable'):
+      typehints.get_yielded_type(typehints.TypeVariable("T"))
 
   def test_union_not_iterable(self):
     with self.assertRaisesRegex(ValueError, r'not iterable'):

--- a/sdks/python/apache_beam/typehints/typehints_test.py
+++ b/sdks/python/apache_beam/typehints/typehints_test.py
@@ -1662,6 +1662,8 @@ class TestGetYieldedType(unittest.TestCase):
   def test_not_iterable(self):
     with self.assertRaisesRegex(ValueError, r'not iterable'):
       typehints.get_yielded_type(int)
+    with self.assertRaisesRegex(ValueError, r'not iterable'):
+      typehints.get_yielded_type(T)
 
   def test_union_not_iterable(self):
     with self.assertRaisesRegex(ValueError, r'not iterable'):


### PR DESCRIPTION
The following pipeline currently throws an error:
```python

    with beam.Pipeline() as pipeline:
      letters = (
          pipeline
          | beam.Create([['abc']], reshuffle=False)
          | beam.FlatMap()
          | beam.Map(lambda s: s.upper()).with_input_types(str))
```
with error: (roughly)
```
TypeCheckError: The transform '[4]: Map(<lambda at <ipython-input-4-04b6d203d131>:6>)' requires PCollections of type '<class 'str'>' but was applied to a PCollection of type 'List[<class 'str'>]' (produced by the transform '[4]: FlatMap(identity)'). 
```

This can be fixed by just updating the `FlatMap` identity function to just have no type hints, which allows trivial inference to correctly determine the right pcollection types.

Before realizing that solution, I ended up fixing a few type hinting functions that strip iterables so that they handle generic `TypeVariable`s better (the yielded type of `TypeVar('T')` should not be `TypeVar('T')` for example).

Those changes aren't actually necessary for this fix, but they seem like a bug in the typehinting logic anyways so I've left them in. 


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
