### PR TITLE
Fix IntelliJ sync project failure due to circular Beam dependency

### DIFF
--- a/examples/java/cdap/hubspot/build.gradle
+++ b/examples/java/cdap/hubspot/build.gradle
@@ -69,9 +69,15 @@ dependencies {
     implementation library.java.cdap_hydrator_common
     //TODO: modify to 'implementation library.java.cdap_plugin_hubspot',
     // when new release with HasOffset interface will be published
-    implementation "com.akvelon:cdap-hubspot-plugins:1.1.0"
+    implementation("com.akvelon:cdap-hubspot-plugins:1.1.0") {
+        // circular dependency to Beam component
+        exclude group: "org.apache.beam", module: "beam-sdks-java-io-sparkreceiver"
+    }
+    // implementation project(":sdks:java:io:sparkreceiver:3")
+    implementation library.java.spark3_streaming
+    permitUnusedDeclared library.java.spark3_streaming
     implementation library.java.google_code_gson
-    implementation library.java.hadoop_common
+    implementation "org.apache.hadoop:hadoop-client-api:3.3.4"
     implementation library.java.slf4j_api
     implementation library.java.vendored_guava_32_1_2_jre
     runtimeOnly project(path: ":runners:direct-java", configuration: "shadow")

--- a/examples/java/cdap/hubspot/build.gradle
+++ b/examples/java/cdap/hubspot/build.gradle
@@ -73,7 +73,6 @@ dependencies {
         // circular dependency to Beam component
         exclude group: "org.apache.beam", module: "beam-sdks-java-io-sparkreceiver"
     }
-    // implementation project(":sdks:java:io:sparkreceiver:3")
     implementation library.java.spark3_streaming
     permitUnusedDeclared library.java.spark3_streaming
     implementation library.java.google_code_gson

--- a/examples/java/cdap/salesforce/build.gradle
+++ b/examples/java/cdap/salesforce/build.gradle
@@ -65,9 +65,14 @@ dependencies {
     implementation library.java.cdap_hydrator_common
     //TODO: modify to 'implementation library.java.cdap_plugin_salesforce',
     // when new release with HasOffset interface will be published
-    implementation "com.akvelon:cdap-salesforce-plugins:1.5.1"
+    implementation("com.akvelon:cdap-salesforce-plugins:1.5.1") {
+        // circular dependency to Beam component
+        exclude group: "org.apache.beam", module: "beam-sdks-java-io-sparkreceiver"
+    }
+    implementation library.java.spark3_streaming
+    permitUnusedDeclared library.java.spark3_streaming
     implementation library.java.google_code_gson
-    implementation library.java.hadoop_common
+    implementation "org.apache.hadoop:hadoop-client-api:3.3.4"
     implementation library.java.slf4j_api
     implementation library.java.vendored_guava_32_1_2_jre
     runtimeOnly project(path: ":runners:direct-java", configuration: "shadow")


### PR DESCRIPTION
IntelliJ sync gradle project see the following error:

```
Could not find avro-mapred-1.11.2-hadoop2.jar (org.apache.avro:avro-mapred:1.11.2).
Searched in the following locations:
    https://repo.maven.apache.org/maven2/org/apache/avro/avro-mapred/1.11.2/avro-mapred-1.11.2-hadoop2.jar
```

On IntelliJ 2022, it prevents IntelliJ resolving all dependencies, with no hint where the problem is

On IntelliJ 2025, it still outputs error, but make it clearer the problem happens on this two subproject.

The problem is the vendored `com:avkelon` plugin depends on Beam 2.41 SparkReceiverIO, confused the dependency resolver.


**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
