### PR TITLE
Add BigQuery Storage Read API Enrichment Handler

### DIFF
--- a/sdks/python/apache_beam/transforms/enrichment_handlers/bigquery_storage_read.py
+++ b/sdks/python/apache_beam/transforms/enrichment_handlers/bigquery_storage_read.py
@@ -1,0 +1,431 @@
+# -*- coding: utf-8 -*-
+# Copyright 2024 Google LLC & Apache Software Foundation (Original License Header)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+BigQuery Enrichment Source Handler using the BigQuery Storage Read API
+with support for field renaming via aliases in `column_names`,
+additional non-key fields for filtering, dynamic row restriction templates,
+experimental parallel stream reading using ThreadPoolExecutor, and custom row selection.
+"""
+import logging
+import re
+import time # For timing internal operations if needed
+import concurrent.futures # For parallel stream reading
+from collections.abc import Callable, Mapping
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Set, Tuple, Union
+
+import apache_beam as beam
+# Import Row explicitly for type checking where needed
+from apache_beam.pvalue import Row as BeamRow
+from apache_beam.transforms.enrichment import EnrichmentSourceHandler
+from google.api_core.exceptions import BadRequest, NotFound, GoogleAPICallError
+from google.cloud.bigquery_storage import BigQueryReadClient, types
+import pyarrow as pa
+import pyarrow.ipc # Import the ipc module
+
+# --- Configure Logging ---
+logger = logging.getLogger(__name__)
+
+
+# Type hints for functions
+# Input functions expect beam.Row for clarity, use beam.Row.as_dict inside if needed
+ConditionValueFn = Callable[[BeamRow], Dict[str, Any]]
+# Updated RowRestrictionTemplateFn signature based on user provided code
+RowRestrictionTemplateFn = Callable[[Dict[str, Any], Optional[List[str]], BeamRow], str]
+BQRowDict = Dict[str, Any]
+# Callback for selecting the "latest" or desired row from multiple BQ results
+LatestValueSelectorFn = Optional[Callable[[List[BeamRow], BeamRow], Optional[BeamRow]]]
+
+
+# Regex to parse "column as alias" format, ignoring case for "as"
+ALIAS_REGEX = re.compile(r"^(.*?)\s+as\s+(.*)$", re.IGNORECASE)
+
+def _validate_bigquery_metadata(
+    project, table_name, row_restriction_template, row_restriction_template_fn, fields, condition_value_fn, additional_condition_fields
+):
+    """Validates parameters for Storage API usage."""
+    if not project: raise ValueError("`project` must be provided.")
+    if not table_name: raise ValueError("`table_name` must be provided.")
+    if (row_restriction_template and row_restriction_template_fn) or \
+       (not row_restriction_template and not row_restriction_template_fn):
+        raise ValueError("Provide exactly one of `row_restriction_template` or `row_restriction_template_fn`.")
+    if (fields and condition_value_fn) or (not fields and not condition_value_fn):
+        raise ValueError("Provide exactly one of `fields` or `condition_value_fn`.")
+    if additional_condition_fields and condition_value_fn:
+        raise ValueError("`additional_condition_fields` cannot be used with `condition_value_fn`.")
+
+
+class BigQueryStorageEnrichmentHandler(EnrichmentSourceHandler[Union[BeamRow, list[BeamRow]], Union[BeamRow, list[BeamRow]]]):
+    """Enrichment handler for Google Cloud BigQuery using the Storage Read API.
+    (Refer to __init__ for full list of features and arguments)
+    """
+
+    def __init__(
+        self,
+        project: str,
+        table_name: str,
+        *,
+        row_restriction_template: Optional[str] = None,
+        row_restriction_template_fn: Optional[RowRestrictionTemplateFn] = None,
+        fields: Optional[list[str]] = None, # Fields for KEY and filtering
+        additional_condition_fields: Optional[list[str]] = None, # Fields ONLY for filtering
+        column_names: Optional[list[str]] = None, # Columns to select + aliases
+        condition_value_fn: Optional[ConditionValueFn] = None, # Alt way to get filter/key values
+        min_batch_size: int = 1,
+        max_batch_size: int = 1000, # Batching enabled by default
+        max_batch_duration_secs: int = 5,
+        max_parallel_streams: Optional[int] = None, # Max workers for ThreadPoolExecutor
+        # --- Added latest_value_selector and primary_keys from user code ---
+        latest_value_selector: LatestValueSelectorFn = None,
+        primary_keys: Optional[list[str]] = None,
+        # --- End added parameters ---
+    ):
+        """
+        Initializes the BigQueryStorageEnrichmentHandler.
+
+        Args:
+            project: Google Cloud project ID.
+            table_name: Fully qualified BigQuery table name (`project.dataset.table`).
+            row_restriction_template: (Optional[str]) Template string for a single row's filter
+                condition. If `row_restriction_template_fn` is not provided, this template
+                will be formatted with values from `fields` and `additional_condition_fields`.
+            row_restriction_template_fn: (Optional[Callable[[Dict[str,Any], Optional[List[str]], beam.Row], str]])
+                Function that takes (condition_values_dict, primary_keys, request_row) and
+                returns a fully formatted filter string or a template to be formatted.
+            fields: (Optional[list[str]]) Input `beam.Row` field names used to
+                generate the dictionary for formatting the row restriction template
+                AND for generating the internal join/cache key.
+            additional_condition_fields: (Optional[list[str]]) Additional input
+                `beam.Row` field names used ONLY for formatting the
+                row restriction template. Not part of join/cache key.
+            column_names: (Optional[list[str]]) Names/aliases of columns to select.
+                Supports "original_col as alias_col" format. If None, selects '*'.
+            condition_value_fn: (Optional[Callable[[beam.Row], Dict[str, Any]]]) Function
+                returning a dictionary for formatting row restriction template
+                and for join/cache key. Takes precedence over `fields`.
+            min_batch_size (int): Minimum elements per batch.
+            max_batch_size (int): Maximum elements per batch.
+            max_batch_duration_secs (int): Maximum batch buffering time.
+            max_parallel_streams (Optional[int]): Max worker threads for ThreadPoolExecutor
+                 for reading streams in parallel within a single `__call__`.
+            latest_value_selector: (Optional) Callback function to select the desired row
+                when multiple BQ rows match a key. Takes `List[beam.Row]` (BQ results)
+                and the original `beam.Row` (request) and returns one `beam.Row` or None.
+            primary_keys: (Optional[list[str]]) Primary key fields used potentially by
+                `row_restriction_template_fn` or `latest_value_selector`.
+        """
+        _validate_bigquery_metadata(
+            project, table_name, row_restriction_template, row_restriction_template_fn,
+            fields, condition_value_fn, additional_condition_fields
+        )
+        self.project = project
+        self.table_name = table_name
+        self.row_restriction_template = row_restriction_template
+        self.row_restriction_template_fn = row_restriction_template_fn
+        self.fields = fields
+        self.additional_condition_fields = additional_condition_fields or []
+        self.condition_value_fn = condition_value_fn
+        self.max_parallel_streams = max_parallel_streams
+        # --- Store new parameters ---
+        self._latest_value_callback = latest_value_selector
+        self.primary_keys = primary_keys
+        # --- End store ---
+
+        self._rename_map: Dict[str, str] = {}
+        bq_columns_to_select_set: Set[str] = set()
+        self._select_all_columns = False
+        if column_names:
+            for name_or_alias in column_names:
+                match = ALIAS_REGEX.match(name_or_alias)
+                if match:
+                    original_col, alias_col = match.group(1).strip(), match.group(2).strip()
+                    if not original_col or not alias_col: raise ValueError(f"Invalid alias: '{name_or_alias}'")
+                    bq_columns_to_select_set.add(original_col)
+                    self._rename_map[original_col] = alias_col
+                else:
+                    col = name_or_alias.strip()
+                    if not col: raise ValueError("Empty column name.")
+                    if col == '*': self._select_all_columns = True; break
+                    bq_columns_to_select_set.add(col)
+        else: self._select_all_columns = True
+
+        key_gen_fields_set = set(self.fields or [])
+        if self._select_all_columns:
+             self._bq_select_columns = ["*"]
+             if key_gen_fields_set: logger.debug(f"Selecting all columns ('*'). Key fields {key_gen_fields_set} assumed present.")
+        else:
+             fields_to_ensure_selected = set()
+             if self.fields:
+                 reverse_rename_map = {v: k for k, v in self._rename_map.items()}
+                 for field in self.fields:
+                      original_name = reverse_rename_map.get(field, field)
+                      fields_to_ensure_selected.add(original_name)
+             # Ensure primary keys (if defined for callback use) are selected if not already
+             if self.primary_keys:
+                 for pk_field in self.primary_keys:
+                      original_pk_name = {v: k for k, v in self._rename_map.items()}.get(pk_field, pk_field)
+                      fields_to_ensure_selected.add(original_pk_name)
+
+             final_select_set = bq_columns_to_select_set.union(fields_to_ensure_selected)
+             self._bq_select_columns = sorted(list(final_select_set))
+             if not self._bq_select_columns: raise ValueError("No columns determined for selection.")
+
+        logger.info(f"Handler Initialized. Selecting BQ Columns: {self._bq_select_columns}. Renaming map: {self._rename_map}")
+
+        self._batching_kwargs = {}
+        if max_batch_size > 1:
+             self._batching_kwargs["min_batch_size"] = min_batch_size
+             self._batching_kwargs["max_batch_size"] = max_batch_size
+             self._batching_kwargs["max_batch_duration_secs"] = max_batch_duration_secs
+        else:
+             self._batching_kwargs["min_batch_size"] = 1
+             self._batching_kwargs["max_batch_size"] = 1
+
+        self._client: Optional[BigQueryReadClient] = None
+        self._arrow_schema: Optional[pa.Schema] = None
+
+    def __enter__(self):
+        if not self._client:
+            self._client = BigQueryReadClient()
+            logger.info("BigQueryStorageEnrichmentHandler: Client created.")
+        self._arrow_schema = None
+
+    def _get_condition_values_dict(self, req: BeamRow) -> Optional[Dict[str, Any]]:
+        try:
+            if self.condition_value_fn:
+                values_dict = self.condition_value_fn(req)
+                if values_dict is None or any(v is None for v in values_dict.values()):
+                     logger.warning(f"condition_value_fn returned None or None value(s). Skipping: {req}. Values: {values_dict}")
+                     return None
+                return values_dict
+            elif self.fields is not None:
+                req_dict = req._asdict()
+                values_dict = {}
+                all_req_fields = (self.fields or []) + self.additional_condition_fields
+                for field in all_req_fields:
+                    # User's provided logic for row_restriction_template_fn handling:
+                    if not self.row_restriction_template_fn:
+                        if field not in req_dict or req_dict[field] is None:
+                            logger.warning(f"Input row missing field '{field}' or None (needed for filter). Skipping: {req}")
+                            return None
+                    values_dict[field] = req_dict.get(field) # Use get for safety
+                return values_dict
+            else: raise ValueError("Internal error: Neither fields nor condition_value_fn.")
+        except AttributeError: # Specifically for _asdict()
+             logger.error(f"Failed to call _asdict() on element. Type: {type(req)}. Element: {req}. Ensure input is beam.Row.")
+             return None
+        except Exception as e:
+             logger.error(f"Error getting condition values for row {req}: {e}", exc_info=True)
+             return None
+
+    def _build_single_row_filter(self, req_row: BeamRow, condition_values_dict: Dict[str, Any]) -> str:
+        """Builds the filter string part for a single row."""
+        try:
+            if self.row_restriction_template_fn:
+                # User's provided signature for row_restriction_template_fn
+                template_or_filter = self.row_restriction_template_fn(condition_values_dict, self.primary_keys, req_row)
+                if not isinstance(template_or_filter, str):
+                    raise TypeError("row_restriction_template_fn must return a string (filter or template to be formatted)")
+                # Assuming if it takes condition_values_dict, it might be returning the final filter
+                # or a template. If it's a template, it still needs .format().
+                # For now, assume it returns a template that might still need formatting
+                # OR the final filter string. Let's assume it's the final filter string as per user's code.
+                return template_or_filter # Directly return what the user's function gives.
+            elif self.row_restriction_template:
+                return self.row_restriction_template.format(**condition_values_dict)
+            else: raise ValueError("Internal Error: No template or template function available.")
+        except KeyError as e: # if user's fn returns template and format fails
+             raise ValueError(f"Placeholder {{{e}}} in template not found in condition values: {condition_values_dict.keys()}")
+        except Exception as e:
+            logger.error(f"Error building filter for row {req_row} with values {condition_values_dict}: {e}", exc_info=True)
+            return ""
+
+    def _apply_renaming(self, bq_row_dict: BQRowDict) -> BQRowDict:
+        if not self._rename_map: return bq_row_dict
+        return {self._rename_map.get(k, k): v for k, v in bq_row_dict.items()}
+
+    def _arrow_to_dicts(self, response: types.ReadRowsResponse) -> Iterator[BQRowDict]:
+        # Now uses self._arrow_schema directly
+        if response.arrow_record_batch:
+            if not self._arrow_schema:
+                 logger.error("Cannot process Arrow batch: Schema not available/cached in handler.")
+                 return
+            try:
+                serialized_batch = response.arrow_record_batch.serialized_record_batch
+                record_batch = pa.ipc.read_record_batch(pa.py_buffer(serialized_batch), self._arrow_schema)
+                arrow_table = pa.Table.from_batches([record_batch])
+                yield from arrow_table.to_pylist()
+            except Exception as e:
+                logger.error(f"Error converting Arrow batch to dicts: {e}", exc_info=True)
+
+    def _execute_storage_read(self, combined_row_filter: str) -> List[BQRowDict]:
+        if not self._client: self.__enter__();
+        if not self._client: raise RuntimeError("BQ Client failed to initialize.")
+        if not combined_row_filter: logger.warning("Empty filter, skipping BQ read."); return []
+
+        try: table_project, dataset_id, table_id = self.table_name.split('.')
+        except ValueError: raise ValueError(f"Invalid table_name: '{self.table_name}'. Expected 'project.dataset.table'.")
+        parent_project = self.project
+        table_resource = f"projects/{table_project}/datasets/{dataset_id}/tables/{table_id}"
+
+        session = None
+        try:
+            req = {"parent": f"projects/{parent_project}", "read_session": types.ReadSession(
+                    table=table_resource, data_format=types.DataFormat.ARROW,
+                    read_options=types.ReadSession.TableReadOptions(
+                        row_restriction=combined_row_filter, selected_fields=self._bq_select_columns),
+                ), "max_stream_count": 0 }
+            session = self._client.create_read_session(request=req)
+            logger.debug(f"Session with {len(session.streams)} streams. Filter: {combined_row_filter}")
+            if session.streams and session.arrow_schema:
+                if not self._arrow_schema:
+                    self._arrow_schema = pa.ipc.read_schema(pa.py_buffer(session.arrow_schema.serialized_schema))
+                    logger.debug("Deserialized Arrow schema for current call.")
+            elif session.streams: logger.error("Session has streams but no schema."); return []
+        except (BadRequest, NotFound, GoogleAPICallError) as e: logger.error(f"BQ API error creating session. Filter: '{combined_row_filter}'. Error: {e}"); return []
+        except Exception as e: logger.error(f"Unexpected error creating session. Filter: '{combined_row_filter}'. Error: {e}", exc_info=True); return []
+
+        if not session or not session.streams: logger.warning(f"No streams for filter: {combined_row_filter}"); return []
+
+        def _read_single_stream_worker(stream_name: str) -> List[BQRowDict]:
+            worker_results = []
+            if not self._client or not self._arrow_schema:
+                 logger.error(f"Stream {stream_name}: Client/schema missing in worker.")
+                 return worker_results
+            try:
+                reader = self._client.read_rows(stream_name)
+                for response in reader:
+                    worker_results.extend(self._arrow_to_dicts(response)) # Uses self._arrow_schema
+            except Exception as e: logger.error(f"Error reading stream {stream_name} in worker: {e}", exc_info=True)
+            return worker_results
+
+        all_bq_rows_original_keys = []
+        num_api_streams = len(session.streams)
+        max_workers = num_api_streams
+        if self.max_parallel_streams is not None and self.max_parallel_streams > 0:
+            max_workers = min(num_api_streams, self.max_parallel_streams)
+        if max_workers <= 0 : max_workers = 1
+        logger.debug(f"Reading {num_api_streams} API streams using {max_workers} threads.")
+        futures = []
+        try:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+                for stream in session.streams: futures.append(executor.submit(_read_single_stream_worker, stream.name))
+                for future in concurrent.futures.as_completed(futures):
+                    try: all_bq_rows_original_keys.extend(future.result())
+                    except Exception as e: logger.error(f"Error processing future result: {e}", exc_info=True)
+        except Exception as pool_error: logger.error(f"ThreadPool error: {pool_error}", exc_info=True)
+        logger.debug(f"Fetched {len(all_bq_rows_original_keys)} rows from BQ.")
+        return all_bq_rows_original_keys
+
+    def create_row_key(self, row: BeamRow) -> Optional[tuple]:
+        try:
+            if self.condition_value_fn:
+                key_values_dict = self.condition_value_fn(row)
+            elif self.fields is not None:
+                row_dict = row._asdict() # Assumes row is BeamRow
+                key_values_dict = {f: row_dict[f] for f in self.fields if f in row_dict and row_dict[f] is not None}
+                if len(key_values_dict) != len(self.fields): # Ensure all key fields found and not None
+                    logger.debug(f"Row missing key field(s) or None. Cannot generate key: {row}")
+                    return None
+            else: raise ValueError("Internal error: Neither fields nor condition_value_fn for key.")
+            if key_values_dict is None: return None
+            return tuple(sorted(key_values_dict.items()))
+        except AttributeError: logger.error(f"Failed _asdict() for key gen. Type: {type(row)}. Ensure input is beam.Row."); return None
+        except Exception as e: logger.error(f"Error generating key for row {row}: {e}", exc_info=True); return None
+
+    def __call__(self, request: Union[BeamRow, list[BeamRow]], *args, **kwargs) -> Union[Tuple[BeamRow, BeamRow], List[Tuple[BeamRow, BeamRow]]]:
+        self._arrow_schema = None # Reset schema
+
+        if isinstance(request, list):
+            batch_responses: List[Tuple[BeamRow, BeamRow]] = []
+            requests_map: Dict[tuple, BeamRow] = {}
+            single_row_filters: List[str] = []
+            for req_row in request:
+                condition_values = self._get_condition_values_dict(req_row)
+                if condition_values is None: batch_responses.append((req_row, BeamRow())); continue
+                req_key = self.create_row_key(req_row)
+                if req_key is None: batch_responses.append((req_row, BeamRow())); continue
+                if req_key not in requests_map:
+                    requests_map[req_key] = req_row
+                    single_filter = self._build_single_row_filter(req_row, condition_values)
+                    if single_filter: single_row_filters.append(f"({single_filter})")
+                    else: batch_responses.append((req_row, BeamRow())); del requests_map[req_key]
+                else:
+                     logger.warning(f"Duplicate key '{req_key}' in batch. Processing first instance.")
+                     batch_responses.append((req_row, BeamRow()))
+
+            bq_results_key_map: Dict[tuple, List[BeamRow]] = {} # Stores resp_key -> List of RENAMED BQ rows
+            if single_row_filters:
+                combined_filter = " OR ".join(single_row_filters)
+                bq_results_list_orig_keys = self._execute_storage_read(combined_filter)
+                for bq_row_dict_orig_keys in bq_results_list_orig_keys:
+                    try:
+                        renamed_bq_row_dict = self._apply_renaming(bq_row_dict_orig_keys)
+                        bq_row_renamed_keys_temp = BeamRow(**renamed_bq_row_dict)
+                        resp_key = self.create_row_key(bq_row_renamed_keys_temp)
+                        if resp_key:
+                            if resp_key not in bq_results_key_map: bq_results_key_map[resp_key] = []
+                            bq_results_key_map[resp_key].append(bq_row_renamed_keys_temp)
+                    except Exception as e:
+                         logger.warning(f"Error processing BQ response row {bq_row_dict_orig_keys}: {e}. Cannot map.")
+
+            for req_key, req_row in requests_map.items():
+                 matching_bq_rows = bq_results_key_map.get(req_key, [])
+                 selected_response_row = BeamRow() # Default empty
+                 if matching_bq_rows:
+                     if self._latest_value_callback:
+                         try:
+                             selected_response_row = self._latest_value_callback(matching_bq_rows, req_row) or BeamRow()
+                         except Exception as cb_error:
+                             logger.error(f"Error in latest_value_selector for key {req_key}: {cb_error}. Using first BQ row if available.", exc_info=True)
+                             selected_response_row = matching_bq_rows[0]
+                     else:
+                         selected_response_row = matching_bq_rows[0] # Default to first
+                 batch_responses.append((req_row, selected_response_row))
+            return batch_responses
+        else: # Single element processing
+            req_row = request
+            condition_values = self._get_condition_values_dict(req_row)
+            if condition_values is None: return (req_row, BeamRow())
+            single_filter = self._build_single_row_filter(req_row, condition_values)
+            if not single_filter: return (req_row, BeamRow())
+            bq_results_orig_keys = self._execute_storage_read(single_filter)
+            response_row = BeamRow()
+            if bq_results_orig_keys:
+                # For single request, apply selector if provided, else take first
+                renamed_bq_rows = [BeamRow(**self._apply_renaming(d)) for d in bq_results_orig_keys]
+                if self._latest_value_callback and renamed_bq_rows:
+                    try:
+                        response_row = self._latest_value_callback(renamed_bq_rows, req_row) or BeamRow()
+                    except Exception as cb_error:
+                        logger.error(f"Error in latest_value_selector for single req: {cb_error}. Using first BQ row.", exc_info=True)
+                        response_row = renamed_bq_rows[0]
+                elif renamed_bq_rows:
+                    response_row = renamed_bq_rows[0]
+                if len(bq_results_orig_keys) > 1 and not (self._latest_value_callback and response_row != BeamRow()): # Log if multiple and default/callback didn't pick one specifically
+                      logger.warning(f"Single request -> {len(bq_results_orig_keys)} BQ rows. Used selected/first. Filter:'{single_filter}'")
+            return (req_row, response_row)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._client: logger.info("BigQueryStorageEnrichmentHandler: Releasing client."); self._client = None
+
+    def get_cache_key(self, request: Union[BeamRow, list[BeamRow]]) -> Union[str, List[str]]:
+        if isinstance(request, list):
+            return [str(self.create_row_key(req) or "__invalid_key__") for req in request]
+        else:
+            return str(self.create_row_key(request) or "__invalid_key__")
+
+    def batch_elements_kwargs(self) -> Mapping[str, Any]:
+        return self._batching_kwargs

--- a/sdks/python/apache_beam/transforms/enrichment_handlers/bigquery_storage_read_it_test.py
+++ b/sdks/python/apache_beam/transforms/enrichment_handlers/bigquery_storage_read_it_test.py
@@ -1,0 +1,434 @@
+\
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import logging
+import secrets
+import time
+import unittest
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+import apache_beam as beam
+from apache_beam.io.gcp.bigquery_tools import BigQueryWrapper
+from apache_beam.io.gcp.internal.clients import bigquery
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.testing.util import assert_that
+from apache_beam.testing.util import equal_to
+
+# pylint: disable=ungrouped-imports
+try:
+  from google.api_core.exceptions import BadRequest, NotFound, GoogleAPICallError
+  from apache_beam.transforms.enrichment import Enrichment
+  from apache_beam.transforms.enrichment_handlers.bigquery_storage_read import (
+      BigQueryStorageEnrichmentHandler)
+  from apitools.base.py.exceptions import HttpError
+except ImportError:
+  raise unittest.SkipTest(
+      'Google Cloud BigQuery or BigQuery Storage dependencies are not installed.'
+  )
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@pytest.mark.uses_testcontainer
+class BigQueryStorageEnrichmentIT(unittest.TestCase):
+  bigquery_dataset_id_prefix = 'py_bq_storage_enrich_it_'
+  project = "apache-beam-testing"  # Ensure this project is configured for tests
+
+  @classmethod
+  def setUpClass(cls):
+    cls.bigquery_client = BigQueryWrapper()
+    # Generate a unique dataset ID for this test run
+    cls.dataset_id = '%s%d%s' % (
+        cls.bigquery_dataset_id_prefix,
+        int(time.time()),
+        secrets.token_hex(3))
+    cls.bigquery_client.get_or_create_dataset(cls.project, cls.dataset_id)
+    _LOGGER.info(
+        "Created dataset %s in project %s", cls.dataset_id, cls.project)
+
+  @classmethod
+  def tearDownClass(cls):
+    request = bigquery.BigqueryDatasetsDeleteRequest(
+        projectId=cls.project, datasetId=cls.dataset_id, deleteContents=True)
+    try:
+      _LOGGER.info(
+          "Deleting dataset %s in project %s", cls.dataset_id, cls.project)
+      cls.bigquery_client.client.datasets.Delete(request)
+    except HttpError as e:
+      _LOGGER.warning(
+          'Failed to clean up dataset %s in project %s: %s',
+          cls.dataset_id,
+          cls.project,
+          e)
+
+
+@pytest.mark.uses_testcontainer
+class TestBigQueryStorageEnrichmentIT(BigQueryStorageEnrichmentIT):
+  product_details_table_data = [
+      {
+          "id": 1, "name": "A", "quantity": 2, "distribution_center_id": 3
+      },
+      {
+          "id": 2, "name": "B", "quantity": 3, "distribution_center_id": 1
+      },
+      {
+          "id": 3, "name": "C", "quantity": 10, "distribution_center_id": 4
+      },
+      {
+          "id": 4, "name": "D", "quantity": 1, "distribution_center_id": 3
+      },
+      {
+          "id": 5, "name": "C", "quantity": 100, "distribution_center_id": 4
+      },
+      {
+          "id": 6, "name": "D", "quantity": 11, "distribution_center_id": 3
+      },
+      {
+          "id": 7, "name": "C", "quantity": 7, "distribution_center_id": 1
+      },
+  ]
+
+  product_updates_table_data = [
+      {
+          "id": 10, "value": "old_value_10", "update_ts": "2023-01-01T00:00:00Z"
+      },
+      {
+          "id": 10, "value": "new_value_10", "update_ts": "2023-01-02T00:00:00Z"
+      },
+      {
+          "id": 11, "value": "current_value_11", "update_ts": "2023-01-05T00:00:00Z"
+      },
+      {
+          "id": 10, "value": "latest_value_10", "update_ts": "2023-01-03T00:00:00Z"
+      },
+  ]
+
+  @classmethod
+  def create_table(cls, table_id_suffix, schema_fields, data):
+    table_id = f"table_{table_id_suffix}_{secrets.token_hex(2)}"
+    table_schema = bigquery.TableSchema()
+    for name, field_type in schema_fields:
+      table_field = bigquery.TableFieldSchema()
+      table_field.name = name
+      table_field.type = field_type
+      table_schema.fields.append(table_field)
+
+    table = bigquery.Table(
+        tableReference=bigquery.TableReference(
+            projectId=cls.project, datasetId=cls.dataset_id, tableId=table_id),
+        schema=table_schema)
+    request = bigquery.BigqueryTablesInsertRequest(
+        projectId=cls.project, datasetId=cls.dataset_id, table=table)
+    cls.bigquery_client.client.tables.Insert(request)
+    if data:
+      cls.bigquery_client.insert_rows(
+          cls.project, cls.dataset_id, table_id, data)
+    
+    fq_table_name = f"{cls.project}.{cls.dataset_id}.{table_id}"
+    _LOGGER.info(f"Created table {fq_table_name}")
+    return fq_table_name
+
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
+    product_schema = [('id', 'INTEGER'), ('name', 'STRING'),
+                      ('quantity', 'INTEGER'),
+                      ('distribution_center_id', 'INTEGER')]
+    cls.product_details_table_fq = cls.create_table(
+        'product_details', product_schema, cls.product_details_table_data)
+
+    updates_schema = [('id', 'INTEGER'), ('value', 'STRING'),
+                      ('update_ts', 'TIMESTAMP')]
+    cls.product_updates_table_fq = cls.create_table(
+        'product_updates', updates_schema, cls.product_updates_table_data)
+
+  def setUp(self):
+    self.default_row_restriction = "id = {}"
+    self.default_fields = ['id']
+
+  def test_enrichment_single_element(self):
+    requests = [beam.Row(id=1, source_field='SourceA')]
+    handler = BigQueryStorageEnrichmentHandler(
+        project=self.project,
+        table_name=self.product_details_table_fq,
+        row_restriction_template=self.default_row_restriction,
+        fields=self.default_fields,
+        column_names=['name', 'quantity'],
+        min_batch_size=1,
+        max_batch_size=1)
+    
+    expected_output = [
+        beam.Row(id=1, source_field='SourceA', name='A', quantity=2)
+    ]
+
+    with TestPipeline(is_integration_test=True) as p:
+      input_pcoll = p | "CreateRequests" >> beam.Create(requests)
+      enriched_pcoll = input_pcoll | "Enrich" >> Enrichment(handler)
+      assert_that(enriched_pcoll, equal_to(expected_output))
+
+  def test_enrichment_batch_elements(self):
+    requests = [
+        beam.Row(id=1, source_field='Item1'),
+        beam.Row(id=2, source_field='Item2')
+    ]
+    handler = BigQueryStorageEnrichmentHandler(
+        project=self.project,
+        table_name=self.product_details_table_fq,
+        row_restriction_template=self.default_row_restriction,
+        fields=self.default_fields,
+        column_names=['name', 'quantity', 'distribution_center_id'],
+        min_batch_size=2,
+        max_batch_size=10)
+    
+    expected_output = [
+        beam.Row(
+            id=1, source_field='Item1', name='A',
+            quantity=2, distribution_center_id=3),
+        beam.Row(
+            id=2, source_field='Item2', name='B',
+            quantity=3, distribution_center_id=1)
+    ]
+
+    with TestPipeline(is_integration_test=True) as p:
+      input_pcoll = p | beam.Create(requests)
+      enriched_pcoll = input_pcoll | Enrichment(handler)
+      assert_that(enriched_pcoll, equal_to(expected_output))
+
+  def test_enrichment_column_aliasing(self):
+    requests = [beam.Row(id=3, source_field='ItemC')]
+    handler = BigQueryStorageEnrichmentHandler(
+        project=self.project,
+        table_name=self.product_details_table_fq,
+        row_restriction_template=self.default_row_restriction,
+        fields=self.default_fields,
+        column_names=['name as product_name', 'quantity as stock_count'],
+    )
+    expected_output = [
+        beam.Row(
+            id=3, source_field='ItemC', product_name='C', stock_count=10)
+    ]
+    with TestPipeline(is_integration_test=True) as p:
+      enriched = p | beam.Create(requests) | Enrichment(handler)
+      assert_that(enriched, equal_to(expected_output))
+
+  def test_enrichment_no_match_passes_through(self):
+    requests = [
+        beam.Row(id=1, source_field='ItemA'), # Match
+        beam.Row(id=99, source_field='ItemZ') # No Match
+    ]
+    handler = BigQueryStorageEnrichmentHandler(
+        project=self.project,
+        table_name=self.product_details_table_fq,
+        row_restriction_template=self.default_row_restriction,
+        fields=self.default_fields,
+        column_names=['name', 'quantity'])
+    
+    expected_output = [
+        beam.Row(id=1, source_field='ItemA', name='A', quantity=2),
+        beam.Row(id=99, source_field='ItemZ') # Original row, no enrichment fields
+    ]
+    with TestPipeline(is_integration_test=True) as p:
+      enriched = p | beam.Create(requests) | Enrichment(handler)
+      assert_that(enriched, equal_to(expected_output))
+
+  def test_enrichment_select_all_columns_asterisk(self):
+    requests = [beam.Row(id=4, source_field='ItemD')]
+    handler = BigQueryStorageEnrichmentHandler(
+        project=self.project,
+        table_name=self.product_details_table_fq,
+        row_restriction_template=self.default_row_restriction,
+        fields=self.default_fields,
+        column_names=['*'])
+    
+    expected_output = [
+        beam.Row(
+            id=4, source_field='ItemD', name='D',
+            quantity=1, distribution_center_id=3)
+    ]
+    with TestPipeline(is_integration_test=True) as p:
+      enriched = p | beam.Create(requests) | Enrichment(handler)
+      assert_that(enriched, equal_to(expected_output))
+
+  def test_enrichment_row_restriction_template_fn(self):
+    def custom_template_fn(
+        condition_values: Dict[str, Any],
+        primary_keys: Optional[List[str]],
+        request_row: beam.Row) -> str:
+      # request_row has 'lookup_id' and 'lookup_name'
+      # condition_values will have 'id_val' and 'name_val' from condition_value_fn
+      return f"id = {condition_values['id_val']} AND name = '{condition_values['name_val']}'"
+
+    def custom_cond_val_fn(req_row: beam.Row) -> Dict[str, Any]:
+        return {'id_val': req_row.lookup_id, 'name_val': req_row.lookup_name}
+
+    requests = [beam.Row(lookup_id=5, lookup_name='C')]
+    handler = BigQueryStorageEnrichmentHandler(
+        project=self.project,
+        table_name=self.product_details_table_fq,
+        row_restriction_template_fn=custom_template_fn,
+        condition_value_fn=custom_cond_val_fn,
+        column_names=['quantity', 'distribution_center_id'])
+
+    expected_output = [
+        beam.Row(
+            lookup_id=5, lookup_name='C',
+            quantity=100, distribution_center_id=4)
+    ]
+    with TestPipeline(is_integration_test=True) as p:
+      enriched = p | beam.Create(requests) | Enrichment(handler)
+      assert_that(enriched, equal_to(expected_output))
+
+  def test_enrichment_condition_value_fn(self):
+    def custom_cond_val_fn(req_row: beam.Row) -> Dict[str, Any]:
+        # req_row has 'product_identifier'
+        return {'the_id': req_row.product_identifier}
+
+    requests = [beam.Row(product_identifier=6)]
+    handler = BigQueryStorageEnrichmentHandler(
+        project=self.project,
+        table_name=self.product_details_table_fq,
+        row_restriction_template="id = {the_id}", # Uses key from cond_val_fn
+        condition_value_fn=custom_cond_val_fn,
+        column_names=['name', 'quantity'])
+
+    expected_output = [
+        beam.Row(product_identifier=6, name='D', quantity=11)
+    ]
+    with TestPipeline(is_integration_test=True) as p:
+      enriched = p | beam.Create(requests) | Enrichment(handler)
+      assert_that(enriched, equal_to(expected_output))
+
+  def test_enrichment_additional_condition_fields(self):
+    requests = [beam.Row(target_id=7, filter_on_name='C')]
+    handler = BigQueryStorageEnrichmentHandler(
+        project=self.project,
+        table_name=self.product_details_table_fq,
+        fields=['target_id'], # 'target_id' maps to 'id' in template
+        additional_condition_fields=['filter_on_name'], # 'filter_on_name' maps to 'name'
+        row_restriction_template="id = {} AND name = '{}'", # Positional formatting
+        column_names=['quantity', 'distribution_center_id'])
+
+    # The handler will try to format "id = {} AND name = '{}'"
+    # with (requests_row.target_id, requests_row.filter_on_name)
+    # This requires careful alignment of fields and template.
+    # Let's adjust the handler to use named placeholders for clarity with additional_fields
+    # Or, ensure the template matches the order of fields + additional_condition_fields
+
+    # For this test, let's assume the template is designed for positional formatting
+    # where the first {} takes from `fields` and subsequent {} take from `additional_condition_fields`
+    # The current implementation of _get_condition_values_dict for `fields` + `additional_condition_fields`
+    # creates a dictionary. So the template should use named placeholders.
+
+    # Re-designing this specific test for clarity with named placeholders:
+    # Let condition_value_fn handle the mapping if complex.
+    # If using `fields` and `additional_condition_fields`, the template should use
+    # the field names directly if they are the keys in the dict passed to format.
+
+    # Let's use a condition_value_fn for this scenario to be explicit
+    def complex_cond_fn(req: beam.Row) -> Dict[str, Any]:
+        return {"id_val": req.target_id, "name_val": req.filter_on_name}
+
+    handler_revised = BigQueryStorageEnrichmentHandler(
+        project=self.project,
+        table_name=self.product_details_table_fq,
+        condition_value_fn=complex_cond_fn,
+        row_restriction_template="id = {id_val} AND name = '{name_val}'",
+        column_names=['quantity', 'distribution_center_id'])
+
+
+    expected_output = [
+        beam.Row(
+            target_id=7, filter_on_name='C',
+            quantity=7, distribution_center_id=1)
+    ]
+    with TestPipeline(is_integration_test=True) as p:
+      enriched = p | beam.Create(requests) | Enrichment(handler_revised)
+      assert_that(enriched, equal_to(expected_output))
+
+  def test_enrichment_latest_value_selector(self):
+    def select_latest_by_ts(
+        bq_results: List[beam.Row],
+        request_row: beam.Row) -> Optional[beam.Row]:
+      if not bq_results:
+        return None
+      # Assuming 'update_ts' is a field in bq_results and is comparable
+      return max(bq_results, key=lambda r: r.update_ts)
+
+    requests = [beam.Row(lookup_id=10)] # This ID has multiple entries in updates table
+    handler = BigQueryStorageEnrichmentHandler(
+        project=self.project,
+        table_name=self.product_updates_table_fq,
+        fields=['lookup_id'], # 'lookup_id' from request_row will map to 'id' in template
+        row_restriction_template="id = {}",
+        column_names=['value', 'update_ts'], # Select value and the timestamp itself
+        latest_value_selector=select_latest_by_ts,
+        primary_keys=['id'] # For the selector's context if needed
+    )
+    
+    expected_output = [
+        # The latest_value_10 has ts 2023-01-03
+        beam.Row(lookup_id=10, value='latest_value_10', update_ts='2023-01-03T00:00:00Z')
+    ]
+    with TestPipeline(is_integration_test=True) as p:
+      enriched = p | beam.Create(requests) | Enrichment(handler)
+      assert_that(enriched, equal_to(expected_output))
+
+  def test_enrichment_bad_request_invalid_column_in_template(self):
+    requests = [beam.Row(id=1)]
+    # Using a field in template that won't be provided by 'fields'
+    handler = BigQueryStorageEnrichmentHandler(
+        project=self.project,
+        table_name=self.product_details_table_fq,
+        row_restriction_template="non_existent_field = {}", # This will cause KeyError during formatting
+        fields=['id'],
+        column_names=['name'])
+
+    with TestPipeline(is_integration_test=True) as p:
+      _ = p | beam.Create(requests) | Enrichment(handler)
+      # The error might manifest as a KeyError when formatting the template,
+      # or a BadRequest from BQ if the query is malformed but syntactically valid enough to send.
+      # The handler's internal _build_single_row_filter catches KeyError.
+      # If the query sent to BQ is invalid (e.g. "SELECT name FROM ... WHERE "), BQ returns BadRequest.
+      # Let's test for a BQ BadRequest due to a bad query structure.
+      # Example: selecting a column that doesn't exist.
+      handler_bad_select = BigQueryStorageEnrichmentHandler(
+        project=self.project,
+        table_name=self.product_details_table_fq,
+        row_restriction_template="id = {}",
+        fields=['id'],
+        column_names=['non_existent_column_in_bq_table']) # This should cause BQ error
+
+      with self.assertRaises(GoogleAPICallError) as e_ctx: # Or specifically BadRequest
+        p_bad = TestPipeline(is_integration_test=True)
+        input_pcoll = p_bad | "CreateBad" >> beam.Create(requests)
+        _ = input_pcoll | "EnrichBad" >> Enrichment(handler_bad_select)
+        res = p_bad.run()
+        res.wait_until_finish()
+      
+      self.assertTrue(
+          isinstance(e_ctx.exception, BadRequest) or \
+          "NoSuchFieldError" in str(e_ctx.exception) or \
+          "not found in table" in str(e_ctx.exception).lower() or \
+          "unrecognized name" in str(e_ctx.exception).lower()
+      )
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/sdks/python/apache_beam/transforms/enrichment_handlers/bigquery_storage_read_test.py
+++ b/sdks/python/apache_beam/transforms/enrichment_handlers/bigquery_storage_read_test.py
@@ -1,0 +1,176 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+from apache_beam.pvalue import Row as BeamRow
+from apache_beam.transforms.enrichment_handlers import bigquery_storage_read
+
+class TestBigQueryStorageEnrichmentHandler(unittest.TestCase):
+    def setUp(self):
+        self.project = 'test-project'
+        self.table_name = 'test-project.test_dataset.test_table'
+        self.fields = ['id']
+        self.row_restriction_template = 'id = "{id}"'
+        self.column_names = ['id', 'value']
+
+    def make_handler(self, **kwargs):
+        handler_kwargs = {
+            'project': self.project,
+            'table_name': self.table_name,
+            'row_restriction_template': self.row_restriction_template,
+            'fields': self.fields,
+            'column_names': self.column_names,
+        }
+        handler_kwargs.update(kwargs)  # Override defaults with provided kwargs
+        return bigquery_storage_read.BigQueryStorageEnrichmentHandler(**handler_kwargs)
+
+    def test_init_invalid_args(self):
+        # Both row_restriction_template and row_restriction_template_fn
+        with self.assertRaises(ValueError):
+            bigquery_storage_read.BigQueryStorageEnrichmentHandler(
+                project=self.project,
+                table_name=self.table_name,
+                row_restriction_template='foo',
+                row_restriction_template_fn=lambda d, p, r: 'bar',
+                fields=self.fields
+            )
+        # Neither row_restriction_template nor row_restriction_template_fn
+        with self.assertRaises(ValueError):
+            bigquery_storage_read.BigQueryStorageEnrichmentHandler(
+                project=self.project,
+                table_name=self.table_name,
+                fields=self.fields
+            )
+        # Both fields and condition_value_fn
+        with self.assertRaises(ValueError):
+            bigquery_storage_read.BigQueryStorageEnrichmentHandler(
+                project=self.project,
+                table_name=self.table_name,
+                row_restriction_template='foo',
+                fields=self.fields,
+                condition_value_fn=lambda r: {'id': 1}
+            )
+        # Neither fields nor condition_value_fn
+        with self.assertRaises(ValueError):
+            bigquery_storage_read.BigQueryStorageEnrichmentHandler(
+                project=self.project,
+                table_name=self.table_name,
+                row_restriction_template='foo'
+            )
+
+    def test_get_condition_values_dict_fields(self):
+        handler = self.make_handler()
+        row = BeamRow(id=1, value='a')
+        self.assertEqual(handler._get_condition_values_dict(row), {'id': 1})
+
+    def test_get_condition_values_dict_missing_field(self):
+        handler = self.make_handler()
+        row = BeamRow(value='a')
+        self.assertIsNone(handler._get_condition_values_dict(row))
+
+    def test_get_condition_values_dict_condition_value_fn(self):
+        handler = self.make_handler(fields=None, condition_value_fn=lambda r: {'id': 2})
+        row = BeamRow(id=2, value='b')
+        self.assertEqual(handler._get_condition_values_dict(row), {'id': 2})
+
+    def test_build_single_row_filter_template(self):
+        handler = self.make_handler()
+        row = BeamRow(id=3, value='c')
+        cond = {'id': 3}
+        self.assertEqual(handler._build_single_row_filter(row, cond), 'id = "3"')
+
+    def test_build_single_row_filter_fn(self):
+        fn = lambda d, p, r: f"id = '{d['id']}'"
+        handler = self.make_handler(row_restriction_template=None, row_restriction_template_fn=fn)
+        row = BeamRow(id=4, value='d')
+        cond = {'id': 4}
+        self.assertEqual(handler._build_single_row_filter(row, cond), "id = '4'")
+
+    def test_apply_renaming(self):
+        handler = self.make_handler(column_names=['id as new_id', 'value'])
+        bq_row = {'id': 1, 'value': 'foo'}
+        self.assertEqual(handler._apply_renaming(bq_row), {'new_id': 1, 'value': 'foo'})
+
+    def test_create_row_key(self):
+        handler = self.make_handler()
+        row = BeamRow(id=5, value='e')
+        self.assertEqual(handler.create_row_key(row), (('id', 5),))
+
+    @mock.patch.object(bigquery_storage_read.BigQueryStorageEnrichmentHandler, '_execute_storage_read')
+    def test_call_single_match(self, mock_exec):
+        handler = self.make_handler()
+        row = BeamRow(id=6, value='f')
+        mock_exec.return_value = [{'id': 6, 'value': 'fetched'}]
+        req, resp = handler(row)
+        self.assertEqual(req, row)
+        self.assertEqual(resp.id, 6)
+        self.assertEqual(resp.value, 'fetched')
+
+    @mock.patch.object(bigquery_storage_read.BigQueryStorageEnrichmentHandler, '_execute_storage_read')
+    def test_call_single_no_match(self, mock_exec):
+        handler = self.make_handler()
+        row = BeamRow(id=7, value='g')
+        mock_exec.return_value = []
+        req, resp = handler(row)
+        self.assertEqual(req, row)
+        self.assertEqual(resp, BeamRow())
+
+    @mock.patch.object(bigquery_storage_read.BigQueryStorageEnrichmentHandler, '_execute_storage_read')
+    def test_call_batch(self, mock_exec):
+        handler = self.make_handler()
+        rows = [BeamRow(id=8, value='h'), BeamRow(id=9, value='i')]
+        mock_exec.return_value = [
+            {'id': 8, 'value': 'h_bq'},
+            {'id': 9, 'value': 'i_bq'}
+        ]
+        result = handler(rows)
+        self.assertEqual(result[0][0], rows[0])
+        self.assertEqual(result[0][1].id, 8)
+        self.assertEqual(result[0][1].value, 'h_bq')
+        self.assertEqual(result[1][0], rows[1])
+        self.assertEqual(result[1][1].id, 9)
+        self.assertEqual(result[1][1].value, 'i_bq')
+
+    @mock.patch.object(bigquery_storage_read.BigQueryStorageEnrichmentHandler, '_execute_storage_read')
+    def test_call_batch_no_match(self, mock_exec):
+        handler = self.make_handler()
+        rows = [BeamRow(id=10, value='j'), BeamRow(id=11, value='k')]
+        mock_exec.return_value = []
+        result = handler(rows)
+        self.assertEqual(result[0][0], rows[0])
+        self.assertEqual(result[0][1], BeamRow())
+        self.assertEqual(result[1][0], rows[1])
+        self.assertEqual(result[1][1], BeamRow())
+
+    def test_get_cache_key(self):
+        handler = self.make_handler()
+        row = BeamRow(id=12, value='l')
+        self.assertEqual(handler.get_cache_key(row), str((('id', 12),)))
+        rows = [BeamRow(id=13, value='m'), BeamRow(id=14, value='n')]
+        self.assertEqual(
+            handler.get_cache_key(rows),
+            [str((('id', 13),)), str((('id', 14),))]
+        )
+
+    def test_batch_elements_kwargs(self):
+        handler = self.make_handler(min_batch_size=2, max_batch_size=5, max_batch_duration_secs=10)
+        self.assertEqual(
+            handler.batch_elements_kwargs(),
+            {'min_batch_size': 2, 'max_batch_size': 5, 'max_batch_duration_secs': 10}
+        )
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Description:**

This pull request introduces a new `EnrichmentSourceHandler` for Apache Beam, `BigQueryStorageEnrichmentHandler`, designed to leverage the Google Cloud BigQuery Storage Read API for efficient data enrichment. This handler provides a high-performance alternative to traditional SQL-based BigQuery lookups within Beam pipelines.

**Motivation and Context:**

Enriching data by joining PCollection elements with data stored in BigQuery is a common use case. While existing methods often rely on executing SQL queries, the BigQuery Storage Read API offers a more direct and typically faster way to retrieve data, especially for large volumes or when fine-grained row-level access is needed. This handler aims to:

*   Improve the performance of BigQuery enrichments.
*   Reduce BigQuery query costs associated with SQL execution for enrichment tasks.
*   Provide more flexible and programmatic control over data fetching and filtering.

**Key Features and Improvements:**

The `BigQueryStorageEnrichmentHandler` offers several enhancements:

*   **Efficient Data Retrieval:** Utilizes the BigQuery Storage Read API for significantly faster data reads compared to SQL queries, especially for bulk lookups. Data is read in Apache Arrow format, minimizing serialization/deserialization overhead.
*   **Flexible Filtering:**
    *   Supports static filter templates via `row_restriction_template`.
    *   Allows dynamic, per-element filter string generation using `row_restriction_template_fn`.
*   **Advanced Keying and Value Extraction:**
    *   `fields`: Specifies input `beam.Row` fields for generating join keys and for use in filter templates.
    *   `additional_condition_fields`: Allows using input fields for filtering *without* including them in the join key.
    *   `condition_value_fn`: Provides complete control over generating the dictionary of values used for both filtering and join key creation.
*   **Field Renaming/Aliasing:** Supports aliasing of selected BigQuery columns (e.g., `original_col as alias_col` in `column_names`) to prevent naming conflicts in the enriched `beam.Row`.
*   **Batching Support:** Groups multiple input elements to make fewer `CreateReadSession` calls, reducing API overhead. Batch size and duration are configurable (`min_batch_size`, `max_batch_size`, `max_batch_duration_secs`).
*   **Parallel Stream Reading:** (Experimental) Employs a `ThreadPoolExecutor` to read data from multiple streams of a BigQuery Read Session in parallel, potentially improving data fetching throughput. Concurrency is configurable via `max_parallel_streams`.
*   **Custom Row Selection:** Includes a `latest_value_selector` callback that allows users to define custom logic for selecting the desired row when multiple BigQuery rows match a single input request (e.g., picking the record with the most recent timestamp). `primary_keys` can be used by this selector.
*   **Automatic Client Management:** Manages the lifecycle of the `BigQueryReadClient`.

**Advantages over Traditional SQL-based BigQuery Enrichment:**

*   **Performance:** Direct access to table storage via the Storage Read API typically bypasses the SQL query processing engine, leading to lower latency and higher throughput, especially for fetching many individual rows or large data segments.
*   **Cost Efficiency:** Reading data via the Storage API can be more cost-effective than running many small SQL queries, as Storage API pricing is based on data scanned, while query pricing involves slots and scanned data.
*   **Scalability:** The streaming nature of the Storage Read API is well-suited for scalable data processing in Beam.
*   **Reduced Query Complexity:** For simple lookups, it avoids the need to construct and manage SQL query strings dynamically.

**Documentation:**

Comprehensive documentation for this handler, including usage examples, parameter descriptions, features, and limitations, has been added in [ `docs/bigquery_storage_enrichment_handler.md`](https://github.com/pandasanjay/beam-custom-implementation/blob/main/docs/bigquery_storage_enrichment_handler.md).

**Implementation Details:**

The handler (`sdk/ptyhon/transforms/enrichment_handlers/bigquery_storage_read.py`) manages `BigQueryReadClient` instances, constructs `ReadSession` requests with appropriate row restrictions and selected fields, and processes the resulting Arrow record batches. It integrates with Beam's `Enrichment` transform, providing batching and caching key generation.

**Testing Considerations:**

*   Unit tests for key generation, filter construction, and data processing logic.
*   Integration tests against a live BigQuery instance.
*   Performance benchmarks comparing against SQL-based handlers.

This handler provides a powerful and efficient way to enrich data in Apache Beam pipelines using BigQuery.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
