### PR TITLE
Allow STRING format in Kafka config

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaReadSchemaTransformConfiguration.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaReadSchemaTransformConfiguration.java
@@ -71,6 +71,9 @@ public abstract class KafkaReadSchemaTransformConfiguration {
     } else if (dataFormat != null && dataFormat.equals("RAW")) {
       checkArgument(
           inputSchema == null, "To read from Kafka in RAW format, you can't provide a schema.");
+    } else if (dataFormat != null && dataFormat.equals("STRING")) {
+      checkArgument(
+          inputSchema == null, "To read from Kafka in STRING format, you can't provide a schema.");
     } else if (dataFormat != null && dataFormat.equals("JSON")) {
       checkNotNull(inputSchema, "To read from Kafka in JSON format, you must provide a schema.");
     } else if (dataFormat != null && dataFormat.equals("PROTO")) {

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaReadSchemaTransformProviderTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaReadSchemaTransformProviderTest.java
@@ -198,6 +198,24 @@ public class KafkaReadSchemaTransformProviderTest {
   }
 
   @Test
+  public void testBuildTransformWithStringFormat() {
+    ServiceLoader<SchemaTransformProvider> serviceLoader =
+        ServiceLoader.load(SchemaTransformProvider.class);
+    List<SchemaTransformProvider> providers =
+        StreamSupport.stream(serviceLoader.spliterator(), false)
+            .filter(provider -> provider.getClass() == KafkaReadSchemaTransformProvider.class)
+            .collect(Collectors.toList());
+    KafkaReadSchemaTransformProvider kafkaProvider =
+        (KafkaReadSchemaTransformProvider) providers.get(0);
+    kafkaProvider.from(
+        KafkaReadSchemaTransformConfiguration.builder()
+            .setTopic("anytopic")
+            .setBootstrapServers("anybootstrap")
+            .setFormat("STRING")
+            .build());
+  }
+
+  @Test
   public void testBuildTransformWithProtoFormat() {
     ServiceLoader<SchemaTransformProvider> serviceLoader =
         ServiceLoader.load(SchemaTransformProvider.class);
@@ -300,15 +318,16 @@ public class KafkaReadSchemaTransformProviderTest {
     List<String> configs =
         Arrays.asList(
             "topic: topic_1\n" + "bootstrap_servers: some bootstrap\n" + "format: RAW",
-            "topic: topic_2\n"
+            "topic: topic_2\n" + "bootstrap_servers: some bootstrap\n" + "format: STRING",
+            "topic: topic_3\n"
                 + "bootstrap_servers: some bootstrap\n"
                 + "schema: '{\"type\":\"record\",\"name\":\"my_record\",\"fields\":[{\"name\":\"bool\",\"type\":\"boolean\"}]}'",
-            "topic: topic_3\n"
+            "topic: topic_4\n"
                 + "bootstrap_servers: some bootstrap\n"
                 + "schema_registry_url: some-url\n"
                 + "schema_registry_subject: some-subject\n"
                 + "format: RAW",
-            "topic: topic_4\n"
+            "topic: topic_5\n"
                 + "bootstrap_servers: some bootstrap\n"
                 + "format: PROTO\n"
                 + "schema: '"


### PR DESCRIPTION
**Please** add a meaningful description for your change here

Fixes https://github.com/apache/beam/issues/35190

The docs says STRING is one of the valid format https://beam.apache.org/releases/yamldoc/current/#readfromkafka, but we're currently not validating for the STRING format here https://github.com/apache/beam/blob/master/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaReadSchemaTransformConfiguration.java#L50-L85...

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
