### PR TITLE
Evaluate namedTuples as equivalent to rows

### DIFF
--- a/sdks/python/apache_beam/testing/util_test.py
+++ b/sdks/python/apache_beam/testing/util_test.py
@@ -32,12 +32,14 @@ from apache_beam.testing.util import equal_to
 from apache_beam.testing.util import equal_to_per_window
 from apache_beam.testing.util import is_empty
 from apache_beam.testing.util import is_not_empty
+from apache_beam.testing.util import row_namedtuple_equals_fn
 from apache_beam.transforms import trigger
 from apache_beam.transforms import window
 from apache_beam.transforms.window import FixedWindows
 from apache_beam.transforms.window import GlobalWindow
 from apache_beam.transforms.window import IntervalWindow
 from apache_beam.utils.timestamp import MIN_TIMESTAMP
+from typing import NamedTuple
 
 
 class UtilTest(unittest.TestCase):
@@ -253,6 +255,54 @@ class UtilTest(unittest.TestCase):
             | beam.GroupByKey()),
                     equal_to_per_window(expected),
                     reify_windows=True)
+
+  def test_row_namedtuple_equals(self):
+    class RowTuple(NamedTuple):
+      a: str
+      b: int
+
+    self.assertTrue(
+        row_namedtuple_equals_fn(
+            beam.Row(a='123', b=456), beam.Row(a='123', b=456)))
+    self.assertTrue(
+        row_namedtuple_equals_fn(
+            beam.Row(a='123', b=456), RowTuple(a='123', b=456)))
+    self.assertTrue(
+        row_namedtuple_equals_fn(
+            RowTuple(a='123', b=456), RowTuple(a='123', b=456)))
+    self.assertTrue(
+        row_namedtuple_equals_fn(
+            RowTuple(a='123', b=456), beam.Row(a='123', b=456)))
+    self.assertTrue(row_namedtuple_equals_fn('foo', 'foo'))
+    self.assertFalse(
+        row_namedtuple_equals_fn(
+            beam.Row(a='123', b=456), beam.Row(a='123', b=4567)))
+    self.assertFalse(
+        row_namedtuple_equals_fn(
+            beam.Row(a='123', b=456), beam.Row(a='123', b=456, c='a')))
+    self.assertFalse(
+        row_namedtuple_equals_fn(
+            beam.Row(a='123', b=456), RowTuple(a='123', b=4567)))
+    self.assertFalse(
+        row_namedtuple_equals_fn(
+            beam.Row(a='123', b=456, c='foo'), RowTuple(a='123', b=4567)))
+    self.assertFalse(
+        row_namedtuple_equals_fn(beam.Row(a='123'), RowTuple(a='123', b=4567)))
+    self.assertFalse(row_namedtuple_equals_fn(beam.Row(a='123'), '123'))
+    self.assertFalse(row_namedtuple_equals_fn('123', RowTuple(a='123', b=4567)))
+
+    class NestedNamedTuple(NamedTuple):
+      a: str
+      b: RowTuple
+
+    self.assertTrue(
+        row_namedtuple_equals_fn(
+            beam.Row(a='foo', b=beam.Row(a='123', b=456)),
+            NestedNamedTuple(a='foo', b=RowTuple(a='123', b=456))))
+    self.assertTrue(
+        row_namedtuple_equals_fn(
+            beam.Row(a='foo', b=beam.Row(a='123', b=456)),
+            beam.Row(a='foo', b=RowTuple(a='123', b=456))))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When crossing the portability layer, portable runners convert Rows to RowTypes, but when converting back they are returned as NamedTuples - https://github.com/apache/beam/blob/df54bf439b28b23c3380b913811633fd8678c403/sdks/python/apache_beam/typehints/schemas.py#L41

This means that equality checks can break even if the items being compared are the same if they've gone across this conversion layer. e.g.

```
foo = beam.Row(...)
foo2 = from_schema_type(to_schema_type(foo))
foo == foo2 # evaluates as false
```

This change allows rows and NamedTuples to be evaluated as equivalent when using portable runners.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
