### PR TITLE
Remove breaking PDone change

### DIFF
--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -856,14 +856,15 @@ class Pipeline(HasDisplayData):
       pvalueish,  # type: Optional[pvalue.PValue]
       transform  # type: ptransform.PTransform
   ):
-    if isinstance(pvalueish, pvalue.PDone) and isinstance(transform, ParDo):
-      # If the input is a PDone, we cannot apply a ParDo transform.
-      full_label = self._current_transform().full_label
-      producer_label = pvalueish.producer.full_label
-      raise TypeCheckError(
-          f'Transform "{full_label}" was applied to the output of '
-          f'"{producer_label}" but "{producer_label.split("/")[-1]}" '
-          'produces no PCollections.')
+    if isinstance(pvalueish, pvalue.PDone) or pvalueish is None:
+      if isinstance(transform, ParDo):
+        # If the input is a PDone, we cannot apply a ParDo transform.
+        full_label = self._current_transform().full_label
+        producer_label = pvalueish.producer.full_label
+        raise TypeCheckError(
+            f'Transform "{full_label}" was applied to the output of '
+            f'"{producer_label}" but "{producer_label.split("/")[-1]}" '
+            'produces no PCollections.')
 
   def _generate_unique_label(
       self,

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -862,15 +862,14 @@ class Pipeline(HasDisplayData):
       pvalueish,  # type: Optional[pvalue.PValue]
       transform  # type: ptransform.PTransform
   ):
-    if isinstance(transform, ParDo):
-      if isinstance(pvalueish, pvalue.PDone):
-        # If the input is a PDone, we cannot apply a ParDo transform.
-        full_label = self._current_transform().full_label
-        producer_label = pvalueish.producer.full_label
-        raise TypeCheckError(
-            f'Transform "{full_label}" was applied to the output of '
-            f'"{producer_label}" but "{producer_label.split("/")[-1]}" '
-            'produces no PCollections.')
+    if isinstance(pvalueish, pvalue.PDone) and isinstance(transform, ParDo):
+      # If the input is a PDone, we cannot apply a ParDo transform.
+      full_label = self._current_transform().full_label
+      producer_label = pvalueish.producer.full_label
+      raise TypeCheckError(
+          f'Transform "{full_label}" was applied to the output of '
+          f'"{producer_label}" but "{producer_label.split("/")[-1]}" '
+          'produces no PCollections.')
 
   def _generate_unique_label(
       self,

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -767,10 +767,10 @@ class Pipeline(HasDisplayData):
     self.applied_labels.add(full_label)
 
     if pvalueish is None:
-        full_label = self._current_transform().full_label
-        raise TypeCheckError(
-            f'Transform "{full_label}" was applied to the output of '
-            f'an object of type None.')
+      full_label = self._current_transform().full_label
+      raise TypeCheckError(
+          f'Transform "{full_label}" was applied to the output of '
+          f'an object of type None.')
 
     pvalueish, inputs = transform._extract_input_pvalues(pvalueish)
     try:

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -856,8 +856,8 @@ class Pipeline(HasDisplayData):
       pvalueish,  # type: Optional[pvalue.PValue]
       transform  # type: ptransform.PTransform
   ):
-    if isinstance(pvalueish, pvalue.PDone) or pvalueish is None:
-      if isinstance(transform, ParDo):
+    if isinstance(transform, ParDo):
+      if isinstance(pvalueish, pvalue.PDone):
         # If the input is a PDone, we cannot apply a ParDo transform.
         full_label = self._current_transform().full_label
         producer_label = pvalueish.producer.full_label
@@ -865,6 +865,11 @@ class Pipeline(HasDisplayData):
             f'Transform "{full_label}" was applied to the output of '
             f'"{producer_label}" but "{producer_label.split("/")[-1]}" '
             'produces no PCollections.')
+      if pvalueish is None:
+        full_label = self._current_transform().full_label
+        raise TypeCheckError(
+            f'Transform "{full_label}" was applied to the output of '
+            f'an object of type None.')
 
   def _generate_unique_label(
       self,

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -766,6 +766,12 @@ class Pipeline(HasDisplayData):
             'streaming jobs.' % full_label)
     self.applied_labels.add(full_label)
 
+    if pvalueish is None:
+        full_label = self._current_transform().full_label
+        raise TypeCheckError(
+            f'Transform "{full_label}" was applied to the output of '
+            f'an object of type None.')
+
     pvalueish, inputs = transform._extract_input_pvalues(pvalueish)
     try:
       if not isinstance(inputs, dict):
@@ -865,11 +871,6 @@ class Pipeline(HasDisplayData):
             f'Transform "{full_label}" was applied to the output of '
             f'"{producer_label}" but "{producer_label.split("/")[-1]}" '
             'produces no PCollections.')
-      if pvalueish is None:
-        full_label = self._current_transform().full_label
-        raise TypeCheckError(
-            f'Transform "{full_label}" was applied to the output of '
-            f'an object of type None.')
 
   def _generate_unique_label(
       self,

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -805,9 +805,6 @@ class Pipeline(HasDisplayData):
       self._assert_not_applying_PDone(pvalueish, transform)
 
       pvalueish_result = self.runner.apply(transform, pvalueish, self._options)
-      if pvalueish_result is None:
-        pvalueish_result = pvalue.PDone(self)
-        pvalueish_result.producer = current
 
       if type_options is not None and type_options.pipeline_type_check:
         transform.type_check_outputs(pvalueish_result)

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -174,7 +174,7 @@ class PipelineTest(unittest.TestCase):
 
     with pytest.raises(
         TypeCheckError,
-        match=r".*applied to the output.*ParentTransform/DoNothingTransform"):
+        match=r".*applied to the output"):
       with TestPipeline() as pipeline:
         _ = pipeline | ParentTransform() | beam.Map(lambda x: x + 1)
 

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -172,9 +172,7 @@ class PipelineTest(unittest.TestCase):
       def expand(self, pcoll):
         return pcoll | DoNothingTransform()
 
-    with pytest.raises(
-        TypeCheckError,
-        match=r".*applied to the output"):
+    with pytest.raises(TypeCheckError, match=r".*applied to the output"):
       with TestPipeline() as pipeline:
         _ = pipeline | ParentTransform() | beam.Map(lambda x: x + 1)
 


### PR DESCRIPTION
This change (introduced in https://github.com/apache/beam/pull/35160) unfortunately can break some pipelines which rely on the current behavior. Specifically, I found people running into issues with pipelines which looked like:

```
class MyDofn(...):
   expand(self, ...):
      if self.condition:
          return None
      ...

def construct_pipeline():
   foo = p | MyDofn(...)
   if foo is not None:
      foo | more_transforms(...)
```

This probably should remain valid, I don't think its worth breaking existing pipelines for the correctness semantics.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
