### PR TITLE
Unpin antlr in BeamModulePlugins

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -674,8 +674,6 @@ class BeamModulePlugin implements Plugin<Project> {
         activemq_junit                              : "org.apache.activemq.tooling:activemq-junit:$activemq_version",
         activemq_kahadb_store                       : "org.apache.activemq:activemq-kahadb-store:$activemq_version",
         activemq_mqtt                               : "org.apache.activemq:activemq-mqtt:$activemq_version",
-        antlr                                       : "org.antlr:antlr4:4.7",
-        antlr_runtime                               : "org.antlr:antlr4-runtime:4.7",
         args4j                                      : "args4j:args4j:2.33",
         auto_value_annotations                      : "com.google.auto.value:auto-value-annotations:$autovalue_version",
         // TODO: https://github.com/apache/beam/issues/34993 after stopping supporting Java 8

--- a/sdks/java/core/build.gradle
+++ b/sdks/java/core/build.gradle
@@ -17,6 +17,9 @@
  */
 
 plugins { id 'org.apache.beam.module' }
+
+def antlr_version = "4.7"
+
 applyJavaNature(
   automaticModuleName: 'org.apache.beam.sdk',
   classesTriggerCheckerBugs: [
@@ -29,7 +32,8 @@ applyJavaNature(
     dependencies {
       include(dependency(library.java.commons_compress))
       include(dependency(library.java.commons_lang3))
-      include(dependency(library.java.antlr_runtime))
+      // Shade and repackage antlr runtime into Java core jar
+      include(dependency("org.antlr:antlr4-runtime:$antlr_version"))
     }
     relocate "com.google.thirdparty", getJavaRelocatedPath("com.google.thirdparty")
     relocate "org.apache.commons.compress", getJavaRelocatedPath("org.apache.commons.compress")
@@ -70,10 +74,8 @@ test {
 }
 
 dependencies {
-  antlr library.java.antlr
   // antlr is used to generate code from sdks/java/core/src/main/antlr/
-  permitUnusedDeclared library.java.antlr
-  permitUsedUndeclared library.java.antlr_runtime
+  antlr "org.antlr:antlr4:$antlr_version"
   // Required to load constants from the model, e.g. max timestamp for global window
   shadow project(path: ":model:pipeline", configuration: "shadow")
   shadow project(path: ":model:fn-execution", configuration: "shadow")

--- a/sdks/java/core/build.gradle
+++ b/sdks/java/core/build.gradle
@@ -76,6 +76,9 @@ test {
 dependencies {
   // antlr is used to generate code from sdks/java/core/src/main/antlr/
   antlr "org.antlr:antlr4:$antlr_version"
+  permitUnusedDeclared "org.antlr:antlr4:$antlr_version"
+  // alrady shaded and repackaged
+  permitUsedUndeclared "org.antlr:antlr4-runtime:$antlr_version"
   // Required to load constants from the model, e.g. max timestamp for global window
   shadow project(path: ":model:pipeline", configuration: "shadow")
   shadow project(path: ":model:fn-execution", configuration: "shadow")


### PR DESCRIPTION
**Please** add a meaningful description for your change here

java.library.antlr/antlr_runtime is only used in Java core

antlr is not a dependency for other Beam component than Java core. For java core, antlr is a (pre)compile only dependency and antlr_runtime is shaded and repackaged, which means antlr isn't a dependency for Java core jar either, see https://mvnrepository.com/artifact/org.apache.beam/beam-sdks-java-core/2.65.0

Unpin it to unblock tests that has transient dependencies on newer antlr (DebeziumIO). This change does not affect any published artifacts

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
