### PR TITLE
[IcebergIO] Change writer open/close logs to debug

### DIFF
--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/RecordWriter.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/RecordWriter.java
@@ -112,7 +112,7 @@ class RecordWriter {
         throw new RuntimeException("Unknown File Format: " + fileFormat);
     }
     activeIcebergWriters.inc();
-    LOG.info(
+    LOG.debug(
         "Opened {} writer for table '{}', partition {}. Writing to path: {}",
         fileFormat,
         table.name(),
@@ -137,7 +137,7 @@ class RecordWriter {
     }
     activeIcebergWriters.dec();
     DataFile dataFile = icebergDataWriter.toDataFile();
-    LOG.info(
+    LOG.debug(
         "Closed {} writer for table '{}' ({} records, {} bytes), path: {}",
         fileFormat,
         table.name(),


### PR DESCRIPTION
These are currently logged at info level, and can be a little noisy:

`INFO: Opened PARQUET writer for table 'apache-beam-2.66.0-SNAPSHOT.bqms_test_catalog_1749651126538_testWriteToPartitionedAndValidateWithBQQuery_new.test_table', partition [false, 482136, value_7]. Writing to path: gs://managed-iceberg-integration-tests/temp/BigQueryMetastoreCatalogIT/423913dc-66cf-4ead-bb01-20b7561a7896/bqms_test_catalog_1749651126538_testWriteToPartitionedAndValidateWithBQQuery_new.db/test_table/data/bool_field=false/datetime_hour=2025-01-01-00/str_trunc=value_7/b29551ce-cd32-4aa2-b832-14589c63b2d5_45eb5c5f-c612-413c-b8a6-ee49dd6fed94_1.parquet`

`INFO: Closed PARQUET writer for table 'apache-beam-2.66.0-SNAPSHOT.bqms_test_catalog_1749651501346_testWriteToDynamicNamespaces_1.table_true' (1 records, 6727 bytes), path: gs://managed-iceberg-integration-tests/temp/BigQueryMetastoreCatalogIT/423913dc-66cf-4ead-bb01-20b7561a7896/bqms_test_catalog_1749651501346_testWriteToDynamicNamespaces_1.db/table_true/data/33850680-a1ea-4554-9af3-55ac7478dc83_ad478be3-677e-415a-8366-5c0472dea905_1.parquet`