### PR TITLE
Speed up StreamingDataflowWorkerTest by removing 10 second wait from shutdown path.

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
@@ -1226,6 +1226,8 @@ public class StreamingDataflowWorkerTest {
             .build(),
         removeDynamicFields(result.get(1L)));
     assertEquals(1, result.size());
+
+    worker.stop();
   }
 
   @Test
@@ -1301,6 +1303,7 @@ public class StreamingDataflowWorkerTest {
       }
     }
     assertTrue(foundErrors);
+    worker.stop();
   }
 
   @Test
@@ -1338,6 +1341,7 @@ public class StreamingDataflowWorkerTest {
     assertEquals(
         makeExpectedOutput(1, 0, bigKey, DEFAULT_SHARDING_KEY, "smaller_key").build(),
         removeDynamicFields(result.get(1L)));
+    worker.stop();
   }
 
   @Test
@@ -1375,6 +1379,7 @@ public class StreamingDataflowWorkerTest {
     assertEquals(
         makeExpectedOutput(1, 0, "key", DEFAULT_SHARDING_KEY, "smaller_key").build(),
         removeDynamicFields(result.get(1L)));
+    worker.stop();
   }
 
   @Test
@@ -1429,6 +1434,7 @@ public class StreamingDataflowWorkerTest {
               .build(),
           removeDynamicFields(result.get((long) i + 1000)));
     }
+    worker.stop();
   }
 
   @Test(timeout = 30000)
@@ -1530,6 +1536,7 @@ public class StreamingDataflowWorkerTest {
     assertEquals(keyString, stats.getKey().toStringUtf8());
     assertEquals(0, stats.getWorkToken());
     assertEquals(1, stats.getShardingKey());
+    worker.stop();
   }
 
   @Test
@@ -1605,6 +1612,7 @@ public class StreamingDataflowWorkerTest {
                     intervalWindowBytes(WINDOW_AT_ONE_SECOND),
                     makeExpectedOutput(timestamp2, timestamp2))
                 .build()));
+    worker.stop();
   }
 
   private void verifyTimers(WorkItemCommitRequest commit, Timer... timers) {
@@ -1929,6 +1937,7 @@ public class StreamingDataflowWorkerTest {
         splitIntToLong(getCounter(counters, "WindmillStateBytesWritten").getInteger()));
     // No input messages
     assertEquals(0L, splitIntToLong(getCounter(counters, "WindmillShuffleBytesRead").getInteger()));
+    worker.stop();
   }
 
   @Test
@@ -2223,6 +2232,7 @@ public class StreamingDataflowWorkerTest {
     LOG.info("cache stats {}", stats);
     assertEquals(1, stats.hitCount());
     assertEquals(4, stats.missCount());
+    worker.stop();
   }
 
   // Helper for running tests for merging sessions based upon Actions consisting of GetWorkResponse
@@ -2304,6 +2314,7 @@ public class StreamingDataflowWorkerTest {
       verifyTimers(actualOutput, action.expectedTimers);
       verifyHolds(actualOutput, action.expectedHolds);
     }
+    worker.stop();
   }
 
   @Test
@@ -2590,6 +2601,7 @@ public class StreamingDataflowWorkerTest {
                 .build()));
 
     assertNull(getCounter(counters, "dataflow_input_size-computation"));
+    worker.stop();
   }
 
   @Test
@@ -2702,6 +2714,7 @@ public class StreamingDataflowWorkerTest {
                 .build()));
 
     assertThat(finalizeTracker, contains(0));
+    worker.stop();
   }
 
   // Regression test to ensure that a reader is not used from the cache
@@ -2835,6 +2848,7 @@ public class StreamingDataflowWorkerTest {
                 .build()));
 
     assertThat(finalizeTracker, contains(0));
+    worker.stop();
   }
 
   @Test
@@ -3412,6 +3426,7 @@ public class StreamingDataflowWorkerTest {
                       parseCommitRequest(sb.toString()))
                   .build()));
     }
+    worker.stop();
   }
 
   @Test
@@ -3909,6 +3924,7 @@ public class StreamingDataflowWorkerTest {
     commit = result.get(2L);
 
     assertThat(commit.getSerializedSize(), isWithinBundleSizeLimits);
+    worker.stop();
   }
 
   @Test
@@ -3990,6 +4006,7 @@ public class StreamingDataflowWorkerTest {
     commit = result.get(2L);
 
     assertThat(commit.getSerializedSize(), isWithinBundleSizeLimits);
+    worker.stop();
   }
 
   @Test


### PR DESCRIPTION
Takes test time from 5m18s to 2m40s.

The previous shutdown() call doesn't do anything since that just means future scheduling won't trigger but we only schedule on the executor once.

Also cleanup test logs by making sure to stop all workers we start so they don't continue to run in the background and log.

This shutdown paths is only used in testing.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
