### PR TITLE
Fix(yaml): Handle missing optional fields in JSON parsing

### DIFF
--- a/sdks/python/apache_beam/yaml/json_utils_test.py
+++ b/sdks/python/apache_beam/yaml/json_utils_test.py
@@ -1,0 +1,140 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+import apache_beam as beam
+from apache_beam.portability.api import schema_pb2
+from apache_beam.yaml import json_utils
+
+
+class JsonUtilsTest(unittest.TestCase):
+  def test_json_to_row_with_missing_optional_field(self):
+    beam_schema = schema_pb2.Schema(
+        fields=[
+            schema_pb2.Field(
+                name='id',
+                type=schema_pb2.FieldType(atomic_type=schema_pb2.STRING)),
+            schema_pb2.Field(
+                name='event_subtype',
+                type=schema_pb2.FieldType(
+                    atomic_type=schema_pb2.STRING, nullable=True)),
+        ])
+    beam_type = schema_pb2.FieldType(
+        row_type=schema_pb2.RowType(schema=beam_schema))
+    converter = json_utils.json_to_row(beam_type)
+    json_data = {'id': '123'}
+    beam_row = converter(json_data)
+    self.assertEqual(beam_row, beam.Row(id='123', event_subtype=None))
+
+  def test_json_to_row_with_missing_optional_object(self):
+    nested_schema = schema_pb2.Schema(
+        fields=[
+            schema_pb2.Field(
+                name='nested_id',
+                type=schema_pb2.FieldType(atomic_type=schema_pb2.STRING)),
+        ])
+    beam_schema = schema_pb2.Schema(
+        fields=[
+            schema_pb2.Field(
+                name='id',
+                type=schema_pb2.FieldType(atomic_type=schema_pb2.STRING)),
+            schema_pb2.Field(
+                name='nested',
+                type=schema_pb2.FieldType(
+                    row_type=schema_pb2.RowType(schema=nested_schema),
+                    nullable=True)),
+        ])
+    beam_type = schema_pb2.FieldType(
+        row_type=schema_pb2.RowType(schema=beam_schema))
+    converter = json_utils.json_to_row(beam_type)
+    json_data = {'id': '123'}
+    beam_row = converter(json_data)
+    self.assertEqual(beam_row, beam.Row(id='123', nested=None))
+
+  def test_json_to_row_with_missing_optional_array(self):
+    beam_schema = schema_pb2.Schema(
+        fields=[
+            schema_pb2.Field(
+                name='id',
+                type=schema_pb2.FieldType(atomic_type=schema_pb2.STRING)),
+            schema_pb2.Field(
+                name='items',
+                type=schema_pb2.FieldType(
+                    array_type=schema_pb2.ArrayType(
+                        element_type=schema_pb2.FieldType(
+                            atomic_type=schema_pb2.STRING)),
+                    nullable=True)),
+        ])
+    beam_type = schema_pb2.FieldType(
+        row_type=schema_pb2.RowType(schema=beam_schema))
+    converter = json_utils.json_to_row(beam_type)
+    json_data = {'id': '123'}
+    beam_row = converter(json_data)
+    self.assertEqual(beam_row, beam.Row(id='123', items=None))
+
+  def test_json_to_row_with_all_fields(self):
+    nested_schema = schema_pb2.Schema(
+        fields=[
+            schema_pb2.Field(
+                name='nested_id',
+                type=schema_pb2.FieldType(atomic_type=schema_pb2.STRING)),
+        ])
+    beam_schema = schema_pb2.Schema(
+        fields=[
+            schema_pb2.Field(
+                name='id',
+                type=schema_pb2.FieldType(atomic_type=schema_pb2.STRING)),
+            schema_pb2.Field(
+                name='event_subtype',
+                type=schema_pb2.FieldType(
+                    atomic_type=schema_pb2.STRING, nullable=True)),
+            schema_pb2.Field(
+                name='nested',
+                type=schema_pb2.FieldType(
+                    row_type=schema_pb2.RowType(schema=nested_schema),
+                    nullable=True)),
+            schema_pb2.Field(
+                name='items',
+                type=schema_pb2.FieldType(
+                    array_type=schema_pb2.ArrayType(
+                        element_type=schema_pb2.FieldType(
+                            atomic_type=schema_pb2.STRING)),
+                    nullable=True)),
+        ])
+    beam_type = schema_pb2.FieldType(
+        row_type=schema_pb2.RowType(schema=beam_schema))
+    converter = json_utils.json_to_row(beam_type)
+    json_data = {
+        'id': '123',
+        'event_subtype': 'subtype_val',
+        'nested': {
+            'nested_id': 'nested_123'
+        },
+        'items': ['a', 'b', 'c']
+    }
+    beam_row = converter(json_data)
+    expected_row = beam.Row(
+        id='123',
+        event_subtype='subtype_val',
+        nested=beam.Row(nested_id='nested_123'),
+        items=['a', 'b', 'c'])
+    self.assertEqual(beam_row, expected_row)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Fixes #35194 

When using ReadFromPubSub with a schema in Beam YAML, the pipeline would fail with a KeyError if a field specified in the schema was missing from the incoming JSON message.

This commit fixes the issue by modifying the `json_to_row` function in `apache_beam/yaml/json_utils.py`. The direct dictionary access `value[name]` is replaced with `value.get(name)` to safely handle missing keys, returning `None` instead of raising an error.

The converters for array, map, and row types have also been made robust to handle `None` values, which can occur for missing optional fields of these complex types.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
