### PR TITLE
Revert "Bump org.ajoberstar.grgit:grgit-gradle from 4.1.1 to 5.3.2"

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
   runtimeOnly("net.linguica.gradle:maven-settings-plugin:0.5")
   runtimeOnly("gradle.plugin.io.pry.gradle.offline_dependencies:gradle-offline-dependencies-plugin:0.5.0") // Enable creating an offline repository
   runtimeOnly("net.ltgt.gradle:gradle-errorprone-plugin:3.1.0")                                            // Enable errorprone Java static analysis
-  runtimeOnly("org.ajoberstar.grgit:grgit-gradle:5.3.2")                                                   // Enable website git publish to asf-site branch
+  runtimeOnly("org.ajoberstar.grgit:grgit-gradle:4.1.1")                                                   // Enable website git publish to asf-site branch
   runtimeOnly("com.avast.gradle:gradle-docker-compose-plugin:0.16.12")                                     // Enable docker compose tasks
   runtimeOnly("ca.cutterslade.gradle:gradle-dependency-analyze:1.8.3")                                     // Enable dep analysis
   runtimeOnly("gradle.plugin.net.ossindex:ossindex-gradle-plugin:0.4.11")                                  // Enable dep vulnerability analysis


### PR DESCRIPTION
Reverts apache/beam#35301

Looks like this broke at least one workflow - https://github.com/apache/beam/actions/runs/15682822701/job/44181078420?pr=35289 - probably more.