### PR TITLE
[Spark runner] Support for ProcessingTime Timer for Spark Runner

### DIFF
--- a/.github/trigger_files/beam_PostCommit_Java_ValidatesRunner_Spark.json
+++ b/.github/trigger_files/beam_PostCommit_Java_ValidatesRunner_Spark.json
@@ -11,5 +11,6 @@
   "https://github.com/apache/beam/pull/34080": "noting that PR #34080 should run this test",
   "https://github.com/apache/beam/pull/34155": "noting that PR #34155 should run this test",
   "https://github.com/apache/beam/pull/34560": "noting that PR #34560 should run this test",
-  "https://github.com/apache/beam/pull/35159": "moving WindowedValue and making an interface"
+  "https://github.com/apache/beam/pull/35159": "moving WindowedValue and making an interface",
+  "https://github.com/apache/beam/pull/35316": "noting that PR #35316 should run this test"
 }

--- a/.github/trigger_files/beam_PostCommit_Java_ValidatesRunner_Spark_Java11.json
+++ b/.github/trigger_files/beam_PostCommit_Java_ValidatesRunner_Spark_Java11.json
@@ -7,5 +7,6 @@
   "https://github.com/apache/beam/pull/33322": "noting that PR #33322 should run this test",
   "https://github.com/apache/beam/pull/34080": "noting that PR #34080 should run this test",
   "https://github.com/apache/beam/pull/34155": "noting that PR #34155 should run this test",
-  "https://github.com/apache/beam/pull/34560": "noting that PR #34560 should run this test"
+  "https://github.com/apache/beam/pull/34560": "noting that PR #34560 should run this test",
+  "https://github.com/apache/beam/pull/35316": "noting that PR #35316 should run this test"
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,6 +73,7 @@
 
 ## New Features / Improvements
 
+* Added support for Processing time Timer in the Spark Classic runner ([#33633](https://github.com/apache/beam/issues/33633)).
 * X feature added (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
 
 ## Breaking Changes

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/stateful/SparkTimerInternals.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/stateful/SparkTimerInternals.java
@@ -21,6 +21,7 @@ import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Pr
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +44,7 @@ import org.joda.time.Instant;
 public class SparkTimerInternals implements TimerInternals {
   private final Instant highWatermark;
   private final Instant synchronizedProcessingTime;
-  private final Set<TimerData> timers = Sets.newHashSet();
+  private final Set<TimerData> timers = Sets.newConcurrentHashSet();
 
   private Instant inputWatermark;
 
@@ -122,7 +123,14 @@ public class SparkTimerInternals implements TimerInternals {
   @Override
   public void deleteTimer(
       StateNamespace namespace, String timerId, String timerFamilyId, TimeDomain timeDomain) {
-    throw new UnsupportedOperationException("Deleting a timer by ID is not yet supported.");
+    this.timers.stream()
+        .filter(
+            timer ->
+                namespace.equals(timer.getNamespace())
+                    && timerId.equals(timer.getTimerId())
+                    && timerFamilyId.equals(timer.getTimerFamilyId())
+                    && timeDomain.equals(timer.getDomain()))
+        .forEach(this::deleteTimer);
   }
 
   @Override
@@ -180,6 +188,34 @@ public class SparkTimerInternals implements TimerInternals {
   public static Iterator<TimerData> deserializeTimers(
       Collection<byte[]> serTimers, TimerDataCoderV2 timerDataCoder) {
     return CoderHelpers.fromByteArrays(serTimers, timerDataCoder).iterator();
+  }
+
+  /**
+   * Finds and removes the latest timer in {@link TimeDomain#PROCESSING_TIME} domain that has
+   * expired based on the current processing time.
+   *
+   * <p>A timer is considered expired when its timestamp is less than the current processing time.
+   * If multiple expired timers exist, the one with the latest timestamp will be returned.
+   *
+   * @return The expired processing timer with the latest timestamp if one exists, or {@code null}
+   *     if no processing timers are ready to fire.
+   */
+  public @Nullable TimerData removeNextProcessingTimer() {
+    final Instant currentProcessingTime = this.currentProcessingTime();
+    final @Nullable TimerData timer =
+        this.timers.stream()
+            .filter(
+                (TimerData timerData) ->
+                    timerData.getDomain().equals(TimeDomain.PROCESSING_TIME)
+                        && currentProcessingTime.isAfter(timerData.getTimestamp()))
+            .max(Comparator.comparing(TimerData::getTimestamp))
+            .orElse(null);
+
+    if (timer != null) {
+      this.deleteTimer(timer);
+      return timer;
+    }
+    return null;
   }
 
   @Override

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/AbstractInOutIterator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/AbstractInOutIterator.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.spark.translation;
+
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
+
+import org.apache.beam.runners.core.StateNamespace;
+import org.apache.beam.runners.core.StateNamespaces;
+import org.apache.beam.runners.core.TimerInternals;
+import org.apache.beam.runners.spark.translation.streaming.ParDoStateUpdateFn;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.WindowedValue;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.AbstractIterator;
+import scala.Tuple2;
+
+/**
+ * Abstract base class for iterators that process Spark input data and produce corresponding output
+ * values. This class serves as a common base for both bounded and unbounded processing strategies
+ * in the Spark runner.
+ *
+ * <p>The class extends Guava's {@link AbstractIterator} and provides common functionality for
+ * iterating through input elements, processing them using a DoFnRunner, and producing output
+ * elements as tuples of {@link TupleTag} and {@link WindowedValue} pairs.
+ *
+ * @param <K> The key type for the processing context
+ * @param <InputT> The input element type to be processed
+ * @param <OutputT> The output element type after processing
+ */
+public abstract class AbstractInOutIterator<K, InputT, OutputT>
+    extends AbstractIterator<Tuple2<TupleTag<?>, WindowedValue<?>>> {
+  protected final SparkProcessContext<K, InputT, OutputT> ctx;
+
+  protected AbstractInOutIterator(SparkProcessContext<K, InputT, OutputT> ctx) {
+    this.ctx = ctx;
+  }
+
+  /**
+   * Fires a timer using the DoFnRunner from the context and performs cleanup afterwards.
+   *
+   * <p>After firing the timer, if the timer data iterator is an instance of {@link
+   * ParDoStateUpdateFn.SparkTimerInternalsIterator}, the fired timer will be deleted as part of
+   * cleanup to prevent re-firing of the same timer.
+   *
+   * @param timer The timer data containing information about the timer to fire
+   * @throws IllegalArgumentException If the timer namespace is not a {@link
+   *     StateNamespaces.WindowNamespace}
+   */
+  public void fireTimer(TimerInternals.TimerData timer) {
+    StateNamespace namespace = timer.getNamespace();
+    checkArgument(namespace instanceof StateNamespaces.WindowNamespace);
+    BoundedWindow window = ((StateNamespaces.WindowNamespace) namespace).getWindow();
+    try {
+      this.ctx
+          .getDoFnRunner()
+          .onTimer(
+              timer.getTimerId(),
+              timer.getTimerFamilyId(),
+              this.ctx.getKey(),
+              window,
+              timer.getTimestamp(),
+              timer.getOutputTimestamp(),
+              timer.getDomain());
+    } finally {
+      if (this.ctx.getTimerDataIterator()
+          instanceof ParDoStateUpdateFn.SparkTimerInternalsIterator) {
+        final ParDoStateUpdateFn.SparkTimerInternalsIterator timerDataIterator =
+            (ParDoStateUpdateFn.SparkTimerInternalsIterator) this.ctx.getTimerDataIterator();
+        timerDataIterator.deleteTimer(timer);
+      }
+    }
+  }
+}

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkInputDataProcessor.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkInputDataProcessor.java
@@ -17,8 +17,6 @@
  */
 package org.apache.beam.runners.spark.translation;
 
-import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
-
 import java.util.ArrayDeque;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -28,16 +26,11 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.CheckForNull;
-import org.apache.beam.runners.core.StateNamespace;
-import org.apache.beam.runners.core.StateNamespaces;
-import org.apache.beam.runners.core.TimerInternals;
 import org.apache.beam.sdk.transforms.reflect.DoFnInvokers;
-import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.WindowedValueMultiReceiver;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.WindowedValue;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
-import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.AbstractIterator;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -183,51 +176,6 @@ class UnboundedSparkInputDataProcessor<FnInputT, FnOutputT>
         throw re;
       }
     }
-  }
-}
-
-/**
- * Abstract base class for iterators that process Spark input data and produce corresponding output
- * values. This class serves as a common base for both bounded and unbounded processing strategies
- * in the Spark runner.
- *
- * <p>The class extends Guava's {@link AbstractIterator} and provides common functionality for
- * iterating through input elements, processing them using a DoFnRunner, and producing output
- * elements as tuples of {@link TupleTag} and {@link WindowedValue} pairs.
- *
- * @param <K> The key type for the processing context
- * @param <InputT> The input element type to be processed
- * @param <OutputT> The output element type after processing
- */
-abstract class AbstractInOutIterator<K, InputT, OutputT>
-    extends AbstractIterator<Tuple2<TupleTag<?>, WindowedValue<?>>> {
-  protected final SparkProcessContext<K, InputT, OutputT> ctx;
-
-  protected AbstractInOutIterator(SparkProcessContext<K, InputT, OutputT> ctx) {
-    this.ctx = ctx;
-  }
-
-  /**
-   * Fires a timer using the DoFnRunner from the context.
-   *
-   * @param timer The timer data containing information about the timer to fire
-   * @throws IllegalArgumentException If the timer namespace is not a {@link
-   *     StateNamespaces.WindowNamespace}
-   */
-  protected void fireTimer(TimerInternals.TimerData timer) {
-    StateNamespace namespace = timer.getNamespace();
-    checkArgument(namespace instanceof StateNamespaces.WindowNamespace);
-    BoundedWindow window = ((StateNamespaces.WindowNamespace) namespace).getWindow();
-    this.ctx
-        .getDoFnRunner()
-        .onTimer(
-            timer.getTimerId(),
-            timer.getTimerFamilyId(),
-            this.ctx.getKey(),
-            window,
-            timer.getTimestamp(),
-            timer.getOutputTimestamp(),
-            timer.getDomain());
   }
 }
 

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TranslationUtils.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TranslationUtils.java
@@ -33,6 +33,8 @@ import org.apache.beam.runners.spark.coders.CoderHelpers;
 import org.apache.beam.runners.spark.util.ByteArray;
 import org.apache.beam.runners.spark.util.SideInputBroadcast;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.state.TimeDomain;
+import org.apache.beam.sdk.state.TimerSpec;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignatures;
@@ -274,22 +276,30 @@ public final class TranslationUtils {
   }
 
   /**
-   * Reject timers {@link DoFn}.
+   * Checks if the given DoFn uses any timers.
    *
-   * @param doFn the {@link DoFn} to possibly reject.
+   * @param doFn the DoFn to check for timer usage
+   * @return true if the DoFn uses timers, false otherwise
    */
-  public static void rejectTimers(DoFn<?, ?> doFn) {
-    DoFnSignature signature = DoFnSignatures.getSignature(doFn.getClass());
-    if (signature.timerDeclarations().size() > 0
-        || signature.timerFamilyDeclarations().size() > 0) {
-      throw new UnsupportedOperationException(
-          String.format(
-              "Found %s annotations on %s, but %s cannot yet be used with timers in the %s.",
-              DoFn.TimerId.class.getSimpleName(),
-              doFn.getClass().getName(),
-              DoFn.class.getSimpleName(),
-              SparkRunner.class.getSimpleName()));
+  public static boolean hasTimers(DoFn<?, ?> doFn) {
+    final DoFnSignature signature = DoFnSignatures.signatureForDoFn(doFn);
+    return signature.usesTimers();
+  }
+
+  /**
+   * Checks if the given DoFn uses event time timers.
+   *
+   * @param doFn the DoFn to check for event time timer usage
+   * @return true if the DoFn uses event time timers, false otherwise. Note: Returns false if the
+   *     DoFn has no timers at all.
+   */
+  public static boolean hasEventTimers(DoFn<?, ?> doFn) {
+    for (DoFnSignature.TimerDeclaration timerDeclaration :
+        DoFnSignatures.signatureForDoFn(doFn).timerDeclarations().values()) {
+      final TimerSpec timerSpec = DoFnSignatures.getTimerSpecOrThrow(timerDeclaration, doFn);
+      return timerSpec.getTimeDomain().equals(TimeDomain.EVENT_TIME);
     }
+    return false;
   }
 
   /**

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/StatefulStreamingParDoEvaluator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/StatefulStreamingParDoEvaluator.java
@@ -18,7 +18,8 @@
 package org.apache.beam.runners.spark.translation.streaming;
 
 import static org.apache.beam.runners.spark.translation.TranslationUtils.getBatchDuration;
-import static org.apache.beam.runners.spark.translation.TranslationUtils.rejectTimers;
+import static org.apache.beam.runners.spark.translation.TranslationUtils.hasEventTimers;
+import static org.apache.beam.runners.spark.translation.TranslationUtils.hasTimers;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
 
@@ -37,8 +38,10 @@ import org.apache.beam.runners.spark.translation.TranslationUtils;
 import org.apache.beam.runners.spark.util.ByteArray;
 import org.apache.beam.runners.spark.util.GlobalWatermarkHolder;
 import org.apache.beam.runners.spark.util.SideInputBroadcast;
+import org.apache.beam.runners.spark.util.TimerUtils;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.state.TimeDomain;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.DoFnSchemaInformation;
 import org.apache.beam.sdk.transforms.ParDo;
@@ -55,11 +58,14 @@ import org.apache.beam.sdk.values.WindowedValues;
 import org.apache.beam.sdk.values.WindowingStrategy;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterators;
+import org.apache.commons.compress.utils.ByteUtils;
 import org.apache.spark.streaming.State;
 import org.apache.spark.streaming.StateSpec;
 import org.apache.spark.streaming.api.java.JavaDStream;
 import org.apache.spark.streaming.api.java.JavaMapWithStateDStream;
 import org.apache.spark.streaming.api.java.JavaPairDStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import scala.Option;
 import scala.Tuple2;
 
@@ -78,8 +84,11 @@ import scala.Tuple2;
  * containing {@code @Timer} annotations, as timer functionality is not currently supported in the
  * Spark streaming context.
  */
+@SuppressWarnings("nullness")
 public class StatefulStreamingParDoEvaluator<KeyT, ValueT, OutputT>
     implements TransformEvaluator<ParDo.MultiOutput<KV<KeyT, ValueT>, OutputT>> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(StatefulStreamingParDoEvaluator.class);
 
   @Override
   public void evaluate(
@@ -87,7 +96,6 @@ public class StatefulStreamingParDoEvaluator<KeyT, ValueT, OutputT>
     final DoFn<KV<KeyT, ValueT>, OutputT> doFn = transform.getFn();
     final DoFnSignature signature = DoFnSignatures.signatureForDoFn(doFn);
 
-    rejectTimers(doFn);
     checkArgument(
         !signature.processElement().isSplittable(),
         "Splittable DoFn not yet supported in streaming mode: %s",
@@ -109,7 +117,18 @@ public class StatefulStreamingParDoEvaluator<KeyT, ValueT, OutputT>
     final UnboundedDataset<KV<KeyT, ValueT>> unboundedDataset =
         (UnboundedDataset<KV<KeyT, ValueT>>) context.borrowDataset(transform);
 
-    final JavaDStream<WindowedValue<KV<KeyT, ValueT>>> dStream = unboundedDataset.getDStream();
+    JavaDStream<WindowedValue<KV<KeyT, ValueT>>> dStream = unboundedDataset.getDStream();
+
+    if (hasTimers(doFn)) {
+      checkState(
+          !hasEventTimers(doFn),
+          "%s not yet supported in streaming mode: %s",
+          TimeDomain.EVENT_TIME,
+          doFn.getClass().getName());
+
+      LOG.info("DoFn {} has timers. create periodic DStream for triggering timers", doFn);
+      dStream = TimerUtils.toPeriodicDStream(dStream);
+    }
 
     final DoFnSchemaInformation doFnSchemaInformation =
         ParDoTranslation.getSchemaInformation(context.getCurrentTransform());
@@ -155,8 +174,12 @@ public class StatefulStreamingParDoEvaluator<KeyT, ValueT, OutputT>
                               windowedKV.withValue(windowedKV.getValue().getValue());
                           final ByteArray keyBytes =
                               new ByteArray(CoderHelpers.toByteArray(key, keyCoder));
-                          final byte[] valueBytes =
-                              CoderHelpers.toByteArray(windowedValue, wvCoder);
+                          byte[] valueBytes;
+                          if (TimerUtils.TIMER_MARKER.equals(windowedValue.getValue())) {
+                            valueBytes = ByteUtils.EMPTY_BYTE_ARRAY;
+                          } else {
+                            valueBytes = CoderHelpers.toByteArray(windowedValue, wvCoder);
+                          }
                           return Tuple2.apply(keyBytes, valueBytes);
                         }));
 

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/StatefulStreamingParDoEvaluator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/StatefulStreamingParDoEvaluator.java
@@ -58,7 +58,6 @@ import org.apache.beam.sdk.values.WindowedValues;
 import org.apache.beam.sdk.values.WindowingStrategy;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterators;
-import org.apache.commons.compress.utils.ByteUtils;
 import org.apache.spark.streaming.State;
 import org.apache.spark.streaming.StateSpec;
 import org.apache.spark.streaming.api.java.JavaDStream;
@@ -176,7 +175,7 @@ public class StatefulStreamingParDoEvaluator<KeyT, ValueT, OutputT>
                               new ByteArray(CoderHelpers.toByteArray(key, keyCoder));
                           byte[] valueBytes;
                           if (TimerUtils.TIMER_MARKER.equals(windowedValue.getValue())) {
-                            valueBytes = ByteUtils.EMPTY_BYTE_ARRAY;
+                            valueBytes = TimerUtils.EMPTY_BYTE_ARRAY;
                           } else {
                             valueBytes = CoderHelpers.toByteArray(windowedValue, wvCoder);
                           }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/util/TimerUtils.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/util/TimerUtils.java
@@ -57,6 +57,8 @@ import scala.runtime.AbstractFunction3;
  */
 public class TimerUtils {
 
+  public static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+
   /**
    * A serializable version of the AbstractFunction3 class from Scala. Used for stateful operations
    * in Spark Streaming.

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/util/TimerUtils.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/util/TimerUtils.java
@@ -17,14 +17,144 @@
  */
 package org.apache.beam.runners.spark.util;
 
+import java.io.Serializable;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.beam.runners.core.TimerInternals;
 import org.apache.beam.runners.spark.stateful.SparkTimerInternals;
+import org.apache.beam.sdk.state.TimeDomain;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.PaneInfo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.WindowedValue;
 import org.apache.beam.sdk.values.WindowingStrategy;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.MoreObjects;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterators;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext$;
+import org.apache.spark.streaming.State;
+import org.apache.spark.streaming.StateSpec;
+import org.apache.spark.streaming.Time;
+import org.apache.spark.streaming.api.java.JavaDStream;
+import org.apache.spark.streaming.api.java.JavaPairDStream;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.joda.time.Instant;
+import scala.Option;
+import scala.Tuple2;
+import scala.collection.JavaConverters;
+import scala.runtime.AbstractFunction3;
 
+/**
+ * Utility class for handling timers in the Spark runner. Provides functionality for managing timer
+ * operations in stateful processing.
+ */
 public class TimerUtils {
+
+  /**
+   * A serializable version of the AbstractFunction3 class from Scala. Used for stateful operations
+   * in Spark Streaming.
+   *
+   * @param <T1> Type of the first parameter
+   * @param <T2> Type of the second parameter
+   * @param <T3> Type of the third parameter
+   * @param <ReturnT> Return type of the function
+   */
+  abstract static class SerializableFunction3<T1, T2, T3, ReturnT>
+      extends AbstractFunction3<T1, T2, T3, ReturnT> implements Serializable {}
+
+  /**
+   * A marker class used to identify timer keys and values in Spark transformations. Helps
+   * distinguish between regular data flow elements and timer events.
+   */
+  public static class TimerMarker implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public String toString() {
+      return "TIMER_MARKER";
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+      return o instanceof TimerMarker;
+    }
+
+    @Override
+    public int hashCode() {
+      return 1; // All instances are equal, so they should have the same hash code
+    }
+  }
+
+  /** Constant marker used to identify timer values in transformations. */
+  public static final TimerMarker TIMER_MARKER = new TimerMarker();
+
+  private static class WindowedValueForTimerMarker<T> implements Serializable, WindowedValue<T> {
+    private final T value;
+
+    public WindowedValueForTimerMarker(T value) {
+      this.value = value;
+    }
+
+    @Override
+    public PaneInfo getPaneInfo() {
+      return PaneInfo.NO_FIRING;
+    }
+
+    @Override
+    public Iterable<WindowedValue<T>> explodeWindows() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public T getValue() {
+      return value;
+    }
+
+    @Override
+    public <NewT> WindowedValue<NewT> withValue(NewT newValue) {
+      return new WindowedValueForTimerMarker<>(newValue);
+    }
+
+    @Override
+    public Instant getTimestamp() {
+      return BoundedWindow.TIMESTAMP_MIN_VALUE;
+    }
+
+    @Override
+    public Collection<? extends BoundedWindow> getWindows() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+      if (o instanceof WindowedValueForTimerMarker) {
+        WindowedValueForTimerMarker<?> that = (WindowedValueForTimerMarker<?>) o;
+        return Objects.equals(this.getValue(), that.getValue());
+      } else {
+        return super.equals(o);
+      }
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(getValue());
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(getClass())
+          .add("value", getValue())
+          .add("pane", getPaneInfo())
+          .toString();
+    }
+  }
 
   public static <W extends BoundedWindow> void dropExpiredTimers(
       SparkTimerInternals sparkTimerInternals, WindowingStrategy<?, W> windowingStrategy) {
@@ -35,10 +165,128 @@ public class TimerUtils {
                     timer
                         .getTimestamp()
                         .plus(windowingStrategy.getAllowedLateness())
-                        .isBefore(sparkTimerInternals.currentInputWatermarkTime()))
+                        .isBefore(
+                            timer.getDomain().equals(TimeDomain.PROCESSING_TIME)
+                                ? sparkTimerInternals.currentProcessingTime()
+                                : sparkTimerInternals.currentInputWatermarkTime()))
             .collect(Collectors.toList());
 
     // Remove the expired timer from the timerInternals structure
-    expiredTimers.forEach(sparkTimerInternals::deleteTimer);
+    if (!expiredTimers.isEmpty()) {
+      expiredTimers.forEach(sparkTimerInternals::deleteTimer);
+    }
+  }
+
+  /**
+   * Converts a standard DStream into a periodic DStream that ensures all keys are processed in
+   * every micro-batch, even if they don't receive new data.
+   *
+   * <p>This method addresses a fundamental challenge in stateful processing with Spark Streaming:
+   * ensuring that timer events for all keys are processed in every batch, regardless of whether
+   * those keys receive new data. Without this mechanism, timers associated with inactive keys would
+   * not fire at the appropriate times.
+   *
+   * <p>Implementation details:
+   *
+   * <ol>
+   *   <li>First, it extracts all unique keys from the input DStream and marks them with a special
+   *       timer key marker.
+   *   <li>Then, it uses Spark's mapWithState operation to maintain a persistent set of all keys
+   *       that have ever been seen.
+   *   <li>For each batch, it takes a snapshot of this state (all known keys).
+   *   <li>It then transforms the original DStream by combining it with synthetic events for all
+   *       known keys.
+   *   <li>These synthetic events use the special {@link WindowedValueForTimerMarker} class with the
+   *       {@link TimerUtils#TIMER_MARKER} to allow downstream operations to distinguish them from
+   *       regular data events.
+   * </ol>
+   *
+   * <p>When processed downstream, the synthetic key-value pairs will trigger evaluation of any
+   * pending timers for all keys, even those that haven't received new data in the current batch.
+   * This ensures consistent and reliable timer execution across the entire stateful pipeline.
+   *
+   * <p>This approach is critical for implementing features like windowing, sessions, and other
+   * time-based operations that rely on timers firing at the correct moments, regardless of data
+   * activity.
+   *
+   * @param <KeyT> The type of keys
+   * @param <ValueT> The type of values
+   * @param originalLRDD The original DStream of windowed key-value pairs to be enhanced with
+   *     periodic timer events
+   * @return A new DStream that includes periodic events for all known keys, ensuring timer
+   *     processing for every key in each batch
+   */
+  @SuppressWarnings({"unchecked", "nullness"})
+  public static <KeyT, ValueT> JavaDStream<WindowedValue<KV<KeyT, ValueT>>> toPeriodicDStream(
+      JavaDStream<WindowedValue<KV<KeyT, ValueT>>> originalLRDD) {
+    // extract only unique keys from original RDD
+    final JavaPairDStream<KeyT, KeyT> uniqueKeysDStream =
+        originalLRDD.mapPartitionsToPair(
+            (Iterator<WindowedValue<KV<KeyT, ValueT>>> iterator) -> {
+              final Set<KeyT> uniqueKeys = new HashSet<>();
+              while (iterator.hasNext()) {
+                final KV<KeyT, ValueT> kv = iterator.next().getValue();
+                uniqueKeys.add(kv.getKey());
+              }
+
+              return Iterators.transform(uniqueKeys.iterator(), key -> Tuple2.apply(null, key));
+            });
+
+    final JavaPairDStream</*(null)*/ KeyT, /*Actual Keys*/ Set<KeyT>> keyStateSnapshotDStream =
+        uniqueKeysDStream
+            .mapWithState(
+                StateSpec.function(
+                    new SerializableFunction3<
+                        /*(null)*/ KeyT,
+                        /*Actual Key*/ Option<KeyT>,
+                        /*State*/ State<Set<KeyT>>,
+                        /*Return type - not needed as we use stateSnapshots*/ Void>() {
+                      @Override
+                      public Void apply(
+                          KeyT timerKeyMarker, Option<KeyT> actualKey, State<Set<KeyT>> state) {
+                        Set<KeyT> keyState;
+                        if (state.exists()) {
+                          keyState = state.get();
+                        } else {
+                          keyState = new HashSet<>();
+                        }
+
+                        keyState.add(actualKey.get());
+                        state.update(keyState);
+                        // We don't need to return anything as we use stateSnapshots
+                        return null;
+                      }
+                    }))
+            .stateSnapshots();
+
+    return originalLRDD.transformWith(
+        keyStateSnapshotDStream,
+        (JavaRDD<WindowedValue<KV<KeyT, ValueT>>> wvRDD,
+            JavaPairRDD<KeyT, Set<KeyT>> stateRDD,
+            Time time) -> {
+          final int numPartitions = wvRDD.getNumPartitions();
+
+          final Set<KeyT> keySet = new HashSet<>();
+
+          // add all keys to keySet
+          stateRDD.distinct().values().collect().forEach(keySet::addAll);
+
+          final List<WindowedValue<KV<KeyT, ValueT>>> collect =
+              keySet.stream()
+                  .map(key -> new WindowedValueForTimerMarker<>(KV.of(key, (ValueT) TIMER_MARKER)))
+                  .collect(Collectors.toList());
+
+          final JavaRDD<WindowedValue<KV<KeyT, ValueT>>> keyConvertedRDD =
+              JavaRDD.fromRDD(
+                  stateRDD
+                      .context()
+                      .parallelize(
+                          JavaConverters.asScalaIterator(collect.iterator()).toSeq(),
+                          numPartitions > 0 ? numPartitions : 1,
+                          JavaSparkContext$.MODULE$.fakeClassTag()),
+                  JavaSparkContext$.MODULE$.fakeClassTag());
+
+          return wvRDD.union(keyConvertedRDD);
+        });
   }
 }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/util/TimerUtils.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/util/TimerUtils.java
@@ -46,7 +46,6 @@ import org.apache.spark.streaming.Time;
 import org.apache.spark.streaming.api.java.JavaDStream;
 import org.apache.spark.streaming.api.java.JavaPairDStream;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.jetbrains.annotations.NotNull;
 import org.joda.time.Instant;
 import scala.Option;
 import scala.Tuple2;
@@ -194,9 +193,8 @@ public class TimerUtils {
     }
   }
 
-  private static <W extends BoundedWindow> @NotNull
-      Collection<TimerInternals.TimerData> getExpiredTimers(
-          SparkTimerInternals sparkTimerInternals, WindowingStrategy<?, W> windowingStrategy) {
+  private static <W extends BoundedWindow> Collection<TimerInternals.TimerData> getExpiredTimers(
+      SparkTimerInternals sparkTimerInternals, WindowingStrategy<?, W> windowingStrategy) {
     return sparkTimerInternals.getTimers().stream()
         .filter(
             timer ->

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/AbstractInOutIteratorTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/AbstractInOutIteratorTest.java
@@ -37,14 +37,11 @@ import org.apache.beam.sdk.values.WindowedValue;
 import org.joda.time.Instant;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import scala.Tuple2;
 
 /** Tests for {@link AbstractInOutIterator}. */
-@RunWith(JUnit4.class)
 public class AbstractInOutIteratorTest {
 
   @Mock private SparkProcessContext<String, Integer, String> mockContext;
@@ -62,7 +59,7 @@ public class AbstractInOutIteratorTest {
 
   private StateNamespace testNamespace;
 
-  /** Test implementation of {@link AbstractInOutIterator} */
+  /** Test implementation of {@link AbstractInOutIterator}. */
   private static class TestAbstractInOutIterator<K, InputT, OutputT>
       extends AbstractInOutIterator<K, InputT, OutputT> {
 

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/AbstractInOutIteratorTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/AbstractInOutIteratorTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.spark.translation;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.beam.runners.core.DoFnRunner;
+import org.apache.beam.runners.core.StateNamespace;
+import org.apache.beam.runners.core.StateNamespaces;
+import org.apache.beam.runners.core.TimerInternals;
+import org.apache.beam.runners.spark.translation.streaming.ParDoStateUpdateFn;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.state.TimeDomain;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.WindowedValue;
+import org.joda.time.Instant;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import scala.Tuple2;
+
+/** Tests for {@link AbstractInOutIterator}. */
+@RunWith(JUnit4.class)
+public class AbstractInOutIteratorTest {
+
+  @Mock private SparkProcessContext<String, Integer, String> mockContext;
+  @Mock private DoFnRunner<Integer, String> mockDoFnRunner;
+  @Mock private TimerInternals.TimerData mockTimer;
+  @Mock private BoundedWindow mockWindow;
+  @Mock private ParDoStateUpdateFn.SparkTimerInternalsIterator mockTimerDataIterator;
+
+  private static final String TEST_KEY = "testKey";
+  private static final String TIMER_ID = "testTimerId";
+  private static final String TIMER_FAMILY_ID = "testTimerFamilyId";
+  private static final Instant TEST_TIMESTAMP = new Instant(42L);
+  private static final Instant TEST_OUTPUT_TIMESTAMP = new Instant(84L);
+  private static final TimeDomain TEST_TIME_DOMAIN = TimeDomain.EVENT_TIME;
+
+  private StateNamespace testNamespace;
+
+  /** Test implementation of {@link AbstractInOutIterator} */
+  private static class TestAbstractInOutIterator<K, InputT, OutputT>
+      extends AbstractInOutIterator<K, InputT, OutputT> {
+
+    protected TestAbstractInOutIterator(SparkProcessContext<K, InputT, OutputT> ctx) {
+      super(ctx);
+    }
+
+    @Override
+    protected Tuple2<TupleTag<?>, WindowedValue<?>> computeNext() {
+      // Simple implementation as this method is not used in the test
+      return this.endOfData();
+    }
+  }
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    testNamespace = StateNamespaces.window((Coder) IntervalWindow.getCoder(), mockWindow);
+
+    when(mockContext.getDoFnRunner()).thenReturn(mockDoFnRunner);
+    when(mockContext.getKey()).thenReturn(TEST_KEY);
+    when(mockTimer.getTimerId()).thenReturn(TIMER_ID);
+    when(mockTimer.getTimerFamilyId()).thenReturn(TIMER_FAMILY_ID);
+    when(mockTimer.getNamespace()).thenReturn(testNamespace);
+    when(mockTimer.getTimestamp()).thenReturn(TEST_TIMESTAMP);
+    when(mockTimer.getOutputTimestamp()).thenReturn(TEST_OUTPUT_TIMESTAMP);
+    when(mockTimer.getDomain()).thenReturn(TEST_TIME_DOMAIN);
+  }
+
+  @Test
+  public void testFireTimer() {
+    // Test basic timer functionality
+    TestAbstractInOutIterator<String, Integer, String> iterator =
+        new TestAbstractInOutIterator<>(mockContext);
+
+    iterator.fireTimer(mockTimer);
+
+    // Verify that DoFnRunner.onTimer was called with the correct arguments
+    verify(mockDoFnRunner)
+        .onTimer(
+            TIMER_ID,
+            TIMER_FAMILY_ID,
+            TEST_KEY,
+            mockWindow,
+            TEST_TIMESTAMP,
+            TEST_OUTPUT_TIMESTAMP,
+            TEST_TIME_DOMAIN);
+
+    // Verify that timer data iterator deletion was not called (no timer iterator was set in this
+    // test)
+    verify(mockTimerDataIterator, never()).deleteTimer(mockTimer);
+  }
+
+  @Test
+  public void testFireTimerWithTimerDataIterator() {
+    // Test when timer data iterator is available
+    when(mockContext.getTimerDataIterator()).thenReturn(mockTimerDataIterator);
+
+    TestAbstractInOutIterator<String, Integer, String> iterator =
+        new TestAbstractInOutIterator<>(mockContext);
+
+    iterator.fireTimer(mockTimer);
+
+    // Verify that DoFnRunner.onTimer was called with the correct arguments
+    verify(mockDoFnRunner)
+        .onTimer(
+            TIMER_ID,
+            TIMER_FAMILY_ID,
+            TEST_KEY,
+            mockWindow,
+            TEST_TIMESTAMP,
+            TEST_OUTPUT_TIMESTAMP,
+            TEST_TIME_DOMAIN);
+
+    // Verify that the timer data iterator's deleteTimer method was called
+    verify(mockTimerDataIterator).deleteTimer(mockTimer);
+  }
+
+  @Test
+  public void testFireTimerWithInvalidNamespace() {
+    // Not WindowNamespace
+    StateNamespace invalidNamespace = mock(StateNamespace.class);
+    TimerInternals.TimerData invalidTimer = mock(TimerInternals.TimerData.class);
+    when(invalidTimer.getNamespace()).thenReturn(invalidNamespace);
+
+    TestAbstractInOutIterator<String, Integer, String> iterator =
+        new TestAbstractInOutIterator<>(mockContext);
+
+    assertThrows(IllegalArgumentException.class, () -> iterator.fireTimer(invalidTimer));
+  }
+}

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/util/TimerUtilsTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/util/TimerUtilsTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.spark.util;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.apache.beam.runners.core.StateNamespace;
+import org.apache.beam.runners.core.StateNamespaces;
+import org.apache.beam.runners.core.TimerInternals;
+import org.apache.beam.runners.spark.stateful.SparkTimerInternals;
+import org.apache.beam.runners.spark.translation.AbstractInOutIterator;
+import org.apache.beam.sdk.state.TimeDomain;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.values.WindowingStrategy;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** Tests for {@link TimerUtils}. */
+public class TimerUtilsTest {
+
+  @Mock private SparkTimerInternals mockTimerInternals;
+  @Mock private WindowingStrategy<?, IntervalWindow> mockWindowingStrategy;
+  @Mock private AbstractInOutIterator<?, ?, ?> mockIterator;
+  @Mock private TimerInternals.TimerData expiredTimer;
+  @Mock private TimerInternals.TimerData activeTimer;
+  @Mock private IntervalWindow mockWindow;
+
+  private static final Instant NOW = new Instant(1000L);
+  private static final Duration ALLOWED_LATENESS = Duration.standardMinutes(5);
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    StateNamespace namespace = StateNamespaces.window(IntervalWindow.getCoder(), mockWindow);
+
+    // Set up an expired event-time timer (timestamp + allowed lateness < watermark)
+    when(expiredTimer.getTimestamp())
+        .thenReturn(NOW.minus(ALLOWED_LATENESS.plus(Duration.standardMinutes(1))));
+    when(expiredTimer.getDomain()).thenReturn(TimeDomain.EVENT_TIME);
+    when(expiredTimer.getNamespace()).thenReturn(namespace);
+
+    // Set up a non-expired event-time timer (timestamp + allowed lateness > watermark)
+    when(activeTimer.getTimestamp()).thenReturn(NOW);
+    when(activeTimer.getDomain()).thenReturn(TimeDomain.EVENT_TIME);
+    when(activeTimer.getNamespace()).thenReturn(namespace);
+
+    // Configure the mocks
+    when(mockWindowingStrategy.getAllowedLateness()).thenReturn(ALLOWED_LATENESS);
+    when(mockTimerInternals.currentInputWatermarkTime()).thenReturn(NOW);
+    when(mockTimerInternals.currentProcessingTime()).thenReturn(NOW);
+  }
+
+  @Test
+  public void testTriggerExpiredTimers() {
+    // Set up the mock timer internals to return both timers
+    when(mockTimerInternals.getTimers()).thenReturn(Arrays.asList(expiredTimer, activeTimer));
+
+    // Call the method under test
+    TimerUtils.triggerExpiredTimers(mockTimerInternals, mockWindowingStrategy, mockIterator);
+
+    // Verify that fireTimer was called only for the expired timer
+    verify(mockIterator).fireTimer(expiredTimer);
+    verify(mockIterator, never()).fireTimer(activeTimer);
+  }
+
+  @Test
+  public void testTriggerExpiredTimersWithNoExpiredTimers() {
+    // Set up the mock timer internals to return only the active timer
+    when(mockTimerInternals.getTimers()).thenReturn(Collections.singletonList(activeTimer));
+
+    // Call the method under test
+    TimerUtils.triggerExpiredTimers(mockTimerInternals, mockWindowingStrategy, mockIterator);
+
+    // Verify that fireTimer was not called for any timer
+    verify(mockIterator, never()).fireTimer(any());
+  }
+
+  @Test
+  public void testTriggerExpiredTimersWithEmptyTimers() {
+    // Set up the mock timer internals to return an empty list
+    when(mockTimerInternals.getTimers()).thenReturn(Collections.emptyList());
+
+    // Call the method under test
+    TimerUtils.triggerExpiredTimers(mockTimerInternals, mockWindowingStrategy, mockIterator);
+
+    // Verify that fireTimer was not called
+    verify(mockIterator, never()).fireTimer(any());
+  }
+
+  @Test
+  public void testTriggerExpiredTimersWithProcessingTimeDomain() {
+    // Set up a processing-time timer
+    when(expiredTimer.getDomain()).thenReturn(TimeDomain.PROCESSING_TIME);
+
+    // Set up the mock timer internals to return only the expired timer
+    when(mockTimerInternals.getTimers()).thenReturn(Collections.singletonList(expiredTimer));
+
+    // Call the method under test
+    TimerUtils.triggerExpiredTimers(mockTimerInternals, mockWindowingStrategy, mockIterator);
+
+    // Verify that fireTimer was called for the expired timer
+    verify(mockIterator).fireTimer(expiredTimer);
+  }
+}


### PR DESCRIPTION
**Please** add a meaningful description for your change here

fixes #33633 

# Problem Statement
The Spark Runner did not support timers due to the following technical challenges:

1. **Timer Triggering Difficulties**: `UnboundedInOutIterator` objects are periodically created and destroyed at each Spark Streaming batch interval, rendering the internal `while (true)` loop ineffective for timer management.

2. **Sparse Key Issue**: As a consequence of the above limitation, sparse keys lose their timer triggering capability once their corresponding `UnboundedInOutIterator` objects are destroyed, leaving no mechanism to fire pending timers.


---
This PR resolves the above issues to enable Processing Time Timer functionality.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
