### PR TITLE
[Dataflow Streaming] Modify AbstractWindmillStream to separate logical stream from physical streams.

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/AbstractWindmillStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/AbstractWindmillStream.java
@@ -467,10 +467,15 @@ public abstract class AbstractWindmillStream<RequestT, ResponseT> implements Win
     }
   }
 
+  @SuppressWarnings("nullness")
+  private void clearPhysicalStreamForDebug() {
+    currentPhysicalStreamForDebug.set(null);
+  }
+
   private void onPhysicalStreamCompletion(Status status, PhysicalStreamHandler handler) {
     synchronized (this) {
       if (currentPhysicalStream == handler) {
-        currentPhysicalStreamForDebug.set(null);
+        clearPhysicalStreamForDebug();
         currentPhysicalStream = null;
       }
     }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/AbstractWindmillStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/AbstractWindmillStream.java
@@ -26,8 +26,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
-import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.observers.StreamObserverCancelledException;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.observers.StreamObserverFactory;
@@ -37,6 +38,7 @@ import org.apache.beam.vendor.grpc.v1p69p0.com.google.api.client.util.Sleeper;
 import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.Status;
 import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.stub.StreamObserver;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.joda.time.DateTime;
 import org.joda.time.Instant;
 import org.slf4j.Logger;
@@ -48,12 +50,12 @@ import org.slf4j.Logger;
  * stream if it is broken. Subclasses are responsible for retrying requests that have been lost on a
  * broken stream.
  *
- * <p>Subclasses should override {@link #onResponse(ResponseT)} to handle responses from the server,
- * and {@link #onNewStream()} to perform any work that must be done when a new stream is created,
- * such as sending headers or retrying requests.
+ * <p>Subclasses should override {@link #newResponseHandler()} to implement a handler for physical
+ * stream connection. {@link #onNewStream()} to perform any work that must be done when a new stream
+ * is created, such as sending headers or retrying requests.
  *
- * <p>{@link #trySend(RequestT)} and {@link #startStream()} should not be called from {@link
- * #onResponse(ResponseT)}; use {@link #executeSafely(Runnable)} instead.
+ * <p>{@link #trySend(RequestT)} and {@link #startStream()} should not be called when handling
+ * responses; use {@link #executeSafely(Runnable)} instead.
  *
  * <p>Synchronization on this is used to synchronize the gRpc stream state and internal data
  * structures. Since grpc channel operations may block, synchronization on this stream may also
@@ -83,9 +85,12 @@ public abstract class AbstractWindmillStream<RequestT, ResponseT> implements Win
   private final Set<AbstractWindmillStream<?, ?>> streamRegistry;
   private final int logEveryNStreamFailures;
   private final String backendWorkerToken;
+
+  private final Function<StreamObserver<ResponseT>, TerminatingStreamObserver<RequestT>>
+      physicalStreamFactory;
+  protected final long physicalStreamDeadlineSeconds;
   private final ResettableThrowingStreamObserver<RequestT> requestObserver;
 
-  private final Supplier<TerminatingStreamObserver<RequestT>> requestObserverFactory;
   private final StreamDebugMetrics debugMetrics;
   private final AtomicBoolean isHealthCheckScheduled;
 
@@ -94,6 +99,17 @@ public abstract class AbstractWindmillStream<RequestT, ResponseT> implements Win
 
   @GuardedBy("this")
   protected boolean isShutdown;
+
+  // The active physical grpc stream. trySend will send messages on the bi-directional stream
+  // associated with this handler. The instances are created by subclasses via newResponseHandler.
+  // Subclasses may wish to store additional per-physical stream state within the handler.
+  @GuardedBy("this")
+  protected @Nullable PhysicalStreamHandler currentPhysicalStream;
+
+  // Generally the same as currentPhysicalStream, set under synchronization of this but can be read
+  // without.
+  private final AtomicReference<PhysicalStreamHandler> currentPhysicalStreamForDebug =
+      new AtomicReference<>();
 
   @GuardedBy("this")
   private boolean started;
@@ -108,6 +124,9 @@ public abstract class AbstractWindmillStream<RequestT, ResponseT> implements Win
       int logEveryNStreamFailures,
       String backendWorkerToken) {
     this.backendWorkerToken = backendWorkerToken;
+    this.physicalStreamFactory =
+        (StreamObserver<ResponseT> observer) -> streamObserverFactory.from(clientFactory, observer);
+    this.physicalStreamDeadlineSeconds = streamObserverFactory.getDeadlineSeconds();
     this.executor =
         Executors.newSingleThreadExecutor(
             new ThreadFactoryBuilder()
@@ -124,10 +143,6 @@ public abstract class AbstractWindmillStream<RequestT, ResponseT> implements Win
     this.finishLatch = new CountDownLatch(1);
     this.logger = logger;
     this.requestObserver = new ResettableThrowingStreamObserver<>(logger);
-    this.requestObserverFactory =
-        () ->
-            streamObserverFactory.from(
-                clientFactory, new AbstractWindmillStream<RequestT, ResponseT>.ResponseObserver());
     this.sleeper = Sleeper.DEFAULT;
     this.debugMetrics = StreamDebugMetrics.create();
   }
@@ -138,19 +153,45 @@ public abstract class AbstractWindmillStream<RequestT, ResponseT> implements Win
         : String.format("%s-WindmillStream-thread", streamType);
   }
 
-  /** Called on each response from the server. */
-  protected abstract void onResponse(ResponseT response);
+  /** Represents a physical grpc stream that is part of the logical windmill stream. */
+  protected abstract class PhysicalStreamHandler {
 
-  /** Called when a new underlying stream to the server has been opened. */
+    /** Called on each response from the server. */
+    public abstract void onResponse(ResponseT response);
+
+    /** Returns whether there are any pending requests that should be retried on a stream break. */
+    public abstract boolean hasPendingRequests();
+
+    /**
+     * Called when the physical stream has finished. For streams with requests that should be
+     * retried, requests should be moved to parent state so that it is captured by the next
+     * flushPendingToStream call.
+     */
+    public abstract void onDone(Status status);
+
+    /**
+     * Renders information useful for debugging as html.
+     *
+     * @implNote Don't require synchronization on AbstractWindmillStream.this, see the {@link
+     *     #appendSummaryHtml(PrintWriter)} comment.
+     */
+    public abstract void appendHtml(PrintWriter writer);
+
+    private final StreamDebugMetrics streamDebugMetrics = StreamDebugMetrics.create();
+  }
+
+  protected abstract PhysicalStreamHandler newResponseHandler();
+
   protected abstract void onNewStream() throws WindmillStreamShutdownException;
-
-  /** Returns whether there are any pending requests that should be retried on a stream break. */
-  protected abstract boolean hasPendingRequests();
 
   /** Try to send a request to the server. Returns true if the request was successfully sent. */
   @CanIgnoreReturnValue
   protected final synchronized boolean trySend(RequestT request)
       throws WindmillStreamShutdownException {
+    if (currentPhysicalStream == null) {
+      return false;
+    }
+    currentPhysicalStream.streamDebugMetrics.recordSend();
     debugMetrics.recordSend();
     try {
       requestObserver.onNext(request);
@@ -182,10 +223,14 @@ public abstract class AbstractWindmillStream<RequestT, ResponseT> implements Win
     // Add the stream to the registry after it has been fully constructed.
     streamRegistry.add(this);
     while (true) {
+      @NonNull PhysicalStreamHandler streamHandler = newResponseHandler();
       try {
         synchronized (this) {
           debugMetrics.recordStart();
-          requestObserver.reset(requestObserverFactory.get());
+          streamHandler.streamDebugMetrics.recordStart();
+          currentPhysicalStream = streamHandler;
+          currentPhysicalStreamForDebug.set(currentPhysicalStream);
+          requestObserver.reset(physicalStreamFactory.apply(new ResponseObserver(streamHandler)));
           onNewStream();
           if (clientClosed) {
             halfClose();
@@ -272,6 +317,23 @@ public abstract class AbstractWindmillStream<RequestT, ResponseT> implements Win
    */
   public final void appendSummaryHtml(PrintWriter writer) {
     appendSpecificHtml(writer);
+
+    @Nullable PhysicalStreamHandler currentHandler = currentPhysicalStreamForDebug.get();
+    if (currentHandler != null) {
+      writer.format("Physical stream: ");
+      currentHandler.appendHtml(writer);
+      StreamDebugMetrics.Snapshot summaryMetrics =
+          currentHandler.streamDebugMetrics.getSummaryMetrics();
+      if (summaryMetrics.isClientClosed()) {
+        writer.write(" client closed");
+      }
+      writer.format(
+          " current stream is %dms old, last send %dms, last response %dms\n",
+          summaryMetrics.streamAge(),
+          summaryMetrics.timeSinceLastSend(),
+          summaryMetrics.timeSinceLastResponse());
+    }
+
     StreamDebugMetrics.Snapshot summaryMetrics = debugMetrics.getSummaryMetrics();
     summaryMetrics
         .restartMetrics()
@@ -304,6 +366,8 @@ public abstract class AbstractWindmillStream<RequestT, ResponseT> implements Win
   }
 
   /**
+   * Add specific debug state for the logical stream.
+   *
    * @implNote Don't require synchronization on stream, see the {@link
    *     #appendSummaryHtml(PrintWriter)} comment.
    */
@@ -315,6 +379,9 @@ public abstract class AbstractWindmillStream<RequestT, ResponseT> implements Win
     debugMetrics.recordHalfClose();
     clientClosed = true;
     try {
+      if (currentPhysicalStream != null) {
+        currentPhysicalStream.streamDebugMetrics.recordHalfClose();
+      }
       requestObserver.onCompleted();
     } catch (ResettableThrowingStreamObserver.StreamClosedException e) {
       logger.warn("Stream was previously closed.");
@@ -354,11 +421,17 @@ public abstract class AbstractWindmillStream<RequestT, ResponseT> implements Win
     }
   }
 
-  protected abstract void shutdownInternal();
+  protected synchronized void shutdownInternal() {}
 
   /** Returns true if the stream was torn down and should not be restarted internally. */
-  private synchronized boolean maybeTearDownStream() {
-    if (isShutdown || (clientClosed && !hasPendingRequests())) {
+  private synchronized boolean maybeTearDownStream(PhysicalStreamHandler doneStream) {
+    if (clientClosed && !doneStream.hasPendingRequests()) {
+      shutdown();
+    }
+
+    if (isShutdown) {
+      // Once we have background closing physicalStreams we will need to improve this to wait for
+      // all of the work of the logical stream to be complete.
       streamRegistry.remove(AbstractWindmillStream.this);
       finishLatch.countDown();
       executor.shutdownNow();
@@ -369,23 +442,44 @@ public abstract class AbstractWindmillStream<RequestT, ResponseT> implements Win
   }
 
   private class ResponseObserver implements StreamObserver<ResponseT> {
+    private final PhysicalStreamHandler handler;
+
+    ResponseObserver(PhysicalStreamHandler handler) {
+      this.handler = handler;
+    }
 
     @Override
     public void onNext(ResponseT response) {
       backoff.reset();
       debugMetrics.recordResponse();
-      onResponse(response);
+      handler.streamDebugMetrics.recordResponse();
+      handler.onResponse(response);
     }
 
     @Override
     public void onError(Throwable t) {
-      if (maybeTearDownStream()) {
-        return;
+      executeSafely(() -> onPhysicalStreamCompletion(Status.fromThrowable(t), handler));
+    }
+
+    @Override
+    public void onCompleted() {
+      executeSafely(() -> onPhysicalStreamCompletion(OK_STATUS, handler));
+    }
+  }
+
+  private void onPhysicalStreamCompletion(Status status, PhysicalStreamHandler handler) {
+    synchronized (this) {
+      if (currentPhysicalStream == handler) {
+        currentPhysicalStreamForDebug.set(null);
+        currentPhysicalStream = null;
       }
-
-      Status errorStatus = Status.fromThrowable(t);
-      recordStreamStatus(errorStatus);
-
+    }
+    handler.onDone(status);
+    if (maybeTearDownStream(handler)) {
+      return;
+    }
+    // Backoff on errors.;
+    if (!status.isOk()) {
       try {
         long sleep = backoff.nextBackOffMillis();
         debugMetrics.recordSleep(sleep);
@@ -394,54 +488,43 @@ public abstract class AbstractWindmillStream<RequestT, ResponseT> implements Win
         Thread.currentThread().interrupt();
         return;
       }
-
-      executeSafely(AbstractWindmillStream.this::startStream);
     }
+    recordStreamRestart(status);
+    startStream();
+  }
 
-    @Override
-    public void onCompleted() {
-      if (maybeTearDownStream()) {
-        return;
-      }
-      recordStreamStatus(OK_STATUS);
-      executeSafely(AbstractWindmillStream.this::startStream);
-    }
-
-    private void recordStreamStatus(Status status) {
-      int currentRestartCount = debugMetrics.incrementAndGetRestarts();
-      if (status.isOk()) {
-        String restartReason =
-            "Stream completed successfully but did not complete requested operations, "
-                + "recreating";
-        logger.warn(restartReason);
-        debugMetrics.recordRestartReason(restartReason);
-      } else {
-        int currentErrorCount = debugMetrics.incrementAndGetErrors();
-        debugMetrics.recordRestartReason(status.toString());
-        Throwable t = status.getCause();
-        if (t instanceof StreamObserverCancelledException) {
-          logger.error(
-              "StreamObserver was unexpectedly cancelled for stream={}, worker={}. stacktrace={}",
-              getClass(),
-              backendWorkerToken,
-              t.getStackTrace(),
-              t);
-        } else if (currentRestartCount % logEveryNStreamFailures == 0) {
-          // Don't log every restart since it will get noisy, and many errors transient.
-          long nowMillis = Instant.now().getMillis();
-          logger.debug(
-              "{} has been restarted {} times. Streaming Windmill RPC Error Count: {}; last was: {}"
-                  + " with status: {}. created {}ms ago; {}. This is normal with autoscaling.",
-              AbstractWindmillStream.this.getClass(),
-              currentRestartCount,
-              currentErrorCount,
-              t,
-              status,
-              nowMillis - debugMetrics.getStartTimeMs(),
-              debugMetrics
-                  .responseDebugString(nowMillis)
-                  .orElse(NEVER_RECEIVED_RESPONSE_LOG_STRING));
-        }
+  private void recordStreamRestart(Status status) {
+    int currentRestartCount = debugMetrics.incrementAndGetRestarts();
+    if (status.isOk()) {
+      String restartReason =
+          "Stream completed successfully but did not complete requested operations, "
+              + "recreating";
+      logger.warn(restartReason);
+      debugMetrics.recordRestartReason(restartReason);
+    } else {
+      int currentErrorCount = debugMetrics.incrementAndGetErrors();
+      debugMetrics.recordRestartReason(status.toString());
+      Throwable t = status.getCause();
+      if (t instanceof StreamObserverCancelledException) {
+        logger.error(
+            "StreamObserver was unexpectedly cancelled for stream={}, worker={}. stacktrace={}",
+            getClass(),
+            backendWorkerToken,
+            t.getStackTrace(),
+            t);
+      } else if (currentRestartCount % logEveryNStreamFailures == 0) {
+        // Don't log every restart since it will get noisy, and many errors transient.
+        long nowMillis = Instant.now().getMillis();
+        logger.debug(
+            "{} has been restarted {} times. Streaming Windmill RPC Error Count: {}; last was: {}"
+                + " with status: {}. created {}ms ago; {}. This is normal with autoscaling.",
+            AbstractWindmillStream.this.getClass(),
+            currentRestartCount,
+            currentErrorCount,
+            t,
+            status,
+            nowMillis - debugMetrics.getStartTimeMs(),
+            debugMetrics.responseDebugString(nowMillis).orElse(NEVER_RECEIVED_RESPONSE_LOG_STRING));
       }
     }
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcCommitWorkStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcCommitWorkStream.java
@@ -214,7 +214,9 @@ final class GrpcCommitWorkStream
 
     @Override
     public void appendHtml(PrintWriter writer) {
-      writer.format("CommitWorkStream: %d pending", pending.size());
+      writer.format(
+          "CommitWorkStream: %d pending",
+          pending.entrySet().stream().filter(e -> e.getValue().getKey() == this).count());
     }
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcCommitWorkStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcCommitWorkStream.java
@@ -177,8 +177,8 @@ final class GrpcCommitWorkStream
           continue;
         }
 
-        // From windmill.proto: Indices must line up with the request_id field, but trailing OKs
-        // may be omitted.
+        // From windmill.proto: Indices must line up with the request_id field, but trailing OKs may
+        // be omitted.
         CommitStatus commitStatus =
             i < response.getStatusCount() ? response.getStatus(i) : CommitStatus.OK;
 
@@ -194,8 +194,7 @@ final class GrpcCommitWorkStream
         try {
           pendingRequest.completeWithStatus(commitStatus);
         } catch (RuntimeException e) {
-          // Catch possible exceptions to ensure that an exception for one commit does not
-          // prevent
+          // Catch possible exceptions to ensure that an exception for one commit does not prevent
           // other commits from being processed. Aggregate all the failures to throw after
           // processing the response if they exist.
           LOG.warn("Exception while processing commit response.", e);
@@ -273,6 +272,7 @@ final class GrpcCommitWorkStream
     synchronized (this) {
       if (isShutdown) {
         pendingRequest.abort();
+        return;
       }
       pending.put(
           id,

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDirectGetWorkStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDirectGetWorkStream.java
@@ -46,6 +46,7 @@ import org.apache.beam.runners.dataflow.worker.windmill.work.budget.GetWorkBudge
 import org.apache.beam.runners.dataflow.worker.windmill.work.refresh.HeartbeatSender;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.util.BackOff;
+import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.Status;
 import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,15 +81,6 @@ final class GrpcDirectGetWorkStream
   private final GetDataClient getDataClient;
   private final AtomicReference<StreamingGetWorkRequest> lastRequest;
 
-  /**
-   * Map of stream IDs to their buffers. Used to aggregate streaming gRPC response chunks as they
-   * come in. Once all chunks for a response has been received, the chunk is processed and the
-   * buffer is cleared.
-   *
-   * @implNote Buffers are not persisted across stream restarts.
-   */
-  private final ConcurrentMap<Long, GetWorkResponseChunkAssembler> workItemAssemblers;
-
   private final boolean requestBatchedGetWorkResponse;
 
   private GrpcDirectGetWorkStream(
@@ -118,7 +110,6 @@ final class GrpcDirectGetWorkStream
         backendWorkerToken);
     this.requestHeader = requestHeader;
     this.workItemScheduler = workItemScheduler;
-    this.workItemAssemblers = new ConcurrentHashMap<>();
     this.heartbeatSender = heartbeatSender;
     this.workCommitter = workCommitter;
     this.getDataClient = getDataClient;
@@ -199,9 +190,47 @@ final class GrpcDirectGetWorkStream
     }
   }
 
+  private class DirectGetWorkPhysicalStreamHandler extends PhysicalStreamHandler {
+    /**
+     * Map of stream IDs to their buffers. Used to aggregate streaming gRPC response chunks as they
+     * come in. Once all chunks for a response has been received, the chunk is processed and the
+     * buffer is cleared.
+     *
+     * @implNote Buffers are not persisted across stream restarts.
+     */
+    final ConcurrentMap<Long, GetWorkResponseChunkAssembler> workItemAssemblers =
+        new ConcurrentHashMap<>();
+
+    @Override
+    public void onResponse(StreamingGetWorkResponseChunk response) {
+      workItemAssemblers
+          .computeIfAbsent(response.getStreamId(), unused -> new GetWorkResponseChunkAssembler())
+          .append(response)
+          .forEach(GrpcDirectGetWorkStream.this::consumeAssembledWorkItem);
+    }
+
+    @Override
+    public boolean hasPendingRequests() {
+      return false;
+    }
+
+    @Override
+    public void onDone(Status status) {}
+
+    @Override
+    public void appendHtml(PrintWriter writer) {
+      // Number of buffers is same as distinct workers that sent work on this stream.
+      writer.format("%d buffers", workItemAssemblers.size());
+    }
+  }
+
+  @Override
+  protected PhysicalStreamHandler newResponseHandler() {
+    return new DirectGetWorkPhysicalStreamHandler();
+  }
+
   @Override
   protected synchronized void onNewStream() throws WindmillStreamShutdownException {
-    workItemAssemblers.clear();
     budgetTracker.reset();
     GetWorkBudget initialGetWorkBudget = budgetTracker.computeBudgetExtension();
     StreamingGetWorkRequest request =
@@ -220,33 +249,14 @@ final class GrpcDirectGetWorkStream
   }
 
   @Override
-  protected boolean hasPendingRequests() {
-    return false;
-  }
-
-  @Override
   public void appendSpecificHtml(PrintWriter writer) {
-    // Number of buffers is same as distinct workers that sent work on this stream.
-    writer.format(
-        "GetWorkStream: %d buffers, " + "last sent request: %s; ",
-        workItemAssemblers.size(), lastRequest.get());
+    writer.format("GetWorkStream: last sent request: %s; ", lastRequest.get());
     writer.print(budgetTracker.debugString());
   }
 
   @Override
   protected void sendHealthCheck() throws WindmillStreamShutdownException {
     trySend(HEALTH_CHECK_REQUEST);
-  }
-
-  @Override
-  protected void shutdownInternal() {}
-
-  @Override
-  protected void onResponse(StreamingGetWorkResponseChunk chunk) {
-    workItemAssemblers
-        .computeIfAbsent(chunk.getStreamId(), unused -> new GetWorkResponseChunkAssembler())
-        .append(chunk)
-        .forEach(this::consumeAssembledWorkItem);
   }
 
   private void consumeAssembledWorkItem(AssembledWorkItem assembledWorkItem) {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetDataStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetDataStream.java
@@ -421,8 +421,10 @@ final class GrpcGetDataStream
         LOG.error("Parsing GetData response failed: ", e);
         try {
           BackOffUtils.next(Sleeper.DEFAULT, backoff);
-        } catch (IOException | InterruptedException ie) {
+        } catch (InterruptedException ie) {
           Thread.currentThread().interrupt();
+        } catch (IOException ie) {
+          // TODO: remove IOException from BackoffUtils
         }
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetDataStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetDataStream.java
@@ -504,7 +504,8 @@ final class GrpcGetDataStream
     try {
       // Peek first to ensure we don't pull off if the wrong batch.
       verify(batch == batches.peekFirst(), "GetDataStream request batch removed before send().");
-      // Pull off before we send, the sending threads in issueRequest will be notified if there is an error and will
+      // Pull off before we send, the sending threads in issueRequest will be notified if there is
+      // an error and will
       // resend requests (possibly with new batching).
       verify(batch == batches.pollFirst());
       verify(!batch.isEmpty());

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetDataStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetDataStream.java
@@ -19,6 +19,7 @@ package org.apache.beam.runners.dataflow.worker.windmill.client.grpc;
 
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Verify.verify;
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Verify.verifyNotNull;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -34,7 +35,9 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.ComputationGetDataRequest;
@@ -55,7 +58,12 @@ import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.GrpcGetDataS
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.GrpcGetDataStreamRequests.QueuedRequest;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.observers.StreamObserverFactory;
 import org.apache.beam.sdk.util.BackOff;
+import org.apache.beam.sdk.util.BackOffUtils;
+import org.apache.beam.sdk.util.FluentBackoff;
+import org.apache.beam.sdk.util.Sleeper;
+import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.Status;
 import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.stub.StreamObserver;
+import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,10 +76,21 @@ final class GrpcGetDataStream
   private static final StreamingGetDataRequest HEALTH_CHECK_REQUEST =
       StreamingGetDataRequest.newBuilder().build();
 
-  /** @implNote {@link QueuedBatch} objects in the queue are is guarded by {@code this} */
+  static final FluentBackoff BACK_OFF_FACTORY =
+      FluentBackoff.DEFAULT
+          .withInitialBackoff(Duration.millis(10))
+          .withMaxBackoff(Duration.standardSeconds(10));
+
+  /**
+   * @implNote {@link QueuedBatch} objects in the queue should also be guarded by {@code this}.
+   *     Batches should be sent from the front of the queue and only removed from the queue once
+   *     added to the pending set of a physical stream.
+   */
+  @GuardedBy("this")
   private final Deque<QueuedBatch> batches;
 
-  private final Map<Long, AppendableInputStream> pending;
+  private final Supplier<Integer> batchesDebugSizeSupplier;
+
   private final AtomicLong idGenerator;
   private final JobHeader jobHeader;
   private final int streamingRpcBatchLimit;
@@ -105,8 +124,11 @@ final class GrpcGetDataStream
     this.idGenerator = idGenerator;
     this.jobHeader = jobHeader;
     this.streamingRpcBatchLimit = streamingRpcBatchLimit;
-    this.batches = new ConcurrentLinkedDeque<>();
-    this.pending = new ConcurrentHashMap<>();
+    // A concurrent deque is used so that we can observe the size without synchronization on "this".
+    // Otherwise the deque is accessed via batches which has a guardedby annotation.
+    ConcurrentLinkedDeque<QueuedBatch> batches = new ConcurrentLinkedDeque<>();
+    this.batches = batches;
+    this.batchesDebugSizeSupplier = batches::size;
     this.sendKeyedGetDataRequests = sendKeyedGetDataRequests;
     this.processHeartbeatResponses = processHeartbeatResponses;
   }
@@ -153,45 +175,110 @@ final class GrpcGetDataStream
     trySend(getDataRequest);
   }
 
-  @Override
-  protected synchronized void onNewStream() throws WindmillStreamShutdownException {
-    trySend(StreamingGetDataRequest.newBuilder().setHeader(jobHeader).build());
-    if (clientClosed) {
-      // We rely on close only occurring after all methods on the stream have returned.
-      // Since the requestKeyedData and requestGlobalData methods are blocking this
-      // means there should be no pending requests.
-      verify(!hasPendingRequests(), "Pending requests not expected if we've half-closed.");
-    } else {
+  class GetDataPhysicalStreamHandler extends PhysicalStreamHandler {
+    private final ConcurrentHashMap<Long, AppendableInputStream> pending =
+        new ConcurrentHashMap<>();
+
+    public void sendBatch(QueuedBatch batch) throws WindmillStreamShutdownException {
+      // Synchronization of pending inserts is necessary with send to ensure duplicates are not
+      // sent on stream reconnect.
+      for (QueuedRequest request : batch.requestsReadOnly()) {
+        boolean alreadyPresent = pending.put(request.id(), request.getResponseStream()) != null;
+        verify(!alreadyPresent, "Request already sent, id: %d", request.id());
+      }
+
+      if (!trySend(batch.asGetDataRequest())) {
+        // The stream broke before this call went through; onNewStream will retry the fetch.
+        LOG.debug("GetData stream broke before call started.");
+      }
+    }
+
+    @Override
+    public void onResponse(StreamingGetDataResponse chunk) {
+      checkArgument(chunk.getRequestIdCount() == chunk.getSerializedResponseCount());
+      checkArgument(chunk.getRemainingBytesForResponse() == 0 || chunk.getRequestIdCount() == 1);
+      onHeartbeatResponse(chunk.getComputationHeartbeatResponseList());
+
+      for (int i = 0; i < chunk.getRequestIdCount(); ++i) {
+        long requestId = chunk.getRequestId(i);
+        boolean completeResponse = chunk.getRemainingBytesForResponse() == 0;
+        @Nullable
+        AppendableInputStream responseStream =
+            completeResponse ? pending.remove(requestId) : pending.get(requestId);
+        verifyNotNull(responseStream, "No pending response stream");
+        responseStream.append(chunk.getSerializedResponse(i).newInput());
+        if (completeResponse) {
+          responseStream.complete();
+        }
+      }
+    }
+
+    @Override
+    public boolean hasPendingRequests() {
+      return !pending.isEmpty();
+    }
+
+    @Override
+    public void onDone(Status status) {
+      if (status.isOk() && hasPendingRequests()) {
+        LOG.warn("Pending requests not expected on successful GetData stream flushing.");
+      }
       for (AppendableInputStream responseStream : pending.values()) {
         responseStream.cancel();
       }
+      pending.clear();
+    }
+
+    @Override
+    public void appendHtml(PrintWriter writer) {
+      writer.format("%d pending requests [", pending.size());
+      for (Map.Entry<Long, AppendableInputStream> entry : pending.entrySet()) {
+        writer.format("Stream %d ", entry.getKey());
+        if (entry.getValue().isCancelled()) {
+          writer.append("cancelled ");
+        }
+        if (entry.getValue().isComplete()) {
+          writer.append("complete ");
+        }
+        int queueSize = entry.getValue().size();
+        if (queueSize > 0) {
+          writer.format("%d queued responses ", queueSize);
+        }
+        long blockedMs = entry.getValue().getBlockedStartMs();
+        if (blockedMs > 0) {
+          writer.format("blocked for %dms", Instant.now().getMillis() - blockedMs);
+        }
+      }
+      writer.append("]");
     }
   }
 
   @Override
-  protected boolean hasPendingRequests() {
-    return !pending.isEmpty() || !batches.isEmpty();
+  protected PhysicalStreamHandler newResponseHandler() {
+    return new GetDataPhysicalStreamHandler();
   }
 
   @Override
-  protected void onResponse(StreamingGetDataResponse chunk) {
-    checkArgument(chunk.getRequestIdCount() == chunk.getSerializedResponseCount());
-    checkArgument(chunk.getRemainingBytesForResponse() == 0 || chunk.getRequestIdCount() == 1);
-    onHeartbeatResponse(chunk.getComputationHeartbeatResponseList());
-
-    for (int i = 0; i < chunk.getRequestIdCount(); ++i) {
-      @Nullable AppendableInputStream responseStream = pending.get(chunk.getRequestId(i));
-      if (responseStream == null) {
-        synchronized (this) {
-          // shutdown()/shutdownInternal() cleans up pending, else we expect a pending
-          // responseStream for every response.
-          verify(isShutdown, "No pending response stream");
+  protected synchronized void onNewStream() throws WindmillStreamShutdownException {
+    trySend(StreamingGetDataRequest.newBuilder().setHeader(jobHeader).build());
+    while (!batches.isEmpty()) {
+      QueuedBatch batch = batches.peekFirst();
+      verify(!batch.isEmpty());
+      if (batch.isFinalized()) {
+        try {
+          ((GetDataPhysicalStreamHandler) currentPhysicalStream).sendBatch(batch);
+          verify(
+              batch == batches.pollFirst(),
+              "Sent GetDataStream request batch removed before send() was complete.");
+          // Notify all waiters with requests in this batch as well as the sender
+          // of the next batch (if one exists).
+          batch.notifySent();
+        } catch (Exception e) {
+          LOG.debug("Batch failed to send on new stream", e);
+          // Free waiters if the send() failed.
+          batch.notifyFailed();
+          throw e;
         }
-        continue;
-      }
-      responseStream.append(chunk.getSerializedResponse(i).newInput());
-      if (chunk.getRemainingBytesForResponse() == 0) {
-        responseStream.complete();
       }
     }
   }
@@ -204,14 +291,17 @@ final class GrpcGetDataStream
   public KeyedGetDataResponse requestKeyedData(String computation, KeyedGetDataRequest request)
       throws WindmillStreamShutdownException {
     return issueRequest(
-        QueuedRequest.forComputation(uniqueId(), computation, request),
+        QueuedRequest.forComputation(
+            uniqueId(), computation, request, physicalStreamDeadlineSeconds),
         KeyedGetDataResponse::parseFrom);
   }
 
   @Override
   public GlobalData requestGlobalData(GlobalDataRequest request)
       throws WindmillStreamShutdownException {
-    return issueRequest(QueuedRequest.global(uniqueId(), request), GlobalData::parseFrom);
+    return issueRequest(
+        QueuedRequest.global(uniqueId(), request, physicalStreamDeadlineSeconds),
+        GlobalData::parseFrom);
   }
 
   @Override
@@ -284,8 +374,8 @@ final class GrpcGetDataStream
   }
 
   @Override
-  protected void sendHealthCheck() throws WindmillStreamShutdownException {
-    if (hasPendingRequests()) {
+  protected synchronized void sendHealthCheck() throws WindmillStreamShutdownException {
+    if (currentPhysicalStream.hasPendingRequests()) {
       trySend(HEALTH_CHECK_REQUEST);
     }
   }
@@ -294,8 +384,13 @@ final class GrpcGetDataStream
   protected synchronized void shutdownInternal() {
     // Stream has been explicitly closed. Drain pending input streams and request batches.
     // Future calls to send RPCs will fail.
-    pending.values().forEach(AppendableInputStream::cancel);
-    pending.clear();
+    if (currentPhysicalStream != null) {
+      for (AppendableInputStream ais :
+          ((GetDataPhysicalStreamHandler) currentPhysicalStream).pending.values()) {
+        ais.cancel();
+      }
+      ((GetDataPhysicalStreamHandler) currentPhysicalStream).pending.clear();
+    }
     batches.forEach(
         batch -> {
           batch.markFinalized();
@@ -306,30 +401,12 @@ final class GrpcGetDataStream
 
   @Override
   public void appendSpecificHtml(PrintWriter writer) {
-    writer.format(
-        "GetDataStream: %d queued batches, %d pending requests [", batches.size(), pending.size());
-    for (Map.Entry<Long, AppendableInputStream> entry : pending.entrySet()) {
-      writer.format("Stream %d ", entry.getKey());
-      if (entry.getValue().isCancelled()) {
-        writer.append("cancelled ");
-      }
-      if (entry.getValue().isComplete()) {
-        writer.append("complete ");
-      }
-      int queueSize = entry.getValue().size();
-      if (queueSize > 0) {
-        writer.format("%d queued responses ", queueSize);
-      }
-      long blockedMs = entry.getValue().getBlockedStartMs();
-      if (blockedMs > 0) {
-        writer.format("blocked for %dms", Instant.now().getMillis() - blockedMs);
-      }
-    }
-    writer.append("]");
+    writer.format("GetDataStream: %d queued batches", batchesDebugSizeSupplier.get());
   }
 
   private <ResponseT> ResponseT issueRequest(QueuedRequest request, ParseFn<ResponseT> parseFn)
       throws WindmillStreamShutdownException {
+    final BackOff backoff = BACK_OFF_FACTORY.backoff();
     while (true) {
       request.resetResponseStream();
       try {
@@ -342,12 +419,15 @@ final class GrpcGetDataStream
         }
       } catch (IOException e) {
         LOG.error("Parsing GetData response failed: ", e);
+        try {
+          BackOffUtils.next(Sleeper.DEFAULT, backoff);
+        } catch (IOException | InterruptedException ie) {
+          Thread.currentThread().interrupt();
+        }
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         throwIfShutdown(request, e);
         throw new RuntimeException(e);
-      } finally {
-        pending.remove(request.id());
       }
     }
   }
@@ -366,6 +446,7 @@ final class GrpcGetDataStream
     QueuedBatch batch;
     boolean responsibleForSend = false;
     @Nullable QueuedBatch prevBatch = null;
+
     synchronized (this) {
       if (isShutdown) {
         throw shutdownExceptionFor(request);
@@ -393,16 +474,6 @@ final class GrpcGetDataStream
       } else {
         prevBatch.waitForSendOrFailNotification();
       }
-      // Finalize the batch so that no additional requests will be added.  Leave the batch in the
-      // queue so that a subsequent batch will wait for its completion.
-      synchronized (this) {
-        if (isShutdown) {
-          throw shutdownExceptionFor(batch);
-        }
-
-        verify(batch == batches.peekFirst(), "GetDataStream request batch removed before send().");
-        batch.markFinalized();
-      }
       trySendBatch(batch);
     } else {
       // Wait for this batch to be sent before parsing the response.
@@ -410,53 +481,37 @@ final class GrpcGetDataStream
     }
   }
 
-  void trySendBatch(QueuedBatch batch) throws WindmillStreamShutdownException {
-    try {
-      sendBatch(batch);
-      synchronized (this) {
-        if (isShutdown) {
-          throw shutdownExceptionFor(batch);
-        }
+  private synchronized void trySendBatch(QueuedBatch batch) throws WindmillStreamShutdownException {
+    // Finalize the batch so that no additional requests will be added.  Leave the batch in the
+    // queue so that a subsequent batch will wait for its completion.
+    batch.markFinalized();
 
-        verify(
-            batch == batches.pollFirst(),
-            "Sent GetDataStream request batch removed before send() was complete.");
-      }
+    if (isShutdown) {
+      batch.notifyFailed();
+      throw shutdownExceptionFor(batch);
+    }
+    if (currentPhysicalStream == null) {
+      // Leave the batch finalized but in the batches queue.  Finalized batches will be sent on the
+      // new stream in onNewStream.
+      return;
+    }
+
+    try {
+      verify(batch == batches.peekFirst(), "GetDataStream request batch removed before send().");
+      verify(!batch.isEmpty());
+      ((GetDataPhysicalStreamHandler) currentPhysicalStream).sendBatch(batch);
+      verify(
+          batch == batches.pollFirst(),
+          "Sent GetDataStream request batch removed before send() was complete.");
       // Notify all waiters with requests in this batch as well as the sender
       // of the next batch (if one exists).
       batch.notifySent();
     } catch (Exception e) {
+      LOG.debug("Batch failed to send", e);
       // Free waiters if the send() failed.
       batch.notifyFailed();
       // Propagate the exception to the calling thread.
       throw e;
-    }
-  }
-
-  private void sendBatch(QueuedBatch batch) throws WindmillStreamShutdownException {
-    if (batch.isEmpty()) {
-      return;
-    }
-
-    // Synchronization of pending inserts is necessary with send to ensure duplicates are not
-    // sent on stream reconnect.
-    synchronized (this) {
-      if (isShutdown) {
-        throw shutdownExceptionFor(batch);
-      }
-
-      for (QueuedRequest request : batch.requestsReadOnly()) {
-        // Map#put returns null if there was no previous mapping for the key, meaning we have not
-        // seen it before.
-        verify(
-            pending.put(request.id(), request.getResponseStream()) == null,
-            "Request already sent.");
-      }
-
-      if (!trySend(batch.asGetDataRequest())) {
-        // The stream broke before this call went through; onNewStream will retry the fetch.
-        LOG.warn("GetData stream broke before call started.");
-      }
     }
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetDataStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetDataStream.java
@@ -185,7 +185,7 @@ final class GrpcGetDataStream
       // sent on stream reconnect.
       for (QueuedRequest request : batch.requestsReadOnly()) {
         boolean alreadyPresent = pending.put(request.id(), request.getResponseStream()) != null;
-        verify(!alreadyPresent, "Request already sent, id: %d", request.id());
+        verify(!alreadyPresent, "Request already sent, id: %s", request.id());
       }
 
       if (!trySend(batch.asGetDataRequest())) {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetDataStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetDataStream.java
@@ -424,8 +424,6 @@ final class GrpcGetDataStream
           BackOffUtils.next(Sleeper.DEFAULT, backoff);
         } catch (InterruptedException ie) {
           Thread.currentThread().interrupt();
-        } catch (IOException ie) {
-          // TODO: remove IOException from BackoffUtils
         }
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/observers/StreamObserverFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/observers/StreamObserverFactory.java
@@ -37,6 +37,8 @@ public abstract class StreamObserverFactory {
       Function<StreamObserver<ResponseT>, StreamObserver<RequestT>> clientFactory,
       StreamObserver<ResponseT> responseObserver);
 
+  public abstract long getDeadlineSeconds();
+
   private static class Direct extends StreamObserverFactory {
     private final long deadlineSeconds;
     private final int messagesBetweenIsReadyChecks;
@@ -58,6 +60,11 @@ public abstract class StreamObserverFactory {
                       inboundObserver, phaser::arrive, phaser::forceTermination));
       return new DirectStreamObserver<>(
           phaser, outboundObserver, deadlineSeconds, messagesBetweenIsReadyChecks);
+    }
+
+    @Override
+    public long getDeadlineSeconds() {
+      return deadlineSeconds;
     }
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
@@ -4190,7 +4190,9 @@ public class StreamingDataflowWorkerTest {
 
   static class TestExceptionFn extends DoFn<String, String> {
 
-    boolean firstTime = true;
+    // Note that the use of static works because this DoFn is only used in a single test.  We need
+    // to use static as the DoFn is not cached after user-code exceptions.
+    static boolean firstTime = true;
 
     @ProcessElement
     public void processElement(ProcessContext c) throws Exception {

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/AbstractWindmillStreamTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/AbstractWindmillStreamTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import org.apache.beam.runners.dataflow.worker.windmill.client.grpc.observers.StreamObserverFactory;
 import org.apache.beam.sdk.util.FluentBackoff;
+import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.Status;
 import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.stub.CallStreamObserver;
 import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.stub.StreamObserver;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.Uninterruptibles;
@@ -157,16 +158,28 @@ public class AbstractWindmillStreamTest {
     }
 
     @Override
-    protected void onResponse(Integer response) {}
+    protected PhysicalStreamHandler newResponseHandler() {
+      return new PhysicalStreamHandler() {
+
+        @Override
+        public void onResponse(Integer response) {}
+
+        @Override
+        public boolean hasPendingRequests() {
+          return false;
+        }
+
+        @Override
+        public void onDone(Status status) {}
+
+        @Override
+        public void appendHtml(PrintWriter writer) {}
+      };
+    }
 
     @Override
     protected void onNewStream() {
       numStarts.incrementAndGet();
-    }
-
-    @Override
-    protected boolean hasPendingRequests() {
-      return false;
     }
 
     private void testSend() throws WindmillStreamShutdownException {
@@ -192,9 +205,6 @@ public class AbstractWindmillStreamTest {
 
     @Override
     protected void appendSpecificHtml(PrintWriter writer) {}
-
-    @Override
-    protected void shutdownInternal() {}
   }
 
   private static class TestCallStreamObserver extends CallStreamObserver<Integer> {

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/WindmillStreamPoolTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/WindmillStreamPoolTest.java
@@ -43,7 +43,11 @@ public class WindmillStreamPoolTest {
   private final ConcurrentHashMap<
           TestWindmillStream, WindmillStreamPool.StreamData<TestWindmillStream>>
       holds = new ConcurrentHashMap<>();
-  @Rule public transient Timeout globalTimeout = Timeout.seconds(600);
+
+  @Rule
+  public transient Timeout globalTimeout =
+      Timeout.builder().withTimeout(10, TimeUnit.MINUTES).withLookingForStuckThread(true).build();
+
   private List<WindmillStreamPool.@Nullable StreamData<TestWindmillStream>> streams;
 
   @Before

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/FakeWindmillGrpcService.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/FakeWindmillGrpcService.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.windmill.client.grpc;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+import javax.annotation.concurrent.GuardedBy;
+import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
+import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.stub.StreamObserver;
+import org.hamcrest.Matchers;
+import org.junit.rules.ErrorCollector;
+
+class FakeWindmillGrpcService
+    extends CloudWindmillServiceV1Alpha1Grpc.CloudWindmillServiceV1Alpha1ImplBase {
+  private final ErrorCollector errorCollector;
+
+  @GuardedBy("this")
+  private boolean failOnNewStreams = false;
+
+  public FakeWindmillGrpcService(ErrorCollector errorCollector) {
+    this.errorCollector = errorCollector;
+  }
+
+  public static class StreamInfo<RequestT, ResponseT> {
+    public StreamInfo(StreamObserver<ResponseT> responseObserver) {
+      this.responseObserver = responseObserver;
+    }
+
+    public final StreamObserver<ResponseT> responseObserver;
+    public final BlockingQueue<RequestT> requests = new LinkedBlockingQueue<>(1000);
+    public final CompletableFuture<Throwable> onDone = new CompletableFuture<>();
+  };
+
+  private final BlockingQueue<CommitStreamInfo> commitStreams = new LinkedBlockingQueue<>(1000);
+  private final BlockingQueue<GetDataStreamInfo> getDataStreams = new LinkedBlockingQueue<>(1000);
+
+  private static class StreamInfoObserver<RequestT, ResponseT> implements StreamObserver<RequestT> {
+    private final StreamInfo<RequestT, ResponseT> streamInfo;
+    private final ErrorCollector errorCollector;
+
+    public StreamInfoObserver(
+        StreamInfo<RequestT, ResponseT> streamInfo, ErrorCollector errorCollector) {
+      this.streamInfo = streamInfo;
+      this.errorCollector = errorCollector;
+    }
+
+    @Override
+    public void onNext(RequestT request) {
+      errorCollector.checkThat(streamInfo.requests.add(request), Matchers.is(true));
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+      streamInfo.onDone.complete(throwable);
+    }
+
+    @Override
+    public void onCompleted() {
+      streamInfo.onDone.complete(null);
+    }
+  }
+
+  public static class CommitStreamInfo
+      extends StreamInfo<Windmill.StreamingCommitWorkRequest, Windmill.StreamingCommitResponse> {
+    CommitStreamInfo(StreamObserver<Windmill.StreamingCommitResponse> responseObserver) {
+      super(responseObserver);
+    }
+  }
+
+  @Override
+  public StreamObserver<Windmill.StreamingCommitWorkRequest> commitWorkStream(
+      StreamObserver<Windmill.StreamingCommitResponse> responseObserver) {
+    CommitStreamInfo info = new CommitStreamInfo(responseObserver);
+    synchronized (this) {
+      errorCollector.checkThat(failOnNewStreams, Matchers.is(false));
+      errorCollector.checkThat(commitStreams.offer(info), Matchers.is(true));
+    }
+    return new StreamInfoObserver<>(info, errorCollector);
+  }
+
+  public CommitStreamInfo waitForConnectedCommitStream() throws InterruptedException {
+    return commitStreams.take();
+  }
+
+  public synchronized void expectNoMoreStreams() {
+    failOnNewStreams = true;
+    errorCollector.checkThat(commitStreams.isEmpty(), Matchers.is(true));
+    errorCollector.checkThat(getDataStreams.isEmpty(), Matchers.is(true));
+  }
+
+  public static class GetDataStreamInfo
+      extends StreamInfo<Windmill.StreamingGetDataRequest, Windmill.StreamingGetDataResponse> {
+    GetDataStreamInfo(StreamObserver<Windmill.StreamingGetDataResponse> responseObserver) {
+      super(responseObserver);
+    }
+  }
+
+  @Override
+  public StreamObserver<Windmill.StreamingGetDataRequest> getDataStream(
+      StreamObserver<Windmill.StreamingGetDataResponse> responseObserver) {
+    GetDataStreamInfo info = new GetDataStreamInfo(responseObserver);
+    synchronized (this) {
+      errorCollector.checkThat(failOnNewStreams, Matchers.is(false));
+      errorCollector.checkThat(getDataStreams.offer(info), Matchers.is(true));
+    }
+    return new StreamInfoObserver<>(info, errorCollector);
+  }
+
+  public GetDataStreamInfo waitForConnectedGetDataStream() throws InterruptedException {
+    return getDataStreams.take();
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcCommitWorkStreamTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcCommitWorkStreamTest.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
@@ -63,7 +64,11 @@ public class GrpcCommitWorkStreamTest {
 
   @Rule public final ErrorCollector errorCollector = new ErrorCollector();
   @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
-  @Rule public transient Timeout globalTimeout = Timeout.seconds(60);
+
+  @Rule
+  public transient Timeout globalTimeout =
+      Timeout.builder().withTimeout(10, TimeUnit.MINUTES).withLookingForStuckThread(true).build();
+
   private final FakeWindmillGrpcService fakeService = new FakeWindmillGrpcService(errorCollector);
   private ManagedChannel inProcessChannel;
   private Server inProcessServer;

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDirectGetWorkStreamTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDirectGetWorkStreamTest.java
@@ -81,7 +81,11 @@ public class GrpcDirectGetWorkStreamTest {
   private static final String FAKE_SERVER_NAME = "Fake server for GrpcDirectGetWorkStreamTest";
   @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
   private final MutableHandlerRegistry serviceRegistry = new MutableHandlerRegistry();
-  @Rule public transient Timeout globalTimeout = Timeout.seconds(600);
+
+  @Rule
+  public transient Timeout globalTimeout =
+      Timeout.builder().withTimeout(10, TimeUnit.MINUTES).withLookingForStuckThread(true).build();
+
   private ManagedChannel inProcessChannel;
   private GrpcDirectGetWorkStream stream;
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetDataStreamRequestsTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetDataStreamRequestsTest.java
@@ -36,6 +36,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class GrpcGetDataStreamRequestsTest {
 
+  private static final int DEADLINE_SECONDS = 10;
+
   @Test
   public void testQueuedRequest_globalRequestsFirstComparator() {
     List<GrpcGetDataStreamRequests.QueuedRequest> requests = new ArrayList<>();
@@ -49,7 +51,7 @@ public class GrpcGetDataStreamRequestsTest {
             .build();
     requests.add(
         GrpcGetDataStreamRequests.QueuedRequest.forComputation(
-            1, "computation1", keyedGetDataRequest1));
+            1, "computation1", keyedGetDataRequest1, DEADLINE_SECONDS));
 
     Windmill.KeyedGetDataRequest keyedGetDataRequest2 =
         Windmill.KeyedGetDataRequest.newBuilder()
@@ -61,7 +63,7 @@ public class GrpcGetDataStreamRequestsTest {
             .build();
     requests.add(
         GrpcGetDataStreamRequests.QueuedRequest.forComputation(
-            2, "computation2", keyedGetDataRequest2));
+            2, "computation2", keyedGetDataRequest2, DEADLINE_SECONDS));
 
     Windmill.GlobalDataRequest globalDataRequest =
         Windmill.GlobalDataRequest.newBuilder()
@@ -72,7 +74,8 @@ public class GrpcGetDataStreamRequestsTest {
                     .build())
             .setComputationId("computation1")
             .build();
-    requests.add(GrpcGetDataStreamRequests.QueuedRequest.global(3, globalDataRequest));
+    requests.add(
+        GrpcGetDataStreamRequests.QueuedRequest.global(3, globalDataRequest, DEADLINE_SECONDS));
 
     requests.sort(GrpcGetDataStreamRequests.QueuedRequest.globalRequestsFirst());
 
@@ -94,7 +97,7 @@ public class GrpcGetDataStreamRequestsTest {
             .build();
     queuedBatch.addRequest(
         GrpcGetDataStreamRequests.QueuedRequest.forComputation(
-            1, "computation1", keyedGetDataRequest1));
+            1, "computation1", keyedGetDataRequest1, DEADLINE_SECONDS));
 
     Windmill.KeyedGetDataRequest keyedGetDataRequest2 =
         Windmill.KeyedGetDataRequest.newBuilder()
@@ -106,7 +109,7 @@ public class GrpcGetDataStreamRequestsTest {
             .build();
     queuedBatch.addRequest(
         GrpcGetDataStreamRequests.QueuedRequest.forComputation(
-            2, "computation2", keyedGetDataRequest2));
+            2, "computation2", keyedGetDataRequest2, DEADLINE_SECONDS));
 
     Windmill.GlobalDataRequest globalDataRequest =
         Windmill.GlobalDataRequest.newBuilder()
@@ -117,7 +120,8 @@ public class GrpcGetDataStreamRequestsTest {
                     .build())
             .setComputationId("computation1")
             .build();
-    queuedBatch.addRequest(GrpcGetDataStreamRequests.QueuedRequest.global(3, globalDataRequest));
+    queuedBatch.addRequest(
+        GrpcGetDataStreamRequests.QueuedRequest.global(3, globalDataRequest, DEADLINE_SECONDS));
 
     Windmill.StreamingGetDataRequest getDataRequest = queuedBatch.asGetDataRequest();
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetWorkerMetadataStreamTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetWorkerMetadataStreamTest.java
@@ -18,7 +18,6 @@
 package org.apache.beam.runners.dataflow.worker.windmill.client.grpc;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -237,7 +236,8 @@ public class GrpcGetWorkerMetadataStreamTest {
   }
 
   @Test
-  public void testGetWorkerMetadata_correctlyAddsAndRemovesStreamFromRegistry() {
+  public void testGetWorkerMetadata_correctlyAddsAndRemovesStreamFromRegistry()
+      throws InterruptedException {
     GetWorkerMetadataTestStub testStub =
         new GetWorkerMetadataTestStub(new TestGetWorkMetadataRequestObserver());
     stream = getWorkerMetadataTestStream(testStub, new TestWindmillEndpointsConsumer());
@@ -250,7 +250,9 @@ public class GrpcGetWorkerMetadataStreamTest {
 
     assertTrue(streamFactory.streamRegistry().contains(stream));
     stream.halfClose();
-    assertFalse(streamFactory.streamRegistry().contains(stream));
+    while (streamFactory.streamRegistry().contains(stream)) {
+      Thread.sleep(100);
+    }
   }
 
   @Test

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillServerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillServerTest.java
@@ -117,7 +117,11 @@ public class GrpcWindmillServerTest {
   private final long clientId = 10L;
   private final Set<ManagedChannel> openedChannels = new HashSet<>();
   private final MutableHandlerRegistry serviceRegistry = new MutableHandlerRegistry();
-  @Rule public transient Timeout globalTimeout = Timeout.seconds(600);
+
+  @Rule
+  public transient Timeout globalTimeout =
+      Timeout.builder().withTimeout(10, TimeUnit.MINUTES).withLookingForStuckThread(true).build();
+
   @Rule public GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
   @Rule public ErrorCollector errorCollector = new ErrorCollector();
   private Server server;

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillServerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillServerTest.java
@@ -482,7 +482,6 @@ public class GrpcWindmillServerTest {
   }
 
   @Test
-  @SuppressWarnings("FutureReturnValueIgnored")
   public void testStreamingGetData() throws Exception {
     // This server responds to GetDataRequests with responses that mirror the requests.
     serviceRegistry.addService(
@@ -623,7 +622,7 @@ public class GrpcWindmillServerTest {
     for (int i = 0; i < 100; ++i) {
       final String key = "key" + i;
       final String s = i % 5 == 0 ? largeString(i) : "tag";
-      executor.submit(
+      executor.execute(
           () -> {
             try {
               errorCollector.checkThat(


### PR DESCRIPTION
Currently this should be equivalent behavior but the separate physical stream handlers will allow for multiple distinct physical substreams when we want to cleanly terminate streams to avoid deadlines.

Add additional tests for the reconnection on stream errors (which already occurs). These could be committed separately if desired.

While at it change the deadline used for get data parsing timeout to be consistent with the deadline used for the response observers.  Currently this won't change much but as we use a longer deadline for direct streams and update that in the future we will avoid these spurious errors.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
