### PR TITLE
Fix broad suppression of dataflow worker windmill package.

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/build.gradle
+++ b/runners/google-cloud-dataflow-java/worker/build.gradle
@@ -90,7 +90,7 @@ applyJavaNature(
                 "org/slf4j/jul/**"
         ],
         generatedClassPatterns: [
-                /^org\.apache\.beam\.runners\.dataflow\.worker\.windmill.*/,
+                /^org\.apache\.beam\.runners\.dataflow\.worker\.windmill\..*AutoBuilder.*/,
                 /^org\.apache\.beam\.runners\.dataflow\.worker\..*AutoBuilder.*/,
         ],
         shadowClosure: {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateRegistry.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateRegistry.java
@@ -51,7 +51,7 @@ public abstract class DataflowExecutionStateRegistry {
   public DataflowOperationContext.DataflowExecutionState getState(
       final NameContext nameContext,
       final String stateName,
-      final MetricsContainer container,
+      final @Nullable MetricsContainer container,
       final ProfileScope profileScope) {
     return getStateInternal(nameContext, stateName, null, null, container, profileScope);
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/KeyTokenInvalidException.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/KeyTokenInvalidException.java
@@ -17,17 +17,16 @@
  */
 package org.apache.beam.runners.dataflow.worker;
 
+import javax.annotation.Nullable;
+
 /** Indicates that the key token was invalid when data was attempted to be fetched. */
-@SuppressWarnings({
-  "nullness" // TODO(https://github.com/apache/beam/issues/20497)
-})
 public class KeyTokenInvalidException extends RuntimeException {
   public KeyTokenInvalidException(String key) {
     super("Unable to fetch data due to token mismatch for key " + key);
   }
 
   /** Returns whether an exception was caused by a {@link KeyTokenInvalidException}. */
-  public static boolean isKeyTokenInvalidException(Throwable t) {
+  public static boolean isKeyTokenInvalidException(@Nullable Throwable t) {
     while (t != null) {
       if (t instanceof KeyTokenInvalidException) {
         return true;

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/logging/DataflowWorkerLoggingMDC.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/logging/DataflowWorkerLoggingMDC.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.runners.dataflow.worker.logging;
 
+import javax.annotation.Nullable;
+
 /** Mapped diagnostic context for the Dataflow worker. */
 @SuppressWarnings({
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
@@ -34,7 +36,7 @@ public class DataflowWorkerLoggingMDC {
   }
 
   /** Sets the Stage Name of the current thread, which will be inherited by child threads. */
-  public static void setStageName(String newStageName) {
+  public static void setStageName(@Nullable String newStageName) {
     stageName.set(newStageName);
   }
 
@@ -44,7 +46,7 @@ public class DataflowWorkerLoggingMDC {
   }
 
   /** Sets the Work ID of the current thread, which will be inherited by child threads. */
-  public static void setWorkId(String newWorkId) {
+  public static void setWorkId(@Nullable String newWorkId) {
     workId.set(newWorkId);
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/ChannelzServlet.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/ChannelzServlet.java
@@ -278,7 +278,11 @@ public class ChannelzServlet extends BaseStatusServlet implements DebugCapture.C
 
       @Override
       public void onCompleted() {
-        future.set(response);
+        if (response == null) {
+          future.setException(new IllegalStateException("No response"));
+        } else {
+          future.set(response);
+        }
       }
     };
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GetWorkResponseChunkAssembler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GetWorkResponseChunkAssembler.java
@@ -125,9 +125,9 @@ final class GetWorkResponseChunkAssembler {
 
     abstract String computationId();
 
-    abstract Instant inputDataWatermark();
+    abstract @Nullable Instant inputDataWatermark();
 
-    abstract Instant synchronizedProcessingTime();
+    abstract @Nullable Instant synchronizedProcessingTime();
   }
 
   @AutoValue

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDirectGetWorkStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDirectGetWorkStream.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.runners.dataflow.worker.windmill.client.grpc;
 
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkNotNull;
+
 import java.io.PrintWriter;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -164,7 +166,7 @@ final class GrpcDirectGetWorkStream
   private static Watermarks createWatermarks(
       WorkItem workItem, GetWorkResponseChunkAssembler.ComputationMetadata metadata) {
     return Watermarks.builder()
-        .setInputDataWatermark(metadata.inputDataWatermark())
+        .setInputDataWatermark(checkNotNull(metadata.inputDataWatermark()))
         .setOutputDataWatermark(workItem.getOutputDataWatermark())
         .setSynchronizedProcessingTime(metadata.synchronizedProcessingTime())
         .build();

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/state/WindmillMapViaMultimap.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/state/WindmillMapViaMultimap.java
@@ -92,11 +92,12 @@ public class WindmillMapViaMultimap<KeyT, ValueT> extends AbstractWindmillMap<Ke
       this.defaultValue = defaultValue;
     }
 
+    @SuppressWarnings("nullness")
     @Override
     public T read() {
       Iterator<T> iterator = wrapped.read().iterator();
       if (!iterator.hasNext()) {
-        return null;
+        return defaultValue;
       }
       return Iterators.getOnlyElement(iterator);
     }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/StreamingWorkScheduler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/StreamingWorkScheduler.java
@@ -375,7 +375,7 @@ public class StreamingWorkScheduler {
       Optional<Coder<?>> keyCoder = computationWorkExecutor.keyCoder();
       @SuppressWarnings("deprecation")
       @Nullable
-      Object executionKey =
+      final Object executionKey =
           !keyCoder.isPresent() ? null : keyCoder.get().decode(key.newInput(), Coder.Context.OUTER);
 
       if (workItem.hasHotKeyInfo()) {
@@ -383,7 +383,9 @@ public class StreamingWorkScheduler {
         Duration hotKeyAge = Duration.millis(hotKeyInfo.getHotKeyAgeUsec() / 1000);
 
         String stepName = getShuffleTaskStepName(computationState.getMapTask());
-        if ((options.isHotKeyLoggingEnabled() || hasExperiment(options, "enable_hot_key_logging"))
+        if (executionKey != null
+            && (options.isHotKeyLoggingEnabled()
+                || hasExperiment(options, "enable_hot_key_logging"))
             && keyCoder.isPresent()) {
           hotKeyLogger.logHotKeyDetection(stepName, hotKeyAge, executionKey);
         } else {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/failures/WorkFailureProcessor.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/failures/WorkFailureProcessor.java
@@ -20,6 +20,7 @@ package org.apache.beam.runners.dataflow.worker.windmill.work.processing.failure
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.beam.runners.dataflow.worker.KeyTokenInvalidException;
 import org.apache.beam.runners.dataflow.worker.WorkItemCancelledException;
@@ -88,7 +89,7 @@ public final class WorkFailureProcessor {
   }
 
   /** Returns whether an exception was caused by a {@link OutOfMemoryError}. */
-  private static boolean isOutOfMemoryError(Throwable t) {
+  private static boolean isOutOfMemoryError(@Nullable Throwable t) {
     while (t != null) {
       if (t instanceof OutOfMemoryError) {
         return true;
@@ -131,7 +132,8 @@ public final class WorkFailureProcessor {
   }
 
   private boolean shouldRetryLocally(String computationId, Work work, Throwable t) {
-    Throwable parsedException = t instanceof UserCodeException ? t.getCause() : t;
+    @Nullable final Throwable cause = t.getCause();
+    Throwable parsedException = (t instanceof UserCodeException && cause != null) ? cause : t;
     if (KeyTokenInvalidException.isKeyTokenInvalidException(parsedException)) {
       LOG.debug(
           "Execution of work for computation '{}' on key '{}' failed due to token expiration. "

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/refresh/ActiveWorkRefresher.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/refresh/ActiveWorkRefresher.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.dataflow.worker.windmill.work.refresh;
 
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap.toImmutableMap;
 
 import java.util.ArrayList;
@@ -30,13 +31,13 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.beam.runners.dataflow.worker.DataflowExecutionStateSampler;
 import org.apache.beam.runners.dataflow.worker.streaming.ComputationState;
 import org.apache.beam.runners.dataflow.worker.streaming.RefreshableWork;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.slf4j.Logger;
@@ -138,7 +139,7 @@ public final class ActiveWorkRefresher {
 
     // Send the first heartbeat on the calling thread, and fan out the rest via the
     // fanOutActiveWorkRefreshExecutor.
-    @Nullable Map.Entry<HeartbeatSender, Heartbeats> firstHeartbeat = null;
+    Map.@MonotonicNonNull Entry<HeartbeatSender, Heartbeats> firstHeartbeat = null;
     for (Map.Entry<HeartbeatSender, Heartbeats> heartbeat : heartbeatsBySender.entrySet()) {
       if (firstHeartbeat == null) {
         firstHeartbeat = heartbeat;
@@ -149,7 +150,7 @@ public final class ActiveWorkRefresher {
       }
     }
 
-    sendHeartbeatSafely(firstHeartbeat);
+    sendHeartbeatSafely(checkNotNull(firstHeartbeat));
     fanOutRefreshActiveWork.forEach(CompletableFuture::join);
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/refresh/FixedStreamHeartbeatSender.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/refresh/FixedStreamHeartbeatSender.java
@@ -81,7 +81,7 @@ public final class FixedStreamHeartbeatSender implements HeartbeatSender {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     return obj instanceof FixedStreamHeartbeatSender
         && getDataStream.equals(((FixedStreamHeartbeatSender) obj).getDataStream);
   }


### PR DESCRIPTION
Remove the broad suppression and fix up errors that are now surfaced.



Fixes #30183

```
/runner/_work/beam/beam/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/getdata/ApplianceGetDataClient.java:140: error: [dereference.of.nullable] dereference of possibly-null reference pendingResponses.get(WindmillComputationKey.create(computationResponse.getComputationId(), keyResponse.getKey(), keyResponse.getShardingKey()))
              .get(
                  ^
> Task :runners:google-cloud-dataflow-java:worker:compileJava
/runner/_work/beam/beam/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GetWorkResponseChunkAssembler.java:121: error: [argument] incompatible argument for parameter inputDataWatermark of AutoValue_GetWorkResponseChunkAssembler_ComputationMetadata constructor.
          WindmillTimeUtils.windmillToHarnessWatermark(metadataProto.getInputDataWatermark()),
                                                      ^
  found   : @Initialized @Nullable Instant
  required: @Initialized @NonNull Instant
/runner/_work/beam/beam/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GetWorkResponseChunkAssembler.java:122: error: [argument] incompatible argument for parameter synchronizedProcessingTime of AutoValue_GetWorkResponseChunkAssembler_ComputationMetadata constructor.
          WindmillTimeUtils.windmillToHarnessWatermark(
                                                      ^
  found   : @Initialized @Nullable Instant
  required: @Initialized @NonNull Instant
/runner/_work/beam/beam/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/ChannelCache.java:96: error: [argument] incompatible argument for parameter channel of ChannelCache.shutdownChannel.
        notification -> shutdownChannel(notification.getValue()),
                                                             ^
  found   : @Initialized @Nullable ManagedChannel
  required: @Initialized @NonNull ManagedChannel
/runner/_work/beam/beam/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/ChannelCache.java:109: error: [argument] incompatible argument for parameter channel of ChannelCache.shutdownChannel.
          shutdownChannel(notification.getValue());
                                               ^
  found   : @Initialized @Nullable ManagedChannel
  required: @Initialized @NonNull ManagedChannel
/runner/_work/beam/beam/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/ChannelCache.java:134: error: [argument] incompatible argument for parameter obj of UserWorkerGrpcFlowControlSettings.equals.
    if (!flowControlSettings.equals(currentFlowControlSettings)) {
                                    ^
  found   : @Initialized @MonotonicNonNull UserWorkerGrpcFlowControlSettings
  required: @Initialized @NonNull Object
/runner/_work/beam/beam/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/ChannelzServlet.java:281: error: [argument] incompatible argument for parameter value of SettableFuture.set.
        future.set(response);
                   ^
  found   : T[ extends @Initialized @Nullable Object super @Initialized @Nullable Void]
  required: T[ extends @Initialized @Nullable Object super @Initialized @NonNull Void]
/runner/_work/beam/beam/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/state/WindmillMapViaMultimap.java:99: error: [return] incompatible types in return.
        return null;
               ^
  type of expression: null (NullType)
  method return type: T extends @Initialized @Nullable Object
/runner/_work/beam/beam/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/refresh/ActiveWorkRefresher.java:152: error: [argument] incompatible argument for parameter heartbeat of ActiveWorkRefresher.sendHeartbeatSafely.
    sendHeartbeatSafely(firstHeartbeat);
                        ^
  found   : @Initialized @Nullable Entry<@Initialized @NonNull HeartbeatSender, @Initialized @NonNull Heartbeats>
  required: @Initialized @NonNull Entry<@Initialized @NonNull HeartbeatSender, @Initialized @NonNull Heartbeats>
/runner/_work/beam/beam/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/refresh/FixedStreamHeartbeatSender.java:84: error: [override.param] Incompatible parameter type for obj.
  public boolean equals(Object obj) {
                               ^
  found   : @Initialized @NonNull Object
  required: @Initialized @Nullable Object
  Consequence: method in @Initialized @NonNull FixedStreamHeartbeatSender
    @Initialized @NonNull boolean equals(@Initialized @NonNull FixedStreamHeartbeatSender this, @Initialized @NonNull Object p0)
  cannot override method in @Initialized @NonNull Object
    @Initialized @NonNull boolean equals(@Initialized @NonNull Object this, @Initialized @Nullable Object p0)
/runner/_work/beam/beam/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/StreamingWorkScheduler.java:199: error: [argument] incompatible argument for parameter newWorkId of DataflowWorkerLoggingMDC.setWorkId.
    DataflowWorkerLoggingMDC.setWorkId(null);
                                       ^
  found   : null (NullType)
  required: @Initialized @NonNull String
/runner/_work/beam/beam/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/StreamingWorkScheduler.java:200: error: [argument] incompatible argument for parameter newStageName of DataflowWorkerLoggingMDC.setStageName.
    DataflowWorkerLoggingMDC.setStageName(null);
                                          ^
  found   : null (NullType)
  required: @Initialized @NonNull String
/runner/_work/beam/beam/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/StreamingWorkScheduler.java:388: error: [argument] incompatible argument for parameter hotkey of HotKeyLogger.logHotKeyDetection.
          hotKeyLogger.logHotKeyDetection(stepName, hotKeyAge, executionKey);
                                                               ^
  found   : @Initialized @Nullable Object
  required: @Initialized @NonNull Object
/runner/_work/beam/beam/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/ComputationWorkExecutorFactory.java:298: error: [argument] incompatible argument for parameter container of DataflowExecutionStateRegistry.getState.
                null,
                ^
  found   : null (NullType)
  required: @Initialized @NonNull MetricsContainer
/runner/_work/beam/beam/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/failures/WorkFailureProcessor.java:96: error: [assignment] incompatible types in assignment.
      t = t.getCause();
                    ^
  found   : @Initialized @Nullable Throwable
  required: @Initialized @NonNull Throwable
/runner/_work/beam/beam/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/failures/WorkFailureProcessor.java:135: error: [argument] incompatible argument for parameter t of KeyTokenInvalidException.isKeyTokenInvalidException.
    if (KeyTokenInvalidException.isKeyTokenInvalidException(parsedException)) {
                                                            ^
  found   : @Initialized @Nullable Throwable
  required: @Initialized @NonNull Throwable
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
16 errors
```