### PR TITLE
added defaultQueryTimeout for jdbc io

### DIFF
--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
@@ -492,6 +492,9 @@ public class JdbcIO {
     abstract @Nullable ValueProvider<Integer> getMaxConnections();
 
     @Pure
+    abstract @Nullable ValueProvider<Integer> getQueryTimeout();
+
+    @Pure
     abstract @Nullable ClassLoader getDriverClassLoader();
 
     @Pure
@@ -519,6 +522,8 @@ public class JdbcIO {
           ValueProvider<Collection<@Nullable String>> connectionInitSqls);
 
       abstract Builder setMaxConnections(ValueProvider<@Nullable Integer> maxConnections);
+
+      abstract Builder setQueryTimeout(ValueProvider<@Nullable Integer> queryTimeout);
 
       abstract Builder setDriverClassLoader(ClassLoader driverClassLoader);
 
@@ -622,6 +627,17 @@ public class JdbcIO {
       return builder().setMaxConnections(maxConnections).build();
     }
 
+    /** Sets the default query timeout that will be used for connections created by this source. */
+    public DataSourceConfiguration withQueryTimeout(Integer queryTimeout) {
+      checkArgument(queryTimeout != null, "queryTimeout can not be null");
+      return withQueryTimeout(ValueProvider.StaticValueProvider.of(queryTimeout));
+    }
+
+    /** Same as {@link #withQueryTimeout(Integer)} but accepting a ValueProvider. */
+    public DataSourceConfiguration withQueryTimeout(ValueProvider<@Nullable Integer> queryTimeout) {
+      return builder().setQueryTimeout(queryTimeout).build();
+    }
+
     /**
      * Sets the class loader instance to be used to load the JDBC driver. If not specified, the
      * default class loader is used.
@@ -657,6 +673,7 @@ public class JdbcIO {
         builder.addIfNotNull(DisplayData.item("jdbcUrl", getUrl()));
         builder.addIfNotNull(DisplayData.item("username", getUsername()));
         builder.addIfNotNull(DisplayData.item("driverJars", getDriverJars()));
+        builder.addIfNotNull(DisplayData.item("queryTimeout", getQueryTimeout()));
       }
     }
 
@@ -699,6 +716,12 @@ public class JdbcIO {
           Integer maxConnections = getMaxConnections().get();
           if (maxConnections != null) {
             basicDataSource.setMaxTotal(maxConnections);
+          }
+        }
+        if (getQueryTimeout() != null) {
+          Integer queryTimeout = getQueryTimeout().get();
+          if (queryTimeout != null) {
+            basicDataSource.setDefaultQueryTimeout(queryTimeout);
           }
         }
         if (getDriverClassLoader() != null) {


### PR DESCRIPTION
following https://commons.apache.org/proper/commons-dbcp/configuration.html,


defaultQueryTimeout: If non-null, the value of this Integer property determines the query timeout that will be used for Statements created from connections managed by the pool. null means that the driver default will be used.

This probably won't help PreparedStatement, but should be useful for some hanging query executions. 


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
