### PR TITLE
Add display_data to AppliedPTransforms

### DIFF
--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -1188,21 +1188,6 @@ class ExternalTransformFinder(PipelineVisitor):
     self._perform_exernal_transform_test(transform_node.transform)
 
 
-class DisplayDataContainer(HasDisplayData):
-  def __init__(self, display_data_dict, display_data_namespace):
-    self.display_data_dict = display_data_dict
-    self.display_data_namespace = display_data_namespace
-
-  def display_data(self):
-    # type: () -> Dict[str, DisplayData]
-
-    """Returns the display data for this object."""
-    return self.display_data_dict
-
-  def _get_display_data_namespace(self):  # type: () -> str
-    return self.display_data_namespace
-
-
 class AppliedPTransform(object):
   """For internal use only; no backwards-compatibility guarantees.
 

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -1188,6 +1188,21 @@ class ExternalTransformFinder(PipelineVisitor):
     self._perform_exernal_transform_test(transform_node.transform)
 
 
+class DisplayDataContainer(HasDisplayData):
+  def __init__(self, display_data_dict, display_data_namespace):
+    self.display_data_dict = display_data_dict
+    self.display_data_namespace = display_data_namespace
+
+  def display_data(self):
+    # type: () -> Dict[str, DisplayData]
+
+    """Returns the display data for this object."""
+    return self.display_data_dict
+
+  def _get_display_data_namespace(self):  # type: () -> str
+    return self.display_data_namespace
+
+
 class AppliedPTransform(object):
   """For internal use only; no backwards-compatibility guarantees.
 
@@ -1229,8 +1244,13 @@ class AppliedPTransform(object):
       annotations = {
           **(annotations or {}), **encode_annotations(transform.annotations())
       }
+      display_data = DisplayDataContainer(
+          transform.display_data(), transform._get_display_data_namespace())
+    else:
+      display_data = None
 
     self.annotations = annotations
+    self.display_data = display_data
 
   @property
   def inputs(self):
@@ -1454,8 +1474,8 @@ class AppliedPTransform(object):
         environment_id=environment_id,
         annotations=self.annotations,
         # TODO(https://github.com/apache/beam/issues/18012): Add display_data.
-        display_data=DisplayData.create_from(self.transform).to_proto()
-        if self.transform else None)
+        display_data=DisplayData.create_from(self.display_data).to_proto()
+        if self.display_data else None)
 
   @staticmethod
   def from_runner_api(

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -1244,13 +1244,10 @@ class AppliedPTransform(object):
       annotations = {
           **(annotations or {}), **encode_annotations(transform.annotations())
       }
-      display_data = DisplayDataContainer(
-          transform.display_data(), transform._get_display_data_namespace())
-    else:
-      display_data = None
 
     self.annotations = annotations
-    self.display_data = display_data
+
+    self.display_data = {}
 
   @property
   def inputs(self):
@@ -1455,6 +1452,11 @@ class AppliedPTransform(object):
         (transform_urn not in Pipeline.runner_implemented_transforms())):
       environment_id = context.get_environment_id_for_resource_hints(
           self.resource_hints)
+    if self.transform is not None:
+      display_data = DisplayData.create_from(
+          self.transform, extra_items=self.display_data)
+    else:
+      display_data = None
 
     return beam_runner_api_pb2.PTransform(
         unique_name=self.full_label,
@@ -1474,8 +1476,7 @@ class AppliedPTransform(object):
         environment_id=environment_id,
         annotations=self.annotations,
         # TODO(https://github.com/apache/beam/issues/18012): Add display_data.
-        display_data=DisplayData.create_from(self.display_data).to_proto()
-        if self.display_data else None)
+        display_data=display_data.to_proto() if display_data else None)
 
   @staticmethod
   def from_runner_api(

--- a/sdks/python/apache_beam/transforms/display.py
+++ b/sdks/python/apache_beam/transforms/display.py
@@ -226,7 +226,7 @@ class DisplayData(object):
     return cls(pipeline_options._get_display_data_namespace(), items)
 
   @classmethod
-  def create_from(cls, has_display_data):
+  def create_from(cls, has_display_data, extra_items=None):
     """ Creates :class:`~apache_beam.transforms.display.DisplayData` from a
     :class:`HasDisplayData` instance.
 
@@ -243,9 +243,11 @@ class DisplayData(object):
       raise ValueError(
           'Element of class {}.{} does not subclass HasDisplayData'.format(
               has_display_data.__module__, has_display_data.__class__.__name__))
+    if extra_items is None:
+      extra_items = {}
     return cls(
         has_display_data._get_display_data_namespace(),
-        has_display_data.display_data())
+        dict(**has_display_data.display_data(), **extra_items))
 
 
 class DisplayDataItem(object):

--- a/sdks/python/apache_beam/transforms/display_test.py
+++ b/sdks/python/apache_beam/transforms/display_test.py
@@ -217,6 +217,14 @@ class DisplayDataTest(unittest.TestCase):
     ]
 
     hc.assert_that(dd.items, hc.has_items(*expected_items))
+    expected_items.append(
+        DisplayDataItemMatcher(
+            key='extra_key', value='extra_value', namespace=nspace))
+    hc.assert_that(
+        DisplayData.create_from(fn, extra_items={
+            'extra_key': 'extra_value'
+        }).items,
+        hc.has_items(*expected_items))
 
   def test_drop_if_none(self):
     class MyDoFn(beam.DoFn):


### PR DESCRIPTION
This adds a `display_data` attribute to `AppliedPTransforms`, similar to `annotations` and `resource_hints`. This gives us a little more flexibility with adding display data, e.g. if someone wants to create a `PipelineVisitor` that adds general display data for every ptransform (like a link to github pointing to the source)

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
