### PR TITLE
Support Docker Compose v2 in Python TransformServiceLauncher

### DIFF
--- a/sdks/python/apache_beam/transforms/external.py
+++ b/sdks/python/apache_beam/transforms/external.py
@@ -1174,16 +1174,6 @@ def _maybe_use_transform_service(provided_service=None, options=None):
 
     return True
 
-  def is_docker_compose_v2_available():
-    cmd = ['docker', 'compose', 'version']
-
-    try:
-      subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    except:  # pylint: disable=bare-except
-      return False
-
-    return True
-
   # We try java and docker based expansion services in that order.
 
   java_available = is_java_available()
@@ -1204,7 +1194,6 @@ def _maybe_use_transform_service(provided_service=None, options=None):
 
     project_name = str(uuid.uuid4())
     port = subprocess_server.pick_port(None)[0]
-    docker_compose_v2_available = is_docker_compose_v2_available()
 
     logging.info(
         'Trying to expand the external transform using the Docker Compose '
@@ -1216,7 +1205,7 @@ def _maybe_use_transform_service(provided_service=None, options=None):
     beam_version = beam_version.__version__
 
     return transform_service_launcher.TransformServiceLauncher(
-        project_name, port, beam_version, docker_compose_v2_available)
+        project_name, port, beam_version)
   else:
     raise ValueError(
         'Cannot start an expansion service since neither Java nor '

--- a/sdks/python/apache_beam/transforms/external.py
+++ b/sdks/python/apache_beam/transforms/external.py
@@ -1174,6 +1174,16 @@ def _maybe_use_transform_service(provided_service=None, options=None):
 
     return True
 
+  def is_docker_compose_v2_available():
+    cmd = ['docker', 'compose', 'version']
+
+    try:
+      subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    except:  # pylint: disable=bare-except
+      return False
+
+    return True
+
   # We try java and docker based expansion services in that order.
 
   java_available = is_java_available()
@@ -1194,6 +1204,7 @@ def _maybe_use_transform_service(provided_service=None, options=None):
 
     project_name = str(uuid.uuid4())
     port = subprocess_server.pick_port(None)[0]
+    docker_compose_v2_available = is_docker_compose_v2_available()
 
     logging.info(
         'Trying to expand the external transform using the Docker Compose '
@@ -1205,7 +1216,7 @@ def _maybe_use_transform_service(provided_service=None, options=None):
     beam_version = beam_version.__version__
 
     return transform_service_launcher.TransformServiceLauncher(
-        project_name, port, beam_version)
+        project_name, port, beam_version, docker_compose_v2_available)
   else:
     raise ValueError(
         'Cannot start an expansion service since neither Java nor '

--- a/sdks/python/apache_beam/utils/transform_service_launcher.py
+++ b/sdks/python/apache_beam/utils/transform_service_launcher.py
@@ -61,10 +61,6 @@ class TransformServiceLauncher(object):
 
     self._launcher_lock = threading.RLock()
 
-    self.docker_compose_command_prefix = [
-        'docker-compose', '-p', project_name, '-f', 'TODO path'
-    ]
-
     # Setting up Docker Compose configuration.
 
     # We use Docker Compose project name as the name of the temporary directory

--- a/sdks/python/apache_beam/utils/transform_service_launcher.py
+++ b/sdks/python/apache_beam/utils/transform_service_launcher.py
@@ -46,13 +46,15 @@ class TransformServiceLauncher(object):
 
   # Maintaining a static list of launchers to prevent temporary resources
   # from being created unnecessarily.
-  def __new__(cls, project_name, port, beam_version=None):
+  def __new__(
+      cls, project_name, port, beam_version=None, use_docker_compose_v2=False):
     if project_name not in TransformServiceLauncher._launchers:
       TransformServiceLauncher._launchers[project_name] = super(
           TransformServiceLauncher, cls).__new__(cls)
     return TransformServiceLauncher._launchers[project_name]
 
-  def __init__(self, project_name, port, beam_version=None):
+  def __init__(
+      self, project_name, port, beam_version=None, use_docker_compose_v2=False):
     logging.info('Initializing the Beam Transform Service %s.' % project_name)
 
     self._project_name = project_name
@@ -126,8 +128,8 @@ class TransformServiceLauncher(object):
     self._environmental_variables['PYTHON_REQUIREMENTS_FILE_NAME'] = (
         'requirements.txt')
 
-    self._docker_compose_start_command_prefix = []
-    self._docker_compose_start_command_prefix.append('docker-compose')
+    self._docker_compose_start_command_prefix = (
+        ['docker', 'compose'] if use_docker_compose_v2 else ['docker-compose'])
     self._docker_compose_start_command_prefix.append('-p')
     self._docker_compose_start_command_prefix.append(project_name)
     self._docker_compose_start_command_prefix.append('-f')


### PR DESCRIPTION
Support Docker Compose v2 in Python TransformServiceLauncher

From July 2023, Compose v1 (`docker-compose`) stopped receiving updates. Probably it's time to migrate to modern Compose v2 (`docker compose`).


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
