### PR TITLE
sdks/python: Check if ML RAG Integration Tests Ever Run in the CI

### DIFF
--- a/sdks/python/apache_beam/ml/rag/enrichment/bigquery_vector_search_it_test.py
+++ b/sdks/python/apache_beam/ml/rag/enrichment/bigquery_vector_search_it_test.py
@@ -153,13 +153,13 @@ class TestBigQueryVectorSearchIT(BigQueryVectorSearchIT):
   @classmethod
   def create_table(cls, table_name, schema_fields, table_data):
     """Create a BigQuery table with the specified schema and data.
-    
+
     Args:
         table_name: Name of the table to create
         schema_fields: List of field definitions in the format:
             (name, type, [mode, [subfields]])
         table_data: List of dictionaries containing the data to insert
-    
+
     Returns:
         Fully qualified table name (project.dataset.table)
     """
@@ -258,7 +258,7 @@ class TestBigQueryVectorSearchIT(BigQueryVectorSearchIT):
     with TestPipeline(is_integration_test=True) as p:
       result = (p | beam.Create(test_chunks) | Enrichment(handler))
 
-      assert_that(result, equal_to(expected_chunks))
+      assert_that(result, equal_to([]))
 
   def test_include_distance(self):
     """Test basic vector similarity search."""


### PR DESCRIPTION
## Description

This PR fails `TestBigQueryVectorSearchIT.test_basic_vector_search` itest deliberately to evaluate the hypothesis if the Integration tests in ML RAG module ever run in the CI. The expected result is that one of the related CI workflows should fail

## Motivation and Context

This issue was observed when working on a related PR #35216. It was found that the integration tests in `sdks/python/apache_beam/ml/rag/enrichment/bigquery_vector_search_it_test.py` where `TestPipeline(is_integration_test=True)` was invoked didn't trigger, or more accurately were skipped, in the `beam_PreCommit_Python_ML` job because `--test-pipeline-options` was not passed.

https://github.com/apache/beam/blob/33ea9388fb99e163948deacfc10e50af72f81b3a/sdks/python/apache_beam/ml/rag/enrichment/bigquery_vector_search_it_test.py#L151

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
