### PR TITLE
✨[Feature]: Add pip-based install support for JupyterLab side panel extension

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,7 @@
 ## New Features / Improvements
 
 * X feature added (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
+* Add pip-based install support for JupyterLab Sidepanel extension ([#35397](https://github.com/apache/beam/issues/#35397)).
 
 ## Breaking Changes
 

--- a/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/.gitignore
+++ b/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/.gitignore
@@ -1,0 +1,6 @@
+.yarn/
+apache_beam_jupyterlab_sidepanel/labextension/
+lib/
+tsconfig.tsbuildinfo
+node_modules/
+dist/

--- a/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/README.md
+++ b/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/README.md
@@ -29,13 +29,56 @@ Includes two different side panels:
 | v3                 | v2.0.0-v3.0.0     |
 | v2                 | v1.0.0            |
 
-## Install
+## Installation
+
+There are two ways to install the extension:
+
+### 1. Via pip (recommended)
+
+The extension is now available as a Python package on PyPI.  
+Install it with:
+
+```bash
+pip install apache-beam-jupyterlab-sidepanel
+```
+
+After installation, rebuild JupyterLab to activate the extension:
+
+```bash
+jupyter lab clean
+jupyter lab build
+```
+
+Then restart JupyterLab. The side panels will be available automatically.
+
+
+### 2. Via JupyterLab Extension Manager (legacy, will be deprecated soon)
 
 ```bash
 jupyter labextension install apache-beam-jupyterlab-sidepanel
 ```
 
+This installs the extension using JupyterLab's legacy extension system.
+
+---
+
+## Notes
+
+- Pip installation is now the preferred method as it handles Python packaging and JupyterLab extension registration seamlessly.
+- After any upgrade or reinstallation, always rebuild JupyterLab to ensure the extension is activated.
+- For detailed usage and development, refer to the source code and issues on [GitHub](https://github.com/apache/beam).
+
+---
+
 ## Contributing
+
+> **Note**: When creating a Python package, the **module name (i.e., the folder name and import path)** must use underscores (`_`) instead of dashes (`-`). Dashes are **not allowed** in Python identifiers.  
+> However, the **distribution name** (the name used in `pip install ...`) **can** include dashes, and this is a common convention in the Python ecosystem.  
+> For example:
+> 
+> - `pip install apache-beam-jupyterlab-sidepanel` ✅  
+> - `import apache_beam_jupyterlab_sidepanel` ✅  
+> - `import apache-beam-jupyterlab-sidepanel` ❌ (invalid syntax)
 
 ### Install
 
@@ -117,8 +160,65 @@ jlpm eslint:check
 jlpm eslint
 ```
 
+### Packaging
+
+This JupyterLab extension is distributed as a prebuilt Python package, and includes all necessary frontend assets (TypeScript-compiled JavaScript, styles, and metadata).
+
+#### Build from source
+
+To build the extension locally and package it into a wheel:
+
+```bash
+# Ensure build dependencies are available
+pip install build jupyterlab jupyter_packaging hatch
+
+# Build the wheel and source tarball
+hatch build
+```
+
+This will generate `dist/*.whl` and `dist/*.tar.gz` files.
+
+#### Install locally via pip
+
+```bash
+pip install .
+```
+
+After installation, JupyterLab will automatically discover and enable the extension. You can verify it was installed via:
+
+```bash
+jupyter labextension list
+```
+
+If properly installed, your extension should appear under the `prebuilt extensions` section.
+
+#### File layout expectations
+
+A typical prebuilt extension should include the following structure under your Python package:
+
+```
+apache_beam_jupyterlab_sidepanel/
+├── __init__.py
+├── _version.py
+└── labextension/
+    ├── package.json
+    ├── install.json
+    └── static/
+        └── ...
+```
+
+These will be copied to:
+
+```
+$PREFIX/share/jupyter/labextensions/apache-beam-jupyterlab-sidepanel/
+```
+
 ### Uninstall
 
 ```bash
 jupyter labextension uninstall apache-beam-jupyterlab-sidepanel
+```
+or
+```bash
+pip uninstall apache-beam-jupyterlab-sidepanel
 ```

--- a/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/apache_beam_jupyterlab_sidepanel/__init__.py
+++ b/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/apache_beam_jupyterlab_sidepanel/__init__.py
@@ -1,0 +1,22 @@
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from ._version import __version__
+
+def _jupyter_labextension_paths():
+    return [{
+        "src": "labextension",
+        "dest": "apache-beam-jupyterlab-sidepanel"
+    }]

--- a/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/apache_beam_jupyterlab_sidepanel/_version.py
+++ b/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/apache_beam_jupyterlab_sidepanel/_version.py
@@ -1,0 +1,16 @@
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+__version__ = "4.0.0"

--- a/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/package.json
+++ b/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/package.json
@@ -92,7 +92,7 @@
   ],
   "jupyterlab": {
     "extension": true,
-    "outputDir": "apache-beam-jupyterlab-sidepanel/labextension"
+    "outputDir": "apache_beam_jupyterlab_sidepanel/labextension"
   },
   "test": "jest",
   "resolutions": {

--- a/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/pyproject.toml
+++ b/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/pyproject.toml
@@ -1,3 +1,18 @@
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
 [build-system]
 requires = [
     "hatchling>=1.5.0",

--- a/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/pyproject.toml
+++ b/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = [
+    "hatchling>=1.5.0",
+    "jupyterlab>=4.0.0,<5",
+    "hatch-nodejs-version>=0.3.2",
+]
+build-backend = "hatchling.build"
+
+[project]
+name = "apache_beam_jupyterlab_sidepanel"
+version = "4.0.0"
+description = "JupyterLab Sidepanel for Apache Beam"
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Apache Beam", email = "dev@beam.apache.org" }]
+classifiers = [
+    "Framework :: Jupyter",
+    "Framework :: Jupyter :: JupyterLab",
+    "Framework :: Jupyter :: JupyterLab :: 4",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+]
+dependencies = ["jupyterlab>=4.0.0,<5", "jupyter_server>=2.0.0"]
+
+[tool.hatch.version]
+source = "nodejs"
+
+[tool.hatch.build.targets.sdist]
+artifacts = ["apache_beam_jupyterlab_sidepanel/labextension"]
+
+[tool.hatch.build.targets.wheel.shared-data]
+"apache_beam_jupyterlab_sidepanel/labextension" = "share/jupyter/labextensions/apache-beam-jupyterlab-sidepanel"
+"install.json" = "share/jupyter/labextensions/apache-beam-jupyterlab-sidepanel/install.json"
+
+[tool.hatch.build.hooks.jupyter-builder]
+dependencies = ["hatch-jupyter-builder>=0.5"]
+build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = [
+    "apache_beam_jupyterlab_sidepanel/labextension/static/style.js",
+    "apache_beam_jupyterlab_sidepanel/labextension/package.json",
+]
+build-kwargs = { build_cmd = "build:prod", npm = ["jlpm"] }
+editable-build-kwargs = { build_cmd = "install:extension", npm = [
+    "jlpm",
+], source_dir = "src", build_dir = "apache_beam_jupyterlab_sidepanel/labextension" }
+
+[tool.jupyter-releaser.options]
+version_cmd = "hatch version"

--- a/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/pyproject.toml
+++ b/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/pyproject.toml
@@ -41,6 +41,9 @@ dependencies = ["jupyterlab>=4.0.0,<5", "jupyter_server>=2.0.0"]
 [tool.hatch.version]
 source = "nodejs"
 
+[tool.hatch.build]
+exclude = [".yarn/", "lib/", "node_modules/", "dist/", "tsconfig.tsbuildinfo"]
+
 [tool.hatch.build.targets.sdist]
 artifacts = ["apache_beam_jupyterlab_sidepanel/labextension"]
 


### PR DESCRIPTION
Summary
This PR enables the `apache-beam-jupyterlab-sidepanel` JupyterLab extension to be installed via `pip` directly, without requiring the use of `jupyter labextension install`. Fixing the issue #35397 

This makes the extension fully compatible with the [JupyterLab prebuilt extension system](https://jupyterlab.readthedocs.io/en/stable/extension/extension_dev.html#prebuilt-extensions), improves ease of use, and aligns with the packaging approaches adopted by other JupyterLab 4.x-compatible projects.

Changes
- Introduced pyproject.toml based on [PEP 621](https://peps.python.org/pep-0621/) and [hatchling](https://hatch.pypa.io/latest/).
- Added hatch-jupyter-builder for handling JS asset bundling.
- Configured shared-data installation of labextension files into share/jupyter/labextensions/apache-beam-jupyterlab-sidepanel.
- Ensured compatibility with JupyterLab 4.x via jupyterlab and hatchling constraints.
- Updated .gitignore and README.md to reflect new packaging steps.

Packaging Example
```bash
pip install apache-beam-jupyterlab-sidepanel
```
After installation, the extension is automatically available in JupyterLab — no jupyter labextension install step required.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
