### PR TITLE
Improve exception raised from cache

### DIFF
--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -448,7 +448,7 @@ class BundleProcessorCache(object):
     self.known_not_running_instruction_ids = collections.OrderedDict(
     )  # type: collections.OrderedDict[str, bool]
     self.failed_instruction_ids = collections.OrderedDict(
-    )  # type: collections.OrderedDict[str, bool]
+    )  # type: collections.OrderedDict[str, Exception]
     self.active_bundle_processors = {
     }  # type: Dict[str, Tuple[str, bundle_processor.BundleProcessor]]
     self.cached_bundle_processors = collections.defaultdict(
@@ -537,9 +537,11 @@ class BundleProcessorCache(object):
     """
     with self._lock:
       if instruction_id in self.failed_instruction_ids:
+        e = self.failed_instruction_ids[instruction_id]
         raise RuntimeError(
             'Bundle processing associated with %s has failed. '
-            'Check prior failing response for details.' % instruction_id)
+            'Check prior failing response and attached exception for details.' %
+            instruction_id) from e
       processor = self.active_bundle_processors.get(
           instruction_id, (None, None))[-1]
       if processor:
@@ -548,14 +550,14 @@ class BundleProcessorCache(object):
         return None
       raise RuntimeError('Unknown process bundle id %s.' % instruction_id)
 
-  def discard(self, instruction_id):
-    # type: (str) -> None
+  def discard(self, instruction_id, exception):
+    # type: (str, Exception) -> None
 
     """
     Marks the instruction id as failed shutting down the ``BundleProcessor``.
     """
     with self._lock:
-      self.failed_instruction_ids[instruction_id] = True
+      self.failed_instruction_ids[instruction_id] = exception
       while len(self.failed_instruction_ids) > MAX_FAILED_INSTRUCTIONS:
         self.failed_instruction_ids.popitem(last=False)
       processor = self.active_bundle_processors[instruction_id][1]
@@ -599,7 +601,7 @@ class BundleProcessorCache(object):
       self.periodic_shutdown = None
 
     for instruction_id in list(self.active_bundle_processors.keys()):
-      self.discard(instruction_id)
+      self.discard(instruction_id, RuntimeError('Shutdown invoked'))
     for cached_bundle_processors in self.cached_bundle_processors.values():
       BundleProcessorCache._shutdown_cached_bundle_processors(
           cached_bundle_processors)
@@ -708,9 +710,9 @@ class SdkWorker(object):
       if not requests_finalization:
         self.bundle_processor_cache.release(instruction_id)
       return response
-    except:  # pylint: disable=bare-except
+    except Exception as e:  # pylint: disable=bare-except
       # Don't re-use bundle processors on failure.
-      self.bundle_processor_cache.discard(instruction_id)
+      self.bundle_processor_cache.discard(instruction_id, e)
       raise
 
   def process_bundle_split(
@@ -779,8 +781,8 @@ class SdkWorker(object):
         self.bundle_processor_cache.release(request.instruction_id)
         return beam_fn_api_pb2.InstructionResponse(
             instruction_id=instruction_id, finalize_bundle=finalize_response)
-      except:
-        self.bundle_processor_cache.discard(request.instruction_id)
+      except Exception as e:
+        self.bundle_processor_cache.discard(request.instruction_id, e)
         raise
     # We can reach this state if there was an erroneous request to finalize
     # the bundle while it is being initialized or has already been finalized

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
@@ -160,7 +160,8 @@ class SdkWorkerTest(unittest.TestCase):
     # Add a mock bundle processor as if it was running before it's discarded
     bundle_processor_cache.active_bundle_processors['instruction_id'] = (
         'descriptor_id', bundle_processor)
-    bundle_processor_cache.discard('instruction_id')
+    bundle_processor_cache.discard(
+        'instruction_id', RuntimeError('test message'))
     split_request = beam_fn_api_pb2.InstructionRequest(
         instruction_id='progress_instruction_id',
         process_bundle_progress=beam_fn_api_pb2.ProcessBundleProgressRequest(
@@ -169,6 +170,9 @@ class SdkWorkerTest(unittest.TestCase):
         worker.do_instruction(split_request).error,
         hc.contains_string(
             'Bundle processing associated with instruction_id has failed'))
+    hc.assert_that(
+        worker.do_instruction(split_request).error,
+        hc.contains_string('test message'))
 
   def test_inactive_bundle_processor_returns_empty_split_response(self):
     bundle_processor = mock.MagicMock()
@@ -265,7 +269,8 @@ class SdkWorkerTest(unittest.TestCase):
     # Add a mock bundle processor as if it was running before it's discarded
     bundle_processor_cache.active_bundle_processors['instruction_id'] = (
         'descriptor_id', bundle_processor)
-    bundle_processor_cache.discard('instruction_id')
+    bundle_processor_cache.discard(
+        'instruction_id', RuntimeError('test message'))
     split_request = beam_fn_api_pb2.InstructionRequest(
         instruction_id='split_instruction_id',
         process_bundle_split=beam_fn_api_pb2.ProcessBundleSplitRequest(
@@ -274,6 +279,9 @@ class SdkWorkerTest(unittest.TestCase):
         worker.do_instruction(split_request).error,
         hc.contains_string(
             'Bundle processing associated with instruction_id has failed'))
+    hc.assert_that(
+        worker.do_instruction(split_request).error,
+        hc.contains_string('test message'))
 
   def test_data_sampling_response(self):
     # Create a data sampler with some fake sampled data. This data will be seen


### PR DESCRIPTION
When we fail an instruction, we tell the instruction cache that we've failed it, but we don't provide details. This makes it harder to raise a good exception, but exceptions can still bubble up from the instruction cache (e.g. this happens in the prism runner when a bundle fails during a split request).

This change provides the original exception context that caused the runner to fail in the first place.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
