### PR TITLE
Revert "Removed < 1.66 for grpcio"

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -366,10 +366,9 @@ if __name__ == '__main__':
           'dill>=0.3.1.1,<0.3.2',
           'fastavro>=0.23.6,<2',
           'fasteners>=0.3,<1.0',
-          # any version between 1.68.0 and 1.73.0 is bad
-          # external issue: https://github.com/grpc/grpc/issues/37710
-          'grpcio>=1.33.1,<1.74.0,!=1.48.0,!=1.59.*,!=1.60.*,!=1.61.*,!=1.62.0,!=1.62.1,!=1.68.*,!=1.69.*,!=1.70.*,!=1.71.*,!=1.72.*,!=1.73.0; python_version <= "3.12"',  # pylint: disable=line-too-long
-          'grpcio>=1.73.1; python_version >= "3.13"',
+          # TODO(https://github.com/grpc/grpc/issues/37710): Unpin grpc
+          'grpcio>=1.33.1,<2,!=1.48.0,!=1.59.*,!=1.60.*,!=1.61.*,!=1.62.0,!=1.62.1,<1.66.0; python_version <= "3.12"',  # pylint: disable=line-too-long
+          'grpcio>=1.67.0; python_version >= "3.13"',
           'hdfs>=2.1.0,<3.0.0',
           'httplib2>=0.8,<0.23.0',
           'jsonschema>=4.0.0,<5.0.0',

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -167,12 +167,6 @@ deps =
   pylint==2.17.5
   isort==4.2.15
   flake8==4.0.1
-# https://github.com/grpc/grpc/issues/37660: ignore pip check
-commands_pre =
-  python --version
-  pip --version
-  # pip check
-  bash {toxinidir}/scripts/run_tox_cleanup.sh
 commands =
   pylint --version
   time {toxinidir}/scripts/run_pylint.sh


### PR DESCRIPTION
Reverts apache/beam#34196

The go tests (https://github.com/apache/beam/actions/runs/15907748034/workflow) are still stuck: 

https://github.com/apache/beam/actions/runs/15907748034/job/44867028781

https://github.com/apache/beam/actions/runs/15908913599/job/44870989192


