### PR TITLE
Drop junit-dep dependency by removing system-rules usage

### DIFF
--- a/sdks/java/container/license_scripts/dep_urls_java.yaml
+++ b/sdks/java/container/license_scripts/dep_urls_java.yaml
@@ -61,10 +61,6 @@ jackson-bom:
   '2.15.4':
     license: "https://raw.githubusercontent.com/FasterXML/jackson-bom/master/LICENSE"
     type: "Apache License 2.0"
-junit-dep:
-  '4.11':
-    license: "https://opensource.org/licenses/cpl1.0.txt"
-    type: "Common Public License Version 1.0"
 org.eclipse.jgit:
   '4.4.1.201607150455-r':
     license: "https://www.eclipse.org/org/documents/edl-v10.html"

--- a/sdks/java/core/build.gradle
+++ b/sdks/java/core/build.gradle
@@ -106,7 +106,6 @@ dependencies {
   implementation library.java.snake_yaml
   shadowTest library.java.everit_json_schema
   provided library.java.junit
-  testImplementation "com.github.stefanbirkner:system-rules:1.19.0"
   provided library.java.hamcrest
   provided 'io.airlift:aircompressor:0.18'
   provided 'com.facebook.presto.hadoop:hadoop-apache2:3.2.0-1'
@@ -125,7 +124,6 @@ dependencies {
   shadowTest library.java.log4j2_api
   shadowTest library.java.jamm
   testRuntimeOnly library.java.slf4j_jdk14
-  testImplementation "com.github.stefanbirkner:system-rules:1.19.0"
 }
 
 project.tasks.compileTestJava {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/fn/JvmInitializersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/fn/JvmInitializersTest.java
@@ -27,6 +27,7 @@ import com.google.auto.service.AutoService;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 import org.apache.beam.sdk.harness.JvmInitializer;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -74,7 +75,7 @@ public final class JvmInitializersTest {
 
     // Capture System.out
     out = System.out;
-    System.setOut(new PrintStream(receivedOut = new ByteArrayOutputStream(), true));
+    System.setOut(new PrintStream(receivedOut = new ByteArrayOutputStream(), true, StandardCharsets.UTF_8));
   }
 
   @After
@@ -88,7 +89,7 @@ public final class JvmInitializersTest {
     JvmInitializers.runOnStartup();
 
     assertTrue(onStartupRan);
-    assertThat(() -> new Scanner(new ByteArrayInputStream(receivedOut.toByteArray())),
+    assertThat(() -> new Scanner(new ByteArrayInputStream(receivedOut.toByteArray()), StandardCharsets.UTF_8),
         contains(containsString("Running JvmInitializer#onStartup")));
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/fn/JvmInitializersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/fn/JvmInitializersTest.java
@@ -26,8 +26,9 @@ import static org.junit.Assert.assertTrue;
 import com.google.auto.service.AutoService;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
+import java.io.UnsupportedEncodingException;
 import java.util.Scanner;
 import org.apache.beam.sdk.harness.JvmInitializer;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -68,7 +69,7 @@ public final class JvmInitializersTest {
   }
 
   @Before
-  public void setUp() {
+  public void setUp() throws UnsupportedEncodingException {
     onStartupRan = false;
     beforeProcessingRan = false;
     receivedOptions = null;
@@ -76,7 +77,7 @@ public final class JvmInitializersTest {
     // Capture System.out
     out = System.out;
     System.setOut(
-        new PrintStream(receivedOut = new ByteArrayOutputStream(), true, StandardCharsets.UTF_8));
+        new PrintStream(receivedOut = new ByteArrayOutputStream(), true, "UTF8"));
   }
 
   @After
@@ -86,14 +87,13 @@ public final class JvmInitializersTest {
   }
 
   @Test
-  public void runOnStartup_runsInitializers() {
-    JvmInitializers.runOnStartup();
+  public void runOnStartup_runsInitializers() throws IOException {
 
     assertTrue(onStartupRan);
     assertThat(
         () ->
             new Scanner(
-                new ByteArrayInputStream(receivedOut.toByteArray()), StandardCharsets.UTF_8),
+                new ByteArrayInputStream(receivedOut.toByteArray()), "UTF8"),
         contains(containsString("Running JvmInitializer#onStartup")));
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/fn/JvmInitializersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/fn/JvmInitializersTest.java
@@ -18,7 +18,7 @@
 package org.apache.beam.sdk.fn;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -94,7 +94,7 @@ public final class JvmInitializersTest {
         () ->
             new Scanner(new ByteArrayInputStream(receivedOut.toByteArray()), "UTF8")
                 .useDelimiter(System.lineSeparator()),
-        contains(containsString("Running JvmInitializer#onStartup")));
+        hasItem(containsString("Running JvmInitializer#onStartup")));
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/fn/JvmInitializersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/fn/JvmInitializersTest.java
@@ -92,8 +92,8 @@ public final class JvmInitializersTest {
     assertTrue(onStartupRan);
     assertThat(
         () ->
-            new Scanner(
-                new ByteArrayInputStream(receivedOut.toByteArray()), "UTF8"),
+            new Scanner(new ByteArrayInputStream(receivedOut.toByteArray()), "UTF8")
+                .useDelimiter(System.lineSeparator()),
         contains(containsString("Running JvmInitializer#onStartup")));
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/fn/JvmInitializersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/fn/JvmInitializersTest.java
@@ -17,8 +17,8 @@
  */
 package org.apache.beam.sdk.fn;
 
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -75,7 +75,8 @@ public final class JvmInitializersTest {
 
     // Capture System.out
     out = System.out;
-    System.setOut(new PrintStream(receivedOut = new ByteArrayOutputStream(), true, StandardCharsets.UTF_8));
+    System.setOut(
+        new PrintStream(receivedOut = new ByteArrayOutputStream(), true, StandardCharsets.UTF_8));
   }
 
   @After
@@ -89,7 +90,10 @@ public final class JvmInitializersTest {
     JvmInitializers.runOnStartup();
 
     assertTrue(onStartupRan);
-    assertThat(() -> new Scanner(new ByteArrayInputStream(receivedOut.toByteArray()), StandardCharsets.UTF_8),
+    assertThat(
+        () ->
+            new Scanner(
+                new ByteArrayInputStream(receivedOut.toByteArray()), StandardCharsets.UTF_8),
         contains(containsString("Running JvmInitializer#onStartup")));
   }
 


### PR DESCRIPTION
The junit-dep dependency seems to be causing build issues lately. The system-rules dependency imports junit-dep instead of junit. As far as I could tell it's the only dependency that imports junit-dep and junit is preferred over junit-dep as a dependency. The system-rules dependency hasn't been updated since 2018 and its functionality can be replaced with relative ease.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
