### PR TITLE
Fix flakiness in fuzzy tests and support TimestampTypes in PeriodicImpulse. 

### DIFF
--- a/sdks/python/apache_beam/transforms/periodicsequence.py
+++ b/sdks/python/apache_beam/transforms/periodicsequence.py
@@ -319,11 +319,11 @@ class PeriodicImpulse(PTransform):
         | 'GenSequence' >> beam.ParDo(ImpulseSeqGenDoFn(self.data)))
 
     if not self.data:
-      # This step is only to ensure the current PTransform expansion is
-      # compatible with the previous Beam versions.
-      result = (
-          result
-          | 'MapToTimestamped' >> beam.Map(lambda tt: TimestampedValue(tt, tt)))
+      # This step is actually an identity transform, because the Timestamped
+      # values have already been generated in `ImpulseSeqGenDoFn`.
+      # We keep this step here to prevent the current PeriodicImpulse from
+      # breaking the compatibility.
+      result = (result | 'MapToTimestamped' >> beam.Map(lambda tt: tt))
 
     if self.apply_windowing:
       result = result | 'ApplyWindowing' >> beam.WindowInto(

--- a/sdks/python/apache_beam/transforms/periodicsequence.py
+++ b/sdks/python/apache_beam/transforms/periodicsequence.py
@@ -32,8 +32,8 @@ from apache_beam.transforms import window
 from apache_beam.transforms.ptransform import PTransform
 from apache_beam.transforms.window import TimestampedValue
 from apache_beam.utils import timestamp
-from apache_beam.utils.timestamp import Duration
 from apache_beam.utils.timestamp import MAX_TIMESTAMP
+from apache_beam.utils.timestamp import Duration
 from apache_beam.utils.timestamp import Timestamp
 from apache_beam.utils.timestamp import TimestampTypes
 

--- a/sdks/python/apache_beam/transforms/periodicsequence_test.py
+++ b/sdks/python/apache_beam/transforms/periodicsequence_test.py
@@ -301,6 +301,39 @@ class PeriodicImpulseTest(unittest.TestCase):
         logging.error("Error occurred at random seed=%d", seed)
         raise e
 
+  def test_int_type_input(self):
+    # This test is to verify that if input timestamps and interval are integers,
+    # the generated timestamped values are also integers.
+    # This is necessary for the following test to pass:
+    # apache_beam.examples.snippets.snippets_test.SlowlyChangingSideInputsTest
+    with TestPipeline() as p:
+      ret = (
+          p | PeriodicImpulse(
+              start_timestamp=1, stop_timestamp=5, fire_interval=1))
+      expected = [1, 2, 3, 4]
+      assert_that(
+          ret, equal_to(expected, lambda x, y: type(x) is type(y) and x == y))
+
+  def test_float_type_input(self):
+    with TestPipeline() as p:
+      ret = (
+          p | PeriodicImpulse(
+              start_timestamp=1.0, stop_timestamp=5.0, fire_interval=1))
+      expected = [1.0, 2.0, 3.0, 4.0]
+      assert_that(
+          ret, equal_to(expected, lambda x, y: type(x) is type(y) and x == y))
+
+  def test_timestamp_type_input(self):
+    with TestPipeline() as p:
+      ret = (
+          p | PeriodicImpulse(
+              start_timestamp=Timestamp.of(1),
+              stop_timestamp=Timestamp.of(5),
+              fire_interval=1))
+      expected = [1.0, 2.0, 3.0, 4.0]
+      assert_that(
+          ret, equal_to(expected, lambda x, y: type(x) is type(y) and x == y))
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/sdks/python/apache_beam/transforms/periodicsequence_test.py
+++ b/sdks/python/apache_beam/transforms/periodicsequence_test.py
@@ -261,22 +261,45 @@ class PeriodicImpulseTest(unittest.TestCase):
                 data=data,
                 fire_interval=0.5))
 
-  def test_fuzzy_interval(self):
-    seed = int(time.time() * 1000)
+  def test_fuzzy_length_and_interval(self):
     times = 30
-    logging.warning("random seed=%d", seed)
-    random.seed(seed)
     for _ in range(times):
+      seed = int(time.time() * 1000)
+      random.seed(seed)
       n = int(random.randint(1, 100))
       data = list(range(n))
       m = random.randint(1, 1000)
       interval = m / 1e6
       now = Timestamp.now()
-      with TestPipeline() as p:
-        ret = (
-            p | PeriodicImpulse(
-                start_timestamp=now, data=data, fire_interval=interval))
-        assert_that(ret, equal_to(data))
+      try:
+        with TestPipeline() as p:
+          ret = (
+              p | PeriodicImpulse(
+                  start_timestamp=now, data=data, fire_interval=interval))
+          assert_that(ret, equal_to(data))
+      except Exception as e:  # pylint: disable=broad-except
+        logging.error("Error occurred at random seed=%d", seed)
+        raise e
+
+  def test_fuzzy_length_at_minimal_interval(self):
+    times = 30
+    for _ in range(times):
+      seed = int(time.time() * 1000)
+      seed = 1751135957975
+      random.seed(seed)
+      n = int(random.randint(1, 100))
+      data = list(range(n))
+      interval = 1e-6
+      now = Timestamp.now()
+      try:
+        with TestPipeline() as p:
+          ret = (
+              p | PeriodicImpulse(
+                  start_timestamp=now, data=data, fire_interval=interval))
+          assert_that(ret, equal_to(data))
+      except Exception as e:  # pylint: disable=broad-except
+        logging.error("Error occurred at random seed=%d", seed)
+        raise e
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A follow-up on #35412.

I've identified a flaky test in the test_fuzzy_interval for periodic impulse, which you can see in this [failed test run](https://github.com/apache/beam/actions/runs/15930463705/job/44938138857). The test fails intermittently because the periodic impulse output is either missing an element or has an extra one.

I can reproduce this failure about once every 50-100 runs. The failure rate increases significantly if the interval is set to 1 microsecond.

Here's a comparison of a normal and a failed run after I added some debugging logs:

- Normal run:
  ```
  WARNING:root:random seed=1751056034036
  start=1751056297.165744 data_duration=7.9e-05 interval=1e-06, end=1751056297.165824
  input: 1751056297165744, 1751056297165824, 1
  WARNING:root:outputs=80.000000, start=1751056297165744.000000, start_micros=1751056297165744.000000, 
    end=1751056297165824.000000, end_micros=1751056297165824.000000, 
  end-start=80, interval=0.000001, delta_micros=80, interval_micros=1, delta_micros/interval=80.000000
  ```

- Failed run:
  ```
  WARNING:root:random seed=1751056034036
  start=1751056301.35949 data_duration=7.9e-05 interval=1e-06, end=1751056301.3595698
  input: 1751056301359490, 1751056301359569, 1
  WARNING:root:outputs=79.000000, start=1751056301359490.000000, start_micros=1751056301359490.000000, 
    end=1751056301359569.000000, end_micros=1751056301359569.000000, 
  end-start=79, interval=0.000001, delta_micros=79, interval_micros=1, delta_micros/interval=79.000000
  ERROR:apache_beam.runners.common:Failed assert: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79] == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78], missing elements [79] [while running 'assert_that/Match']
  ```

The root cause is a loss of precision with 64-bit floating-point numbers. As noted in the Wikipedia article on [floating-point arithmetic](https://en.wikipedia.org/wiki/Floating-point_arithmetic#Internal_representation), the precision is limited to about 15-17 decimal digits.

In the failing example, the start time is `1751056301.35949` (16 digits). However, the calculated end time is `1751056301.3595698` (17 digits). When converting the end time to microseconds (`round(end * 1000000)`), we get `1751056301359569` instead of the expected `1751056301359570`. This rounding error causes `delta_micros` to be off by one, leading to the test failure.

This shows we can't rely on floating-point representations of start, end, and interval to accurately determine the number of elements to emit.

To fix this, I propose using integer-based timestamp arithmetic for all calculations. By performing these operations on microseconds directly, we can avoid floating-point inaccuracies and ensure the test's stability.