### PR TITLE
Fix(java/sql): Fix NullPointerException in TextTableProvider for Java 17

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/TextJsonTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/TextJsonTable.java
@@ -22,7 +22,11 @@ import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.extensions.sql.meta.BeamSqlTable;
 import org.apache.beam.sdk.extensions.sql.meta.provider.text.TextTableProvider.JsonToRow;
 import org.apache.beam.sdk.extensions.sql.meta.provider.text.TextTableProvider.RowToJson;
+import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PDone;
+import org.apache.beam.sdk.values.Row;
 
 /**
  * {@link TextJsonTable} is a {@link BeamSqlTable} that reads text files and converts them according
@@ -38,5 +42,12 @@ public class TextJsonTable extends TextTable {
   public TextJsonTable(
       Schema schema, String filePattern, JsonToRow readConverter, RowToJson writerConverter) {
     super(schema, filePattern, readConverter, writerConverter);
+  }
+
+  @Override
+  public PDone buildIOWriter(PCollection<Row> input) {
+    return input
+        .apply("RowToString", writeConverter)
+        .apply("WriteTextFiles", TextIO.write().to(getFilePattern()));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/TextTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/TextTable.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
 public class TextTable extends SchemaBaseBeamTable {
 
   private final PTransform<PCollection<String>, PCollection<Row>> readConverter;
-  private final PTransform<PCollection<Row>, PCollection<String>> writeConverter;
+  protected final PTransform<PCollection<Row>, PCollection<String>> writeConverter;
   private static final TextRowCountEstimator.SamplingStrategy DEFAULT_SAMPLING_STRATEGY =
       new TextRowCountEstimator.LimitNumberOfTotalBytes(1024 * 1024L);
   private final String filePattern;


### PR DESCRIPTION
The TextTableProvider was failing with a NullPointerException when using the JSON format on java 17:

```
> Task :sdks:java:extensions:sql:test

org.apache.beam.sdk.extensions.sql.meta.provider.text.TextTableProviderTest > testJson FAILED
    org.apache.beam.sdk.extensions.sql.impl.ParseException at TextTableProviderTest.java:224
        Caused by: org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.tools.ValidationException at TextTableProviderTest.java:224
            Caused by: java.lang.NullPointerException at TextTableProviderTest.java:224

org.apache.beam.sdk.extensions.sql.meta.provider.text.TextTableProviderTest > testWriteJson FAILED
    org.apache.beam.sdk.extensions.sql.impl.ParseException at TextTableProviderTest.java:305
        Caused by: org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.tools.ValidationException at TextTableProviderTest.java:305
            Caused by: java.lang.NullPointerException at TextTableProviderTest.java:305
```

Overriding the `buildIOWriter` method in `TextJsonTable` to correctly handle writing JSON files.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
