### PR TITLE
Support Protobuf 6.x.

### DIFF
--- a/sdks/python/apache_beam/runners/worker/data_sampler_test.py
+++ b/sdks/python/apache_beam/runners/worker/data_sampler_test.py
@@ -395,7 +395,8 @@ class DataSamplerTest(unittest.TestCase):
       raise Exception('test')
     except Exception:
       exc_info = sys.exc_info()
-    first_sampler.sample_exception('first', exc_info, MAIN_TRANSFORM_ID, 'instid')
+    first_sampler.sample_exception(
+        'first', exc_info, MAIN_TRANSFORM_ID, 'instid')
 
     # Sample a normal element for the output 'b', this will not show up in the
     # final samples response.
@@ -404,11 +405,13 @@ class DataSamplerTest(unittest.TestCase):
 
     samples = self.data_sampler.wait_for_samples(['a', 'b'])
     self.assertEqual(len(samples.element_samples), 2)
-    sample_elements = list(s.elements[0] for s in samples.element_samples.values())
+    sample_elements = list(
+        s.elements[0] for s in samples.element_samples.values())
     num_exceptions = sum(
         1 for element in sample_elements if element.HasField('exception'))
     self.assertEqual(
-        num_exceptions, 1,
+        num_exceptions,
+        1,
         "Only one of the samples should have an exception, found: {}".format(
             sample_elements))
 
@@ -437,7 +440,8 @@ class DataSamplerTest(unittest.TestCase):
       raise Exception('test')
     except Exception:
       exc_info = sys.exc_info()
-    first_sampler.sample_exception('first', exc_info, MAIN_TRANSFORM_ID, 'instid')
+    first_sampler.sample_exception(
+        'first', exc_info, MAIN_TRANSFORM_ID, 'instid')
 
     # Sample a normal element for the output 'b', this will not show up in the
     # final samples response.

--- a/sdks/python/apache_beam/runners/worker/data_sampler_test.py
+++ b/sdks/python/apache_beam/runners/worker/data_sampler_test.py
@@ -383,8 +383,10 @@ class DataSamplerTest(unittest.TestCase):
         MAIN_TRANSFORM_ID, descriptor, self.primitives_coder_factory)
 
     # Get the samples for the two outputs.
-    a_sampler = self.data_sampler.sampler_for_output(MAIN_TRANSFORM_ID, 0)
-    b_sampler = self.data_sampler.sampler_for_output(MAIN_TRANSFORM_ID, 1)
+    # N.B. the order of the samplers is not guaranteed due to Protobuf not
+    # guaranteeing map iteration order.
+    first_sampler = self.data_sampler.sampler_for_output(MAIN_TRANSFORM_ID, 0)
+    second_sampler = self.data_sampler.sampler_for_output(MAIN_TRANSFORM_ID, 1)
 
     # Sample an exception for the output 'a', this will show up in the final
     # samples response.
@@ -393,19 +395,22 @@ class DataSamplerTest(unittest.TestCase):
       raise Exception('test')
     except Exception:
       exc_info = sys.exc_info()
-    a_sampler.sample_exception('a', exc_info, MAIN_TRANSFORM_ID, 'instid')
+    first_sampler.sample_exception('first', exc_info, MAIN_TRANSFORM_ID, 'instid')
 
     # Sample a normal element for the output 'b', this will not show up in the
     # final samples response.
-    b_sampler.element_sampler.el = 'b'
-    b_sampler.element_sampler.has_element = True
+    second_sampler.element_sampler.el = 'second'
+    second_sampler.element_sampler.has_element = True
 
     samples = self.data_sampler.wait_for_samples(['a', 'b'])
     self.assertEqual(len(samples.element_samples), 2)
-    self.assertTrue(
-        samples.element_samples['a'].elements[0].HasField('exception'))
-    self.assertFalse(
-        samples.element_samples['b'].elements[0].HasField('exception'))
+    sample_elements = list(s.elements[0] for s in samples.element_samples.values())
+    num_exceptions = sum(
+        1 for element in sample_elements if element.HasField('exception'))
+    self.assertEqual(
+        num_exceptions, 1,
+        "Only one of the samples should have an exception, found: {}".format(
+            sample_elements))
 
   def test_only_sample_exceptions(self):
     """Tests that the exception sampling experiment only samples exceptions."""
@@ -420,8 +425,10 @@ class DataSamplerTest(unittest.TestCase):
         MAIN_TRANSFORM_ID, descriptor, self.primitives_coder_factory)
 
     # Get the samples for the two outputs.
-    a_sampler = self.data_sampler.sampler_for_output(MAIN_TRANSFORM_ID, 0)
-    b_sampler = self.data_sampler.sampler_for_output(MAIN_TRANSFORM_ID, 1)
+    # N.B. the order of the samplers is not guaranteed due to Protobuf not
+    # guaranteeing map iteration order.
+    first_sampler = self.data_sampler.sampler_for_output(MAIN_TRANSFORM_ID, 0)
+    second_sampler = self.data_sampler.sampler_for_output(MAIN_TRANSFORM_ID, 1)
 
     # Sample an exception for the output 'a', this will show up in the final
     # samples response.
@@ -430,16 +437,17 @@ class DataSamplerTest(unittest.TestCase):
       raise Exception('test')
     except Exception:
       exc_info = sys.exc_info()
-    a_sampler.sample_exception('a', exc_info, MAIN_TRANSFORM_ID, 'instid')
+    first_sampler.sample_exception('first', exc_info, MAIN_TRANSFORM_ID, 'instid')
 
     # Sample a normal element for the output 'b', this will not show up in the
     # final samples response.
-    b_sampler.element_sampler.el = 'b'
-    b_sampler.element_sampler.has_element = True
+    second_sampler.element_sampler.el = 'second'
+    second_sampler.element_sampler.has_element = True
 
     samples = self.data_sampler.wait_for_samples([])
     self.assertEqual(len(samples.element_samples), 1)
-    self.assertIsNotNone(samples.element_samples['a'].elements[0].exception)
+    value = list(samples.element_samples.values())[0]
+    self.assertIsNotNone(value.elements[0].exception)
 
 
 class OutputSamplerTest(unittest.TestCase):

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -390,7 +390,7 @@ if __name__ == '__main__':
           #
           # 3. Exclude protobuf 4 versions that leak memory, see:
           # https://github.com/apache/beam/issues/28246
-          'protobuf>=3.20.3,<6.0.0.dev0,!=4.0.*,!=4.21.*,!=4.22.0,!=4.23.*,!=4.24.*',  # pylint: disable=line-too-long
+          'protobuf>=3.20.3,<7.0.0.dev0,!=4.0.*,!=4.21.*,!=4.22.0,!=4.23.*,!=4.24.*',  # pylint: disable=line-too-long
           'pydot>=1.2.0,<2',
           'python-dateutil>=2.8.0,<3',
           'pytz>=2018.3',


### PR DESCRIPTION
Why? Currently Apache Beam pins protobuf<6.0.0.dev0. Protobuf 6.30.0 was released on March 4, 2025: https://pypi.org/project/protobuf/6.30.0/, https://github.com/protocolbuffers/protobuf/releases/tag/v30.0 is the corresponding release.

Also fixed two flaky tests that became more flaky with the new Protobuf version. They were flaky because Protobuf doesn't guarantee map iteration order, so the sampler instances created [here](https://github.com/apache/beam/blob/b60ce5be96b2ea97084c1330430c8556ca59a8d9/sdks/python/apache_beam/runners/worker/data_sampler.py#L320) doesn't guarantee `'a'` is the first and `'b'` is the second sampler when the tests use `self.make_test_descriptor(outputs=['a', 'b'])`.

Fixes #35432.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
