### PR TITLE
Set pubsup topic cleaner to run

### DIFF
--- a/.test-infra/tools/stale_cleaner.py
+++ b/.test-infra/tools/stale_cleaner.py
@@ -334,4 +334,4 @@ if __name__ == "__main__":
     cleaner.refresh()
 
     # Delete stale resources
-    cleaner.delete_stale()
+    cleaner.delete_stale(dry_run=False)


### PR DESCRIPTION
This is a follow up for the issue #35439. There the cleaner was added as a part of a GitHub Action to be running on cron. After some days reading the output we can confirm this is working as expected so it can be configured with dry_run=false 