### PR TITLE
Remove warning for dofns that don't return anything

### DIFF
--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -1521,9 +1521,6 @@ def _check_fn_use_yield_and_return(fn):
       if has_yield and has_return:
         return True
 
-    if not has_yield and not has_return:
-      _LOGGER.warning(return_none_warning)
-
     return False
   except Exception as e:
     _LOGGER.debug(str(e))


### PR DESCRIPTION
This is often a useful pattern but this warning makes it seem like a bug.

e.g.[ _PassThroughThenCleanup](https://github.com/apache/beam/blob/d5eea11b6fb5c7f5fd8f107be19dc713acb2e0ee/sdks/python/apache_beam/io/gcp/bigquery_read_internal.py#L122) is an example where we have a dofn that doesn't return anything