### PR TITLE
Adding clustering support for python storage write api

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TableDestination.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TableDestination.java
@@ -64,7 +64,7 @@ public class TableDestination implements Serializable {
   public TableDestination(
       String tableSpec,
       @Nullable String tableDescription,
-      TimePartitioning timePartitioning,
+      @Nullable TimePartitioning timePartitioning,
       Clustering clustering) {
     this(
         tableSpec,

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProvider.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProvider.java
@@ -307,19 +307,11 @@ public class BigQueryStorageWriteApiSchemaTransformProvider
             CreateDisposition.valueOf(configuration.getCreateDisposition().toUpperCase());
         write = write.withCreateDisposition(createDisposition);
       }
-
       if (!Strings.isNullOrEmpty(configuration.getWriteDisposition())) {
         WriteDisposition writeDisposition =
             WriteDisposition.valueOf(configuration.getWriteDisposition().toUpperCase());
         write = write.withWriteDisposition(writeDisposition);
       }
-
-      // List<String> clusteringFields = configuration.getClustering();
-      // if (clusteringFields != null && !clusteringFields.isEmpty()) {
-      //   Clustering clustering = new Clustering().setFields(clusteringFields);
-      //   write = write.withClustering(clustering);
-      // }
-
       if (!Strings.isNullOrEmpty(configuration.getKmsKey())) {
         write = write.withKmsKey(configuration.getKmsKey());
       }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProvider.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProvider.java
@@ -313,13 +313,12 @@ public class BigQueryStorageWriteApiSchemaTransformProvider
             WriteDisposition.valueOf(configuration.getWriteDisposition().toUpperCase());
         write = write.withWriteDisposition(writeDisposition);
       }
-      
 
-      List<String> clusteringFields = configuration.getClustering();
-      if (clusteringFields != null && !clusteringFields.isEmpty()) {
-        Clustering clustering = new Clustering().setFields(clusteringFields);
-        write = write.withClustering(clustering);
-      }
+      // List<String> clusteringFields = configuration.getClustering();
+      // if (clusteringFields != null && !clusteringFields.isEmpty()) {
+      //   Clustering clustering = new Clustering().setFields(clusteringFields);
+      //   write = write.withClustering(clustering);
+      // }
 
       if (!Strings.isNullOrEmpty(configuration.getKmsKey())) {
         write = write.withKmsKey(configuration.getKmsKey());

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProvider.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProvider.java
@@ -313,6 +313,14 @@ public class BigQueryStorageWriteApiSchemaTransformProvider
             WriteDisposition.valueOf(configuration.getWriteDisposition().toUpperCase());
         write = write.withWriteDisposition(writeDisposition);
       }
+      
+
+      List<String> clusteringFields = configuration.getClustering();
+      if (clusteringFields != null && !clusteringFields.isEmpty()) {
+        Clustering clustering = new Clustering().setFields(clusteringFields);
+        write = write.withClustering(clustering);
+      }
+
       if (!Strings.isNullOrEmpty(configuration.getKmsKey())) {
         write = write.withKmsKey(configuration.getKmsKey());
       }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryWriteConfiguration.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryWriteConfiguration.java
@@ -195,7 +195,7 @@ public abstract class BigQueryWriteConfiguration {
   public abstract @Nullable String getOnly();
 
   @SchemaFieldDescription("A list of columns to cluster the BigQuery table by.")
-  public abstract @Nullable List<String> getClustering();
+  public abstract @Nullable List<String> getClusteringFields();
 
   /** Builder for {@link BigQueryWriteConfiguration}. */
   @AutoValue.Builder
@@ -229,7 +229,7 @@ public abstract class BigQueryWriteConfiguration {
 
     public abstract Builder setOnly(String only);
 
-    public abstract Builder setClustering(List<String> clustering);
+    public abstract Builder setClusteringFields(List<String> clusteringFields);
 
     /** Builds a {@link BigQueryWriteConfiguration} instance. */
     public abstract BigQueryWriteConfiguration build();

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryWriteConfiguration.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryWriteConfiguration.java
@@ -194,6 +194,9 @@ public abstract class BigQueryWriteConfiguration {
           + "Is mutually exclusive with 'keep' and 'drop'.")
   public abstract @Nullable String getOnly();
 
+  @SchemaFieldDescription("A list of columns to cluster the BigQuery table by.")
+  public abstract @Nullable List<String> getClustering();
+
   /** Builder for {@link BigQueryWriteConfiguration}. */
   @AutoValue.Builder
   public abstract static class Builder {
@@ -225,6 +228,8 @@ public abstract class BigQueryWriteConfiguration {
     public abstract Builder setDrop(List<String> drop);
 
     public abstract Builder setOnly(String only);
+
+    public abstract Builder setClustering(List<String> clustering);
 
     /** Builds a {@link BigQueryWriteConfiguration} instance. */
     public abstract BigQueryWriteConfiguration build();

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/PortableBigQueryDestinations.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/PortableBigQueryDestinations.java
@@ -52,7 +52,7 @@ public class PortableBigQueryDestinations extends DynamicDestinations<Row, Strin
   private final @Nullable List<String> clusteringFields;
 
   public PortableBigQueryDestinations(Schema rowSchema, BigQueryWriteConfiguration configuration) {
-    this.clusteringFields = configuration.getClustering();
+    this.clusteringFields = configuration.getClusteringFields();
     // DYNAMIC_DESTINATIONS magic string is the old way of doing it for cross-language.
     // In that case, we do no interpolation
     if (!configuration.getTable().equals(DYNAMIC_DESTINATIONS)) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/PortableBigQueryDestinations.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/PortableBigQueryDestinations.java
@@ -21,6 +21,7 @@ import static org.apache.beam.sdk.io.gcp.bigquery.providers.BigQueryWriteConfigu
 import static org.apache.beam.sdk.util.Preconditions.checkArgumentNotNull;
 import static org.apache.beam.sdk.util.Preconditions.checkStateNotNull;
 
+import com.google.api.services.bigquery.model.Clustering;
 import com.google.api.services.bigquery.model.TableConstraints;
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.api.services.bigquery.model.TableSchema;
@@ -48,8 +49,10 @@ public class PortableBigQueryDestinations extends DynamicDestinations<Row, Strin
   private @MonotonicNonNull RowStringInterpolator interpolator = null;
   private final @Nullable List<String> primaryKey;
   private final RowFilter rowFilter;
+  private final @Nullable List<String> clusteringFields;
 
   public PortableBigQueryDestinations(Schema rowSchema, BigQueryWriteConfiguration configuration) {
+    this.clusteringFields = configuration.getClustering();
     // DYNAMIC_DESTINATIONS magic string is the old way of doing it for cross-language.
     // In that case, we do no interpolation
     if (!configuration.getTable().equals(DYNAMIC_DESTINATIONS)) {
@@ -79,6 +82,11 @@ public class PortableBigQueryDestinations extends DynamicDestinations<Row, Strin
 
   @Override
   public TableDestination getTable(String destination) {
+
+    if (clusteringFields != null && !clusteringFields.isEmpty()) {
+      Clustering clustering = new Clustering().setFields(clusteringFields);
+      return new TableDestination(destination, null, null, clustering);
+    }
     return new TableDestination(destination, null);
   }
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryManagedIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryManagedIT.java
@@ -103,7 +103,7 @@ public class BigQueryManagedIT {
     String table =
         String.format("%s.%s.%s", PROJECT, BIG_QUERY_DATASET_ID, testName.getMethodName());
     Map<String, Object> writeConfig =
-        ImmutableMap.of("table", table, "clustering", Collections.singletonList("str"));
+        ImmutableMap.of("table", table, "clustering_fields", Collections.singletonList("str"));
 
     // file loads requires a GCS temp location
     String tempLocation = writePipeline.getOptions().as(TestPipelineOptions.class).getTempRoot();

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryManagedIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryManagedIT.java
@@ -20,6 +20,8 @@ package org.apache.beam.sdk.io.gcp.bigquery.providers;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
+import com.google.api.services.bigquery.model.Clustering;
+import com.google.api.services.bigquery.model.Table;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -50,6 +52,7 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Immuta
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -82,6 +85,8 @@ public class BigQueryManagedIT {
       TestPipeline.testingPipelineOptions().as(GcpOptions.class).getProject();
   private static final String BIG_QUERY_DATASET_ID = "bigquery_managed_" + System.nanoTime();
 
+  private static final Clustering CLUSTERING = new Clustering().setFields(Arrays.asList("str"));
+
   @BeforeClass
   public static void setUpTestEnvironment() throws IOException, InterruptedException {
     // Create one BQ dataset for all test cases.
@@ -94,10 +99,11 @@ public class BigQueryManagedIT {
   }
 
   @Test
-  public void testBatchFileLoadsWriteRead() {
+  public void testBatchFileLoadsWriteRead() throws IOException, InterruptedException {
     String table =
         String.format("%s.%s.%s", PROJECT, BIG_QUERY_DATASET_ID, testName.getMethodName());
-    Map<String, Object> writeConfig = ImmutableMap.of("table", table);
+    Map<String, Object> writeConfig =
+        ImmutableMap.of("table", table, "clustering", Collections.singletonList("str"));
 
     // file loads requires a GCS temp location
     String tempLocation = writePipeline.getOptions().as(TestPipelineOptions.class).getTempRoot();
@@ -117,6 +123,11 @@ public class BigQueryManagedIT {
             .getSinglePCollection();
     PAssert.that(outputRows).containsInAnyOrder(ROWS);
     readPipeline.run().waitUntilFinish();
+
+    // Asserting clustering
+    Table tableMetadata =
+        BQ_CLIENT.getTableResource(PROJECT, BIG_QUERY_DATASET_ID, testName.getMethodName());
+    Assert.assertEquals(CLUSTERING, tableMetadata.getClustering());
   }
 
   @Test
@@ -148,7 +159,7 @@ public class BigQueryManagedIT {
 
   public void testDynamicDestinations(boolean streaming) throws IOException, InterruptedException {
     String baseTableName =
-        String.format("%s:%s.dynamic_" + System.nanoTime(), PROJECT, BIG_QUERY_DATASET_ID);
+        String.format("%s.%s.dynamic_" + System.nanoTime(), PROJECT, BIG_QUERY_DATASET_ID);
     String destinationTemplate = baseTableName + "_{dest}";
     Map<String, Object> config =
         ImmutableMap.of("table", destinationTemplate, "drop", Collections.singletonList("dest"));
@@ -173,8 +184,7 @@ public class BigQueryManagedIT {
       long mod = i;
       String dest = destinations.get(i);
       List<Row> writtenRows =
-          BQ_CLIENT
-              .queryUnflattened(String.format("SELECT * FROM [%s]", dest), PROJECT, true, false)
+          BQ_CLIENT.queryUnflattened(String.format("SELECT * FROM `%s`", dest), PROJECT, true, true)
               .stream()
               .map(tableRow -> BigQueryUtils.toBeamRow(rowFilter.outputSchema(), tableRow))
               .collect(Collectors.toList());

--- a/sdks/python/apache_beam/io/external/xlang_bigqueryio_it_test.py
+++ b/sdks/python/apache_beam/io/external/xlang_bigqueryio_it_test.py
@@ -249,6 +249,11 @@ class BigQueryXlangStorageWriteIT(unittest.TestCase):
     table = 'write_with_clustering'
     table_id = '{}:{}.{}'.format(self.project, self.dataset_id, table)
 
+    bq_matcher = BigqueryFullResultMatcher(
+        project=self.project,
+        query="SELECT * FROM {}.{}".format(self.dataset_id, table),
+        data=self.parse_expected_data(self.ELEMENTS))
+
     with beam.Pipeline(argv=self.args) as p:
       _ = (
           p
@@ -268,6 +273,7 @@ class BigQueryXlangStorageWriteIT(unittest.TestCase):
     clustering_fields = table.clustering.fields if table.clustering else []
 
     self.assertEqual(clustering_fields, ['int'])
+    hamcrest_assert(p, bq_matcher)
 
   def test_write_with_beam_rows_cdc(self):
     table = 'write_with_beam_rows_cdc'

--- a/sdks/python/apache_beam/io/external/xlang_bigqueryio_it_test.py
+++ b/sdks/python/apache_beam/io/external/xlang_bigqueryio_it_test.py
@@ -107,7 +107,6 @@ class BigQueryXlangStorageWriteIT(unittest.TestCase):
     self.test_pipeline = TestPipeline(is_integration_test=True)
     self.args = self.test_pipeline.get_full_options_as_args()
     self.project = self.test_pipeline.get_option('project')
-    self.project = "tanusharmaa"
     self._runner = PipelineOptions(self.args).get_all_options()['runner']
 
     self.bigquery_client = BigQueryWrapper()
@@ -247,29 +246,28 @@ class BigQueryXlangStorageWriteIT(unittest.TestCase):
     hamcrest_assert(p, bq_matcher)
 
   def test_write_with_clustering(self):
-        table = 'write_with_clustering'
-        table_id = '{}:{}.{}'.format(self.project, self.dataset_id, table)
+    table = 'write_with_clustering'
+    table_id = '{}:{}.{}'.format(self.project, self.dataset_id, table)
 
-        with beam.Pipeline(argv=self.args) as p:
-            _ = (
-                p
-                | "Create test data" >> beam.Create(self.ELEMENTS)
-                | beam.io.WriteToBigQuery(
-                    table=table_id,
-                    method=beam.io.WriteToBigQuery.Method.STORAGE_WRITE_API,
-                    schema=self.ALL_TYPES_SCHEMA,
-                    create_disposition='CREATE_IF_NEEDED',
-                    write_disposition='WRITE_TRUNCATE',
-                    additional_bq_parameters={
-                        'clustering': {'fields': ['int']}
-                    }))
+    with beam.Pipeline(argv=self.args) as p:
+      _ = (
+          p
+          | "Create test data" >> beam.Create(self.ELEMENTS)
+          | beam.io.WriteToBigQuery(
+                table=table_id,
+                method=beam.io.WriteToBigQuery.Method.STORAGE_WRITE_API,
+                schema=self.ALL_TYPES_SCHEMA,
+                create_disposition='CREATE_IF_NEEDED',
+                write_disposition='WRITE_TRUNCATE',
+                additional_bq_parameters={
+                'clustering': {'fields': ['int']}
+                }))
 
-        # After pipeline finishes, verify clustering is applied
-        table = self.bigquery_client.get_table(self.project, self.dataset_id, table)
-        clustering_fields = table.clustering.fields if table.clustering else []
+    # After pipeline finishes, verify clustering is applied
+    table = self.bigquery_client.get_table(self.project, self.dataset_id, table)
+    clustering_fields = table.clustering.fields if table.clustering else []
 
-        self.assertEqual(clustering_fields, ['int'])
-  
+    self.assertEqual(clustering_fields, ['int'])
 
   def test_write_with_beam_rows_cdc(self):
     table = 'write_with_beam_rows_cdc'

--- a/sdks/python/apache_beam/io/external/xlang_bigqueryio_it_test.py
+++ b/sdks/python/apache_beam/io/external/xlang_bigqueryio_it_test.py
@@ -254,14 +254,14 @@ class BigQueryXlangStorageWriteIT(unittest.TestCase):
           p
           | "Create test data" >> beam.Create(self.ELEMENTS)
           | beam.io.WriteToBigQuery(
-                table=table_id,
-                method=beam.io.WriteToBigQuery.Method.STORAGE_WRITE_API,
-                schema=self.ALL_TYPES_SCHEMA,
-                create_disposition='CREATE_IF_NEEDED',
-                write_disposition='WRITE_TRUNCATE',
-                additional_bq_parameters={
-                'clustering': {'fields': ['int']}
-                }))
+              table=table_id,
+              method=beam.io.WriteToBigQuery.Method.STORAGE_WRITE_API,
+              schema=self.ALL_TYPES_SCHEMA,
+              create_disposition='CREATE_IF_NEEDED',
+              write_disposition='WRITE_TRUNCATE',
+              additional_bq_parameters={'clustering': {
+                  'fields': ['int']
+              }}))
 
     # After pipeline finishes, verify clustering is applied
     table = self.bigquery_client.get_table(self.project, self.dataset_id, table)

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -2631,14 +2631,17 @@ class StorageWriteToBigQuery(PTransform):
                 schema, True).with_output_types())
       # communicate to Java that this write should use dynamic destinations
       table = StorageWriteToBigQuery.DYNAMIC_DESTINATIONS
-    
-    clustering_fields = []
-    if self.additional_bq_parameters and "clustering" in self.additional_bq_parameters:
-      clustering_fields = self.additional_bq_parameters.get("clustering", {}).get("fields", [])
-    else:
-      clustering_fields = []
 
-    print(clustering_fields)  
+    clustering_fields = []
+    if self.additional_bq_parameters:
+      if callable(self.additional_bq_parameters):
+        raise NotImplementedError(
+          "Currently, dynamic clustering and timepartitioning is not "
+          "supported for this write method.")
+      clustering_fields = (
+          self.additional_bq_parameters
+          .get("clustering", {})
+          .get("fields", []))
 
     output = (
         input_beam_rows

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -2636,12 +2636,10 @@ class StorageWriteToBigQuery(PTransform):
     if self.additional_bq_parameters:
       if callable(self.additional_bq_parameters):
         raise NotImplementedError(
-          "Currently, dynamic clustering and timepartitioning is not "
-          "supported for this write method.")
+            "Currently, dynamic clustering and timepartitioning is not "
+            "supported for this write method.")
       clustering_fields = (
-          self.additional_bq_parameters
-          .get("clustering", {})
-          .get("fields", []))
+          self.additional_bq_parameters.get("clustering", {}).get("fields", []))
 
     output = (
         input_beam_rows

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -2637,7 +2637,7 @@ class StorageWriteToBigQuery(PTransform):
       if callable(self.additional_bq_parameters):
         raise NotImplementedError(
             "Currently, dynamic clustering and timepartitioning is not "
-            "supported for this write method.")
+            "supported for STORAGE_WRITE_API write method.")
       clustering_fields = (
           self.additional_bq_parameters.get("clustering", {}).get("fields", []))
 
@@ -2656,7 +2656,7 @@ class StorageWriteToBigQuery(PTransform):
             use_at_least_once_semantics=self._use_at_least_once,
             use_cdc_writes=self._use_cdc_writes,
             primary_key=self._primary_key,
-            clustering=clustering_fields,
+            clustering_fields=clustering_fields,
             error_handling={
                 'output': StorageWriteToBigQuery.FAILED_ROWS_WITH_ERRORS
             }))

--- a/website/www/site/content/en/documentation/io/managed-io.md
+++ b/website/www/site/content/en/documentation/io/managed-io.md
@@ -775,18 +775,6 @@ and Beam SQL is invoked via the Managed API under the hood.
         Determines how often to 'commit' progress into BigQuery. Default is every 5 seconds.
       </td>
     </tr>
-    <tr>
-      <td>
-        clustering
-      </td>
-      <td>
-        <code>list[<span style="color: green;">str</span>]</code>
-      </td>
-      <td>
-        A list of clustering fields to use when writing to output table.
-      </td>
-    </tr>
-    <tr>
   </table>
 </div>
 

--- a/website/www/site/content/en/documentation/io/managed-io.md
+++ b/website/www/site/content/en/documentation/io/managed-io.md
@@ -775,6 +775,18 @@ and Beam SQL is invoked via the Managed API under the hood.
         Determines how often to 'commit' progress into BigQuery. Default is every 5 seconds.
       </td>
     </tr>
+    <tr>
+      <td>
+        clustering
+      </td>
+      <td>
+        <code>list[<span style="color: green;">str</span>]</code>
+      </td>
+      <td>
+        A list of clustering fields to use when writing to output table.
+      </td>
+    </tr>
+    <tr>
   </table>
 </div>
 


### PR DESCRIPTION
It resolves a part of #35329 

1.Dynamic clustering is not supported yet. It makes sense to support dynamic clustering after we support dynamic schema for Python Bigquery Storage Write API.
2.Clustering Support for Bigquery Managed IO.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
