### PR TITLE
feat(options): add support for comma-separated options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,9 @@
 * X feature added (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
 * Add pip-based install support for JupyterLab Sidepanel extension ([#35397](https://github.com/apache/beam/issues/#35397)).
 * [IcebergIO] Create tables with a specified table properties ([#35496](https://github.com/apache/beam/pull/35496))
+* Add support for comma-separated options in Python SDK (Python) ([#35580](https://github.com/apache/beam/pull/35580)).
+  Python SDK now supports comma-separated values for experiments and dataflow_service_options,
+  matching Java SDK behavior while maintaining backward compatibility.
 * Milvus enrichment handler added (Python) ([#35216](https://github.com/apache/beam/pull/35216)).
   Beam now supports Milvus enrichment handler capabilities for vector, keyword,
   and hybrid search operations.

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -227,9 +227,10 @@ class _CommaSeparatedListAction(argparse.Action):
   as separate experiments 'abc' and 'def', similar to how Java SDK handles
   them.
   
-  For key=value experiments, only splits at commas that are not part of the
-  value. For example: 'abc,def,master_key=k1=v1,k2=v2' becomes
-  ['abc', 'def', 'master_key=k1=v1,k2=v2']
+  If there are key=value experiments in a raw argument, the remaining part of
+  the argument are treated as values and won't split further. For example:
+  'abc,def,master_key=k1=v1,k2=v2' becomes
+  ['abc', 'def', 'master_key=k1=v1,k2=v2'].
   """
   def __call__(self, parser, namespace, values, option_string=None):
     if not hasattr(namespace, self.dest) or getattr(namespace,

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -227,7 +227,8 @@ class _CommaSeparatedListAction(argparse.Action):
   experiments 'abc' and 'def', similar to how Java SDK handles them.
   
   For key=value experiments, only splits at commas that are not part of the value.
-  For example: 'abc,def,master_key=k1=v1,k2=v2' becomes ['abc', 'def', 'master_key=k1=v1,k2=v2']
+  For example: 'abc,def,master_key=k1=v1,k2=v2' becomes
+  ['abc', 'def', 'master_key=k1=v1,k2=v2']
   """
   def __call__(self, parser, namespace, values, option_string=None):
     if not hasattr(namespace,
@@ -236,7 +237,8 @@ class _CommaSeparatedListAction(argparse.Action):
 
     # Split comma-separated values and extend the list
     if isinstance(values, str):
-      # Smart splitting: only split at commas that are not part of key=value pairs
+      # Smart splitting: only split at commas that are not part of
+      # key=value pairs
       split_values = self._smart_split(values)
       getattr(namespace, self.dest).extend(split_values)
     else:
@@ -244,7 +246,8 @@ class _CommaSeparatedListAction(argparse.Action):
       getattr(namespace, self.dest).append(values)
 
   def _smart_split(self, values):
-    """Split comma-separated values, but preserve commas within key=value pairs."""
+    """Split comma-separated values, but preserve commas within
+    key=value pairs."""
     result = []
     current = []
     equals_depth = 0

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -222,12 +222,13 @@ class _GcsCustomAuditEntriesAction(argparse.Action):
 
 class _CommaSeparatedListAction(argparse.Action):
   """
-  Argparse Action that splits comma-separated values and appends them to a list.
-  This allows options like --experiments=abc,def to be treated as separate
-  experiments 'abc' and 'def', similar to how Java SDK handles them.
+  Argparse Action that splits comma-separated values and appends them to
+  a list. This allows options like --experiments=abc,def to be treated
+  as separate experiments 'abc' and 'def', similar to how Java SDK handles
+  them.
   
-  For key=value experiments, only splits at commas that are not part of the value.
-  For example: 'abc,def,master_key=k1=v1,k2=v2' becomes
+  For key=value experiments, only splits at commas that are not part of the
+  value. For example: 'abc,def,master_key=k1=v1,k2=v2' becomes
   ['abc', 'def', 'master_key=k1=v1,k2=v2']
   """
   def __call__(self, parser, namespace, values, option_string=None):

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -143,8 +143,8 @@ class _DictUnionAction(argparse.Action):
   than one of the values, the last value takes precedence.
   """
   def __call__(self, parser, namespace, values, option_string=None):
-    if not hasattr(namespace,
-                   self.dest) or getattr(namespace, self.dest) is None:
+    if not hasattr(namespace, self.dest) or getattr(namespace,
+                                                    self.dest) is None:
       setattr(namespace, self.dest, {})
     getattr(namespace, self.dest).update(values)
 
@@ -194,8 +194,8 @@ class _GcsCustomAuditEntriesAction(argparse.Action):
                                  key] = value
 
   def __call__(self, parser, namespace, values, option_string=None):
-    if not hasattr(namespace,
-                   self.dest) or getattr(namespace, self.dest) is None:
+    if not hasattr(namespace, self.dest) or getattr(namespace,
+                                                    self.dest) is None:
       setattr(namespace, self.dest, {})
       self._custom_audit_entries = getattr(namespace, self.dest)
 
@@ -232,8 +232,8 @@ class _CommaSeparatedListAction(argparse.Action):
   ['abc', 'def', 'master_key=k1=v1,k2=v2']
   """
   def __call__(self, parser, namespace, values, option_string=None):
-    if not hasattr(namespace,
-                   self.dest) or getattr(namespace, self.dest) is None:
+    if not hasattr(namespace, self.dest) or getattr(namespace,
+                                                    self.dest) is None:
       setattr(namespace, self.dest, [])
 
     # Split comma-separated values and extend the list
@@ -791,7 +791,8 @@ def additional_option_ptransform_fn():
 
 # Optional type checks that aren't enabled by default.
 additional_type_checks: Dict[str, Callable[[], None]] = {
-    'ptransform_fn': additional_option_ptransform_fn, }
+    'ptransform_fn': additional_option_ptransform_fn,
+}
 
 
 def enable_all_additional_type_checks():

--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -920,7 +920,8 @@ class PipelineOptionsTest(unittest.TestCase):
     self.assertEqual(['abc', 'def'], options.get_all_options()['experiments'])
 
   def test_comma_separated_dataflow_service_options(self):
-    """Test that comma-separated dataflow service options are parsed correctly."""
+    """Test that comma-separated dataflow service options are parsed
+    correctly."""
     # Test single option
     options = PipelineOptions(['--dataflow_service_options=option1=value1'])
     self.assertEqual(['option1=value1'],
@@ -928,7 +929,8 @@ class PipelineOptionsTest(unittest.TestCase):
 
     # Test comma-separated options
     options = PipelineOptions([
-        '--dataflow_service_options=option1=value1,option2=value2,option3=value3'
+        '--dataflow_service_options=option1=value1,option2=value2,'
+        'option3=value3'
     ])
     self.assertEqual(['option1=value1', 'option2=value2', 'option3=value3'],
                      options.get_all_options()['dataflow_service_options'])

--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -893,6 +893,56 @@ class PipelineOptionsTest(unittest.TestCase):
             'staging_location.'
         ])
 
+  def test_comma_separated_experiments(self):
+    """Test that comma-separated experiments are parsed correctly."""
+    # Test single experiment
+    options = PipelineOptions(['--experiments=abc'])
+    self.assertEqual(['abc'], options.get_all_options()['experiments'])
+
+    # Test comma-separated experiments
+    options = PipelineOptions(['--experiments=abc,def,ghi'])
+    self.assertEqual(['abc', 'def', 'ghi'],
+                     options.get_all_options()['experiments'])
+
+    # Test multiple flags with comma-separated values
+    options = PipelineOptions(
+        ['--experiments=abc,def', '--experiments=ghi,jkl'])
+    self.assertEqual(['abc', 'def', 'ghi', 'jkl'],
+                     options.get_all_options()['experiments'])
+
+    # Test with spaces around commas
+    options = PipelineOptions(['--experiments=abc, def , ghi'])
+    self.assertEqual(['abc', 'def', 'ghi'],
+                     options.get_all_options()['experiments'])
+
+    # Test empty values are filtered out
+    options = PipelineOptions(['--experiments=abc,,def,'])
+    self.assertEqual(['abc', 'def'], options.get_all_options()['experiments'])
+
+  def test_comma_separated_dataflow_service_options(self):
+    """Test that comma-separated dataflow service options are parsed correctly."""
+    # Test single option
+    options = PipelineOptions(['--dataflow_service_options=option1=value1'])
+    self.assertEqual(['option1=value1'],
+                     options.get_all_options()['dataflow_service_options'])
+
+    # Test comma-separated options
+    options = PipelineOptions([
+        '--dataflow_service_options=option1=value1,option2=value2,option3=value3'
+    ])
+    self.assertEqual(['option1=value1', 'option2=value2', 'option3=value3'],
+                     options.get_all_options()['dataflow_service_options'])
+
+    # Test multiple flags with comma-separated values
+    options = PipelineOptions([
+        '--dataflow_service_options=option1=value1,option2=value2',
+        '--dataflow_service_options=option3=value3,option4=value4'
+    ])
+    self.assertEqual([
+        'option1=value1', 'option2=value2', 'option3=value3', 'option4=value4'
+    ],
+                     options.get_all_options()['dataflow_service_options'])
+
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)

--- a/sdks/python/apache_beam/options/value_provider_test.py
+++ b/sdks/python/apache_beam/options/value_provider_test.py
@@ -216,8 +216,8 @@ class ValueProviderTests(unittest.TestCase):
     options = PipelineOptions(['--experiments', 'a', '--experiments', 'b,c'])
     options = options.view_as(DebugOptions)
     self.assertIn('a', options.experiments)
-    self.assertIn('b,c', options.experiments)
-    self.assertNotIn('c', options.experiments)
+    self.assertIn('b', options.experiments)
+    self.assertIn('c', options.experiments)
 
   def test_nested_value_provider_wrap_static(self):
     vp = NestedValueProvider(StaticValueProvider(int, 1), lambda x: x + 1)


### PR DESCRIPTION

Implement _CommaSeparatedListAction to handle comma-separated values for experiments and dataflow_service_options, matching Java SDK behavior. This allows more flexible input formats while maintaining backward compatibility.

Fixes #35563

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
