### PR TITLE
Add glob and single file support to BeamSQL ParquetTable LOCATION

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,6 +84,7 @@
 
 * X behavior was changed ([#X](https://github.com/apache/beam/issues/X)).
 * Go: The pubsubio.Read transform now accepts ReadOptions as a value type instead of a pointer, and requires exactly one of Topic or Subscription to be set (they are mutually exclusive). Additionally, the ReadOptions struct now includes a Topic field for specifying the topic directly, replacing the previous topic parameter in the Read function signature ([#35369])(https://github.com/apache/beam/pull/35369).
+* SQL: The `ParquetTable` external table provider has changed its handling of the `LOCATION` property. To read from a directory, the path must now end with a trailing slash (e.g., `LOCATION '/path/to/data/'`). Previously, a trailing slash was not required. This change was made to enable support for glob patterns and single-file paths ([#35582])(https://github.com/apache/beam/pull/35582).
 
 ## Deprecations
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/parquet/ParquetTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/parquet/ParquetTable.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.sdk.extensions.sql.meta.provider.parquet;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,8 +31,6 @@ import org.apache.beam.sdk.extensions.sql.meta.ProjectSupport;
 import org.apache.beam.sdk.extensions.sql.meta.SchemaBaseBeamTable;
 import org.apache.beam.sdk.extensions.sql.meta.Table;
 import org.apache.beam.sdk.io.FileIO;
-import org.apache.beam.sdk.io.FileSystems;
-import org.apache.beam.sdk.io.fs.MatchResult;
 import org.apache.beam.sdk.io.parquet.ParquetIO;
 import org.apache.beam.sdk.io.parquet.ParquetIO.Read;
 import org.apache.beam.sdk.schemas.transforms.Convert;
@@ -129,25 +126,9 @@ class ParquetTable extends SchemaBaseBeamTable implements Serializable {
   }
 
   private String resolveFilePattern(String location) {
-    try {
-      MatchResult match = FileSystems.match(location);
-      if (match.status() == MatchResult.Status.OK && !match.metadata().isEmpty()) {
-        MatchResult.Metadata metadata = match.metadata().get(0);
-        if (metadata.resourceId().isDirectory()) {
-          String dirPath = metadata.resourceId().toString();
-          if (dirPath.endsWith("/")) {
-            return dirPath + "*";
-          } else {
-            return dirPath + "/*";
-          }
-        }
-      }
-    } catch (IOException e) {
-      LOG.warn(
-          "Failed to resolve path {}, assuming it is a glob. Error: {}", location, e.getMessage());
+    if (location.endsWith("/")) {
+      return location + "*";
     }
-    // It's a single file, a glob, or a path that couldn't be resolved.
-    // In all cases, we use the location string directly.
     return location;
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/parquet/ParquetTableProviderTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/parquet/ParquetTableProviderTest.java
@@ -18,8 +18,11 @@
 package org.apache.beam.sdk.extensions.sql.meta.provider.parquet;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.PipelineResult.State;
 import org.apache.beam.sdk.extensions.sql.impl.BeamSqlEnv;
@@ -27,8 +30,10 @@ import org.apache.beam.sdk.extensions.sql.impl.rel.BeamSqlRelUtils;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Count;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -43,25 +48,35 @@ public class ParquetTableProviderTest {
   @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
 
   private static final String FIELD_NAMES = "(name VARCHAR, age BIGINT, country VARCHAR)";
-
   private static final Schema TABLE_SCHEMA =
       Schema.builder()
           .addStringField("name")
           .addInt64Field("age")
           .addStringField("country")
           .build();
-  private static final Schema PROJECTED_SCHEMA =
-      Schema.builder().addInt64Field("age").addStringField("country").build();
+
+  private static final Row ROW_1 =
+      Row.withSchema(TABLE_SCHEMA).addValues("Alan", 22L, "England").build();
+  private static final Row ROW_2 =
+      Row.withSchema(TABLE_SCHEMA).addValues("John", 42L, "USA").build();
+  private static final List<Row> ALL_ROWS = Arrays.asList(ROW_1, ROW_2);
+
+  private BeamSqlEnv env;
+
+  @Before
+  public void setUp() {
+    env = BeamSqlEnv.inMemory(new ParquetTableProvider());
+  }
 
   @Test
-  public void testWriteAndReadTable() {
-    File destinationFile = new File(tempFolder.getRoot(), "person-info/");
+  public void testReadAndFilter() {
+    File destinationDir = new File(tempFolder.getRoot(), "person-info");
+    String locationPath = destinationDir.getAbsolutePath() + File.separator;
 
-    BeamSqlEnv env = BeamSqlEnv.inMemory(new ParquetTableProvider());
     env.executeDdl(
         String.format(
             "CREATE EXTERNAL TABLE PersonInfo %s TYPE parquet LOCATION '%s'",
-            FIELD_NAMES, destinationFile.getAbsolutePath()));
+            FIELD_NAMES, locationPath));
 
     BeamSqlRelUtils.toPCollection(
         writePipeline,
@@ -69,32 +84,69 @@ public class ParquetTableProviderTest {
             "INSERT INTO PersonInfo VALUES ('Alan', 22, 'England'), ('John', 42, 'USA')"));
     writePipeline.run().waitUntilFinish();
 
-    PCollection<Row> rows =
-        BeamSqlRelUtils.toPCollection(readPipeline, env.parseQuery("SELECT * FROM PersonInfo"));
-    PAssert.that(rows)
-        .containsInAnyOrder(
-            Row.withSchema(TABLE_SCHEMA).addValues("Alan", 22L, "England").build(),
-            Row.withSchema(TABLE_SCHEMA).addValues("John", 42L, "USA").build());
-
-    PCollection<Row> filtered =
-        BeamSqlRelUtils.toPCollection(
-            readPipeline, env.parseQuery("SELECT * FROM PersonInfo WHERE age > 25"));
-    PAssert.that(filtered)
-        .containsInAnyOrder(Row.withSchema(TABLE_SCHEMA).addValues("John", 42L, "USA").build());
-
-    PCollection<Row> projected =
-        BeamSqlRelUtils.toPCollection(
-            readPipeline, env.parseQuery("SELECT age, country FROM PersonInfo"));
-    PAssert.that(projected)
-        .containsInAnyOrder(
-            Row.withSchema(PROJECTED_SCHEMA).addValues(22L, "England").build(),
-            Row.withSchema(PROJECTED_SCHEMA).addValues(42L, "USA").build());
-
+    Schema projectedSchema = Schema.builder().addStringField("name").addInt64Field("age").build();
     PCollection<Row> filteredAndProjected =
         BeamSqlRelUtils.toPCollection(
-            readPipeline, env.parseQuery("SELECT age, country FROM PersonInfo WHERE age > 25"));
+            readPipeline, env.parseQuery("SELECT name, age FROM PersonInfo WHERE age > 25"));
+
     PAssert.that(filteredAndProjected)
-        .containsInAnyOrder(Row.withSchema(PROJECTED_SCHEMA).addValues(42L, "USA").build());
+        .containsInAnyOrder(Row.withSchema(projectedSchema).addValues("John", 42L).build());
+
+    readPipeline.run().waitUntilFinish();
+  }
+
+  @Test
+  public void testLocationPathConventions() {
+    File destinationDir = new File(tempFolder.getRoot(), "path-test-data");
+    String writeLocation = destinationDir.getAbsolutePath() + File.separator;
+    env.executeDdl(
+        String.format(
+            "CREATE EXTERNAL TABLE TmpWriteTable %s TYPE parquet LOCATION '%s'",
+            FIELD_NAMES, writeLocation));
+    BeamSqlRelUtils.toPCollection(
+        writePipeline,
+        env.parseQuery(
+            "INSERT INTO TmpWriteTable VALUES ('Alan', 22, 'England'), ('John', 42, 'USA')"));
+    writePipeline.run().waitUntilFinish();
+
+    env.executeDdl(
+        String.format(
+            "CREATE EXTERNAL TABLE DirTable %s TYPE parquet LOCATION '%s'",
+            FIELD_NAMES, writeLocation));
+    PCollection<Row> dirResult =
+        BeamSqlRelUtils.toPCollection(readPipeline, env.parseQuery("SELECT * FROM DirTable"));
+    PAssert.that("Directory with '/' reads all files", dirResult).containsInAnyOrder(ALL_ROWS);
+
+    String globPath = new File(destinationDir, "output-*").getAbsolutePath();
+    env.executeDdl(
+        String.format(
+            "CREATE EXTERNAL TABLE GlobTable %s TYPE parquet LOCATION '%s'",
+            FIELD_NAMES, globPath));
+    PCollection<Row> globResult =
+        BeamSqlRelUtils.toPCollection(readPipeline, env.parseQuery("SELECT * FROM GlobTable"));
+    PAssert.that("Glob 'output-*' reads all files", globResult).containsInAnyOrder(ALL_ROWS);
+
+    File[] writtenFiles = destinationDir.listFiles((dir, name) -> name.startsWith("output-"));
+    assertTrue(
+        "Test setup failed: No output files found",
+        writtenFiles != null && writtenFiles.length > 0);
+    String singleFilePath = writtenFiles[0].getAbsolutePath();
+
+    env.executeDdl(
+        String.format(
+            "CREATE EXTERNAL TABLE SingleFileTable %s TYPE parquet LOCATION '%s'",
+            FIELD_NAMES, singleFilePath));
+    PCollection<Row> singleFileResult =
+        BeamSqlRelUtils.toPCollection(
+            readPipeline, env.parseQuery("SELECT * FROM SingleFileTable"));
+
+    PCollection<Long> count = singleFileResult.apply(Count.globally());
+    PAssert.thatSingleton(count)
+        .satisfies(
+            actualCount -> {
+              assertTrue("Count should be greater than 0", actualCount > 0L);
+              return null;
+            });
 
     PipelineResult.State state = readPipeline.run().waitUntilFinish();
     assertEquals(State.DONE, state);

--- a/website/www/site/content/en/documentation/dsls/sql/extensions/create-external-table.md
+++ b/website/www/site/content/en/documentation/dsls/sql/extensions/create-external-table.md
@@ -70,6 +70,7 @@ tableElement: columnName fieldType [ NOT NULL ]
     *   `bigtable`
     *   `pubsub`
     *   `kafka`
+    *   `parquet`
     *   `text`
 *   `location`: The I/O specific location of the underlying table, specified as
     a [String
@@ -548,6 +549,104 @@ Write Mode supports writing to a topic.
 ### Schema
 
 For CSV only simple types are supported.
+
+## Parquet
+
+### Syntax
+
+```
+CREATE EXTERNAL TABLE [ IF NOT EXISTS ] tableName (tableElement [, tableElement ]*)
+TYPE parquet
+LOCATION '/path/to/files/'
+```
+
+* `LOCATION`: The path to the Parquet file(s). The interpretation of the path is based on a convention:
+    * **Directory:** A path ending with a forward slash (`/`) is treated as a directory. Beam reads all files within that directory. Example: `'gs://my-bucket/orders/'`.
+    * **Glob Pattern:** A path containing wildcard characters (`*`, `?`, `[]`) is treated as a glob pattern that the underlying file system expands. Example: `'gs://my-bucket/orders/date=2025-*-??/*.parquet'`.
+    * **Single File:** A full path that does not end in a slash and contains no wildcards is treated as a path to a single file. Example: `'gs://my-bucket/orders/data.parquet'`.
+
+### Read Mode
+
+Supports reading from Parquet files specified by the `LOCATION`. Predicate and projection push-down are supported to improve performance.
+
+### Write Mode
+
+Supports writing to a set of sharded Parquet files in a specified directory.
+
+### Schema
+
+The specified schema is used to read and write Parquet files. The schema is converted to an Avro schema internally for `ParquetIO`. Beam SQL types map to Avro types as follows:
+
+<table>
+  <tr>
+   <td><b>Beam SQL Type</b>
+   </td>
+   <td><b>Avro Type</b>
+   </td>
+  </tr>
+  <tr>
+   <td>TINYINT, SMALLINT, INTEGER, BIGINT &nbsp;
+   </td>
+   <td>long
+   </td>
+  </tr>
+  <tr>
+   <td>FLOAT, DOUBLE
+   </td>
+   <td>double
+   </td>
+  </tr>
+  <tr>
+   <td>DECIMAL
+   </td>
+   <td>bytes (with logical type)
+   </td>
+  </tr>
+  <tr>
+   <td>BOOLEAN
+   </td>
+   <td>boolean
+   </td>
+  </tr>
+  <tr>
+   <td>DATE, TIME, TIMESTAMP
+   </td>
+   <td>long (with logical type)
+   </td>
+  </tr>
+  <tr>
+   <td>CHAR, VARCHAR
+   </td>
+   <td>string
+   </td>
+  </tr>
+  <tr>
+   <td>ARRAY
+   </td>
+   <td>array
+   </td>
+  </tr>
+  <tr>
+   <td>ROW
+   </td>
+   <td>record
+   </td>
+  </tr>
+</table>
+
+### Example
+
+```
+CREATE EXTERNAL TABLE daily_orders (
+  order_id BIGINT,
+  product_name VARCHAR,
+  purchase_ts TIMESTAMP
+)
+TYPE parquet
+LOCATION '/gcs/my-data/orders/2025-07-14/*';
+```
+
+---
 
 ## MongoDB
 


### PR DESCRIPTION
This PR modifies ParquetTable to intelligently resolve the file path before passing it to ParquetIO.

It uses FileSystems.match() to check if the provided LOCATION corresponds to a directory.

If it's a directory, a wildcard (*) is appended to the path to maintain the existing behavior of reading all files within it.

If it's not a directory (i.e., it's a file or a path that doesn't exist yet), it's treated as a user-provided pattern (either a glob or a single file path) and is used as-is.

fixes #20884 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
