### PR TITLE
Fix json schema test

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JsonSchemaConversionTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JsonSchemaConversionTest.java
@@ -291,12 +291,14 @@ public class JsonSchemaConversionTest {
       assertEquals("vegetables", Iterables.getOnlyElement(parsedSchema.getFieldNames()));
       Schema.Field field = parsedSchema.getField("vegetables");
 
-      // 2 out of 3 top-level fields are required, so ordering should be preserved on that level
+      // Top-level fields include only one nullable field, so ordering should be preserved on that
+      // level.
       assertEquals(
           Arrays.asList("veggieName", "veggieLike", "origin"),
           field.getType().getCollectionElementType().getRowSchema().getFieldNames());
-      // inner schema contains nullable fields, which can be out of order. test the remaining using
-      // equivalency instead
+      // Inner schema contains multiple nullable fields, which can be out of order. Test the
+      // remaining using
+      // equivalency instead.
       assertTrue(
           field
               .getType()

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JsonSchemaConversionTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JsonSchemaConversionTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.utils.JsonUtils;
@@ -290,7 +291,12 @@ public class JsonSchemaConversionTest {
       assertEquals("vegetables", Iterables.getOnlyElement(parsedSchema.getFieldNames()));
       Schema.Field field = parsedSchema.getField("vegetables");
 
-      // test using equivalency, which permits out-of-orderness
+      // 2 out of 3 top-level fields are required, so ordering should be preserved on that level
+      assertEquals(
+          Arrays.asList("veggieName", "veggieLike", "origin"),
+          field.getType().getCollectionElementType().getRowSchema().getFieldNames());
+      // inner schema contains nullable fields, which can be out of order. test the remaining using
+      // equivalency instead
       assertTrue(
           field
               .getType()


### PR DESCRIPTION
Test was sometimes failing because it validated using strict equality, but json schema with multiple nullable fields can result in random Beam schema field ordering:

https://github.com/apache/beam/blob/1fd8ce382d71ea5cb37281cf0b9f439ef3b87734/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/JsonUtils.java#L231-L233

Fixing test by checking for equivalence, which permits fields being out of order 