### PR TITLE
[Java Harness] Improve caching performance and measure overhead for cache internals.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/fn/data/WeightedList.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/fn/data/WeightedList.java
@@ -19,15 +19,20 @@ package org.apache.beam.sdk.fn.data;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+import org.apache.beam.sdk.util.Weighted;
 
 /** Facade for a {@link List<T>} that keeps track of weight, for cache limit reasons. */
-public class WeightedList<T> {
+public class WeightedList<T> implements Weighted {
 
   /** Original list that is being wrapped. */
   private final List<T> backing;
 
   /** Weight of all the elements being tracked. */
   private final AtomicLong weight;
+
+  public static <T> WeightedList<T> of(List<T> backing, long weight) {
+    return new WeightedList<>(backing, weight);
+  }
 
   public WeightedList(List<T> backing, long weight) {
     this.backing = backing;
@@ -46,6 +51,7 @@ public class WeightedList<T> {
     return this.backing.isEmpty();
   }
 
+  @Override
   public long getWeight() {
     return weight.longValue();
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/fn/stream/DataStreams.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/fn/stream/DataStreams.java
@@ -214,7 +214,7 @@ public class DataStreams {
         long elementOverhead = rvals.size() * BYTES_LIST_ELEMENT_OVERHEAD;
         long totalWeight = byteString.size() + elementOverhead;
 
-        return new WeightedList<>(rvals, totalWeight);
+        return WeightedList.of(rvals, totalWeight);
       } catch (IOException e) {
         throw new IllegalStateException(e);
       }

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/BagUserState.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/BagUserState.java
@@ -108,7 +108,9 @@ public class BagUserState<T> {
         "Bag user state is no longer usable because it is closed for %s",
         request.getStateKey());
     isCleared = true;
-    newValues = new ArrayList<>();
+    if (!newValues.isEmpty()) {
+      newValues = new ArrayList<>();
+    }
   }
 
   @SuppressWarnings("FutureReturnValueIgnored")

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/StateFetchingIterators.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/StateFetchingIterators.java
@@ -208,6 +208,18 @@ public class StateFetchingIterators {
       public abstract List<Block<T>> getBlocks();
     }
 
+    static class EmptyBlocks<T> extends Blocks<T> {
+      @Override
+      public List<Block<T>> getBlocks() {
+        return Collections.singletonList(Block.emptyBlock());
+      }
+
+      @Override
+      public long getWeight() {
+        return 8;
+      }
+    }
+
     static class MutatedBlocks<T> extends Blocks<T> {
 
       private final Block<T> wholeBlock;
@@ -223,19 +235,7 @@ public class StateFetchingIterators {
 
       @Override
       public long getWeight() {
-        return wholeBlock.getWeight();
-      }
-    }
-
-    private static <T> long sumWeight(List<Block<T>> blocks) {
-      try {
-        long sum = 0;
-        for (Block<T> block : blocks) {
-          sum = Math.addExact(sum, block.getWeight());
-        }
-        return sum;
-      } catch (ArithmeticException e) {
-        return Long.MAX_VALUE;
+        return wholeBlock.getWeight() + 8;
       }
     }
 
@@ -249,7 +249,15 @@ public class StateFetchingIterators {
 
       @Override
       public long getWeight() {
-        return sumWeight(blocks);
+        try {
+          long sum = 8 + blocks.size() * 8L;
+          for (Block<T> block : blocks) {
+            sum = Math.addExact(sum, block.getWeight());
+          }
+          return sum;
+        } catch (ArithmeticException e) {
+          return Long.MAX_VALUE;
+        }
       }
 
       BlocksPrefix(List<Block<T>> blocks) {
@@ -274,24 +282,38 @@ public class StateFetchingIterators {
 
     @AutoValue
     abstract static class Block<T> implements Weighted {
+      private static final Block<Void> EMPTY =
+          fromValues(WeightedList.of(Collections.emptyList(), 0), null);
 
-      public static <T> Block<T> mutatedBlock(List<T> values, long weight) {
-        return mutatedBlock(new WeightedList<>(values, weight));
+      @SuppressWarnings("unchecked") // Based upon as Collections.emptyList()
+      public static <T> Block<T> emptyBlock() {
+        return (Block<T>) EMPTY;
       }
 
-      public static <T> Block<T> mutatedBlock(WeightedList<T> weightedList) {
-        return new AutoValue_StateFetchingIterators_CachingStateIterable_Block<>(
-            weightedList.getBacking(), null, weightedList.getWeight());
+      public static <T> Block<T> mutatedBlock(List<T> values) {
+        return fromValues(values, null);
+      }
+
+      public static <T> Block<T> mutatedBlock(WeightedList<T> values) {
+        return fromValues(values, null);
       }
 
       public static <T> Block<T> fromValues(List<T> values, @Nullable ByteString nextToken) {
-        return fromValues(new WeightedList<>(values, Caches.weigh(values)), nextToken);
+        return fromValues(WeightedList.of(values, Caches.weigh(values)), nextToken);
       }
 
       public static <T> Block<T> fromValues(
           WeightedList<T> values, @Nullable ByteString nextToken) {
+        long weight = values.getWeight() + 24;
+        if (nextToken != null) {
+          if (nextToken.isEmpty()) {
+            nextToken = ByteString.EMPTY;
+          } else {
+            weight += Caches.weigh(nextToken);
+          }
+        }
         return new AutoValue_StateFetchingIterators_CachingStateIterable_Block<>(
-            values.getBacking(), nextToken, values.getWeight() + Caches.weigh(nextToken));
+            values.getBacking(), nextToken, weight);
       }
 
       abstract List<T> getValues();
@@ -350,7 +372,7 @@ public class StateFetchingIterators {
         totalSize += tBlock.getValues().size();
       }
 
-      WeightedList<T> allValues = new WeightedList<>(new ArrayList<>(totalSize), 0L);
+      WeightedList<T> allValues = WeightedList.of(new ArrayList<>(totalSize), 0L);
       for (Block<T> block : blocks) {
         boolean valueRemovedFromBlock = false;
         List<T> blockValuesToKeep = new ArrayList<>();
@@ -383,7 +405,11 @@ public class StateFetchingIterators {
      * requesting data from the state cache.
      */
     public void clearAndAppend(List<T> values) {
-      clearAndAppend(new WeightedList<>(values, Caches.weigh(values)));
+      if (values.isEmpty()) {
+        cache.put(IterableCacheKey.INSTANCE, new EmptyBlocks<>());
+      } else {
+        cache.put(IterableCacheKey.INSTANCE, new MutatedBlocks<>(Block.mutatedBlock(values)));
+      }
     }
 
     /**
@@ -396,7 +422,11 @@ public class StateFetchingIterators {
      * requesting data from the state cache.
      */
     public void clearAndAppend(WeightedList<T> values) {
-      cache.put(IterableCacheKey.INSTANCE, new MutatedBlocks<>(Block.mutatedBlock(values)));
+      if (values.isEmpty()) {
+        cache.put(IterableCacheKey.INSTANCE, new EmptyBlocks<>());
+      } else {
+        cache.put(IterableCacheKey.INSTANCE, new MutatedBlocks<>(Block.mutatedBlock(values)));
+      }
     }
 
     @Override
@@ -413,7 +443,7 @@ public class StateFetchingIterators {
      * cache.
      */
     public void append(List<T> values) {
-      append(new WeightedList<>(values, Caches.weigh(values)));
+      appendHelper(values, -1);
     }
 
     /**
@@ -425,7 +455,15 @@ public class StateFetchingIterators {
      * cache.
      */
     public void append(WeightedList<T> values) {
-      if (values.isEmpty()) {
+      appendHelper(values.getBacking(), values.getWeight());
+    }
+
+    /**
+     * Appends the newValues to the cached iterable with newWeight weight. If newWeight is negative,
+     * the weight will be calculated using Caches.weigh.
+     */
+    private void appendHelper(List<T> newValues, long newWeight) {
+      if (newValues.isEmpty()) {
         return;
       }
       Blocks<T> existing = cache.peek(IterableCacheKey.INSTANCE);
@@ -442,15 +480,23 @@ public class StateFetchingIterators {
       // they were mutated, and we must evict all or none of the blocks. When consuming the blocks,
       // we must have a reference to all or none of the blocks (which forces a load).
       List<Block<T>> blocks = existing.getBlocks();
-      int totalSize = values.size();
+      int totalSize = newValues.size();
       for (Block<T> block : blocks) {
         totalSize += block.getValues().size();
       }
-      WeightedList<T> allValues = new WeightedList<>(new ArrayList<>(totalSize), 0L);
+      WeightedList<T> allValues = WeightedList.of(new ArrayList<>(totalSize), 0L);
       for (Block<T> block : blocks) {
         allValues.addAll(block.getValues(), block.getWeight());
       }
-      allValues.addAll(values);
+      if (newWeight < 0) {
+        if (newValues.size() == 1) {
+          // Optimize weighing of the common value state as single single-element bag state.
+          newWeight = Caches.weigh(newValues.get(0));
+        } else {
+          newWeight = Caches.weigh(newValues);
+        }
+      }
+      allValues.addAll(newValues, newWeight);
 
       cache.put(IterableCacheKey.INSTANCE, new MutatedBlocks<>(Block.mutatedBlock(allValues)));
     }
@@ -469,7 +515,7 @@ public class StateFetchingIterators {
             new DataStreamDecoder<>(valueCoder, underlyingStateFetchingIterator);
         this.currentBlock =
             Block.fromValues(
-                new WeightedList<>(Collections.emptyList(), 0L),
+                WeightedList.of(Collections.emptyList(), 0L),
                 stateRequestForFirstChunk.getGet().getContinuationToken());
         this.currentCachedBlockValueIndex = 0;
       }
@@ -535,7 +581,7 @@ public class StateFetchingIterators {
           }
           // Release the block while we are loading the next one.
           currentBlock =
-              Block.fromValues(new WeightedList<>(Collections.emptyList(), 0L), ByteString.EMPTY);
+              Block.fromValues(WeightedList.of(Collections.emptyList(), 0L), ByteString.EMPTY);
 
           @Nullable Blocks<T> existing = cache.peek(IterableCacheKey.INSTANCE);
           boolean isFirstBlock = ByteString.EMPTY.equals(nextToken);


### PR DESCRIPTION
[Java SDK] Improvements to state caching to reduce weighing overhead and track cache internal memory usage.

Prior to this change in a benchmark up to 10% of CPU was used in MemoryMeter.weigh. This was reduced by using the Weighted interface for common keys for the cache, reserving weighing for actual user values.

Additionally the cache internal overhead is measured by improving the Weigher
used to account for additional bytes for each entry. This better respects the
configured cache size.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
