### PR TITLE
[Beam SQL] Support DATABASE concept in Beam SQL, with implementation for Iceberg

### DIFF
--- a/.github/trigger_files/beam_PostCommit_SQL.json
+++ b/.github/trigger_files/beam_PostCommit_SQL.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run ",
-  "modification": 3
+  "modification": 2
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,6 +84,7 @@
 * Milvus enrichment handler added (Python) ([#35216](https://github.com/apache/beam/pull/35216)).
   Beam now supports Milvus enrichment handler capabilities for vector, keyword,
   and hybrid search operations.
+* [Beam SQL] Add support for DATABASEs, with an implementation for Iceberg ([]())
 
 ## Breaking Changes
 

--- a/sdks/java/extensions/sql/src/main/codegen/config.fmpp
+++ b/sdks/java/extensions/sql/src/main/codegen/config.fmpp
@@ -26,11 +26,14 @@ data: {
         "org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlDrop"
         "org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.type.SqlTypeName"
         "org.apache.beam.sdk.extensions.sql.impl.parser.SqlCreateCatalog"
+        "org.apache.beam.sdk.extensions.sql.impl.parser.SqlCreateDatabase"
         "org.apache.beam.sdk.extensions.sql.impl.parser.SqlCreateExternalTable"
         "org.apache.beam.sdk.extensions.sql.impl.parser.SqlCreateFunction"
         "org.apache.beam.sdk.extensions.sql.impl.parser.SqlDropCatalog"
+        "org.apache.beam.sdk.extensions.sql.impl.parser.SqlDropDatabase"
         "org.apache.beam.sdk.extensions.sql.impl.parser.SqlDdlNodes"
         "org.apache.beam.sdk.extensions.sql.impl.parser.SqlUseCatalog"
+        "org.apache.beam.sdk.extensions.sql.impl.parser.SqlUseDatabase"
         "org.apache.beam.sdk.extensions.sql.impl.parser.SqlSetOptionBeam"
         "org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils"
         "org.apache.beam.sdk.schemas.Schema"
@@ -395,6 +398,7 @@ data: {
       # Example: SqlShowDatabases(), SqlShowTables().
       statementParserMethods: [
         "SqlUseCatalog(Span.of(), null)"
+        "SqlUseDatabase(Span.of(), null)"
         "SqlSetOptionBeam(Span.of(), null)"
       ]
 
@@ -427,6 +431,7 @@ data: {
       # Each must accept arguments "(SqlParserPos pos, boolean replace)".
       createStatementParserMethods: [
         "SqlCreateCatalog"
+        "SqlCreateDatabase"
         "SqlCreateExternalTable"
         "SqlCreateFunction"
         "SqlCreateTableNotSupportedMessage"
@@ -436,6 +441,7 @@ data: {
       # Each must accept arguments "(SqlParserPos pos)".
       dropStatementParserMethods: [
         "SqlDropTable"
+        "SqlDropDatabase"
         "SqlDropCatalog"
       ]
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlCreateDatabase.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlCreateDatabase.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.impl.parser;
+
+import static java.lang.String.format;
+import static org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.util.Static.RESOURCE;
+
+import java.util.List;
+import org.apache.beam.sdk.extensions.sql.impl.BeamCalciteSchema;
+import org.apache.beam.sdk.extensions.sql.meta.catalog.Catalog;
+import org.apache.beam.sdk.extensions.sql.meta.catalog.CatalogManager;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.schema.Schema;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlCreate;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlIdentifier;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlKind;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlNode;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlOperator;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlUtil;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlWriter;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.util.Pair;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SqlCreateDatabase extends SqlCreate implements BeamSqlParser.ExecutableStatement {
+  private static final Logger LOG = LoggerFactory.getLogger(SqlCreateDatabase.class);
+  private final SqlIdentifier databaseName;
+  private static final SqlOperator OPERATOR =
+      new SqlSpecialOperator("CREATE DATABASE", SqlKind.OTHER_DDL);
+
+  public SqlCreateDatabase(
+      SqlParserPos pos, boolean replace, boolean ifNotExists, SqlNode databaseName) {
+    super(OPERATOR, pos, replace, ifNotExists);
+    this.databaseName = SqlDdlNodes.getIdentifier(databaseName, pos);
+  }
+
+  @Override
+  public List<SqlNode> getOperandList() {
+    ImmutableList.Builder<SqlNode> operands = ImmutableList.builder();
+    operands.add(databaseName);
+    return operands.build();
+  }
+
+  @Override
+  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("CREATE");
+    if (getReplace()) {
+      writer.keyword("OR REPLACE");
+    }
+    writer.keyword("DATABASE");
+    if (ifNotExists) {
+      writer.keyword("IF NOT EXISTS");
+    }
+    databaseName.unparse(writer, leftPrec, rightPrec);
+    writer.keyword("TYPE");
+  }
+
+  @Override
+  public void execute(CalcitePrepare.Context context) {
+    final Pair<CalciteSchema, String> pair = SqlDdlNodes.schema(context, true, databaseName);
+    Schema schema = pair.left.schema;
+    String name = pair.right;
+
+    if (!(schema instanceof BeamCalciteSchema)) {
+      throw SqlUtil.newContextException(
+          databaseName.getParserPosition(),
+          RESOURCE.internal("Schema is not of instance BeamCalciteSchema"));
+    }
+
+    @Nullable CatalogManager catalogManager = ((BeamCalciteSchema) schema).getCatalogManager();
+    if (catalogManager == null) {
+      throw SqlUtil.newContextException(
+          databaseName.getParserPosition(),
+          RESOURCE.internal(
+              format(
+                  "Unexpected 'CREATE DATABASE' call using Schema '%s' that is not a Catalog.",
+                  name)));
+    }
+
+    // Attempt to create the database.
+    Catalog catalog = catalogManager.currentCatalog();
+    try {
+      LOG.info("Creating database '{}'", name);
+      boolean created = catalog.createDatabase(name);
+
+      if (created) {
+        LOG.info("Successfully created database '{}'", name);
+      } else if (ifNotExists) {
+        LOG.info("Database '{}' already exists.", name);
+      } else {
+        throw SqlUtil.newContextException(
+            databaseName.getParserPosition(),
+            RESOURCE.internal(format("Database '%s' already exists.", name)));
+      }
+    } catch (Exception e) {
+      throw SqlUtil.newContextException(
+          databaseName.getParserPosition(),
+          RESOURCE.internal(
+              format("Encountered an error when creating database '%s': %s", name, e)));
+    }
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlCreateDatabase.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlCreateDatabase.java
@@ -72,7 +72,6 @@ public class SqlCreateDatabase extends SqlCreate implements BeamSqlParser.Execut
       writer.keyword("IF NOT EXISTS");
     }
     databaseName.unparse(writer, leftPrec, rightPrec);
-    writer.keyword("TYPE");
   }
 
   @Override

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlDropDatabase.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlDropDatabase.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.impl.parser;
+
+import static java.lang.String.format;
+import static org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.util.Static.RESOURCE;
+
+import java.util.List;
+import org.apache.beam.sdk.extensions.sql.impl.BeamCalciteSchema;
+import org.apache.beam.sdk.extensions.sql.meta.catalog.Catalog;
+import org.apache.beam.sdk.extensions.sql.meta.catalog.CatalogManager;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.schema.Schema;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlDrop;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlIdentifier;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlKind;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlNode;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlOperator;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlUtil;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlWriter;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.util.Pair;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SqlDropDatabase extends SqlDrop implements BeamSqlParser.ExecutableStatement {
+  private static final Logger LOG = LoggerFactory.getLogger(SqlDropDatabase.class);
+  private static final SqlOperator OPERATOR =
+      new SqlSpecialOperator("DROP DATABASE", SqlKind.OTHER_DDL);
+  private final SqlIdentifier databaseName;
+  private final boolean cascade;
+
+  public SqlDropDatabase(
+      SqlParserPos pos, boolean ifExists, SqlNode databaseName, boolean cascade) {
+    super(OPERATOR, pos, ifExists);
+    this.databaseName = SqlDdlNodes.getIdentifier(databaseName, pos);
+    this.cascade = cascade;
+  }
+
+  @Override
+  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword(getOperator().getName());
+    if (ifExists) {
+      writer.keyword("IF EXISTS");
+    }
+    databaseName.unparse(writer, leftPrec, rightPrec);
+    if (cascade) {
+      writer.keyword("CASCADE");
+    } else {
+      writer.keyword("RESTRICT");
+    }
+  }
+
+  @Override
+  public void execute(CalcitePrepare.Context context) {
+    final Pair<CalciteSchema, String> pair = SqlDdlNodes.schema(context, true, databaseName);
+    Schema schema = pair.left.schema;
+    String name = pair.right;
+
+    if (!(schema instanceof BeamCalciteSchema)) {
+      throw SqlUtil.newContextException(
+          databaseName.getParserPosition(),
+          RESOURCE.internal("Schema is not of instance BeamCalciteSchema"));
+    }
+
+    BeamCalciteSchema beamCalciteSchema = (BeamCalciteSchema) schema;
+    @Nullable CatalogManager catalogManager = beamCalciteSchema.getCatalogManager();
+    if (catalogManager == null) {
+      throw SqlUtil.newContextException(
+          databaseName.getParserPosition(),
+          RESOURCE.internal(
+              String.format(
+                  "Unexpected 'DROP DATABASE' call using Schema '%s' that is not a Catalog.",
+                  name)));
+    }
+
+    Catalog catalog = catalogManager.currentCatalog();
+    try {
+      LOG.info("Dropping database '{}'", name);
+      boolean dropped = catalog.dropDatabase(name, cascade);
+
+      if (dropped) {
+        LOG.info("Successfully dropped database '{}'", name);
+      } else if (ifExists) {
+        LOG.info("Database '{}' does not exist.", name);
+      } else {
+        throw SqlUtil.newContextException(
+            databaseName.getParserPosition(),
+            RESOURCE.internal(String.format("Database '%s' does not exist.", name)));
+      }
+    } catch (Exception e) {
+      throw SqlUtil.newContextException(
+          databaseName.getParserPosition(),
+          RESOURCE.internal(
+              format("Encountered an error when dropping database '%s': %s", name, e)));
+    }
+  }
+
+  @Override
+  public List<SqlNode> getOperandList() {
+    return ImmutableList.of(databaseName);
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlUseDatabase.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlUseDatabase.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.impl.parser;
+
+import static org.apache.beam.sdk.util.Preconditions.checkStateNotNull;
+import static org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.util.Static.RESOURCE;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.beam.sdk.extensions.sql.impl.BeamCalciteSchema;
+import org.apache.beam.sdk.extensions.sql.meta.catalog.Catalog;
+import org.apache.beam.sdk.extensions.sql.meta.catalog.CatalogManager;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.schema.Schema;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlIdentifier;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlKind;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlNode;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlOperator;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlSetOption;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.SqlUtil;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.util.Pair;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SqlUseDatabase extends SqlSetOption implements BeamSqlParser.ExecutableStatement {
+  private static final Logger LOG = LoggerFactory.getLogger(SqlUseDatabase.class);
+  private final SqlIdentifier databaseName;
+
+  private static final SqlOperator OPERATOR = new SqlSpecialOperator("USE DATABASE", SqlKind.OTHER);
+
+  public SqlUseDatabase(SqlParserPos pos, String scope, SqlNode databaseName) {
+    super(pos, scope, SqlDdlNodes.getIdentifier(databaseName, pos), null);
+    this.databaseName = SqlDdlNodes.getIdentifier(databaseName, pos);
+  }
+
+  @Override
+  public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override
+  public List<SqlNode> getOperandList() {
+    return Collections.singletonList(databaseName);
+  }
+
+  @Override
+  public void execute(CalcitePrepare.Context context) {
+    final Pair<CalciteSchema, String> pair = SqlDdlNodes.schema(context, true, databaseName);
+    Schema schema = pair.left.schema;
+    String name = checkStateNotNull(pair.right);
+
+    if (!(schema instanceof BeamCalciteSchema)) {
+      throw SqlUtil.newContextException(
+          databaseName.getParserPosition(),
+          RESOURCE.internal("Schema is not of instance BeamCalciteSchema"));
+    }
+
+    BeamCalciteSchema beamCalciteSchema = (BeamCalciteSchema) schema;
+    @Nullable CatalogManager catalogManager = beamCalciteSchema.getCatalogManager();
+    if (catalogManager == null) {
+      throw SqlUtil.newContextException(
+          databaseName.getParserPosition(),
+          RESOURCE.internal(
+              String.format(
+                  "Unexpected 'USE DATABASE' call using Schema '%s' that is not a Catalog.",
+                  name)));
+    }
+
+    Catalog catalog = catalogManager.currentCatalog();
+    if (!catalog.listDatabases().contains(name)) {
+      throw SqlUtil.newContextException(
+          databaseName.getParserPosition(),
+          RESOURCE.internal(String.format("Cannot use database: '%s' not found.", name)));
+    }
+
+    if (name.equals(catalog.currentDatabase())) {
+      LOG.info("Database '{}' is already in use.", name);
+      return;
+    }
+
+    catalog.useDatabase(name);
+    LOG.info("Switched to database '{}'.", name);
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/catalog/Catalog.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/catalog/Catalog.java
@@ -18,8 +18,10 @@
 package org.apache.beam.sdk.extensions.sql.meta.catalog;
 
 import java.util.Map;
+import java.util.Set;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.extensions.sql.meta.store.MetaStore;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Represents a named and configurable container for managing tables. Is defined with a type and
@@ -28,11 +30,54 @@ import org.apache.beam.sdk.extensions.sql.meta.store.MetaStore;
  */
 @Internal
 public interface Catalog {
+  // Default database name
+  String DEFAULT = "default";
+
   /** A type that defines this catalog. */
   String type();
 
   /** The underlying {@link MetaStore} that actually manages tables. */
   MetaStore metaStore();
+
+  /**
+   * Produces the currently active database. Can be null if no database is active.
+   *
+   * @return the current active database
+   */
+  @Nullable
+  String currentDatabase();
+
+  /**
+   * Creates a database with this name.
+   *
+   * @param databaseName
+   * @return true if the database was created, false otherwise.
+   */
+  boolean createDatabase(String databaseName);
+
+  /**
+   * Returns a set of existing databases accessible to this catalog.
+   *
+   * @return a set of existing database names
+   */
+  Set<String> listDatabases();
+
+  /**
+   * Switches to use the specified database.
+   *
+   * @param databaseName
+   */
+  void useDatabase(String databaseName);
+
+  /**
+   * Drops the database with this name. If cascade is true, the catalog should first drop all tables
+   * contained in this database.
+   *
+   * @param databaseName
+   * @param cascade
+   * @return true if the database was dropped, false otherwise.
+   */
+  boolean dropDatabase(String databaseName, boolean cascade);
 
   /** The name of this catalog, specified by the user. */
   String name();

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/catalog/InMemoryCatalog.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/catalog/InMemoryCatalog.java
@@ -18,7 +18,7 @@
 package org.apache.beam.sdk.extensions.sql.meta.catalog;
 
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
-import static org.apache.curator.shaded.com.google.common.base.Preconditions.checkState;
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/catalog/InMemoryCatalog.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/catalog/InMemoryCatalog.java
@@ -17,15 +17,24 @@
  */
 package org.apache.beam.sdk.extensions.sql.meta.catalog;
 
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
+import static org.apache.curator.shaded.com.google.common.base.Preconditions.checkState;
+
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import org.apache.beam.sdk.extensions.sql.meta.store.InMemoryMetaStore;
 import org.apache.beam.sdk.extensions.sql.meta.store.MetaStore;
 import org.apache.beam.sdk.util.Preconditions;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class InMemoryCatalog implements Catalog {
   private final String name;
   private final Map<String, String> properties;
   private final InMemoryMetaStore metaStore = new InMemoryMetaStore();
+  private final HashSet<String> databases = new HashSet<>(Collections.singleton(DEFAULT));
+  protected @Nullable String currentDatabase = DEFAULT;
 
   public InMemoryCatalog(String name, Map<String, String> properties) {
     this.name = name;
@@ -51,5 +60,37 @@ public class InMemoryCatalog implements Catalog {
   @Override
   public Map<String, String> properties() {
     return Preconditions.checkStateNotNull(properties, "InMemoryCatalog has not been initialized");
+  }
+
+  @Override
+  public boolean createDatabase(String database) {
+    return databases.add(database);
+  }
+
+  @Override
+  public void useDatabase(String database) {
+    checkArgument(listDatabases().contains(database), "Database '%s' does not exist.");
+    currentDatabase = database;
+  }
+
+  @Override
+  public @Nullable String currentDatabase() {
+    return currentDatabase;
+  }
+
+  @Override
+  public boolean dropDatabase(String database, boolean cascade) {
+    checkState(!cascade, getClass().getSimpleName() + " does not support CASCADE.");
+
+    boolean removed = databases.remove(database);
+    if (database.equals(currentDatabase)) {
+      currentDatabase = null;
+    }
+    return removed;
+  }
+
+  @Override
+  public Set<String> listDatabases() {
+    return databases;
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/iceberg/IcebergCatalog.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/iceberg/IcebergCatalog.java
@@ -18,15 +18,41 @@
 package org.apache.beam.sdk.extensions.sql.meta.provider.iceberg;
 
 import java.util.Map;
+import java.util.Set;
 import org.apache.beam.sdk.extensions.sql.meta.catalog.InMemoryCatalog;
 import org.apache.beam.sdk.extensions.sql.meta.store.InMemoryMetaStore;
+import org.apache.beam.sdk.io.iceberg.IcebergCatalogConfig;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 
 public class IcebergCatalog extends InMemoryCatalog {
+  // TODO(ahmedabu98): extend this to the IO implementation so
+  //  other SDKs can make use of it too
+  private static final String BEAM_HADOOP_PREFIX = "beam.catalog.hadoop";
   private final InMemoryMetaStore metaStore = new InMemoryMetaStore();
+  @VisibleForTesting final IcebergCatalogConfig catalogConfig;
 
   public IcebergCatalog(String name, Map<String, String> properties) {
     super(name, properties);
-    metaStore.registerProvider(new IcebergTableProvider(name, properties));
+
+    ImmutableMap.Builder<String, String> catalogProps = ImmutableMap.builder();
+    ImmutableMap.Builder<String, String> hadoopProps = ImmutableMap.builder();
+
+    for (Map.Entry<String, String> entry : properties.entrySet()) {
+      if (entry.getKey().startsWith(BEAM_HADOOP_PREFIX)) {
+        hadoopProps.put(entry.getKey(), entry.getValue());
+      } else {
+        catalogProps.put(entry.getKey(), entry.getValue());
+      }
+    }
+
+    catalogConfig =
+        IcebergCatalogConfig.builder()
+            .setCatalogName(name)
+            .setCatalogProperties(catalogProps.build())
+            .setConfigProperties(hadoopProps.build())
+            .build();
+    metaStore.registerProvider(new IcebergTableProvider(catalogConfig));
   }
 
   @Override
@@ -37,5 +63,24 @@ public class IcebergCatalog extends InMemoryCatalog {
   @Override
   public String type() {
     return "iceberg";
+  }
+
+  @Override
+  public boolean createDatabase(String database) {
+    return catalogConfig.createNamespace(database);
+  }
+
+  @Override
+  public boolean dropDatabase(String database, boolean cascade) {
+    boolean removed = catalogConfig.dropNamespace(database, cascade);
+    if (database.equals(currentDatabase)) {
+      currentDatabase = null;
+    }
+    return removed;
+  }
+
+  @Override
+  public Set<String> listDatabases() {
+    return catalogConfig.listNamespaces();
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/iceberg/IcebergTableProvider.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/iceberg/IcebergTableProvider.java
@@ -28,7 +28,6 @@ import org.apache.beam.sdk.extensions.sql.meta.provider.TableProvider;
 import org.apache.beam.sdk.io.iceberg.IcebergCatalogConfig;
 import org.apache.beam.sdk.io.iceberg.TableAlreadyExistsException;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
-import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,30 +37,11 @@ import org.slf4j.LoggerFactory;
  */
 public class IcebergTableProvider implements TableProvider {
   private static final Logger LOG = LoggerFactory.getLogger(IcebergTableProvider.class);
-  // TODO(ahmedabu98): extend this to the IO implementation so
-  //  other SDKs can make use of it too
-  private static final String BEAM_HADOOP_PREFIX = "beam.catalog.hadoop";
   @VisibleForTesting final IcebergCatalogConfig catalogConfig;
   private final Map<String, Table> tables = new HashMap<>();
 
-  public IcebergTableProvider(String name, Map<String, String> properties) {
-    ImmutableMap.Builder<String, String> catalogProps = ImmutableMap.builder();
-    ImmutableMap.Builder<String, String> hadoopProps = ImmutableMap.builder();
-
-    for (Map.Entry<String, String> entry : properties.entrySet()) {
-      if (entry.getKey().startsWith(BEAM_HADOOP_PREFIX)) {
-        hadoopProps.put(entry.getKey(), entry.getValue());
-      } else {
-        catalogProps.put(entry.getKey(), entry.getValue());
-      }
-    }
-
-    catalogConfig =
-        IcebergCatalogConfig.builder()
-            .setCatalogName(name)
-            .setCatalogProperties(catalogProps.build())
-            .setConfigProperties(hadoopProps.build())
-            .build();
+  public IcebergTableProvider(IcebergCatalogConfig catalogConfig) {
+    this.catalogConfig = catalogConfig;
   }
 
   @Override

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlCliDatabaseTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlCliDatabaseTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.beam.sdk.extensions.sql.meta.catalog.InMemoryCatalogManager;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.runtime.CalciteContextException;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableSet;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/** UnitTest for {@link BeamSqlCli} using databases. */
+public class BeamSqlCliDatabaseTest {
+  @Rule public transient ExpectedException thrown = ExpectedException.none();
+  private InMemoryCatalogManager catalogManager;
+  private BeamSqlCli cli;
+
+  @Before
+  public void setupCli() {
+    catalogManager = new InMemoryCatalogManager();
+    cli = new BeamSqlCli().catalogManager(catalogManager);
+  }
+
+  @Test
+  public void testCreateDatabase() {
+    cli.execute("CREATE DATABASE my_database");
+    assertEquals(
+        ImmutableSet.of("default", "my_database"), catalogManager.currentCatalog().listDatabases());
+  }
+
+  @Test
+  public void testCreateDuplicateDatabase_error() {
+    cli.execute("CREATE DATABASE my_database");
+    thrown.expect(CalciteContextException.class);
+    thrown.expectMessage("Database 'my_database' already exists.");
+    cli.execute("CREATE DATABASE my_database");
+  }
+
+  @Test
+  public void testCreateDuplicateDatabase_ifNotExists() {
+    cli.execute("CREATE DATABASE my_database");
+    cli.execute("CREATE DATABASE IF NOT EXISTS my_database");
+    assertEquals(
+        ImmutableSet.of("default", "my_database"), catalogManager.currentCatalog().listDatabases());
+  }
+
+  @Test
+  public void testUseDatabase() {
+    assertEquals("default", catalogManager.currentCatalog().currentDatabase());
+    cli.execute("CREATE DATABASE my_database");
+    cli.execute("CREATE DATABASE my_database2");
+    assertEquals("default", catalogManager.currentCatalog().currentDatabase());
+    cli.execute("USE DATABASE my_database");
+    assertEquals("my_database", catalogManager.currentCatalog().currentDatabase());
+    cli.execute("USE DATABASE my_database2");
+    assertEquals("my_database2", catalogManager.currentCatalog().currentDatabase());
+  }
+
+  @Test
+  public void testUseDatabase_doesNotExist() {
+    assertEquals("default", catalogManager.currentCatalog().currentDatabase());
+    thrown.expect(CalciteContextException.class);
+    thrown.expectMessage("Cannot use database: 'non_existent' not found.");
+    cli.execute("USE DATABASE non_existent");
+  }
+
+  @Test
+  public void testDropDatabase() {
+    cli.execute("CREATE DATABASE my_database");
+    assertEquals(
+        ImmutableSet.of("default", "my_database"), catalogManager.currentCatalog().listDatabases());
+    cli.execute("DROP DATABASE my_database");
+    assertEquals(ImmutableSet.of("default"), catalogManager.currentCatalog().listDatabases());
+  }
+
+  @Test
+  public void testDropDatabase_nonexistent() {
+    assertEquals(ImmutableSet.of("default"), catalogManager.currentCatalog().listDatabases());
+    thrown.expect(CalciteContextException.class);
+    thrown.expectMessage("Database 'my_database' does not exist.");
+    cli.execute("DROP DATABASE my_database");
+  }
+}

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/iceberg/BeamSqlCliIcebergTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/iceberg/BeamSqlCliIcebergTest.java
@@ -94,8 +94,8 @@ public class BeamSqlCliIcebergTest {
     thrown.expectMessage("Database 'new_namespace' already exists.");
     cli.execute("CREATE DATABASE new_namespace");
 
-    // cleanup
-    catalog.dropDatabase("new_namespace", true);
+    // assert there was a database, and cleanup
+    assertTrue(catalog.dropDatabase("new_namespace", true));
   }
 
   @Test
@@ -113,8 +113,8 @@ public class BeamSqlCliIcebergTest {
     thrown.expectMessage("Cannot use database: 'non_existent' not found.");
     cli.execute("USE DATABASE non_existent");
 
-    // cleanup
-    catalog.dropDatabase("new_namespace", true);
+    // assert there was a database, and cleanup
+    assertTrue(catalog.dropDatabase("new_namespace", true));
   }
 
   @Test

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/iceberg/BeamSqlCliIcebergTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/iceberg/BeamSqlCliIcebergTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.meta.provider.iceberg;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+import org.apache.beam.sdk.extensions.sql.BeamSqlCli;
+import org.apache.beam.sdk.extensions.sql.meta.catalog.InMemoryCatalogManager;
+import org.apache.beam.vendor.calcite.v1_28_0.org.apache.calcite.runtime.CalciteContextException;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+/** UnitTest for {@link BeamSqlCli} using Iceberg catalog. */
+public class BeamSqlCliIcebergTest {
+  @Rule public transient ExpectedException thrown = ExpectedException.none();
+  private InMemoryCatalogManager catalogManager;
+  private BeamSqlCli cli;
+  private String warehouse;
+  @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+  @Before
+  public void setup() throws IOException {
+    catalogManager = new InMemoryCatalogManager();
+    cli = new BeamSqlCli().catalogManager(catalogManager);
+    File warehouseFile = TEMPORARY_FOLDER.newFolder();
+    Assert.assertTrue(warehouseFile.delete());
+    warehouse = "file:" + warehouseFile + "/" + UUID.randomUUID();
+  }
+
+  private String createCatalog(String name) {
+    return format("CREATE CATALOG %s \n", name)
+        + "TYPE iceberg \n"
+        + "PROPERTIES (\n"
+        + "  'type' = 'hadoop', \n"
+        + format("  'warehouse' = '%s')", warehouse);
+  }
+
+  @Test
+  public void testCreateCatalog() {
+    assertEquals("default", catalogManager.currentCatalog().name());
+
+    cli.execute(createCatalog("my_catalog"));
+    assertNotNull(catalogManager.getCatalog("my_catalog"));
+    assertEquals("default", catalogManager.currentCatalog().name());
+
+    cli.execute("USE CATALOG my_catalog");
+    assertEquals("my_catalog", catalogManager.currentCatalog().name());
+    assertEquals("iceberg", catalogManager.currentCatalog().type());
+  }
+
+  @Test
+  public void testCreateNamespace() {
+    testCreateCatalog();
+
+    IcebergCatalog catalog = (IcebergCatalog) catalogManager.currentCatalog();
+    assertEquals("default", catalog.currentDatabase());
+    cli.execute("CREATE DATABASE new_namespace");
+    assertEquals("new_namespace", Iterables.getOnlyElement(catalog.listDatabases()));
+
+    // Specifies IF NOT EXISTS, so should be a no-op
+    cli.execute("CREATE DATABASE IF NOT EXISTS new_namespace");
+    assertEquals("new_namespace", Iterables.getOnlyElement(catalog.listDatabases()));
+
+    // This one doesn't, so it should throw an error.
+    thrown.expect(CalciteContextException.class);
+    thrown.expectMessage("Database 'new_namespace' already exists.");
+    cli.execute("CREATE DATABASE new_namespace");
+
+    // cleanup
+    catalog.dropDatabase("new_namespace", true);
+  }
+
+  @Test
+  public void testUseNamespace() {
+    testCreateCatalog();
+
+    IcebergCatalog catalog = (IcebergCatalog) catalogManager.currentCatalog();
+    cli.execute("CREATE DATABASE new_namespace");
+    assertEquals("default", catalog.currentDatabase());
+    cli.execute("USE DATABASE new_namespace");
+    assertEquals("new_namespace", catalog.currentDatabase());
+
+    // Cannot use a non-existent namespace
+    thrown.expect(CalciteContextException.class);
+    thrown.expectMessage("Cannot use database: 'non_existent' not found.");
+    cli.execute("USE DATABASE non_existent");
+
+    // cleanup
+    catalog.dropDatabase("new_namespace", true);
+  }
+
+  @Test
+  public void testDropNamespace() {
+    testCreateCatalog();
+
+    IcebergCatalog catalog = (IcebergCatalog) catalogManager.currentCatalog();
+    cli.execute("CREATE DATABASE new_namespace");
+    cli.execute("USE DATABASE new_namespace");
+    assertEquals("new_namespace", catalog.currentDatabase());
+    cli.execute("DROP DATABASE new_namespace");
+    assertTrue(catalog.listDatabases().isEmpty());
+    assertNull(catalog.currentDatabase());
+
+    // Drop non-existent namespace with IF EXISTS
+    cli.execute("DROP DATABASE IF EXISTS new_namespace");
+
+    // Throw an error when IF EXISTS is not specified
+    thrown.expect(CalciteContextException.class);
+    thrown.expectMessage("Database 'new_namespace' does not exist.");
+    cli.execute("DROP DATABASE new_namespace");
+  }
+}

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/iceberg/IcebergTableProviderTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/iceberg/IcebergTableProviderTest.java
@@ -34,8 +34,8 @@ import org.junit.Test;
 
 /** UnitTest for {@link IcebergTableProvider}. */
 public class IcebergTableProviderTest {
-  private final IcebergTableProvider provider =
-      new IcebergTableProvider(
+  private final IcebergCatalog catalog =
+      new IcebergCatalog(
           "test_catalog",
           ImmutableMap.of(
               "catalog-impl", "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
@@ -46,7 +46,7 @@ public class IcebergTableProviderTest {
 
   @Test
   public void testGetTableType() {
-    assertEquals("iceberg", provider.getTableType());
+    assertEquals("iceberg", catalog.metaStore().getTableType());
   }
 
   @Test
@@ -59,14 +59,14 @@ public class IcebergTableProviderTest {
         fakeTableBuilder("my_table")
             .properties(TableUtils.parseProperties(propertiesString))
             .build();
-    BeamSqlTable sqlTable = provider.buildBeamSqlTable(table);
+    BeamSqlTable sqlTable = catalog.metaStore().buildBeamSqlTable(table);
 
     assertNotNull(sqlTable);
     assertTrue(sqlTable instanceof IcebergTable);
 
     IcebergTable icebergTable = (IcebergTable) sqlTable;
     assertEquals("namespace.my_table", icebergTable.tableIdentifier);
-    assertEquals(provider.catalogConfig, icebergTable.catalogConfig);
+    assertEquals(catalog.catalogConfig, icebergTable.catalogConfig);
   }
 
   private static Table.Builder fakeTableBuilder(String name) {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/iceberg/IcebergTableProviderTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/iceberg/IcebergTableProviderTest.java
@@ -46,7 +46,7 @@ public class IcebergTableProviderTest {
 
   @Test
   public void testGetTableType() {
-    assertEquals("iceberg", catalog.metaStore().getTableType());
+    assertNotNull(catalog.metaStore().getProvider("iceberg"));
   }
 
   @Test

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergCatalogConfig.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergCatalogConfig.java
@@ -21,13 +21,20 @@ import com.google.auto.value.AutoValue;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.util.ReleaseInfo;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Splitter;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
@@ -83,6 +90,51 @@ public abstract class IcebergCatalogConfig implements Serializable {
     return cachedCatalog;
   }
 
+  private void checkSupportsNamespaces() {
+    Preconditions.checkState(
+        catalog() instanceof SupportsNamespaces,
+        "Catalog '%s' does not support handling namespaces.",
+        catalog().name());
+  }
+
+  public boolean createNamespace(String namespace) {
+    checkSupportsNamespaces();
+    String[] components = Iterables.toArray(Splitter.on('.').split(namespace), String.class);
+
+    try {
+      ((SupportsNamespaces) catalog()).createNamespace(Namespace.of(components));
+      return true;
+    } catch (AlreadyExistsException e) {
+      return false;
+    }
+  }
+
+  public Set<String> listNamespaces() {
+    checkSupportsNamespaces();
+
+    return ((SupportsNamespaces) catalog())
+        .listNamespaces().stream().map(Namespace::toString).collect(Collectors.toSet());
+  }
+
+  public boolean dropNamespace(String namespace, boolean cascade) {
+    checkSupportsNamespaces();
+
+    String[] components = Iterables.toArray(Splitter.on('.').split(namespace), String.class);
+    Namespace ns = Namespace.of(components);
+
+    if (!((SupportsNamespaces) catalog()).namespaceExists(ns)) {
+      return false;
+    }
+
+    // Cascade will delete all contained tables first
+    if (cascade) {
+      catalog().listTables(ns).forEach(catalog()::dropTable);
+    }
+
+    // Drop the namespace
+    return ((SupportsNamespaces) catalog()).dropNamespace(Namespace.of(components));
+  }
+
   public void createTable(
       String tableIdentifier, Schema tableSchema, @Nullable List<String> partitionFields) {
     TableIdentifier icebergIdentifier = TableIdentifier.parse(tableIdentifier);
@@ -103,6 +155,12 @@ public abstract class IcebergCatalogConfig implements Serializable {
   public boolean dropTable(String tableIdentifier) {
     TableIdentifier icebergIdentifier = TableIdentifier.parse(tableIdentifier);
     return catalog().dropTable(icebergIdentifier);
+  }
+
+  public Set<String> listTables(String namespace) {
+    return catalog().listTables(Namespace.of(namespace)).stream()
+        .map(TableIdentifier::name)
+        .collect(Collectors.toSet());
   }
 
   @AutoValue.Builder


### PR DESCRIPTION
Addresses #35637

These changes allow the following:

- `CREATE DATABASE ( IF NOT EXISTS )? database_name`
- `USE DATABASE database_name`
- `DROP DATABASE [ IF EXISTS ] database_name [ RESTRICT | CASCADE ]`
  - `RESTRICT` (default) will throw an error if the database contains a table. `CASCADE` will drop all tables within the database before dropping the database. 

For Iceberg catalogs, `CREATE` and `DROP` will create/drop real external tables in the appropriate data platform.

These implementations will help bring Beam closer to alignment with existing [Flink](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/sql/overview/) and [Spark](https://spark.apache.org/docs/4.0.0/sql-ref-syntax.html) syntax