### PR TITLE
Upgrade base image for dev-support docker image(Ubuntu 20.04 -> Ubuntu 24.04)

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -18,7 +18,7 @@
 # Dockerfile for installing the necessary dependencies for building Hadoop.
 # See BUILDING.txt.
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -62,12 +62,13 @@ ENV LC_ALL en_US.UTF-8
 ###
 # Install grpcio-tools mypy-protobuf for `python3 sdks/python/setup.py sdist` to work
 ###
-RUN pip3 install grpcio-tools mypy-protobuf
+RUN pip3 install --break-system-packages grpcio-tools mypy-protobuf
 
 ###
 # Install useful tools
 # Install distlib to avoid https://github.com/pypa/virtualenv/issues/2006
-RUN pip3 install distlib==0.3.1 yapf==0.29.0 pytest
+# Specify the version of pluggy to fix it to the version installed on the system.
+RUN pip3 install --break-system-packages distlib==0.3.1 yapf==0.29.0 pytest pluggy==1.4.0
 ###
 
 ###

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -68,7 +68,7 @@ RUN pip3 install --break-system-packages grpcio-tools mypy-protobuf
 # Install useful tools
 # Install distlib to avoid https://github.com/pypa/virtualenv/issues/2006
 # Specify the version of pluggy to fix it to the version installed on the system.
-RUN pip3 install --break-system-packages distlib==0.3.1 yapf==0.29.0 pytest pluggy==1.4.0
+RUN pip3 install --break-system-packages distlib==0.3.9 yapf==0.43.0 pytest pluggy==1.4.0
 ###
 
 ###


### PR DESCRIPTION
**Please** add a meaningful description for your change here

Ubuntu 20.04 has reached its end of life, so container images created with `dev-support/docker` no longer seem to work.

<details><summary>Log for start-build-env.sh on master (fail)</summary>

```
shingofuruyama@shingofuruyama:~/git/beam$ ./start-build-env.sh 
Sending build context to Docker daemon  15.87kB
Step 1/28 : FROM ubuntu:20.04
 ---> 626a42b93d93
Step 2/28 : ARG DEBIAN_FRONTEND=noninteractive
 ---> Using cache
 ---> deee3d578557
Step 3/28 : WORKDIR /root
 ---> Using cache
 ---> 770ab9a5fad2
Step 4/28 : SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ---> Using cache
 ---> 53829ca48107
Step 5/28 : RUN echo APT::Install-Recommends "0"\; > /etc/apt/apt.conf.d/10disableextras
 ---> Using cache
 ---> fa1b85cfa64d
Step 6/28 : RUN echo APT::Install-Suggests "0"\; >>  /etc/apt/apt.conf.d/10disableextras
 ---> Using cache
 ---> be85068c291a
Step 7/28 : ENV DEBIAN_FRONTEND noninteractive
 ---> Using cache
 ---> e67598ee9923
Step 8/28 : ENV DEBCONF_TERSE true
 ---> Using cache
 ---> 89c918daf919
Step 9/28 : RUN apt -q update    && apt install -y software-properties-common apt-utils apt-transport-https ca-certificates    && add-apt-repository -y ppa:deadsnakes/ppa    && apt -q update
 ---> Using cache
 ---> a2bd2c5105f1
Step 10/28 : RUN mkdir /package
 ---> Using cache
 ---> dd38b70c991e
Step 11/28 : COPY pkglist /package/pkglist
 ---> Using cache
 ---> 1d6b6ffd7b11
Step 12/28 : RUN apt-get -q install -y --no-install-recommends $(grep -v '^#' /package/pkglist | cat)
 ---> Running in 2f4ae5a952f2

...

E: Failed to fetch http://ppa.launchpad.net/deadsnakes/ppa/ubuntu/pool/main/p/python3.9/python3.9-venv_3.9.21-1+focal1_amd64.deb  404  Not Found [IP: 185.125.190.80 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/v/vim/vim-runtime_8.1.2269-1ubuntu5.29_all.deb  404  Not Found [IP: 185.125.190.82 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/v/vim/vim_8.1.2269-1ubuntu5.29_amd64.deb  404  Not Found [IP: 185.125.190.82 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
The command '/bin/bash -o pipefail -c apt-get -q install -y --no-install-recommends $(grep -v '^#' /package/pkglist | cat)' returned a non-zero code: 100
shingofuruyama@shingofuruyama:~/git/beam$ 
```
</details>

<details><summary>Log for start-build-env.sh on this branch (success)</summary>

```
shingofuruyama@shingofuruyama:~/git/beam$ ./start-build-env.sh 
Sending build context to Docker daemon  15.87kB
Step 1/28 : FROM ubuntu:24.04
24.04: Pulling from library/ubuntu
Digest: sha256:a08e551cb33850e4740772b38217fc1796a66da2506d312abe51acda354ff061
Status: Downloaded newer image for ubuntu:24.04
 ---> 65ae7a6f3544
Step 2/28 : ARG DEBIAN_FRONTEND=noninteractive
 ---> Using cache
 ---> 7b01fc347144
Step 3/28 : WORKDIR /root
 ---> Using cache
 ---> fce0a3b4e261
Step 4/28 : SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ---> Using cache
 ---> 01eef7bb437f
Step 5/28 : RUN echo APT::Install-Recommends "0"\; > /etc/apt/apt.conf.d/10disableextras
 ---> Using cache
 ---> b2d46d6a3429
Step 6/28 : RUN echo APT::Install-Suggests "0"\; >>  /etc/apt/apt.conf.d/10disableextras
 ---> Using cache
 ---> bd8f43585e7c
Step 7/28 : ENV DEBIAN_FRONTEND noninteractive
 ---> Using cache
 ---> 3c02fc70f65d
Step 8/28 : ENV DEBCONF_TERSE true
 ---> Using cache
 ---> 68e188d251e7
Step 9/28 : RUN apt -q update    && apt install -y software-properties-common apt-utils apt-transport-https ca-certificates    && add-apt-repository -y ppa:deadsnakes/ppa    && apt -q update
 ---> Using cache
 ---> 10def99a6fda
Step 10/28 : RUN mkdir /package
 ---> Using cache
 ---> 161ccbf8bf07
Step 11/28 : COPY pkglist /package/pkglist
 ---> Using cache
 ---> 9ec8c7cc813a
Step 12/28 : RUN apt-get -q install -y --no-install-recommends $(grep -v '^#' /package/pkglist | cat)
 ---> Using cache
 ---> c54690635cee
Step 13/28 : RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen &&     locale-gen
 ---> Using cache
 ---> 0bc47438e98c
Step 14/28 : ENV LANG en_US.UTF-8
 ---> Using cache
 ---> 40c39959ea87
Step 15/28 : ENV LANGUAGE en_US:en
 ---> Using cache
 ---> 4d9c2bfc5569
Step 16/28 : ENV LC_ALL en_US.UTF-8
 ---> Using cache
 ---> d72307d78c65
Step 17/28 : RUN pip3 install --break-system-packages grpcio-tools mypy-protobuf
 ---> Using cache
 ---> c049520e1511
Step 18/28 : RUN pip3 install --break-system-packages distlib==0.3.1 yapf==0.29.0 pytest pluggy==1.4.0
 ---> Using cache
 ---> af7a5c9eff58
Step 19/28 : ENV DOWNLOAD_GO_VERSION=1.24.0
 ---> Using cache
 ---> 8f903858cfbf
Step 20/28 : RUN wget https://golang.org/dl/go${DOWNLOAD_GO_VERSION}.linux-amd64.tar.gz &&     tar -C /usr/local -xzf go${DOWNLOAD_GO_VERSION}.linux-amd64.tar.gz
 ---> Using cache
 ---> 6d2e15343a01
Step 21/28 : ENV GOROOT /usr/local/go
 ---> Using cache
 ---> 1abb78256643
Step 22/28 : ENV PATH $PATH:$GOROOT/bin
 ---> Using cache
 ---> 7fc13c17b860
Step 23/28 : RUN mkdir /scripts
 ---> Using cache
 ---> 50070bedb656
Step 24/28 : COPY beam_env_checks.sh /scripts/beam_env_checks.sh
 ---> Using cache
 ---> 0ff6a01b15dc
Step 25/28 : COPY bashcolors.sh      /scripts/bashcolors.sh
 ---> Using cache
 ---> 63a25bfeee67
Step 26/28 : RUN chmod 755 /scripts /scripts/beam_env_checks.sh /scripts/bashcolors.sh
 ---> Using cache
 ---> b5b37600bd52
Step 27/28 : RUN echo '. /etc/bash_completion'        >> /root/.bash_aliases
 ---> Using cache
 ---> b6a0a406cd34
Step 28/28 : RUN echo '. /scripts/beam_env_checks.sh' >> /root/.bash_aliases
 ---> Using cache
 ---> 777b173e7fc7
Successfully built 777b173e7fc7
Successfully tagged beam-build:latest
Sending build context to Docker daemon   2.56kB
Step 1/10 : FROM beam-build
 ---> 777b173e7fc7
Step 2/10 : RUN rm -f /var/log/faillog /var/log/lastlog
 ---> Using cache
 ---> 5bc2a1610f93
Step 3/10 : RUN groupadd --non-unique -g 89939 shingofuruyama
 ---> Using cache
 ---> 9871cedef316
Step 4/10 : RUN groupmod -g 992 docker
 ---> Using cache
 ---> 862d8566425b
Step 5/10 : RUN useradd -g 89939 -G docker -u 1053292 -k /root -m shingofuruyama -d "/home/shingofuruyama"
 ---> Using cache
 ---> 9a82e2a3f6a4
Step 6/10 : RUN echo "shingofuruyama ALL=NOPASSWD: ALL" > "/etc/sudoers.d/beam-build-1053292"
 ---> Using cache
 ---> d3aac58c723a
Step 7/10 : ENV HOME "/home/shingofuruyama"
 ---> Using cache
 ---> 080b8d3db0ee
Step 8/10 : ENV GOPATH /home/shingofuruyama/beam/sdks/go/examples/.gogradle/project_gopath
 ---> Using cache
 ---> fe4816fb7523
Step 9/10 : RUN go mod init beam-build-1053292 && go get github.com/linkedin/goavro/v2
 ---> Using cache
 ---> 1a658e9a72e2
Step 10/10 : RUN chown -R shingofuruyama:89939 /home/shingofuruyama/.cache
 ---> Using cache
 ---> 175ee840616d
Successfully built 175ee840616d
Successfully tagged beam-build-1053292:latest

Docker image build completed.
==============================================================================================

Enabling Docker support with the docker build environment.

______                       ______       _ _     _   _____
| ___ \                      | ___ \     (_) |   | | |  ___|
| |_/ / ___  __ _ _ __ ___   | |_/ /_   _ _| | __| | | |__ _ ____   __
| ___ \/ _ \/ _` | '_ ` _ \  | ___ \ | | | | |/ _` | |  __| '_ \ \ / /
| |_/ /  __/ (_| | | | | | | | |_/ / |_| | | | (_| | | |__| | | \ V /
\____/ \___|\__,_|_| |_| |_| \____/ \__,_|_|_|\__,_| \____/_| |_|\_(_)

This is the standard Beam Developer build environment.
This has all the right tools installed required to build
Apache Beam from source.

 shingofuruyama@[Beam Build Env.]:~/beam {upgrade-dev-docker-base} ]
$ 
```
</details>

<details><summary>Log for ./gradlew :checkSetup on this branch (success)</summary>

```
 shingofuruyama@[Beam Build Env.]:~/beam {upgrade-dev-docker-base} ]
$ ./gradlew :checkSetup
To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/8.14.3/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.
Daemon will be stopped at the end of the build 
Configuration on demand is an incubating feature.
> Task :buildSrc:compileJava NO-SOURCE
> Task :buildSrc:compileGroovy UP-TO-DATE
> Task :buildSrc:pluginDescriptors UP-TO-DATE
> Task :buildSrc:processResources UP-TO-DATE
> Task :buildSrc:classes UP-TO-DATE
> Task :buildSrc:jar UP-TO-DATE

> Configure project :sdks:java:container:java11
docker-pull-licenses not set, skipping go-licenses

...

INFO:apache_beam.io.iobase:*** WriteImpl min_shards undef so it's 1, and we write per Bundle
INFO:apache_beam.runners.worker.statecache:Creating state cache with size 104857600
WARNING:apache_beam.io.filebasedsink:Deleting 1 existing files in target path matching: -*-of-%(num_shards)05d
INFO:apache_beam.io.filebasedsink:Starting finalize_write threads with num_shards: 1 (skipped: 0), batches: 1, num_threads: 1
INFO:apache_beam.io.filebasedsink:Renamed 1 shards in 0.01 seconds.

> Task :checkSetup

[Incubating] Problems report is available at: file:///home/shingofuruyama/beam/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.14.3/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 4m 47s
141 actionable tasks: 6 executed, 135 up-to-date

```
</details>


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
