### PR TITLE
Fix(df): Remove obsolete version check in doctest checker & fix rate limit hits

### DIFF
--- a/.github/actions/setup-java-gradle/action.yml
+++ b/.github/actions/setup-java-gradle/action.yml
@@ -1,0 +1,23 @@
+name: 'Setup Java and Gradle'
+description: 'Installs Java and sets up Gradle for a job'
+inputs:
+  java-version:
+    required: false
+    description: "The Java version to install. Use 'default' for version 11."
+    default: 'default'
+  disable-cache:
+    required: false
+    description: 'Whether to disable the gradle cache'
+    default: false
+runs:
+  using: "composite"
+  steps:
+    - name: Install Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: ${{ inputs.java-version == 'default' && '11' || inputs.java-version }}
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v3
+      with:
+        cache-disabled: ${{ inputs.disable-cache }}

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -1,0 +1,38 @@
+name: 'Setup Python Environment'
+description: 'Installs Python and caches dependencies'
+inputs:
+  python-version:
+    required: true
+    description: 'Install Python version'
+  python-cache:
+    required: false
+    description: 'Whether to enable Python pip caching'
+    default: true
+  tox-cache:
+    required: false
+    description: 'Whether to enable tox environment caching'
+    default: true
+runs:
+  using: "composite"
+  steps:
+    - name: Install Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: ${{ inputs.python-cache && 'pip' || 'none' }}
+        cache-dependency-path: |
+          sdks/python/setup.py
+          sdks/python/tox.ini
+
+    - name: Cache tox environments
+      if: ${{ inputs.tox-cache == 'true' }}
+      uses: actions/cache@v4
+      with:
+        path: |
+          sdks/python/target/.tox
+          !sdks/python/target/.tox/**/log
+          !sdks/python/target/.tox/.package_cache
+        key: tox-${{ runner.os }}-py${{ inputs.python-version }}-${{ hashFiles('sdks/python/tox.ini') }}-${{ hashFiles('sdks/python/setup.py') }}
+        restore-keys: |
+          tox-${{ runner.os }}-py${{ inputs.python-version }}-${{ hashFiles('sdks/python/tox.ini') }}-
+          tox-${{ runner.os }}-py${{ inputs.python-version }}-

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -25,7 +25,7 @@ runs:
           sdks/python/tox.ini
 
     - name: Cache tox environments
-      if: ${{ inputs.tox-cache == 'true' }}
+      if: ${{ inputs.tox-cache }}
       uses: actions/cache@v4
       with:
         path: |

--- a/.github/workflows/beam_PreCommit_Python_Dataframes.yml
+++ b/.github/workflows/beam_PreCommit_Python_Dataframes.yml
@@ -79,10 +79,11 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase}} ${{ matrix.python_version}}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name}} (${{ matrix.job_phrase}} ${{ matrix.python_version}})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Setup Java and Gradle
+        uses: ./.github/actions/setup-java-gradle
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
         with:
-          java-version: default
           python-version: ${{ matrix.python_version }}
       - name: Set PY_VER_CLEAN
         id: set_py_ver_clean

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -136,6 +136,7 @@
 * [YAML] Fixed handling of missing optional fields in JSON parsing ([#35179](https://github.com/apache/beam/issues/35179)).
 * [Python] Fix WriteToBigQuery transform using CopyJob does not work with WRITE_TRUNCATE write disposition ([#34247](https://github.com/apache/beam/issues/34247))
 * [Python] Fixed dicomio tags mismatch in integration tests ([#35658](https://github.com/apache/beam/pull/35658)).
+* [Python] Fixed flaky workflow: PreCommit_Python_Dataframes which was caused by newer numpy versions and GitHub rate limits.
 
 
 ## Known Issues

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -135,8 +135,8 @@
 * Fixed X (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
 * [YAML] Fixed handling of missing optional fields in JSON parsing ([#35179](https://github.com/apache/beam/issues/35179)).
 * [Python] Fix WriteToBigQuery transform using CopyJob does not work with WRITE_TRUNCATE write disposition ([#34247](https://github.com/apache/beam/issues/34247))
-* [Python] Fixed dicomio tags mismatch in integration tests ([#35658](https://github.com/apache/beam/pull/35658)).
-* [Python] Fixed flaky workflow: PreCommit_Python_Dataframes which was caused by newer numpy versions and GitHub rate limits.
+* [Python] Fixed dicomio tags mismatch in integration tests ([#30760](https://github.com/apache/beam/issues/30760)).
+* [Python] Fixed flaky workflow: PreCommit_Python_Dataframes which was caused by newer numpy versions and GitHub rate limits ([35691](https://github.com/apache/beam/issues/35691)).
 
 
 ## Known Issues

--- a/sdks/python/apache_beam/dataframe/doctests.py
+++ b/sdks/python/apache_beam/dataframe/doctests.py
@@ -288,7 +288,7 @@ class _DeferrredDataframeOutputChecker(doctest.OutputChecker):
       except Exception:
         got = traceback.format_exc()
 
-    if sys.version_info < (3, 11) and 'NumpyExtensionArray' in got:
+    if 'NumpyExtensionArray' in got:
       # Work around formatting differences (np.int32(1) vs 1).
       got = re.sub('np.(int32|str_)[(]([^()]+)[)]', r'\2', got)
       got = re.sub('np.complex128[(]([^()]+)[)]', r'(\1)', got)


### PR DESCRIPTION
### Description
This PR fixes a flaky test, which was caused by two unrelated issues:
1. Test case: pandas_doctests_test.py::DoctestTest::test_top_level, that fails intermittently in CI on Python 3.12.
2. GitHub rate limits (fixed by modifying the actions yml files). The new action files resolve preemptive downloads.

### Issue
The test fails with an AssertionError: 4 != 0 due to a doctest mismatch. This occurs because newer versions of numpy, particularly when run on Python 3.12, produce a more explicit string representation for arrays (e.g., [np.int32(1)] instead of [1]).

### Solution
The project's custom _DeferrredDataframeOutputChecker already contains logic to normalize these string representations. However, this logic was incorrectly guarded by a version check:

```Python
if sys.version_info < (3, 11) and 'NumpyExtensionArray' in got:
  # ... normalization logic ...
```
This prevented the fix from running on Python 3.12 environments. This PR removes the obsolete sys.version_info < (3, 11) condition, allowing the output normalization to run on all Python versions and resolving the test failure.

### Verification
I have verified this fix locally by:
Creating a clean environment using Python 3.12.10 to reliably reproduce the AssertionError.
Applying this code change, which caused the test to pass consistently in the same Python 3.12.10 environment.
This change makes our doctests more resilient to environmental differences.

### More Info
Successful run: https://github.com/A1K28/beam/actions/runs/16601134722.
Related Issues: Fixes #35691

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
