### PR TITLE
Adding time partitioning support for python storage write api

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryWriteConfiguration.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryWriteConfiguration.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.io.gcp.bigquery.providers;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
 
 import com.google.auto.value.AutoValue;
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -55,6 +56,39 @@ public abstract class BigQueryWriteConfiguration {
       public abstract Builder setOutput(String output);
 
       public abstract ErrorHandling build();
+    }
+  }
+
+  @AutoValue
+  public abstract static class TimePartitioningConfig implements Serializable {
+    @SchemaFieldDescription("The time partitioning type.")
+    public abstract @Nullable String getType();
+
+    @SchemaFieldDescription("If not set, the table is partitioned by pseudo column '_PARTITIONTIME'; if set, the table is partitioned by this field.")
+    public abstract @Nullable String getField();
+
+    @SchemaFieldDescription("The number of milliseconds for which to keep the storage for a partition.")
+    public abstract @Nullable Long getExpirationMs();
+
+    @SchemaFieldDescription("If set to true, queries over this table require a partition filter.")
+    public abstract @Nullable Boolean getRequirePartitionFilter();
+
+    public static Builder builder() {
+      return new AutoValue_BigQueryWriteConfiguration_TimePartitioningConfig.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder implements Serializable {
+
+      public abstract Builder setType(String type);
+
+      public abstract Builder setField(String field);
+
+      public abstract Builder setExpirationMs(Long expirationMs);
+
+      public abstract Builder setRequirePartitionFilter(Boolean requirePartitionFilter);
+
+      public abstract TimePartitioningConfig build();
     }
   }
 
@@ -197,6 +231,9 @@ public abstract class BigQueryWriteConfiguration {
   @SchemaFieldDescription("A list of columns to cluster the BigQuery table by.")
   public abstract @Nullable List<String> getClusteringFields();
 
+  @SchemaFieldDescription("Configuration for BigQuery time partitioning.")
+  public abstract @Nullable TimePartitioningConfig getTimePartitioningConfig();
+
   /** Builder for {@link BigQueryWriteConfiguration}. */
   @AutoValue.Builder
   public abstract static class Builder {
@@ -230,6 +267,8 @@ public abstract class BigQueryWriteConfiguration {
     public abstract Builder setOnly(String only);
 
     public abstract Builder setClusteringFields(List<String> clusteringFields);
+
+    public abstract Builder setTimePartitioningConfig(TimePartitioningConfig config);
 
     /** Builds a {@link BigQueryWriteConfiguration} instance. */
     public abstract BigQueryWriteConfiguration build();

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -2702,6 +2702,8 @@ class StorageWriteToBigQuery(PTransform):
       table = StorageWriteToBigQuery.DYNAMIC_DESTINATIONS
 
     clustering_fields = []
+    time_partitioning_config= {}
+
     if self.additional_bq_parameters:
       if callable(self.additional_bq_parameters):
         raise NotImplementedError(
@@ -2709,6 +2711,8 @@ class StorageWriteToBigQuery(PTransform):
             "supported for STORAGE_WRITE_API write method.")
       clustering_fields = (
           self.additional_bq_parameters.get("clustering", {}).get("fields", []))
+      time_partitioning_config = (
+          self.additional_bq_parameters.get("timePartitioning", None))
 
     output = (
         input_beam_rows
@@ -2726,6 +2730,7 @@ class StorageWriteToBigQuery(PTransform):
             use_cdc_writes=self._use_cdc_writes,
             primary_key=self._primary_key,
             clustering_fields=clustering_fields,
+            time_partitioning_config=time_partitioning_config,
             error_handling={
                 'output': StorageWriteToBigQuery.FAILED_ROWS_WITH_ERRORS
             }))

--- a/website/www/site/content/en/documentation/io/managed-io.md
+++ b/website/www/site/content/en/documentation/io/managed-io.md
@@ -811,6 +811,18 @@ For more information on table properties, please visit https://iceberg.apache.or
         Determines how often to 'commit' progress into BigQuery. Default is every 5 seconds.
       </td>
     </tr>
+    <tr>
+      <td>
+        Time Partitiong
+      </td>
+      <td>
+        <code>map[<span style="color: green;">str</span>, <span style="color: green;">str</span>]</code>
+      </td>
+      <td>
+        Configuration for time-based partitioning on a DATE, TIMESTAMP, or DATETIME column when writing to the output table.
+      </td>
+    </tr>
+    <tr>
   </table>
 </div>
 


### PR DESCRIPTION
It resolves a part of #35329 

1.Dynamic Time Partitioning is not supported yet. It makes sense to support dynamic Time Partitioning after we support dynamic schema for Python Bigquery Storage Write API.
2.Time Partitioning Support for Bigquery Managed IO.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
