### PR TITLE
adapt to new np outputs (#35691)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -141,7 +141,7 @@
 * Fixed X (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
 * [YAML] Fixed handling of missing optional fields in JSON parsing ([#35179](https://github.com/apache/beam/issues/35179)).
 * [Python] Fix WriteToBigQuery transform using CopyJob does not work with WRITE_TRUNCATE write disposition ([#34247](https://github.com/apache/beam/issues/34247))
-* [Python] Fixed dicomio tags mismatch in integration tests ([#35658](https://github.com/apache/beam/pull/35658)).
+* [Python] Fixed dicomio tags mismatch in integration tests ([#30760](https://github.com/apache/beam/issues/30760)).
 * [Java] Fixed spammy logging issues that affected versions 2.64.0 to 2.66.0.
 
 

--- a/sdks/python/apache_beam/dataframe/doctests.py
+++ b/sdks/python/apache_beam/dataframe/doctests.py
@@ -288,7 +288,7 @@ class _DeferrredDataframeOutputChecker(doctest.OutputChecker):
       except Exception:
         got = traceback.format_exc()
 
-    if sys.version_info < (3, 11) and 'NumpyExtensionArray' in got:
+    if 'NumpyExtensionArray' in got:
       # Work around formatting differences (np.int32(1) vs 1).
       got = re.sub('np.(int32|str_)[(]([^()]+)[)]', r'\2', got)
       got = re.sub('np.complex128[(]([^()]+)[)]', r'(\1)', got)


### PR DESCRIPTION
# Fixes PreCommit Python Dataframes workflow

### Description
This PR fixes a flaky test, which is caused by pandas_doctests_test.py::DoctestTest::test_top_level, that fails intermittently in CI on Python 3.12.

Additionally, there is one more point that is not addressed by the PR nor by the github issue.
https://github.com/apache/beam/actions/runs/16573283602/job/46871045376
The latter occasionally gives 429 rate limit errors from GitHub. It should be addressed in the long run for stability.

### Issue
The test fails with an AssertionError: 4 != 0 due to a doctest mismatch. This occurs because newer versions of numpy, particularly when run on Python 3.12, produce a more explicit string representation for arrays (e.g., [np.int32(1)] instead of [1]).

### Solution
The project's custom _DeferrredDataframeOutputChecker already contains logic to normalize these string representations. However, this logic was incorrectly guarded by a version check:

```Python
if sys.version_info < (3, 11) and 'NumpyExtensionArray' in got:
  # ... normalization logic ...
```
This prevented the fix from running on Python 3.12 environments. This PR removes the obsolete sys.version_info < (3, 11) condition, allowing the output normalization to run on all Python versions and resolving the test failure.

### Verification
I have verified this fix locally by:
Creating a clean environment using Python 3.12.10 to reliably reproduce the AssertionError.
Applying this code change, which caused the test to pass consistently in the same Python 3.12.10 environment.
This change makes our doctests more resilient to environmental differences.

Related Issue: Fixes #35691

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
