### PR TITLE
feat(io): Add option to include source filename in file reads

### DIFF
--- a/sdks/python/apache_beam/dataframe/io.py
+++ b/sdks/python/apache_beam/dataframe/io.py
@@ -789,7 +789,8 @@ class ReadViaPandas(beam.PTransform):
       objects_as_strings=True,
       include_filename=False,
       **kwargs):
-    kwargs['include_filename'] = include_filename
+    if format == 'csv':
+      kwargs['include_filename'] = include_filename
     self._reader = globals()['read_%s' % format](*args, **kwargs)
     self._include_indexes = include_indexes
     self._objects_as_strings = objects_as_strings

--- a/sdks/python/apache_beam/io/textio.py
+++ b/sdks/python/apache_beam/io/textio.py
@@ -479,12 +479,12 @@ class _TextSink(filebasedsink.FileBasedSink):
         shard number and shard count respectively.  This argument can be ``''``
         in which case it behaves as if num_shards was set to 1 and only one file
         will be generated. The default pattern used is ``'-SSSSS-of-NNNNN'`` for
-        bounded PCollections and for ``'-W-SSSSS-of-NNNNN'`` unbounded 
+        bounded PCollections and for ``'-W-SSSSS-of-NNNNN'`` unbounded
         PCollections.
-        W is used for windowed shard naming and is replaced with 
+        W is used for windowed shard naming and is replaced with
         ``[window.start, window.end)``
-        V is used for windowed shard naming and is replaced with 
-        ``[window.start.to_utc_datetime().strftime("%Y-%m-%dT%H-%M-%S"), 
+        V is used for windowed shard naming and is replaced with
+        ``[window.start.to_utc_datetime().strftime("%Y-%m-%dT%H-%M-%S"),
         window.end.to_utc_datetime().strftime("%Y-%m-%dT%H-%M-%S")``
       coder: Coder used to encode each line.
       compression_type: Used to handle compressed output files. Typical value
@@ -505,7 +505,7 @@ class _TextSink(filebasedsink.FileBasedSink):
         to exceed this value.  This also tracks the uncompressed,
         not compressed, size of the shard.
       skip_if_empty: Don't write any shards if the PCollection is empty.
-      triggering_frequency: (int) Every triggering_frequency duration, a window 
+      triggering_frequency: (int) Every triggering_frequency duration, a window
         will be triggered and all bundles in the window will be written.
         If set it overrides user windowing. Mandatory for GlobalWindow.
 
@@ -877,12 +877,12 @@ class WriteToText(PTransform):
         shard number and shard count respectively.  This argument can be ``''``
         in which case it behaves as if num_shards was set to 1 and only one file
         will be generated. The default pattern used is ``'-SSSSS-of-NNNNN'`` for
-        bounded PCollections and for ``'-W-SSSSS-of-NNNNN'`` unbounded 
+        bounded PCollections and for ``'-W-SSSSS-of-NNNNN'`` unbounded
         PCollections.
-        W is used for windowed shard naming and is replaced with 
+        W is used for windowed shard naming and is replaced with
         ``[window.start, window.end)``
-        V is used for windowed shard naming and is replaced with 
-        ``[window.start.to_utc_datetime().strftime("%Y-%m-%dT%H-%M-%S"), 
+        V is used for windowed shard naming and is replaced with
+        ``[window.start.to_utc_datetime().strftime("%Y-%m-%dT%H-%M-%S"),
         window.end.to_utc_datetime().strftime("%Y-%m-%dT%H-%M-%S")``
       coder (~apache_beam.coders.coders.Coder): Coder used to encode each line.
       compression_type (str): Used to handle compressed output files.
@@ -908,8 +908,8 @@ class WriteToText(PTransform):
       skip_if_empty: Don't write any shards if the PCollection is empty.
         In case of an empty PCollection, this will still delete existing
         files having same file path and not create new ones.
-      triggering_frequency: (int) Every triggering_frequency duration, a window 
-        will be triggered and all bundles in the window will be written. 
+      triggering_frequency: (int) Every triggering_frequency duration, a window
+        will be triggered and all bundles in the window will be written.
     """
 
     self._sink = _TextSink(
@@ -973,7 +973,12 @@ try:
 
   @append_pandas_args(
       pandas.read_csv, exclude=['filepath_or_buffer', 'iterator'])
-  def ReadFromCsv(path: str, *, splittable: bool = True, **kwargs):
+  def ReadFromCsv(
+      path: str,
+      *,
+      splittable: bool = True,
+      include_filename: bool = False,
+      **kwargs):
     """A PTransform for reading comma-separated values (csv) files into a
     PCollection.
 
@@ -985,11 +990,17 @@ try:
         This should be set to False if single records span multiple lines (e.g.
         a quoted field has a newline inside of it).  Setting this to false may
         disable liquid sharding.
+      include_filename (bool): Whether to include the source filename in each
+        record.
       **kwargs: Extra arguments passed to `pandas.read_csv` (see below).
     """
     from apache_beam.dataframe.io import ReadViaPandas
     return 'ReadFromCsv' >> ReadViaPandas(
-        'csv', path, splittable=splittable, **kwargs)
+        'csv',
+        path,
+        splittable=splittable,
+        include_filename=include_filename,
+        **kwargs)
 
   @append_pandas_args(
       pandas.DataFrame.to_csv, exclude=['path_or_buf', 'index', 'index_label'])

--- a/sdks/python/apache_beam/io/textio.py
+++ b/sdks/python/apache_beam/io/textio.py
@@ -977,7 +977,7 @@ try:
       path: str,
       *,
       splittable: bool = True,
-      include_filename: bool = False,
+      filename_column: Optional[str] = None,
       **kwargs):
     """A PTransform for reading comma-separated values (csv) files into a
     PCollection.
@@ -990,8 +990,8 @@ try:
         This should be set to False if single records span multiple lines (e.g.
         a quoted field has a newline inside of it).  Setting this to false may
         disable liquid sharding.
-      include_filename (bool): Whether to include the source filename in each
-        record.
+      filename_column (str): If not None, the name of the column to add
+        to each record, containing the filename of the source file.
       **kwargs: Extra arguments passed to `pandas.read_csv` (see below).
     """
     from apache_beam.dataframe.io import ReadViaPandas
@@ -999,7 +999,7 @@ try:
         'csv',
         path,
         splittable=splittable,
-        include_filename=include_filename,
+        filename_column=filename_column,
         **kwargs)
 
   @append_pandas_args(

--- a/sdks/python/apache_beam/io/textio_test.py
+++ b/sdks/python/apache_beam/io/textio_test.py
@@ -1775,7 +1775,8 @@ class CsvTest(unittest.TestCase):
       with TestPipeline() as p:
         pcoll = (
             p
-            | beam.io.ReadFromCsv(file_path + '*', include_filename=True)
+            | beam.io.ReadFromCsv(
+                file_path + '*', filename_column='source_filename')
             | beam.Map(lambda t: beam.Row(**dict(zip(type(t)._fields, t)))))
 
         # Get the sharded file name
@@ -1784,7 +1785,8 @@ class CsvTest(unittest.TestCase):
         sharded_file_path = files[0]
 
         expected = [
-            beam.Row(a=r.a, b=r.b, filename=sharded_file_path) for r in records
+            beam.Row(a=r.a, b=r.b, source_filename=sharded_file_path)
+            for r in records
         ]
         assert_that(pcoll, equal_to(expected))
 

--- a/sdks/python/apache_beam/io/textio_test.py
+++ b/sdks/python/apache_beam/io/textio_test.py
@@ -1765,6 +1765,29 @@ class CsvTest(unittest.TestCase):
 
         assert_that(pcoll, equal_to(records))
 
+  def test_csv_read_with_filename(self):
+    records = [beam.Row(a='str', b=ix) for ix in range(3)]
+    with tempfile.TemporaryDirectory() as dest:
+      file_path = os.path.join(dest, 'out.csv')
+      with TestPipeline() as p:
+        # pylint: disable=expression-not-assigned
+        p | beam.Create(records) | beam.io.WriteToCsv(file_path)
+      with TestPipeline() as p:
+        pcoll = (
+            p
+            | beam.io.ReadFromCsv(file_path + '*', include_filename=True)
+            | beam.Map(lambda t: beam.Row(**dict(zip(type(t)._fields, t)))))
+
+        # Get the sharded file name
+        files = glob.glob(file_path + '*')
+        self.assertEqual(len(files), 1)
+        sharded_file_path = files[0]
+
+        expected = [
+            beam.Row(a=r.a, b=r.b, filename=sharded_file_path) for r in records
+        ]
+        assert_that(pcoll, equal_to(expected))
+
   def test_non_utf8_csv_read_write(self):
     content = b"\xe0,\xe1,\xe2\n0,1,2\n1,2,3\n"
 

--- a/sdks/python/apache_beam/yaml/standard_io.yaml
+++ b/sdks/python/apache_beam/yaml/standard_io.yaml
@@ -169,7 +169,7 @@
         path: 'path'
         delimiter: 'sep'
         comment: 'comment'
-        include_filename: 'include_filename'
+        filename_column: 'filename_column'
       'WriteToCsv':
         path: 'path'
         delimiter: 'sep'

--- a/sdks/python/apache_beam/yaml/standard_io.yaml
+++ b/sdks/python/apache_beam/yaml/standard_io.yaml
@@ -169,6 +169,7 @@
         path: 'path'
         delimiter: 'sep'
         comment: 'comment'
+        include_filename: 'include_filename'
       'WriteToCsv':
         path: 'path'
         delimiter: 'sep'

--- a/sdks/python/apache_beam/yaml/tests/csv.yaml
+++ b/sdks/python/apache_beam/yaml/tests/csv.yaml
@@ -53,15 +53,14 @@ pipelines:
           config:
             path: "{TEMP_DIR}/out.csv*"
             include_filename: true
-        - type: Map
+        - type: MapToFields
           name: Check Filename
           config:
-            expression: |
-              lambda row: {
-                'label': row.label,
-                'rank': row.rank,
-                'filename_ok': row.filename.startswith(f'{TEMP_DIR}/out.csv')
-              }
+            language: python
+            fields:
+              label: label
+              rank: rank
+              filename_ok: filename.startswith(f'{TEMP_DIR}/out.csv')
         - type: AssertEqual
           config:
             elements:

--- a/sdks/python/apache_beam/yaml/tests/csv.yaml
+++ b/sdks/python/apache_beam/yaml/tests/csv.yaml
@@ -52,7 +52,7 @@ pipelines:
         - type: ReadFromCsv
           config:
             path: "{TEMP_DIR}/out.csv*"
-            include_filename: true
+            filename_column: "source_file"
         - type: MapToFields
           name: Check Filename
           config:
@@ -60,7 +60,7 @@ pipelines:
             fields:
               label: label
               rank: rank
-              filename_ok: filename.startswith(f'{TEMP_DIR}/out.csv')
+              filename_ok: source_file.startswith(f'{TEMP_DIR}/out.csv')
         - type: AssertEqual
           config:
             elements:

--- a/sdks/python/apache_beam/yaml/tests/csv.yaml
+++ b/sdks/python/apache_beam/yaml/tests/csv.yaml
@@ -45,3 +45,26 @@ pipelines:
               - {label: "11a", rank: 0}
               - {label: "37a", rank: 1}
               - {label: "389a", rank: 2}
+
+  - pipeline:
+      type: chain
+      transforms:
+        - type: ReadFromCsv
+          config:
+            path: "{TEMP_DIR}/out.csv*"
+            include_filename: true
+        - type: Map
+          name: Check Filename
+          config:
+            expression: |
+              lambda row: {
+                'label': row.label,
+                'rank': row.rank,
+                'filename_ok': row.filename.startswith(f'{TEMP_DIR}/out.csv')
+              }
+        - type: AssertEqual
+          config:
+            elements:
+              - {label: "11a", rank: 0, filename_ok: true}
+              - {label: "37a", rank: 1, filename_ok: true}
+              - {label: "389a", rank: 2, filename_ok: true}


### PR DESCRIPTION
This commit introduces a feature to include the source filename alongside the data when reading from files. This is useful for data provenance and downstream processing that depends on the origin of the data.

The following changes are included:

- Rather than suing the boolean `include_filename` parameter, switch to a more flexible `filename_column` string parameter.
- This functionality is exposed in the Beam YAML API for both `ReadFromText` and `ReadFromCsv`.
- Unit tests have been added to validate the new behavior for the Python SDK, DataFrame API, and YAML interface.

Fixes https://github.com/apache/beam/issues/35773

Tested:
```
python -m pytest -v sdks/python/apache_beam/yaml/integration_tests.py::CsvTest 
python -m pytest sdks/python/apache_beam/io/textio_test.py
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
