### PR TITLE
fix(bigquery): use correct project for temp dataset operations

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery_read_internal.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_read_internal.py
@@ -239,6 +239,17 @@ class _BigQueryReadSplit(beam.transforms.DoFn):
     else:
       raise ValueError("temp_dataset has to be either str or DatasetReference")
 
+  def _get_temp_dataset_project(self):
+    """Returns the project ID for temporary dataset operations.
+    
+    If temp_dataset is a DatasetReference, returns its projectId.
+    Otherwise, returns the pipeline project for billing.
+    """
+    if isinstance(self.temp_dataset, DatasetReference):
+      return self.temp_dataset.projectId
+    else:
+      return self._get_project()
+
   def start_bundle(self):
     self.bq = bigquery_tools.BigQueryWrapper(
         temp_dataset_id=self._get_temp_dataset_id(),
@@ -278,7 +289,9 @@ class _BigQueryReadSplit(beam.transforms.DoFn):
 
   def finish_bundle(self):
     if self.bq.created_temp_dataset:
-      self.bq.clean_up_temporary_dataset(self._get_project())
+      # Use the same project that was used to create the temp dataset
+      temp_dataset_project = self._get_temp_dataset_project()
+      self.bq.clean_up_temporary_dataset(temp_dataset_project)
 
   def _get_bq_metadata(self):
     if not self.bq_io_metadata:
@@ -303,7 +316,10 @@ class _BigQueryReadSplit(beam.transforms.DoFn):
       element: 'ReadFromBigQueryRequest'):
     location = bq.get_query_location(
         self._get_project(), element.query, not element.use_standard_sql)
-    bq.create_temporary_dataset(self._get_project(), location)
+    # Use the project from temp_dataset if it's a DatasetReference,
+    # otherwise use the pipeline project
+    temp_dataset_project = self._get_temp_dataset_project()
+    bq.create_temporary_dataset(temp_dataset_project, location)
 
   def _execute_query(
       self,

--- a/sdks/python/apache_beam/io/gcp/bigquery_read_internal_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_read_internal_test.py
@@ -1,0 +1,163 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for BigQuery read internal module."""
+
+import unittest
+from unittest import mock
+
+from apache_beam.io.gcp import bigquery_read_internal
+from apache_beam.io.gcp import bigquery_tools
+from apache_beam.io.gcp.internal.clients.bigquery import DatasetReference
+from apache_beam.options.pipeline_options import GoogleCloudOptions
+from apache_beam.options.pipeline_options import PipelineOptions
+from apache_beam.options.value_provider import StaticValueProvider
+
+
+class BigQueryReadSplitTest(unittest.TestCase):
+  """Tests for _BigQueryReadSplit DoFn."""
+  def setUp(self):
+    self.options = PipelineOptions()
+    self.gcp_options = self.options.view_as(GoogleCloudOptions)
+    self.gcp_options.project = 'test-project'
+
+  def test_get_temp_dataset_project_with_string_temp_dataset(self):
+    """Test _get_temp_dataset_project with string temp_dataset."""
+    split = bigquery_read_internal._BigQueryReadSplit(
+        options=self.options, temp_dataset='temp_dataset_id')
+
+    # Should return the pipeline project when temp_dataset is a string
+    self.assertEqual(split._get_temp_dataset_project(), 'test-project')
+
+  def test_get_temp_dataset_project_with_dataset_reference(self):
+    """Test _get_temp_dataset_project with DatasetReference temp_dataset."""
+    dataset_ref = DatasetReference(
+        projectId='custom-project', datasetId='temp_dataset_id')
+    split = bigquery_read_internal._BigQueryReadSplit(
+        options=self.options, temp_dataset=dataset_ref)
+
+    # Should return the project from DatasetReference
+    self.assertEqual(split._get_temp_dataset_project(), 'custom-project')
+
+  def test_get_temp_dataset_project_with_none_temp_dataset(self):
+    """Test _get_temp_dataset_project with None temp_dataset."""
+    split = bigquery_read_internal._BigQueryReadSplit(
+        options=self.options, temp_dataset=None)
+
+    # Should return the pipeline project when temp_dataset is None
+    self.assertEqual(split._get_temp_dataset_project(), 'test-project')
+
+  def test_get_temp_dataset_project_with_value_provider_project(self):
+    """Test _get_temp_dataset_project with ValueProvider project."""
+    self.gcp_options.project = StaticValueProvider(str, 'vp-project')
+    dataset_ref = DatasetReference(
+        projectId='custom-project', datasetId='temp_dataset_id')
+    split = bigquery_read_internal._BigQueryReadSplit(
+        options=self.options, temp_dataset=dataset_ref)
+
+    # Should still return the project from DatasetReference
+    self.assertEqual(split._get_temp_dataset_project(), 'custom-project')
+
+  @mock.patch('apache_beam.io.gcp.bigquery_tools.BigQueryWrapper')
+  def test_setup_temporary_dataset_uses_correct_project(self, mock_bq_wrapper):
+    """Test that _setup_temporary_dataset uses the correct project."""
+    dataset_ref = DatasetReference(
+        projectId='custom-project', datasetId='temp_dataset_id')
+    split = bigquery_read_internal._BigQueryReadSplit(
+        options=self.options, temp_dataset=dataset_ref)
+
+    # Mock the BigQueryWrapper instance
+    mock_bq = mock.Mock()
+    mock_bq.get_query_location.return_value = 'US'
+
+    # Mock ReadFromBigQueryRequest
+    mock_element = mock.Mock()
+    mock_element.query = 'SELECT * FROM table'
+    mock_element.use_standard_sql = True
+
+    # Call _setup_temporary_dataset
+    split._setup_temporary_dataset(mock_bq, mock_element)
+
+    # Verify that create_temporary_dataset was called with the custom project
+    mock_bq.create_temporary_dataset.assert_called_once_with(
+        'custom-project', 'US')
+    # Verify that get_query_location was called with the pipeline project
+    mock_bq.get_query_location.assert_called_once_with(
+        'test-project', 'SELECT * FROM table', False)
+
+  @mock.patch('apache_beam.io.gcp.bigquery_tools.BigQueryWrapper')
+  def test_finish_bundle_uses_correct_project(self, mock_bq_wrapper):
+    """Test that finish_bundle uses the correct project for cleanup."""
+    dataset_ref = DatasetReference(
+        projectId='custom-project', datasetId='temp_dataset_id')
+    split = bigquery_read_internal._BigQueryReadSplit(
+        options=self.options, temp_dataset=dataset_ref)
+
+    # Mock the BigQueryWrapper instance
+    mock_bq = mock.Mock()
+    mock_bq.created_temp_dataset = True
+    split.bq = mock_bq
+
+    # Call finish_bundle
+    split.finish_bundle()
+
+    # Verify that clean_up_temporary_dataset was called with the custom project
+    mock_bq.clean_up_temporary_dataset.assert_called_once_with('custom-project')
+
+  @mock.patch('apache_beam.io.gcp.bigquery_tools.BigQueryWrapper')
+  def test_setup_temporary_dataset_with_string_temp_dataset(
+      self, mock_bq_wrapper):
+    """Test _setup_temporary_dataset with string temp_dataset uses pipeline project."""
+    split = bigquery_read_internal._BigQueryReadSplit(
+        options=self.options, temp_dataset='temp_dataset_id')
+
+    # Mock the BigQueryWrapper instance
+    mock_bq = mock.Mock()
+    mock_bq.get_query_location.return_value = 'US'
+
+    # Mock ReadFromBigQueryRequest
+    mock_element = mock.Mock()
+    mock_element.query = 'SELECT * FROM table'
+    mock_element.use_standard_sql = True
+
+    # Call _setup_temporary_dataset
+    split._setup_temporary_dataset(mock_bq, mock_element)
+
+    # Verify that create_temporary_dataset was called with the pipeline project
+    mock_bq.create_temporary_dataset.assert_called_once_with(
+        'test-project', 'US')
+
+  @mock.patch('apache_beam.io.gcp.bigquery_tools.BigQueryWrapper')
+  def test_finish_bundle_with_string_temp_dataset(self, mock_bq_wrapper):
+    """Test finish_bundle with string temp_dataset uses pipeline project."""
+    split = bigquery_read_internal._BigQueryReadSplit(
+        options=self.options, temp_dataset='temp_dataset_id')
+
+    # Mock the BigQueryWrapper instance
+    mock_bq = mock.Mock()
+    mock_bq.created_temp_dataset = True
+    split.bq = mock_bq
+
+    # Call finish_bundle
+    split.finish_bundle()
+
+    # Verify that clean_up_temporary_dataset was called with the pipeline project
+    mock_bq.clean_up_temporary_dataset.assert_called_once_with('test-project')
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Add _get_temp_dataset_project helper method to determine the correct project ID for temporary dataset operations. Update _setup_temporary_dataset and finish_bundle to use this method instead of _get_project when cleaning up or creating temporary datasets. This ensures the correct project is used when temp_dataset is a DatasetReference.

Add comprehensive unit tests to verify the behavior with different temp_dataset configurations.

Fixes https://github.com/apache/beam/issues/35813

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
