### PR TITLE
Add Action to generate ManagedIO doc PR

### DIFF
--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -40,6 +40,8 @@ on:
           beam_site_pr: create the documentation update PR against apache/beam-site.
           --
           prism: build and upload the artifacts to the release for this tag
+          --
+          managed_io_docs_pr: create the managed-io.md update PR against apache/beam.
         required: true
         default: |
            {java_artifacts: "no",
@@ -47,7 +49,8 @@ on:
             docker_artifacts: "no",
             python_artifacts: "no",
             beam_site_pr: "no",
-            prism: "no"}
+            prism: "no",
+            managed_io_docs_pr: "no"}
 
 env:
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -545,3 +545,68 @@ jobs:
           svn add --force --parents prism
           svn status
           svn commit -m "Staging Prism artifacts for Apache Beam ${RELEASE} RC${RC_NUM}" --non-interactive --username "${{ github.event.inputs.APACHE_ID }}" --password "${{ github.event.inputs.APACHE_PASSWORD }}"
+
+  managed_io_docs_pr:
+    if:  ${{ fromJson(github.event.inputs.STAGE).managed_io_docs_pr == 'yes'}}
+    runs-on: ubuntu-22.04
+    env:
+      BRANCH_NAME: updates_managed_io_docs_${{ github.event.inputs.RELEASE }}
+      BEAM_ROOT_DIR: ${{ github.workspace }}/beam
+      MANAGED_IO_DOCS_PATH: website/www/site/content/en/documentation/io/managed-io.md
+    steps:
+      - name: Checkout Beam Repo
+        uses: actions/checkout@v4
+        with:
+          ref: "v${{ github.event.inputs.RELEASE }}-RC${{ github.event.inputs.RC }}"
+          repository: apache/beam
+          path: beam
+          token: ${{ github.event.inputs.REPO_TOKEN }}
+          persist-credentials: false
+      - name: Install Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - name: Install Java 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: Remove default github maven configuration
+        # This step is a workaround to avoid a decryption issue of Beam's
+        # net.linguica.gradle.maven.settings plugin and github's provided maven
+        # settings.xml file
+        run: rm ~/.m2/settings.xml || true
+      - name: Install SDK
+        working-directory: beam/sdks/python
+        run: |
+          pip install -e.
+      - name: Build Expansion Service Jar
+        working-directory: beam
+        run: |
+          ./gradlew sdks:java:io:expansion-service:shadowJar
+      - name: Build GCP Expansion Service Jar
+        working-directory: beam
+        run: |
+          ./gradlew sdks:java:io:google-cloud-platform:expansion-service:shadowJar
+      - name: Generate Managed IO Docs
+        working-directory: beam/sdks/python
+        run: |
+          python gen_managed_doc.py --output_location ${{ runner.temp }}/managed-io.md
+      - name: Create commit on beam branch
+        working-directory: beam
+        run: |
+          git checkout -b $BRANCH_NAME
+          mv ${{ runner.temp }}/managed-io.md ${{ env.MANAGED_IO_DOCS_PATH }}
+          git config user.name $GITHUB_ACTOR
+          git config user.email actions@"$RUNNER_NAME".local
+          git add -A
+          git commit -m "Update managed-io.md for release ${{ github.event.inputs.RELEASE }}."
+          git push -f --set-upstream origin $BRANCH_NAME
+      - name: Create beam PR
+        working-directory: beam
+        env:
+          GH_TOKEN: ${{ github.event.inputs.REPO_TOKEN }}
+          PR_TITLE: "Update managed-io.md for ${{ github.event.inputs.RELEASE }} release"
+          PR_BODY: "Content generated from release ${{ github.event.inputs.RELEASE }}."
+        run: |
+          gh pr create -t "$PR_TITLE" -b "$PR_BODY" --base master --repo apache/beam

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -596,7 +596,6 @@ jobs:
         run: |
           python gen_managed_doc.py --output_location ${{ runner.temp }}/managed-io.md
       - name: Create commit on beam branch
-        id: create_commit
         working-directory: beam
         run: |
           git checkout -b $BRANCH_NAME
@@ -604,16 +603,9 @@ jobs:
           git config user.name $GITHUB_ACTOR
           git config user.email actions@"$RUNNER_NAME".local
           git add -A
-          if ! git diff-index --quiet HEAD --; then
-            git commit -m "Update managed-io.md for release ${{ github.event.inputs.RELEASE }}."
-            git push -f --set-upstream origin $BRANCH_NAME
-            echo "commit_made=true" >> $GITHUB_OUTPUT
-          else
-            echo "No changes detected in managed-io.md. Skipping commit and PR creation."
-            echo "commit_made=false" >> $GITHUB_OUTPUT
-          fi
+          git commit --allow-empty -m "Update managed-io.md for release ${{ github.event.inputs.RELEASE }}."
+          git push -f --set-upstream origin $BRANCH_NAME
       - name: Create beam PR
-        if: steps.create_commit.outputs.commit_made == 'true'
         working-directory: beam
         env:
           GH_TOKEN: ${{ github.event.inputs.REPO_TOKEN }}

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -553,7 +553,7 @@ jobs:
     if:  ${{ fromJson(github.event.inputs.STAGE).managed_io_docs_pr == 'yes'}}
     runs-on: ubuntu-22.04
     env:
-      BRANCH_NAME: updates_managed_io_docs_${{ github.event.inputs.RELEASE }}
+      BRANCH_NAME: updates_managed_io_docs_${{ github.event.inputs.RELEASE }}_rc${{ github.event.inputs.RC }}
       BEAM_ROOT_DIR: ${{ github.workspace }}/beam
       MANAGED_IO_DOCS_PATH: website/www/site/content/en/documentation/io/managed-io.md
     steps:
@@ -598,18 +598,19 @@ jobs:
       - name: Create commit on beam branch
         working-directory: beam
         run: |
+          git fetch origin master
           git checkout -b $BRANCH_NAME origin/master
           mv ${{ runner.temp }}/managed-io.md ${{ env.MANAGED_IO_DOCS_PATH }}
           git config user.name $GITHUB_ACTOR
           git config user.email actions@"$RUNNER_NAME".local
           git add ${{ env.MANAGED_IO_DOCS_PATH }}
-          git commit --allow-empty -m "Update managed-io.md for release ${{ github.event.inputs.RELEASE }}."
+          git commit --allow-empty -m "Update managed-io.md for release ${{ github.event.inputs.RELEASE }}-RC${{ github.event.inputs.RC }}."
           git push -f --set-upstream origin $BRANCH_NAME
       - name: Create beam PR
         working-directory: beam
         env:
           GH_TOKEN: ${{ github.event.inputs.REPO_TOKEN }}
-          PR_TITLE: "Update managed-io.md for ${{ github.event.inputs.RELEASE }} release"
-          PR_BODY: "Content generated from release ${{ github.event.inputs.RELEASE }}."
+          PR_TITLE: "Update managed-io.md for release ${{ github.event.inputs.RELEASE }}-RC${{ github.event.inputs.RC }}"
+          PR_BODY: "Content generated from release ${{ github.event.inputs.RELEASE }}-RC${{ github.event.inputs.RC }}."
         run: |
           gh pr create -t "$PR_TITLE" -b "$PR_BODY" --base master --repo apache/beam

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -598,11 +598,11 @@ jobs:
       - name: Create commit on beam branch
         working-directory: beam
         run: |
-          git checkout -b $BRANCH_NAME
+          git checkout -b $BRANCH_NAME origin/master
           mv ${{ runner.temp }}/managed-io.md ${{ env.MANAGED_IO_DOCS_PATH }}
           git config user.name $GITHUB_ACTOR
           git config user.email actions@"$RUNNER_NAME".local
-          git add -A
+          git add ${{ env.MANAGED_IO_DOCS_PATH }}
           git commit --allow-empty -m "Update managed-io.md for release ${{ github.event.inputs.RELEASE }}."
           git push -f --set-upstream origin $BRANCH_NAME
       - name: Create beam PR

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -596,6 +596,7 @@ jobs:
         run: |
           python gen_managed_doc.py --output_location ${{ runner.temp }}/managed-io.md
       - name: Create commit on beam branch
+        id: create_commit
         working-directory: beam
         run: |
           git checkout -b $BRANCH_NAME
@@ -603,9 +604,16 @@ jobs:
           git config user.name $GITHUB_ACTOR
           git config user.email actions@"$RUNNER_NAME".local
           git add -A
-          git commit -m "Update managed-io.md for release ${{ github.event.inputs.RELEASE }}."
-          git push -f --set-upstream origin $BRANCH_NAME
+          if ! git diff-index --quiet HEAD --; then
+            git commit -m "Update managed-io.md for release ${{ github.event.inputs.RELEASE }}."
+            git push -f --set-upstream origin $BRANCH_NAME
+            echo "commit_made=true" >> $GITHUB_OUTPUT
+          else
+            echo "No changes detected in managed-io.md. Skipping commit and PR creation."
+            echo "commit_made=false" >> $GITHUB_OUTPUT
+          fi
       - name: Create beam PR
+        if: steps.create_commit.outputs.commit_made == 'true'
         working-directory: beam
         env:
           GH_TOKEN: ${{ github.event.inputs.REPO_TOKEN }}


### PR DESCRIPTION
part-1 fix for https://github.com/apache/beam/issues/35746. This new action creates the managed-io doc PR against master. To maintain consistency we raise an empty PR incase of no changes that release manager choose to close. 

<img width="949" height="353" alt="Screenshot 2025-08-08 at 2 11 31 PM" src="https://github.com/user-attachments/assets/3f14e386-bc16-4b96-85db-eca1c36d6417" />

 
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
