### PR TITLE
fix(test): improve redis container startup reliability in tests

### DIFF
--- a/sdks/python/apache_beam/io/requestresponse_it_test.py
+++ b/sdks/python/apache_beam/io/requestresponse_it_test.py
@@ -17,6 +17,7 @@
 import base64
 import logging
 import sys
+import time
 import typing
 import unittest
 from dataclasses import dataclass
@@ -294,6 +295,8 @@ class TestRedisCache(unittest.TestCase):
     for i in range(self.retries):
       try:
         self.container = RedisContainer(image='redis:7.2.4')
+        # Add wait strategy and increase timeout for flaky startup
+        self.container = self.container.with_startup_timeout(120)  # 2 min
         self.container.start()
         self.host = self.container.get_container_host_ip()
         self.port = self.container.get_exposed_port(6379)
@@ -303,6 +306,8 @@ class TestRedisCache(unittest.TestCase):
         if i == self.retries - 1:
           _LOGGER.error('Unable to start redis container for RRIO tests.')
           raise e
+        # Add a small delay between retries to avoid rapid successive failures
+        time.sleep(2)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/transforms/enrichment_handlers/bigquery_it_test.py
+++ b/sdks/python/apache_beam/transforms/enrichment_handlers/bigquery_it_test.py
@@ -147,6 +147,8 @@ class TestBigQueryEnrichmentIT(BigQueryEnrichmentIT):
     for i in range(self.retries):
       try:
         self.container = RedisContainer(image='redis:7.2.4')
+        # Add wait strategy and increase timeout for flaky startup
+        self.container = self.container.with_startup_timeout(120)  # 2 min
         self.container.start()
         self.host = self.container.get_container_host_ip()
         self.port = self.container.get_exposed_port(6379)
@@ -158,6 +160,8 @@ class TestBigQueryEnrichmentIT(BigQueryEnrichmentIT):
               'Unable to start redis container for BigQuery '
               ' enrichment tests.')
           raise e
+        # Add a small delay between retries to avoid rapid successive failures
+        time.sleep(2)
 
   def tearDown(self) -> None:
     self.container.stop()

--- a/sdks/python/apache_beam/transforms/enrichment_handlers/bigtable_it_test.py
+++ b/sdks/python/apache_beam/transforms/enrichment_handlers/bigtable_it_test.py
@@ -17,6 +17,7 @@
 
 import datetime
 import logging
+import time
 import unittest
 from typing import NamedTuple
 from unittest.mock import MagicMock
@@ -174,6 +175,8 @@ class TestBigTableEnrichment(unittest.TestCase):
     for i in range(self.retries):
       try:
         self.container = RedisContainer(image='redis:7.2.4')
+        # Add wait strategy and increase timeout for flaky startup
+        self.container = self.container.with_startup_timeout(120)  # 2 min
         self.container.start()
         self.host = self.container.get_container_host_ip()
         self.port = self.container.get_exposed_port(6379)
@@ -183,6 +186,8 @@ class TestBigTableEnrichment(unittest.TestCase):
         if i == self.retries - 1:
           _LOGGER.error('Unable to start redis container for RRIO tests.')
           raise e
+        # Add a small delay between retries to avoid rapid successive failures
+        time.sleep(2)
 
   def tearDown(self) -> None:
     self.container.stop()

--- a/sdks/python/apache_beam/transforms/enrichment_handlers/vertex_ai_feature_store_it_test.py
+++ b/sdks/python/apache_beam/transforms/enrichment_handlers/vertex_ai_feature_store_it_test.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 import logging
+import time
 import unittest
 from unittest.mock import MagicMock
 
@@ -78,6 +79,8 @@ class TestVertexAIFeatureStoreHandler(unittest.TestCase):
     for i in range(3):
       try:
         self.container = RedisContainer(image='redis:7.2.4')
+        # Add wait strategy and increase timeout for flaky startup
+        self.container = self.container.with_startup_timeout(120)  # 2 min
         self.container.start()
         self.host = self.container.get_container_host_ip()
         self.port = self.container.get_exposed_port(6379)
@@ -87,6 +90,8 @@ class TestVertexAIFeatureStoreHandler(unittest.TestCase):
         if i == self.retries - 1:
           _LOGGER.error('Unable to start redis container for RRIO tests.')
           raise e
+        # Add a small delay between retries to avoid rapid successive failures
+        time.sleep(2)
 
   def tearDown(self) -> None:
     self.container.stop()


### PR DESCRIPTION
Add startup timeout and delay between retries to handle flaky redis container initialization. The changes apply to multiple test files that use RedisContainer for testing.

Failed flaky runs: https://github.com/apache/beam/actions/runs/16915674582/job/47928839425

Errors:
```
2025-08-12T17:53:49.8291529Z =================================== FAILURES ===================================
2025-08-12T17:53:49.8329872Z _______ TestBigQueryEnrichmentIT.test_bigquery_enrichment_with_query_fn ________
2025-08-12T17:53:49.8331576Z [gw3] linux -- Python 3.9.22 /runner/_work/beam/beam/sdks/python/test-suites/tox/py39/build/srcs/sdks/python/target/.tox-py39-cloudcoverage/py39-cloudcoverage/bin/python
2025-08-12T17:53:49.8332705Z 
2025-08-12T17:53:49.8333614Z self = <apache_beam.transforms.enrichment_handlers.bigquery_it_test.TestBigQueryEnrichmentIT testMethod=test_bigquery_enrichment_with_query_fn>
2025-08-12T17:53:49.8334545Z 
2025-08-12T17:53:49.8334770Z     def setUp(self) -> None:
2025-08-12T17:53:49.8335272Z       self.condition_template = "id = {}"
2025-08-12T17:53:49.8335817Z       self.retries = 3
2025-08-12T17:53:49.8336302Z >     self._start_container()
2025-08-12T17:53:49.8336594Z 
2025-08-12T17:53:49.8337285Z apache_beam/transforms/enrichment_handlers/bigquery_it_test.py:144: 
2025-08-12T17:53:49.8338376Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2025-08-12T17:53:49.8339429Z apache_beam/transforms/enrichment_handlers/bigquery_it_test.py:160: in _start_container
2025-08-12T17:53:49.8340226Z     raise e
2025-08-12T17:53:49.8340957Z apache_beam/transforms/enrichment_handlers/bigquery_it_test.py:150: in _start_container
2025-08-12T17:53:49.8341975Z     self.container.start()
2025-08-12T17:53:49.8343169Z target/.tox-py39-cloudcoverage/py39-cloudcoverage/lib/python3.9/site-packages/testcontainers/redis/__init__.py:71: in start
2025-08-12T17:53:49.8344327Z     self._connect()
2025-08-12T17:53:49.8344859Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2025-08-12T17:53:49.8345336Z 
2025-08-12T17:53:49.8346039Z wrapped = <bound method RedisContainer._connect of <testcontainers.redis.RedisContainer object at 0x7f48e439dfd0>>
2025-08-12T17:53:49.8347167Z instance = <testcontainers.redis.RedisContainer object at 0x7f48e439dfd0>
2025-08-12T17:53:49.8347789Z args = (), kwargs = {}
2025-08-12T17:53:49.8348183Z 
2025-08-12T17:53:49.8348610Z     @wrapt.decorator  # type: ignore[misc]
2025-08-12T17:53:49.8349356Z     def wrapper(wrapped: Callable[..., Any], instance: Any, args: list[Any], kwargs: dict[str, Any]) -> Any:
2025-08-12T17:53:49.8350209Z         from testcontainers.core.container import DockerContainer
2025-08-12T17:53:49.8350719Z     
2025-08-12T17:53:49.8351137Z         if isinstance(instance, DockerContainer):
2025-08-12T17:53:49.8351922Z             logger.info("Waiting for container %s with image %s to be ready ...", instance._container, instance.image)
2025-08-12T17:53:49.8352611Z         else:
2025-08-12T17:53:49.8353017Z             logger.info("Waiting for %s to be ready ...", instance)
2025-08-12T17:53:49.8353508Z     
2025-08-12T17:53:49.8353856Z         exception = None
2025-08-12T17:53:49.8354274Z         for attempt_no in range(config.max_tries):
2025-08-12T17:53:49.8354708Z             try:
2025-08-12T17:53:49.8355054Z                 return wrapped(*args, **kwargs)
2025-08-12T17:53:49.8355716Z             except transient_exceptions as e:
2025-08-12T17:53:49.8356178Z                 logger.debug(
2025-08-12T17:53:49.8356801Z                     f"Connection attempt '{attempt_no + 1}' of '{config.max_tries + 1}' "
2025-08-12T17:53:49.8357498Z                     f"failed: {traceback.format_exc()}"
2025-08-12T17:53:49.8357935Z                 )
2025-08-12T17:53:49.8358739Z                 time.sleep(config.sleep_time)
2025-08-12T17:53:49.8359170Z                 exception = e
2025-08-12T17:53:49.8359538Z >       raise TimeoutError(
2025-08-12T17:53:49.8360130Z             f"Wait time ({config.timeout}s) exceeded for {wrapped.__name__}(args: {args}, kwargs: "
2025-08-12T17:53:49.8360791Z             f"{kwargs}). Exception: {exception}"
2025-08-12T17:53:49.8361299Z         )
2025-08-12T17:53:49.8362176Z E       TimeoutError: Wait time (1s) exceeded for _connect(args: (), kwargs: {}). Exception: Error while reading from localhost:32799 : (104, 'Connection reset by peer')
2025-08-12T17:53:49.8363015Z 
2025-08-12T17:53:49.8363859Z target/.tox-py39-cloudcoverage/py39-cloudcoverage/lib/python3.9/site-packages/testcontainers/core/waiting_utils.py:67: TimeoutError
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
