### PR TITLE
Fix a bug in cogbk for not using registered coder.

### DIFF
--- a/sdks/python/apache_beam/transforms/util.py
+++ b/sdks/python/apache_beam/transforms/util.py
@@ -266,7 +266,9 @@ class _CoGBKImpl(PTransform):
     ]
             | Flatten(pipeline=self.pipeline)
             | GroupByKey()
-            | MapTuple(collect_values))
+            | MapTuple(collect_values).with_input_types(
+                tuple[K, Iterable[tuple[str, V]]]).with_output_types(
+                    tuple[K, dict[str, list[V]]]))
 
 
 @ptransform_fn

--- a/sdks/python/apache_beam/transforms/util.py
+++ b/sdks/python/apache_beam/transforms/util.py
@@ -106,6 +106,7 @@ __all__ = [
 K = TypeVar('K')
 V = TypeVar('V')
 T = TypeVar('T')
+U = TypeVar('U')
 
 RESHUFFLE_TYPEHINT_BREAKING_CHANGE_VERSION = "2.64.0"
 
@@ -267,8 +268,8 @@ class _CoGBKImpl(PTransform):
             | Flatten(pipeline=self.pipeline)
             | GroupByKey()
             | MapTuple(collect_values).with_input_types(
-                tuple[K, Iterable[tuple[str, V]]]).with_output_types(
-                    tuple[K, dict[str, list[V]]]))
+                tuple[K, Iterable[tuple[U, V]]]).with_output_types(
+                    tuple[K, dict[U, list[V]]]))
 
 
 @ptransform_fn


### PR DESCRIPTION
We received an internal report (internal bug id: 430560535) that cogbk does not honor custom coders.

Below is the code to reproduce.
```Python
"""Test Beam's use of coders for keys in CoGroupByKey."""
import apache_beam as beam
from apache_beam.options import pipeline_options


class _Unpicklable:

  def __init__(self, value):
    self.value = value

  def __getstate__(self):
    raise NotImplementedError()

  def __setstate__(self, state):
    raise NotImplementedError()

  def __repr__(self):
    return f"Unpicklable({self.value})"


class _UnpicklableCoder(beam.coders.Coder):
  """."""

  def encode(self, value):
    return str(value.value).encode()

  def decode(self, encoded):
    return _Unpicklable(int(encoded.decode()))

  def to_type_hint(self):
    return _Unpicklable

  def is_deterministic(self):
    return True


beam.coders.registry.register_coder(_Unpicklable, _UnpicklableCoder)


def pipeline_fn(root):
  values = [_Unpicklable(i) for i in range(5)]
  xs = root | beam.Create(values) | beam.WithKeys(lambda x: x)
  return (
      {'x': xs}
      | beam.CoGroupByKey()
      | beam.FlatMapTuple(lambda k, tagged: (k.value, tagged['x'][0].value * 2))
      | beam.LogElements()
  )


def main():
  options = pipeline_options.PipelineOptions(
      runner='DirectRunner', direct_num_workers=1, type_check_additional='all'
  )
  with beam.Pipeline(options=options) as pipeline:
    _ = pipeline_fn(pipeline)

if __name__ == '__main__':
  main()
```

Running this code will result in a "NotImplementedError", because pickled coder rather than the registered coder is used.

My current PR can fix this problem by propagating type hints correctly.


Related PR: #33932