### PR TITLE
Add type checking to confirm that the flatten inputs are actually pco…

### DIFF
--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -3849,11 +3849,15 @@ class Flatten(PTransform):
       raise ValueError(
           'Input to Flatten must be an iterable. '
           'Got a value of type %s instead.' % type(pvalueish))
+
+    # Spot check to see if any of the items are iterables of PCollections
+    # and raise an error if so. This is always a user-error
     for idx, item in enumerate(pvalueish):
-      if not isinstance(item, pvalue.PCollection):
-        raise ValueError(
-            'Input to Flatten must be an iterable of PCollections. '
-            'Item %d of the iterable is type %s' % (idx, type(item)))
+      if (isinstance(item, typing.Sequence) and len(item) and
+          isinstance(item[0], pvalue.PCollection)):
+        raise TypeError(
+            'Inputs to Flatten cannot include an iterable of PCollections. '
+            f'(input at index {idx}: "{item}")')
     return pvalueish, pvalueish
 
   def expand(self, pcolls):

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -3849,6 +3849,11 @@ class Flatten(PTransform):
       raise ValueError(
           'Input to Flatten must be an iterable. '
           'Got a value of type %s instead.' % type(pvalueish))
+    for idx, item in enumerate(pvalueish):
+      if not isinstance(item, pvalue.PCollection):
+        raise ValueError(
+            'Input to Flatten must be an iterable of PCollections. '
+            'Item %d of the iterable is type %s' % (idx, type(item)))
     return pvalueish, pvalueish
 
   def expand(self, pcolls):

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -3853,8 +3853,8 @@ class Flatten(PTransform):
     # Spot check to see if any of the items are iterables of PCollections
     # and raise an error if so. This is always a user-error
     for idx, item in enumerate(pvalueish):
-      if (isinstance(item, typing.Sequence) and len(item) and
-          isinstance(item[0], pvalue.PCollection)):
+      if isinstance(item, (list, tuple)) and any(
+          isinstance(sub_item, pvalue.PCollection) for sub_item in item):
         raise TypeError(
             'Inputs to Flatten cannot include an iterable of PCollections. '
             f'(input at index {idx}: "{item}")')

--- a/sdks/python/apache_beam/typehints/typecheck_test.py
+++ b/sdks/python/apache_beam/typehints/typecheck_test.py
@@ -179,6 +179,14 @@ class PerformanceRuntimeTypeCheckTest(unittest.TestCase):
       (self.p | beam.Create(['1', '1']) | beam.ParDo(ToInt()))
       self.p.run().wait_until_finish()
 
+  def test_bad_flatten_input(self):
+    with self.assertRaisesRegex(
+        ValueError, "Input to Flatten must be an iterable of PCollections."):
+      with beam.Pipeline() as p:
+        pc = p | beam.Create([1, 1])
+        flatten_inputs = [pc, (pc, )]
+        flatten_inputs | beam.Flatten()
+
   def test_do_fn_returning_non_iterable_throws_error(self):
     # This function is incorrect because it returns a non-iterable object
     def incorrect_par_do_fn(x):

--- a/sdks/python/apache_beam/typehints/typecheck_test.py
+++ b/sdks/python/apache_beam/typehints/typecheck_test.py
@@ -181,7 +181,8 @@ class PerformanceRuntimeTypeCheckTest(unittest.TestCase):
 
   def test_bad_flatten_input(self):
     with self.assertRaisesRegex(
-        ValueError, "Input to Flatten must be an iterable of PCollections."):
+        TypeError,
+        "Inputs to Flatten cannot include an iterable of PCollections. "):
       with beam.Pipeline() as p:
         pc = p | beam.Create([1, 1])
         flatten_inputs = [pc, (pc, )]


### PR DESCRIPTION
User ran into an error from accidentally passing a `[pcoll, DoOutputsTuple]` to `Flatten` and Flatten never throws an error so the downstream issue was very difficult to debug.

Added some validation to `Flatten`. We now sample any iterable inputs to `Flatten()` (if possible) and check to see if it's a PCollection. If so, we raise the following error:
```
E           TypeError: Input to Flatten cannot include an iterable of PCollections. (input at index 1: "(<PCollection[Create/Map(decode).None] at 0x289acbd10>,)")
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
