### PR TITLE
fix: support vector features in PyOD anomaly detection batching logic

### DIFF
--- a/sdks/python/apache_beam/ml/anomaly/detectors/pyod_adapter.py
+++ b/sdks/python/apache_beam/ml/anomaly/detectors/pyod_adapter.py
@@ -77,7 +77,13 @@ class PyODModelHandler(ModelHandler[beam.Row,
   ) -> Iterable[PredictionResult]:
     np_batch = []
     for row in batch:
-      np_batch.append(np.fromiter(row, dtype=np.float64))
+      features = []
+      for value in row:
+        if isinstance(value, (list, tuple, np.ndarray)):
+          features.extend(value)
+        else:
+          features.append(value)
+      np_batch.append(np.array(features, dtype=np.float64))
 
     # stack a batch of samples into a 2-D array for better performance
     vectorized_batch = np.stack(np_batch, axis=0)


### PR DESCRIPTION
The anomaly detection module previously failed when a `[beam.Row]` contained vector features (e.g., embeddings).
This PR updates the batching logic in `[run_inference]` to flatten both scalar and vector fields, enabling support for use cases like `[beam.Row(embedding=[...])]`.
No breaking changes; scalar-only rows continue to work as before.

Issue: #35841
