### PR TITLE
Switch streaming engine worker harness based on job settings

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowStreamingPipelineOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowStreamingPipelineOptions.java
@@ -310,6 +310,9 @@ public interface DataflowStreamingPipelineOptions extends PipelineOptions {
   class EnableWindmillServiceDirectPathFactory implements DefaultValueFactory<Boolean> {
     @Override
     public Boolean create(PipelineOptions options) {
+      if (ExperimentalOptions.hasExperiment(options, "enable_windmill_service_direct_path=false")) {
+        return false;
+      }
       return ExperimentalOptions.hasExperiment(options, "enable_windmill_service_direct_path");
     }
   }

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowStreamingPipelineOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowStreamingPipelineOptions.java
@@ -310,7 +310,7 @@ public interface DataflowStreamingPipelineOptions extends PipelineOptions {
   class EnableWindmillServiceDirectPathFactory implements DefaultValueFactory<Boolean> {
     @Override
     public Boolean create(PipelineOptions options) {
-      if (ExperimentalOptions.hasExperiment(options, "enable_windmill_service_direct_path=false")) {
+      if (ExperimentalOptions.hasExperiment(options, "disable_windmill_service_direct_path")) {
         return false;
       }
       return ExperimentalOptions.hasExperiment(options, "enable_windmill_service_direct_path");

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -539,13 +539,11 @@ public final class StreamingDataflowWorker {
             .setGlobalConfigHandle(this.configFetcher.getGlobalConfigHandle())
             .setChannelzServlet(newHarnessFactoryOutput.channelzServlet())
             .setGetDataStatusProvider(newHarnessFactoryOutput.getDataStatusProvider())
-            .setCurrentActiveCommitBytes(
-                newHarnessFactoryOutput.currentActiveCommitBytesProvider())
+            .setCurrentActiveCommitBytes(newHarnessFactoryOutput.currentActiveCommitBytesProvider())
             .setChannelCache(newHarnessFactoryOutput.channelCache())
             .build());
     this.statusPages.get().start(this.options);
     LOG.info("Started new StreamingWorkerStatusPages instance.");
-
   }
 
   private static StreamingWorkerStatusPages.Builder createStatusPageBuilder(

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -891,6 +891,11 @@ public final class StreamingDataflowWorker {
         createGrpcwindmillStreamFactoryBuilder(options, 1)
             .setProcessHeartbeatResponses(
                 new WorkHeartbeatResponseProcessor(computationStateCache::get));
+    GrpcDispatcherClient grpcDispatcherClient = GrpcDispatcherClient.create(options, stubFactory);
+    grpcDispatcherClient.consumeWindmillDispatcherEndpoints(
+        ImmutableSet.<HostAndPort>builder()
+            .add(HostAndPort.fromHost("StreamingDataflowWorkerTest"))
+            .build());
 
     return new StreamingDataflowWorker(
         windmillServer,
@@ -916,7 +921,7 @@ public final class StreamingDataflowWorker {
             : windmillStreamFactory.build(),
         executorSupplier.apply("RefreshWork"),
         stageInfo,
-        GrpcDispatcherClient.create(options, stubFactory));
+        grpcDispatcherClient);
   }
 
   private static GrpcWindmillStreamFactory.Builder createGrpcwindmillStreamFactoryBuilder(

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -228,7 +228,7 @@ public final class StreamingDataflowWorker {
     this.workUnitExecutor = workUnitExecutor;
     this.harnessSwitchExecutor =
         Executors.newSingleThreadExecutor(
-            new ThreadFactoryBuilder().setNameFormat("HarnessSwtichExecutor").build());
+            new ThreadFactoryBuilder().setNameFormat("HarnessSwitchExecutor").build());
     this.clock = clock;
     this.memoryMonitor = BackgroundMemoryMonitor.create(memoryMonitor);
     this.numCommitThreads =
@@ -527,26 +527,25 @@ public final class StreamingDataflowWorker {
       streamingWorkerHarness.get().start();
       LOG.debug("Started SingleSourceWorkerHarness");
     }
-    if (newHarnessFactoryOutput != null) {
-      this.statusPages.set(
-          createStatusPageBuilder(
-                  this.options, this.windmillStreamFactory, this.memoryMonitor.memoryMonitor())
-              .setClock(this.clock)
-              .setClientId(this.clientId)
-              .setIsRunning(this.running)
-              .setStateCache(this.stateCache)
-              .setComputationStateCache(this.computationStateCache)
-              .setWorkUnitExecutor(this.workUnitExecutor)
-              .setGlobalConfigHandle(this.configFetcher.getGlobalConfigHandle())
-              .setChannelzServlet(newHarnessFactoryOutput.channelzServlet())
-              .setGetDataStatusProvider(newHarnessFactoryOutput.getDataStatusProvider())
-              .setCurrentActiveCommitBytes(
-                  newHarnessFactoryOutput.currentActiveCommitBytesProvider())
-              .setChannelCache(newHarnessFactoryOutput.channelCache())
-              .build());
-      this.statusPages.get().start(this.options);
-      LOG.info("Started new StreamingWorkerStatusPages instance.");
-    }
+    this.statusPages.set(
+        createStatusPageBuilder(
+                this.options, this.windmillStreamFactory, this.memoryMonitor.memoryMonitor())
+            .setClock(this.clock)
+            .setClientId(this.clientId)
+            .setIsRunning(this.running)
+            .setStateCache(this.stateCache)
+            .setComputationStateCache(this.computationStateCache)
+            .setWorkUnitExecutor(this.workUnitExecutor)
+            .setGlobalConfigHandle(this.configFetcher.getGlobalConfigHandle())
+            .setChannelzServlet(newHarnessFactoryOutput.channelzServlet())
+            .setGetDataStatusProvider(newHarnessFactoryOutput.getDataStatusProvider())
+            .setCurrentActiveCommitBytes(
+                newHarnessFactoryOutput.currentActiveCommitBytesProvider())
+            .setChannelCache(newHarnessFactoryOutput.channelCache())
+            .build());
+    this.statusPages.get().start(this.options);
+    LOG.info("Started new StreamingWorkerStatusPages instance.");
+
   }
 
   private static StreamingWorkerStatusPages.Builder createStatusPageBuilder(

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -496,6 +496,19 @@ public final class StreamingDataflowWorker {
     LOG.debug("Stopped StreamingWorkerStatusPages before switching connectivity type.");
     StreamingWorkerHarnessFactoryOutput newHarnessFactoryOutput = null;
     if (connectivityType == ConnectivityType.CONNECTIVITY_TYPE_DIRECTPATH) {
+      // If dataflow experiment `enable_windmill_service_direct_path` is not set for
+      // the job, do not switch to FanOutStreamingEngineWorkerHarness. This is because
+      // `enable_windmill_service_direct_path` is tied to SDK version and is only
+      // enabled for job running with SDK above the cut off version,
+      // and we do not want jobs below the cutoff to switch to
+      // FanOutStreamingEngineWorkerHarness
+      if (!options.getIsWindmillServiceDirectPathEnabled()) {
+        LOG.info(
+            "Dataflow experiment `enable_windmill_service_direct_path` is not set for the job. Job"
+                + " cannot switch to connectivity type DIRECTPATH. Job will continue running on"
+                + " CLOUDPATH");
+        return;
+      }
       LOG.info("Switching connectivity type from CLOUDPATH to DIRECTPATH");
       LOG.debug("Shutting down to SingleSourceWorkerHarness");
       this.streamingWorkerHarness.get().shutdown();

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/SingleSourceWorkerHarness.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/SingleSourceWorkerHarness.java
@@ -186,10 +186,7 @@ public final class SingleSourceWorkerHarness implements StreamingWorkerHarness {
         // we half-close the stream after some time and create a new one.
         if (getWorkStream != null) {
           if (!getWorkStream.awaitTermination(GET_WORK_STREAM_TIMEOUT_MINUTES, TimeUnit.MINUTES)) {
-            if (getWorkStream
-                != null) { // checking for null again to keep the static analyzer happy.
-              getWorkStream.halfClose();
-            }
+            Preconditions.checkNotNull(getWorkStream).halfClose();
           }
         }
       } catch (InterruptedException e) {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/StreamingWorkerStatusPages.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/StreamingWorkerStatusPages.java
@@ -124,10 +124,6 @@ public final class StreamingWorkerStatusPages {
                 new ThreadFactoryBuilder().setNameFormat(DUMP_STATUS_PAGES_EXECUTOR).build()));
   }
 
-  public void updateChannelCache(@Nullable ChannelCache channelCache) {
-    this.channelCache = channelCache;
-  }
-
   public void start(DataflowWorkerHarnessOptions options) {
     statusPages.addServlet(stateCache.statusServlet());
     statusPages.addServlet(newSpecServlet());

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/StreamingWorkerStatusPages.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/StreamingWorkerStatusPages.java
@@ -80,7 +80,7 @@ public final class StreamingWorkerStatusPages {
   private final @Nullable GrpcWindmillStreamFactory windmillStreamFactory;
   private final DebugCapture.@Nullable Manager debugCapture;
   private final @Nullable ChannelzServlet channelzServlet;
-  private @Nullable ChannelCache channelCache;
+  private final @Nullable ChannelCache channelCache;
 
   private final AtomicReference<StreamingGlobalConfig> globalConfig = new AtomicReference<>();
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/StreamingWorkerStatusPages.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/StreamingWorkerStatusPages.java
@@ -80,7 +80,7 @@ public final class StreamingWorkerStatusPages {
   private final @Nullable GrpcWindmillStreamFactory windmillStreamFactory;
   private final DebugCapture.@Nullable Manager debugCapture;
   private final @Nullable ChannelzServlet channelzServlet;
-  private final @Nullable ChannelCache channelCache;
+  private @Nullable ChannelCache channelCache;
 
   private final AtomicReference<StreamingGlobalConfig> globalConfig = new AtomicReference<>();
 
@@ -122,6 +122,10 @@ public final class StreamingWorkerStatusPages {
         .setStatusPageDumper(
             Executors.newSingleThreadScheduledExecutor(
                 new ThreadFactoryBuilder().setNameFormat(DUMP_STATUS_PAGES_EXECUTOR).build()));
+  }
+
+  public void updateChannelCache(@Nullable ChannelCache channelCache) {
+    this.channelCache = channelCache;
   }
 
   public void start(DataflowWorkerHarnessOptions options) {

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/FakeWindmillServer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/FakeWindmillServer.java
@@ -47,6 +47,7 @@ import javax.annotation.concurrent.GuardedBy;
 import org.apache.beam.runners.dataflow.worker.streaming.ComputationState;
 import org.apache.beam.runners.dataflow.worker.streaming.WorkHeartbeatResponseProcessor;
 import org.apache.beam.runners.dataflow.worker.streaming.WorkId;
+import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillMetadataServiceV1Alpha1Grpc;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.CommitWorkResponse;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.ComputationCommitWorkRequest;
@@ -60,12 +61,15 @@ import org.apache.beam.runners.dataflow.worker.windmill.Windmill.KeyedGetDataReq
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.LatencyAttribution;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.LatencyAttribution.State;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.WorkItemCommitRequest;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill.WorkerMetadataRequest;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill.WorkerMetadataResponse;
 import org.apache.beam.runners.dataflow.worker.windmill.WindmillServerStub;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStream.CommitWorkStream;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStream.GetDataStream;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStream.GetWorkStream;
 import org.apache.beam.runners.dataflow.worker.windmill.work.WorkItemReceiver;
 import org.apache.beam.runners.dataflow.worker.windmill.work.budget.GetWorkBudget;
+import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.stub.StreamObserver;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableSet;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.net.HostAndPort;
@@ -92,6 +96,8 @@ public final class FakeWindmillServer extends WindmillServerStub {
   private final ConcurrentHashMap<Long, Consumer<Windmill.CommitStatus>> droppedStreamingCommits;
   private final List<Windmill.GetDataRequest> getDataRequests = new ArrayList<>();
   private final Consumer<List<Windmill.ComputationHeartbeatResponse>> processHeartbeatResponses;
+  private StreamObserver<WorkerMetadataResponse> workerMetadataObserver = null;
+
   private int commitsRequested = 0;
   private boolean dropStreamingCommits = false;
 
@@ -551,6 +557,47 @@ public final class FakeWindmillServer extends WindmillServerStub {
   @Override
   public synchronized void setWindmillServiceEndpoints(Set<HostAndPort> endpoints) {
     this.dispatcherEndpoints = ImmutableSet.copyOf(endpoints);
+  }
+
+  public void injectWorkerMetadata(WorkerMetadataResponse response) {
+    if (workerMetadataObserver != null) {
+      workerMetadataObserver.onNext(response);
+    }
+  }
+
+  private void setWorkerMetadataObserver(
+      StreamObserver<WorkerMetadataResponse> workerMetadataObserver) {
+    this.workerMetadataObserver = workerMetadataObserver;
+  }
+
+  public static class FakeWindmillMetadataService
+      extends CloudWindmillMetadataServiceV1Alpha1Grpc
+          .CloudWindmillMetadataServiceV1Alpha1ImplBase {
+    private final FakeWindmillServer server;
+
+    public FakeWindmillMetadataService(FakeWindmillServer server) {
+      this.server = server;
+    }
+
+    @Override
+    public StreamObserver<WorkerMetadataRequest> getWorkerMetadata(
+        StreamObserver<WorkerMetadataResponse> responseObserver) {
+      server.setWorkerMetadataObserver(responseObserver);
+      return new StreamObserver<WorkerMetadataRequest>() {
+        @Override
+        public void onNext(WorkerMetadataRequest value) {}
+
+        @Override
+        public void onError(Throwable t) {
+          responseObserver.onError(t);
+        }
+
+        @Override
+        public void onCompleted() {
+          responseObserver.onCompleted();
+        }
+      };
+    }
   }
 
   public static class ResponseQueue<T, U> {

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
@@ -4181,6 +4181,11 @@ public class StreamingDataflowWorkerTest {
     assertTrue(
         "Worker should switch back to SingleSourceWorkerHarness",
         worker.getStreamingWorkerHarness() instanceof SingleSourceWorkerHarness);
+    // Process some work with CloudPath again.
+    server.whenGetWorkCalled().thenReturn(makeInput(2, 2000));
+    result = server.waitForAndGetCommits(1);
+    assertEquals(2, result.size());
+    assertTrue(result.containsKey(2L));
 
     worker.stop();
   }

--- a/runners/google-cloud-dataflow-java/worker/windmill/src/main/proto/windmill.proto
+++ b/runners/google-cloud-dataflow-java/worker/windmill/src/main/proto/windmill.proto
@@ -958,6 +958,12 @@ message UserWorkerGrpcFlowControlSettings {
   optional int32 on_ready_threshold_bytes = 3;
 }
 
+enum ConnectivityType {
+  CONNECTIVITY_TYPE_DEFAULT = 0;
+  CONNECTIVITY_TYPE_CLOUDPATH = 1;
+  CONNECTIVITY_TYPE_DIRECTPATH = 2;
+}
+
 // Settings to control runtime behavior of the java runner v1 user worker.
 message UserWorkerRunnerV1Settings {
   // If true, use separate channels for each windmill RPC.
@@ -967,6 +973,9 @@ message UserWorkerRunnerV1Settings {
   optional bool use_separate_windmill_heartbeat_streams = 2 [default = true];
 
   optional UserWorkerGrpcFlowControlSettings flow_control_settings = 3;
+
+  optional ConnectivityType connectivity_type = 4
+    [default = CONNECTIVITY_TYPE_DEFAULT];
 }
 
 service WindmillAppliance {


### PR DESCRIPTION
Based on Streaming engine global config which is pulled periodically, switch the type to worker harness to use. This is to switch between directpath (FanOutStreamingEngineWorkerHarness) and cloudpath (SingleSourceWorkerHarness) connectivity type. The StreamingWorkerStatusPages are also restarted with new status providers whenever the harness type changes.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
