### PR TITLE
Add GitHub Actions workflow for managing GCP Service Account keys

### DIFF
--- a/.github/workflows/beam_Infrastructure_ServiceAccountKeys.yml
+++ b/.github/workflows/beam_Infrastructure_ServiceAccountKeys.yml
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This workflow modifies the GCP Service Account keys and manages the
+# storage, saving them onto Google Cloud Secret Manager. It also handles
+# the rotation of the keys.
+
+name: Service Account Keys Management
+
+on:
+  workflow_dispatch:
+  # Trigger when the keys.yaml file is modified on the main branch
+  push:
+    branches:
+      - main
+    paths:
+      - 'infra/keys/keys.yaml'
+  schedule:
+    # Once a week at 9:00 AM on Sunday
+    - cron: '0 9 * * 0'
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.issue.number || github.sha || github.head_ref || github.ref }}-${{ github.event.schedule || github.event.comment.id || github.event.sender.login }}'
+  cancel-in-progress: true
+
+#Setting explicit permissions for the action to avoid the default permissions which are `write-all` in case of pull_request_target event
+permissions:
+  contents: read
+
+jobs:
+  beam_UserRoles:
+    name: Apply user roles changes
+    runs-on: [self-hosted, ubuntu-20.04, main]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.13'
+
+      - name: Install Python dependencies
+        working-directory: ./infra/keys
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      
+      - name: Run Service Account Key Management
+        working-directory: ./infra/keys
+        run: python keys.py --cron

--- a/infra/keys/README.md
+++ b/infra/keys/README.md
@@ -44,7 +44,17 @@ This section is intended for developers who need to manage service accounts and 
 
 ### How it works
 
-This module provide a script `keys.py` that allows you to manage the service accounts and their keys. This script is run as a cron job daily to ensure that service account keys are rotated regularly and that the latest keys are available for authorized users. It is also run every time a PR is merged over the `keys.yaml` file to ensure that the service accounts, their keys and authorized users are up to date.
+This module provide a script `keys.py` that allows you to manage the service accounts and their keys. This script is run automatically by a GitHub Action to ensure that service account keys are rotated regularly and that the latest keys are available for authorized users. It is also run every time a PR is merged over the `keys.yaml` file to ensure that the service accounts, their keys and authorized users are up to date.
+
+### Automation with GitHub Actions
+
+A GitHub Actions workflow is set up to automate the execution of the `keys.py` script. This workflow is defined in `.github/workflows/beam_Infrastructure_ServiceAccountKeys.yml`.
+
+The workflow is triggered automatically on the following events:
+- A push to the `main` branch that includes changes to the `infra/keys/keys.yaml` file.
+- A manual trigger (`workflow_dispatch`) by a developer.
+
+When triggered, the workflow runs the `python keys.py --cron` command, which handles the creation and rotation of service account keys based on the configuration in `keys.yaml` and `config.yaml`.
 
 ### Files
 
@@ -88,6 +98,6 @@ This will rotate keys for all service accounts defined in the `keys.yaml` file t
 To retrieve the latest service account key, use the `--get-key` flag:
 
 ```bash
-python main.py --get-key my-service-account
+python keys.py --get-key my-service-account
 ```
 

--- a/infra/keys/keys.yaml
+++ b/infra/keys/keys.yaml
@@ -23,4 +23,4 @@
 #     - email: "user1@google.com"
 #     - email: "user2@google.com"
 
-service_accounts:
+service_accounts: []


### PR DESCRIPTION
This pull request introduces automation for managing and rotating Google Cloud service account keys using GitHub Actions. It adds a new workflow to handle key rotation, updates the documentation to reflect this automation, and makes a minor change to the `keys.yaml` configuration. These changes help ensure that service account keys are kept up-to-date and that the management process is streamlined and well-documented.

**Automation and Workflow Integration:**
* Added a new GitHub Actions workflow (`.github/workflows/beam_Infrastructure_ServiceAccountKeys.yml`) that automatically manages, rotates, and stores GCP service account keys using the `keys.py` script. The workflow is triggered on schedule, on manual dispatch, and when `infra/keys/keys.yaml` is updated.

**Documentation Updates:**
* Updated `infra/keys/README.md` to describe the new automation process, including details about the workflow triggers and how the script is executed via GitHub Actions.
* Corrected a documentation example to use the correct script name (`keys.py` instead of `main.py`) for retrieving a service account key.

**Configuration Changes:**
* Set the `service_accounts` list in `infra/keys/keys.yaml` to be empty (`[]`), clarifying the initial configuration state.