### PR TITLE
[Prism] Fix an issue when running a pipeline on docker in python

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/worker/worker.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/worker.go
@@ -156,6 +156,14 @@ func (wk *W) GetProvisionInfo(_ context.Context, _ *fnpb.GetProvisionInfoRequest
 	endpoint := &pipepb.ApiServiceDescriptor{
 		Url: wk.Endpoint(),
 	}
+
+	var rt string
+	if len(wk.EnvPb.GetDependencies()) > 0 {
+		rt = wk.JobKey
+	} else {
+		rt = "__no_artifacts_staged__"
+	}
+
 	resp := &fnpb.GetProvisionInfoResponse{
 		Info: &fnpb.ProvisionInfo{
 			// TODO: Include runner capabilities with the per job configuration.
@@ -168,7 +176,7 @@ func (wk *W) GetProvisionInfo(_ context.Context, _ *fnpb.GetProvisionInfoRequest
 				Url: wk.ArtifactEndpoint,
 			},
 
-			RetrievalToken:  wk.JobKey,
+			RetrievalToken:  rt,
 			Dependencies:    wk.EnvPb.GetDependencies(),
 			PipelineOptions: wk.PipelineOptions,
 


### PR DESCRIPTION
When running a pipeline directly with `PrismRunner` (not using `PortableRunner`) and configuring a Docker environment type, the pipeline fails during the artifact staging phase.

The core issue seems to lie in how artifact materialization is handled in `boot.go`. Specifically, when the dependencies field in the environment proto is empty, the system falls back to using the legacy artifact service. This legacy service expects a manifest file, which is not provided in this scenario, leading to an error.

The fallback logic can be seen here:
https://github.com/apache/beam/blob/e28a69a36eec73b24e2229be48d171e41fd67c13/sdks/go/pkg/beam/artifact/materialize.go#L60-L68

This fallback is problematic because Prism always set the retrieval token (rt in the above code) to be `JobKey`: 
https://github.com/apache/beam/blob/e28a69a36eec73b24e2229be48d171e41fd67c13/sdks/go/pkg/beam/runners/prism/internal/worker/worker.go#L171. As a result, the materialize code will always proceed to `legacyMaterialize` when no dependencies are specified.

