### PR TITLE
update description and logs for timeout

### DIFF
--- a/sdks/go/pkg/beam/core/metrics/sampler.go
+++ b/sdks/go/pkg/beam/core/metrics/sampler.go
@@ -67,7 +67,7 @@ func (s *StateSampler) Sample(ctx context.Context, t time.Duration) error {
 			s.nextLogTime += s.logInterval
 		}
 		if s.restartLullTimeout > 0 && s.millisSinceLastTransition > s.restartLullTimeout {
-			return errors.Errorf("Operation ongoing in transform %v for at least %v ms without outputting or completing in state %v, the SDK harness will be terminated and restarted", ps.pid, s.millisSinceLastTransition, getState(ps.state))
+			return errors.Errorf("Processing of an element in transform %v has exceeded the specified timeout of %v ms without outputting or completing in state %v, SDK harness will be terminated", ps.pid, s.restartLullTimeout, getState(ps.state))
 		}
 	}
 	return nil

--- a/sdks/go/pkg/beam/options/jobopts/options.go
+++ b/sdks/go/pkg/beam/options/jobopts/options.go
@@ -102,7 +102,9 @@ var (
 	ResourceHints stringSlice
 
 	// ElementProcessingTimeout flag to set the timeout for processing an element in a PTransform operation. If set to -1, there is no timeout.
-	ElementProcessingTimeout = flag.Duration("element_processing_timeout", -1, "The timeout for processing an element in a PTransform operation. If set to -1, there is no timeout.")
+	ElementProcessingTimeout = flag.Duration("element_processing_timeout", -1,
+	"The time limit (in minutes) for any PTransform to finish processing a single element. If exceeded, " +
+	"the SDK worker process self-terminates and processing may be restarted by a runner. There is no time limit if the value is set to -1.")
 )
 
 type missingFlagError error

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/SdkHarnessOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/SdkHarnessOptions.java
@@ -433,8 +433,9 @@ public interface SdkHarnessOptions extends PipelineOptions, MemoryMonitorOptions
    * signaling the runner harness to restart the SDK worker.
    */
   @Description(
-      "The time limit (minute) that an SDK worker allows for a PTransform operation "
-          + "before signaling the runner harness to restart the SDK worker. There is no time limit if the value is set to 0.")
+      "The time limit (in minutes) for any PTransform to finish processing a single element." +
+      " If exceeded, the SDK worker process self-terminates and processing may be restarted by a runner." +
+      " There is no time limit if the value is set to 0.")
   @NonNegative
   int getElementProcessingTimeoutMinutes();
 

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ExecutionStateSampler.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ExecutionStateSampler.java
@@ -400,16 +400,16 @@ public class ExecutionStateSampler {
           if (thread == null) {
             timeoutMessage =
                 String.format(
-                    "Operation ongoing in bundle %s for at least %s without outputting "
-                        + "or completing (stack trace unable to be generated). The SDK worker will restart.",
+                    "Processing of an element in bundle %s has exceeded the specified timeout of %s "
+                        + "(stack trace unable to be generated). The SDK worker will be terminated.",
                     processBundleId.get(),
                     DURATION_FORMATTER.print(
                         Duration.millis(userSpecifiedLullTimeMsForRestart).toPeriod()));
           } else if (currentExecutionState == null) {
             timeoutMessage =
                 String.format(
-                    "Operation ongoing in bundle %s for at least %s without outputting "
-                        + "or completing:%n  at %s. The SDK worker will restart.",
+                    "Processing of an element in bundle %s has exceeded the specified timeout of %s "
+                        + "without outputting or completing:%n  at %s. The SDK worker will be terminated.",
                     processBundleId.get(),
                     DURATION_FORMATTER.print(
                         Duration.millis(userSpecifiedLullTimeMsForRestart).toPeriod()),
@@ -417,8 +417,9 @@ public class ExecutionStateSampler {
           } else {
             timeoutMessage =
                 String.format(
-                    "Operation ongoing in bundle %s for PTransform{id=%s, name=%s, state=%s} "
-                        + "for at least %s without outputting or completing:%n  at %s. The SDK worker will restart.",
+                    "Processing of an element in bundle %s for PTransform{id=%s, name=%s, state=%s} "
+                        + "has exceeded the specified timeout of %s without outputting or completing:%n  at %s. "
+                        + "The SDK worker will be terminated.",
                     processBundleId.get(),
                     currentExecutionState.ptransformId,
                     currentExecutionState.ptransformUniqueName,

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -1460,10 +1460,10 @@ class WorkerOptions(PipelineOptions):
         '--element_processing_timeout_minutes',
         type=int,
         default=None,
-        help=(
-            'The time limit (in minutes) that an SDK worker allows for a'
-            ' PTransform operation to process one element before signaling'
-            ' the runner harness to restart the SDK worker.'))
+        help=('The time limit (in minutes) for any PTransform to finish '
+              'processing a single element. If exceeded, the SDK worker '
+              'process self-terminates and processing may be restarted '
+              'by a runner.'))
 
   def validate(self, validator):
     errors = []

--- a/sdks/python/apache_beam/runners/worker/worker_status.py
+++ b/sdks/python/apache_beam/runners/worker/worker_status.py
@@ -285,12 +285,12 @@ class FnApiWorkerStatusHandler(object):
     if timeout_exceeded:
       _LOGGER.error(
           (
-              'Operation ongoing in bundle %s%s for at least %.2f seconds'
-              ' without outputting or completing.\n'
+              'Processing of an element in bundle %s%s has exceeded the specified'
+              'timeout of %.2f minutes. SDK harness will be terminated.\n'
               'Current Traceback:\n%s'),
           instruction,
           step_name_log,
-          lull_seconds,
+          self._element_processing_timeout_ns / 1e9 / 60,
           stack_trace,
       )
       from apache_beam.runners.worker.sdk_worker_main import terminate_sdk_harness


### PR DESCRIPTION
Address the issue https://github.com/apache/beam/issues/35174 in Java/Go/Python SDK

- Make the description of the timeout flag '--element_processing_timeout' more accurate
- Make the error message logs more accurate when the processing of an element exceeds the specified timeout

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
