### PR TITLE
[Prism] Surface log format option and improve logging presentation

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -1960,11 +1960,11 @@ class PrismRunnerOptions(PipelineOptions):
             '"warn", and "error". Default log level is "info".'))
     parser.add_argument(
         '--prism_log_kind',
-        default="json",
-        choices=["dev", "json", "text", "natural"],
+        default="console",
+        choices=["dev", "json", "text", "console"],
         help=(
             'Controls the log format in Prism. Values can be "dev", "json", '
-            '"text", and "natural". Default log format is "natural".'))
+            '"text", and "console". Default log format is "console".'))
 
 
 class TestOptions(PipelineOptions):


### PR DESCRIPTION
- Surface log format to pipeline option (`--prism_log_kind`)
- Add a log filter to process nested logs from Prism
  - Turn multiple-line logs into one-line for better filtering
  - Set the logger metadata (e.g. logger name, level, etc) correctly for the nested message.
  - The log filter is only applied when `--prism_log_kind` is set to `natural`.

## Before
The log level was fixed to INFO and the logger name was always `subprocess_server`:
<img width="2166" height="1158" alt="image" src="https://github.com/user-attachments/assets/f65d2876-8e4c-47a2-b12d-df7fe3554549" />

## After:
<img width="2162" height="904" alt="image" src="https://github.com/user-attachments/assets/f61012e1-7503-4bb2-82c0-030084016b76" />
