### PR TITLE
[Prism[ Fix two kinds of errors when using json log format.

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
@@ -89,6 +89,15 @@ type PColInfo struct {
 	KeyDec      func(io.Reader) []byte
 }
 
+func (info PColInfo) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("GlobalID", info.GlobalID),
+		slog.String("WindowCoder", info.WindowCoder.String()),
+		slog.Any("WDec", info.WDec),
+		slog.Any("WEnc", info.WEnc),
+	)
+}
+
 // WinCoderType indicates what kind of coder
 // the window is using. There are only 3
 // valid single window encodings.
@@ -109,6 +118,19 @@ const (
 	// WinCustom indicates the window customm coded with end event time timestamp followed by a custom coder.
 	WinCustom
 )
+
+func (wct WinCoderType) String() string {
+	switch wct {
+	case WinGlobal:
+		return "WinGlobal"
+	case WinInterval:
+		return "WinInterval"
+	case WinCustom:
+		return "WinCustom"
+	default:
+		return fmt.Sprintf("Unknown(%d)", wct)
+	}
+}
 
 // ToData recodes the elements with their approprate windowed value header.
 func (es elements) ToData(info PColInfo) [][]byte {
@@ -338,7 +360,7 @@ func (rb RunBundle) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("ID", rb.BundleID),
 		slog.String("stage", rb.StageID),
-		slog.Time("watermark", rb.Watermark.ToTime()))
+		slog.Any("watermark", rb.Watermark))
 }
 
 // Bundles is the core execution loop. It produces a sequences of bundles able to be executed.

--- a/sdks/go/pkg/beam/runners/prism/internal/execute.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/execute.go
@@ -360,7 +360,11 @@ func executePipeline(ctx context.Context, wks map[string]*worker.W, j *jobservic
 		case rb, ok := <-bundles:
 			if !ok {
 				err := eg.Wait()
-				j.Logger.Debug("pipeline done!", slog.String("job", j.String()), slog.Any("error", err), slog.Any("topo", topo))
+				var topoAttrs []slog.Attr
+				for _, s := range topo {
+					topoAttrs = append(topoAttrs, slog.Any(s.ID, s))
+				}
+				j.Logger.Debug("pipeline done!", slog.String("job", j.String()), slog.Any("error", err), slog.Any("topo", topoAttrs))
 				return err
 			}
 			eg.Go(func() error {

--- a/sdks/go/pkg/beam/runners/prism/internal/stage.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/stage.go
@@ -108,6 +108,19 @@ func clampTick(dur time.Duration) time.Duration {
 	}
 }
 
+func (s *stage) LogValue() slog.Value {
+	var outAttrs []slog.Attr
+	for k, v := range s.OutputsToCoders {
+		outAttrs = append(outAttrs, slog.Any(k, v))
+	}
+	return slog.GroupValue(
+		slog.String("ID", s.ID),
+		slog.Any("transforms", s.transforms),
+		slog.Any("inputInfo", s.inputInfo),
+		slog.Any("outputInfo", outAttrs),
+	)
+}
+
 func (s *stage) Execute(ctx context.Context, j *jobservices.Job, wk *worker.W, comps *pipepb.Components, em *engine.ElementManager, rb engine.RunBundle) (err error) {
 	if s.baseProgTick.Load() == nil {
 		s.baseProgTick.Store(minimumProgTick)

--- a/sdks/python/apache_beam/runners/portability/prism_runner.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner.py
@@ -120,9 +120,7 @@ class PrismRunnerLogFilter(logging.Filter):
   def filter(self, record):
     if record.funcName == 'log_stdout':
       try:
-        # TODO: Fix this error message from prism
-        message = record.getMessage().replace(
-            '"!ERROR:time.Time year outside of range [0,9999]"', '')
+        message = record.getMessage()
         json_record = json.loads(message)
         record.levelno = getattr(logging, json_record["level"])
         record.levelname = logging.getLevelName(record.levelno)


### PR DESCRIPTION
Two types of errors can be seen when using json log format:

```
INFO:apache_beam.utils.subprocess_server:{"time":"2025-08-29T21:58:03.309126-04:00","level":"DEBUG","source":{"function":"github.com/apache/beam/sdks/v2/go/pkg/beam/runners/prism/internal.executePipeline","file":"/Users/shunping/Projects/beam-dev-python-3/sdks/go/pkg/beam/runners/prism/internal/execute.go","line":363},"msg":"pipeline done!","job":"job-001[job]","error":null,"topo":"!ERROR:json: unsupported type: func(io.Reader) []uint8"}
```

```
INFO:apache_beam.utils.subprocess_server:{"time":"2025-08-29T22:05:24.038412-04:00","level":"DEBUG","source":{"function":"github.com/apache/beam/sdks/v2/go/pkg/beam/runners/prism/internal.(*stage).Execute","file":"/Users/shunping/Projects/beam-dev-python-3/sdks/go/pkg/beam/runners/prism/internal/stage.go","line":287},"msg":"Execute: committing data","bundle":{"ID":"inst002","stage":"stage-005","watermark":"!ERROR:time.Time year outside of range [0,9999]""294247-01-10T04:00:54.775Z"},"outputsWithData":[],"outputs":[]}
```

This PR fixed both.