### PR TITLE
Correctly exclude prism when using external transforms

### DIFF
--- a/sdks/python/apache_beam/runners/direct/direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner.py
@@ -137,6 +137,14 @@ class SwitchingDirectRunner(PipelineRunner):
           self.supported_by_prism_runner = False
         else:
           pipeline.visit(self)
+        # Avoid circular import
+        from apache_beam.pipeline import ExternalTransformFinder
+        if ExternalTransformFinder.contains_external_transforms(pipeline):
+          # TODO(https://github.com/apache/beam/issues/33623): Prism currently
+          # seems to not be able to consistently bring up external transforms.
+          # It does sometimes, but at volume suites start to fail. We will try
+          # to enable this in a future release.
+          self.supported_by_prism_runner = False
         return self.supported_by_prism_runner
 
       def visit_transform(self, applied_ptransform):
@@ -144,12 +152,6 @@ class SwitchingDirectRunner(PipelineRunner):
         # Python SDK assumes the direct runner TestStream implementation is
         # being used.
         if isinstance(transform, TestStream):
-          self.supported_by_prism_runner = False
-        if isinstance(transform, beam.ExternalTransform):
-          # TODO(https://github.com/apache/beam/issues/33623): Prism currently
-          # seems to not be able to consistently bring up external transforms.
-          # It does sometimes, but at volume suites start to fail. We will try
-          # to enable this in a future release.
           self.supported_by_prism_runner = False
         if isinstance(transform, beam.ParDo):
           dofn = transform.dofn


### PR DESCRIPTION
In https://github.com/apache/beam/pull/36031#pullrequestreview-3185384741 it became clear that external transforms were not being correctly excluded from Prism which was causing some flakiness across probably several tests. This PR should correctly exclude these by using the same mechanism we use for external transforms generally in pipelines.

I'm still not totally sure why the previous mechanism wasn't working, but I am confident in this version.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
