### PR TITLE
Update default max publish batch byte size calculation

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
@@ -1348,7 +1348,7 @@ public class PubsubIO {
      * Max batch byte size. Messages are base64 encoded which encodes each set of three bytes into
      * four bytes.
      */
-    private static final int MAX_PUBLISH_BATCH_BYTE_SIZE_DEFAULT = ((10 * 1000 * 1000) / 4) * 3;
+    private static final int MAX_PUBLISH_BATCH_BYTE_SIZE_DEFAULT = 10 * 1000 * 1000 ;
 
     private static final int MAX_PUBLISH_BATCH_SIZE = 100;
 


### PR DESCRIPTION
**Addresses:** [#36067](https://github.com/apache/beam/issues/36067)

**Description:**
This PR updates the default value of `MAX_PUBLISH_BATCH_BYTE_SIZE_DEFAULT` in `PubsubIO.java` from 7.5MB (`((10 * 1000 * 1000) / 4) * 3`) to 10MB (`10 * 1000 * 1000`). This change aligns the Beam Java SDK's default Pub/Sub batch size limit with the documented Google Cloud Pub/Sub maximum message size, preventing unexpected failures when sending messages between 7.5MB and 10MB.

- The previous default (7.5MB) could cause confusing errors for users sending large messages, despite those messages being under Pub/Sub's official limit.
- With this change, users can now send any message up to the documented 10MB limit without extra configuration.
- The code comment is also updated to clarify this default matches the Pub/Sub limit.

**Checklist:**
- [x] Addresses #36067
- [ ] Update `CHANGES.md` with noteworthy changes.
- [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.