### PR TITLE
[Python] Fix: Propagate resource hints through with_exception_handling

### DIFF
--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -1664,7 +1664,7 @@ class ParDo(PTransformWithSideInputs):
           subject to change.
     """
     args, kwargs = self.raw_side_inputs
-    return self.label >> _ExceptionHandlingWrapper(
+    wrapper = self.label >> _ExceptionHandlingWrapper(
         self.fn,
         args,
         kwargs,
@@ -1679,6 +1679,12 @@ class ParDo(PTransformWithSideInputs):
         error_handler,
         on_failure_callback,
         allow_unsafe_userstate_in_process)
+    # Propagate resource hints
+    if hasattr(wrapper, 'transform'):
+      wrapper.transform.get_resource_hints().update(self.get_resource_hints())
+    else:
+      wrapper.get_resource_hints().update(self.get_resource_hints())
+    return wrapper
 
   def with_error_handler(self, error_handler, **exception_handling_kwargs):
     """An alias for `with_exception_handling(error_handler=error_handler, ...)`
@@ -2317,17 +2323,23 @@ class _ExceptionHandlingWrapper(ptransform.PTransform):
       wrapped_fn = _TimeoutDoFn(self._fn, timeout=self._timeout)
     else:
       wrapped_fn = self._fn
-    result = pcoll | ParDo(
+    pardo = ParDo(
         _ExceptionHandlingWrapperDoFn(
             wrapped_fn,
             self._dead_letter_tag,
             self._exc_class,
             self._partial,
             self._on_failure_callback,
-            self._allow_unsafe_userstate_in_process),
+            self._allow_unsafe_userstate_in_process,
+        ),
         *self._args,
-        **self._kwargs).with_outputs(
-            self._dead_letter_tag, main=self._main_tag, allow_unknown_tags=True)
+        **self._kwargs,
+    )
+    # This is the fix: propagate hints.
+    pardo.get_resource_hints().update(self.get_resource_hints())
+
+    result = pcoll | pardo.with_outputs(
+        self._dead_letter_tag, main=self._main_tag, allow_unknown_tags=True)
     #TODO(BEAM-18957): Fix when type inference supports tagged outputs.
     result[self._main_tag].element_type = self._fn.infer_output_type(
         pcoll.element_type)

--- a/sdks/python/apache_beam/transforms/ptransform.py
+++ b/sdks/python/apache_beam/transforms/ptransform.py
@@ -453,8 +453,6 @@ class PTransform(WithTypeHints, HasDisplayData, Generic[InputT, OutputT]):
       PTransform: A reference to the instance of this particular
       :class:`PTransform` object.
     """
-    if hasattr(self, 'transform'):
-      self.transform.with_resource_hints(**kwargs)
     self.get_resource_hints().update(resources.parse_resource_hints(kwargs))
     return self
 
@@ -1165,6 +1163,10 @@ class _NamedPTransform(PTransform):
 
   def __rrshift__(self, label):
     return _NamedPTransform(self.transform, label)
+
+  def with_resource_hints(self, **kwargs):
+    self.transform.with_resource_hints(**kwargs)
+    return self
 
   def __getattr__(self, attr):
     transform_attr = getattr(self.transform, attr)

--- a/sdks/python/apache_beam/transforms/ptransform.py
+++ b/sdks/python/apache_beam/transforms/ptransform.py
@@ -453,6 +453,8 @@ class PTransform(WithTypeHints, HasDisplayData, Generic[InputT, OutputT]):
       PTransform: A reference to the instance of this particular
       :class:`PTransform` object.
     """
+    if hasattr(self, 'transform'):
+      self.transform.with_resource_hints(**kwargs)
     self.get_resource_hints().update(resources.parse_resource_hints(kwargs))
     return self
 


### PR DESCRIPTION
Fixes #36088 

**Description:**

This PR addresses an issue where resource hints, particularly `tags`, are not correctly propagated when using the `with_exception_handling()` method on a `ParDo` transform.

Currently, any resource hints applied via `.with_resource_hints()` are lost when `with_exception_handling()` wraps the transform. The hints are not passed from the original `ParDo` to the `_ExceptionHandlingWrapper`, and subsequently not to the inner `ParDo` created within the wrapper's `expand` method. This prevents effective control over stage fusion, which is critical for pipelines utilizing accelerators like TPUs.

**Fix:**

This PR implements the following changes:

1.  Modified `ParDo.with_exception_handling` to copy resource hints from the `ParDo` instance to the created `_ExceptionHandlingWrapper` instance.
2.  Modified `_ExceptionHandlingWrapper.expand` to copy resource hints from the wrapper to the inner `beam.ParDo` instance it constructs.

These changes ensure that resource hints are preserved across the `with_exception_handling` boundary.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
