### PR TITLE
Pin avro 1.12.0 in expansion service

### DIFF
--- a/.github/trigger_files/beam_PostCommit_Python_Xlang_IO_Direct.json
+++ b/.github/trigger_files/beam_PostCommit_Python_Xlang_IO_Direct.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run",
-  "modification": 6
+  "modification": 1
 }

--- a/sdks/java/io/expansion-service/build.gradle
+++ b/sdks/java/io/expansion-service/build.gradle
@@ -35,9 +35,8 @@ applyJavaNature(
 configurations.runtimeClasspath {
   // Pin kafka-clients version due to <3.4.0 missing auth callback classes.
   resolutionStrategy.force 'org.apache.kafka:kafka-clients:3.9.0'
-  // Pin avro to 1.11.4 due to https://github.com/apache/beam/issues/34968
-  // cannot upgrade this to the latest version due to https://github.com/apache/beam/issues/34993
-  resolutionStrategy.force 'org.apache.avro:avro:1.11.4'
+  // iceberg needs avro:1.12.0
+  resolutionStrategy.force 'org.apache.avro:avro:1.12.0'
   // force parquet-avro:1.15.2 to fix CVE-2025-46762
   resolutionStrategy.force 'org.apache.parquet:parquet-avro:1.15.2'
 


### PR DESCRIPTION
Fixes #32603

Avro was upgraded in iceberg module in #35981, but IO expansion service pins it to 1.11.4, causing a problem for Python/YAML pipelines