### PR TITLE
Remove ORC from Iceberg module

### DIFF
--- a/.github/trigger_files/IO_Iceberg_Integration_Tests.json
+++ b/.github/trigger_files/IO_Iceberg_Integration_Tests.json
@@ -1,4 +1,4 @@
 {
     "comment": "Modify this file in a trivial way to cause this test suite to run.",
-    "modification": 4
+    "modification": 1
 }

--- a/.github/trigger_files/IO_Iceberg_Integration_Tests_Dataflow.json
+++ b/.github/trigger_files/IO_Iceberg_Integration_Tests_Dataflow.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run.",
-  "modification": 1
+  "modification": 2
 }

--- a/.github/trigger_files/IO_Iceberg_Managed_Integration_Tests_Dataflow.json
+++ b/.github/trigger_files/IO_Iceberg_Managed_Integration_Tests_Dataflow.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run.",
-  "modification": 1
+  "modification": 2
 }

--- a/.github/trigger_files/beam_PostCommit_Python_Xlang_IO_Direct.json
+++ b/.github/trigger_files/beam_PostCommit_Python_Xlang_IO_Direct.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run",
-  "modification": 1
+  "modification": 2
 }

--- a/sdks/java/io/iceberg/build.gradle
+++ b/sdks/java/io/iceberg/build.gradle
@@ -41,7 +41,6 @@ hadoopVersions.each {kv -> configurations.create("hadoopVersion$kv.key")}
 
 def iceberg_version = "1.9.2"
 def parquet_version = "1.15.2"
-def orc_version = "1.9.2"
 def hive_version = "3.1.3"
 
 dependencies {
@@ -53,7 +52,6 @@ dependencies {
     implementation library.java.joda_time
     implementation "org.apache.parquet:parquet-column:$parquet_version"
     implementation "org.apache.parquet:parquet-hadoop:$parquet_version"
-    implementation "org.apache.orc:orc-core:$orc_version"
     implementation "org.apache.iceberg:iceberg-core:$iceberg_version"
     implementation "org.apache.iceberg:iceberg-api:$iceberg_version"
     implementation "org.apache.iceberg:iceberg-parquet:$iceberg_version"

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/ScanTaskReader.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/ScanTaskReader.java
@@ -39,7 +39,6 @@ import org.apache.iceberg.data.GenericDeleteFilter;
 import org.apache.iceberg.data.IdentityPartitionConverters;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.data.avro.DataReader;
-import org.apache.iceberg.data.orc.GenericOrcReader;
 import org.apache.iceberg.data.parquet.GenericParquetReaders;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.encryption.InputFilesDecryptor;
@@ -48,7 +47,6 @@ import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.mapping.NameMappingParser;
-import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.parquet.Parquet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -126,23 +124,6 @@ class ScanTaskReader extends BoundedSource.BoundedReader<Row> {
 
       CloseableIterable<Record> iterable;
       switch (file.format()) {
-        case ORC:
-          LOG.info("Preparing ORC input");
-          ORC.ReadBuilder orcReader =
-              ORC.read(input)
-                  .split(fileTask.start(), fileTask.length())
-                  .project(requiredSchema)
-                  .createReaderFunc(
-                      fileSchema ->
-                          GenericOrcReader.buildReader(requiredSchema, fileSchema, idToConstants))
-                  .filter(fileTask.residual());
-
-          if (nameMapping != null) {
-            orcReader.withNameMapping(NameMappingParser.fromJson(nameMapping));
-          }
-
-          iterable = orcReader.build();
-          break;
         case PARQUET:
           LOG.info("Preparing Parquet input.");
           Parquet.ReadBuilder parquetReader =


### PR DESCRIPTION
It's not a widely used format, and it's pulling in CVEs that require an ORC version beyond what Iceberg's latest version uses.