### PR TITLE
Fix JDBC type validation to check for empty strings in Postgres

### DIFF
--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/providers/ReadFromPostgresSchemaTransformProvider.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/providers/ReadFromPostgresSchemaTransformProvider.java
@@ -58,7 +58,7 @@ public class ReadFromPostgresSchemaTransformProvider extends JdbcReadSchemaTrans
   public @UnknownKeyFor @NonNull @Initialized SchemaTransform from(
       JdbcReadSchemaTransformConfiguration configuration) {
     String jdbcType = configuration.getJdbcType();
-    if (jdbcType != null && !jdbcType.equals(jdbcType())) {
+    if (jdbcType != null && !jdbcType.isEmpty() && !jdbcType.equals(jdbcType())) {
       throw new IllegalArgumentException(
           String.format("Wrong JDBC type. Expected '%s' but got '%s'", jdbcType(), jdbcType));
     }

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/providers/WriteToPostgresSchemaTransformProvider.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/providers/WriteToPostgresSchemaTransformProvider.java
@@ -58,7 +58,7 @@ public class WriteToPostgresSchemaTransformProvider extends JdbcWriteSchemaTrans
   public @UnknownKeyFor @NonNull @Initialized SchemaTransform from(
       JdbcWriteSchemaTransformConfiguration configuration) {
     String jdbcType = configuration.getJdbcType();
-    if (jdbcType != null && !jdbcType.equals(jdbcType())) {
+    if (jdbcType != null && !jdbcType.isEmpty() && !jdbcType.equals(jdbcType())) {
       throw new IllegalArgumentException(
           String.format("Wrong JDBC type. Expected '%s' but got '%s'", jdbcType(), jdbcType));
     }


### PR DESCRIPTION
Fixes https://github.com/apache/beam/issues/35198

```
025-09-09T17:57:22.3193168Z =========================== short test summary info ============================
2025-09-09T17:57:22.3194694Z FAILED apache_beam/yaml/integration_tests.py::PostgresTest::test_only - ValueError: Error applying transform "WriteToPostgres" at line 33: java.lang.IllegalArgumentException: Wrong JDBC type. Expected 'postgres' but got ''
2025-09-09T17:57:22.3196717Z 	at org.apache.beam.sdk.io.jdbc.providers.WriteToPostgresSchemaTransformProvider.from(WriteToPostgresSchemaTransformProvider.java:63)
2025-09-09T17:57:22.3198431Z 	at org.apache.beam.sdk.io.jdbc.providers.WriteToPostgresSchemaTransformProvider.from(WriteToPostgresSchemaTransformProvider.java:36)
2025-09-09T17:57:22.3200284Z 	at org.apache.beam.sdk.schemas.transforms.TypedSchemaTransformProvider.from(TypedSchemaTransformProvider.java:111)
2025-09-09T17:57:22.3202104Z 	at org.apache.beam.sdk.expansion.service.ExpansionServiceSchemaTransformProvider.getTransform(ExpansionServiceSchemaTransformProvider.java:137)
2025-09-09T17:57:22.3203904Z 	at org.apache.beam.sdk.expansion.service.ExpansionService$TransformProviderForPayloadTranslator.getTransform(ExpansionService.java:263)
2025-09-09T17:57:22.3205314Z 	at org.apache.beam.sdk.expansion.service.TransformProvider.apply(TransformProvider.java:121)
2025-09-09T17:57:22.3206436Z 	at org.apache.beam.sdk.expansion.service.ExpansionService.expand(ExpansionService.java:657)
2025-09-09T17:57:22.3207518Z 	at org.apache.beam.sdk.expansion.service.ExpansionService.expand(ExpansionService.java:758)
2025-09-09T17:57:22.3208770Z 	at org.apache.beam.model.expansion.v1.ExpansionServiceGrpc$MethodHandlers.invoke(ExpansionServiceGrpc.java:306)
2025-09-09T17:57:22.3210315Z 	at org.apache.beam.vendor.grpc.v1p69p0.io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
2025-09-09T17:57:22.3212054Z 	at org.apache.beam.vendor.grpc.v1p69p0.io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:356)
2025-09-09T17:57:22.3213774Z 	at org.apache.beam.vendor.grpc.v1p69p0.io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:861)
2025-09-09T17:57:22.3215505Z 	at org.apache.beam.vendor.grpc.v1p69p0.io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
2025-09-09T17:57:22.3216814Z 	at org.apache.beam.vendor.grpc.v1p69p0.io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
2025-09-09T17:57:22.3218012Z 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
2025-09-09T17:57:22.3219129Z 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
2025-09-09T17:57:22.3219926Z 	at java.base/java.lang.Thread.run(Thread.java:829)
2025-09-09T17:57:22.3220360Z 
2025-09-09T17:57:22.3220369Z 
2025-09-09T17:57:22.3220855Z java.lang.IllegalArgumentException: Wrong JDBC type. Expected 'postgres' but got ''
```
https://productionresultssa0.blob.core.windows.net/actions-results/a9bd2633-9ccb-4bb2-8ccf-21615d49b6d6/workflow-job-run-0f8530dd-c0d8-5110-bc4c-cd0b75d084b9/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-09-09T18%3A54%3A01Z&sig=y0KMBQT0dBpYy99Lm4COR1H3wPjUHpuRnN9%2B0UtW7e0%3D&ske=2025-09-10T06%3A20%3A17Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-09-09T18%3A20%3A17Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-05-05&sp=r&spr=https&sr=b&st=2025-09-09T18%3A43%3A56Z&sv=2025-05-05

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
