### PR TITLE
infra/security: update project_id and bucket_name to match the correct configuration

### DIFF
--- a/infra/security/config.yml
+++ b/infra/security/config.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project_id: testing-me-460223
+project_id: apache-beam-testing
 
 # Logging
 logging:
@@ -21,7 +21,7 @@ logging:
   format: "[%(asctime)s] %(levelname)s: %(message)s"
 
 # gcloud storage bucket
-bucket_name: "testing-me-460223-tfstate"
+bucket_name: "beam-sec-analytics-and-logging"
 
 # GCP Log sinks
 sinks:


### PR DESCRIPTION
This pull request updates the GCP project and storage bucket configuration in the `infra/security/config.yml` file to align with the current project and resource naming conventions.

Configuration updates:

* Changed the `project_id` from `testing-me-460223` to `apache-beam-testing` to reflect the correct GCP project.
* Updated the `bucket_name` from `testing-me-460223-tfstate` to `beam-sec-analytics-and-logging` to use the appropriate storage bucket for the project.