### PR TITLE
[Prism] Support AfterProcessingTime triggers - part 1

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/engine/strategy.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/strategy.go
@@ -668,7 +668,7 @@ func (t *TriggerAfterProcessingTime) reset(state *StateData) {
 	// We keep the state (especially the next possible firing time) in case the trigger is called again
 	ts.finished = false
 	s := ts.extra.(afterProcessingTimeState)
-	s.firingTime = t.applyTimestampTransforms(s.firingTime) // compute next possible firing time
+	s.firingTime = t.applyTimestampTransforms(s.emNow) // compute next possible firing time
 	ts.extra = s
 	state.setTriggerState(t, ts)
 }

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/strategy_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/strategy_test.go
@@ -409,10 +409,10 @@ func TestTriggers_isReady(t *testing.T) {
 				},
 			},
 			inputs: []io{
-				{triggerInput{emNow: 0}, false},
+				{triggerInput{emNow: 0}, false}, // the trigger is set to fire at 3s after 0
 				{triggerInput{emNow: 1000}, false},
 				{triggerInput{emNow: 2000}, false},
-				{triggerInput{emNow: 3000}, true},
+				{triggerInput{emNow: 3000}, true}, // fire
 				{triggerInput{emNow: 4000}, false},
 				{triggerInput{emNow: 5000}, false},
 				{triggerInput{emNow: 6000}, false},
@@ -426,10 +426,10 @@ func TestTriggers_isReady(t *testing.T) {
 				},
 			},
 			inputs: []io{
-				{triggerInput{emNow: 0}, false},
+				{triggerInput{emNow: 0}, false}, // the trigger is set to fire at 3s after 0
 				{triggerInput{emNow: 1000}, false},
 				{triggerInput{emNow: 2000}, false},
-				{triggerInput{emNow: 3001}, true}, // a little after the expected firing time
+				{triggerInput{emNow: 3001}, true}, // fire a little after the preset time
 				{triggerInput{emNow: 4000}, false},
 			},
 		}, {
@@ -440,10 +440,10 @@ func TestTriggers_isReady(t *testing.T) {
 				},
 			},
 			inputs: []io{
-				{triggerInput{emNow: 1500}, false},
+				{triggerInput{emNow: 1500}, false}, // align 1.5s to 5s
 				{triggerInput{emNow: 2000}, false},
 				{triggerInput{emNow: 4999}, false},
-				{triggerInput{emNow: 5000}, true}, // 1.5 is aligned to 5
+				{triggerInput{emNow: 5000}, true}, // fire at 5
 				{triggerInput{emNow: 5001}, false},
 			},
 		}, {
@@ -454,10 +454,10 @@ func TestTriggers_isReady(t *testing.T) {
 				},
 			},
 			inputs: []io{
-				{triggerInput{emNow: 1500}, false},
+				{triggerInput{emNow: 1500}, false}, // align 1.5s to 5s plus an 0.2 offset
 				{triggerInput{emNow: 2000}, false},
 				{triggerInput{emNow: 5119}, false},
-				{triggerInput{emNow: 5200}, true}, // 1.5 is aligned to 5.2
+				{triggerInput{emNow: 5200}, true}, // fire at 5.2s
 				{triggerInput{emNow: 5201}, false},
 			},
 		}, {
@@ -469,13 +469,13 @@ func TestTriggers_isReady(t *testing.T) {
 				},
 			},
 			inputs: []io{
-				{triggerInput{emNow: 1500}, false},
+				{triggerInput{emNow: 1500}, false}, // align 1.5s to 5s plus an 0.2 offset and a 1s delay
 				{triggerInput{emNow: 2000}, false},
 				{triggerInput{emNow: 5119}, false},
 				{triggerInput{emNow: 5200}, false},
 				{triggerInput{emNow: 5201}, false},
 				{triggerInput{emNow: 6119}, false},
-				{triggerInput{emNow: 6200}, true}, // 1.5 is aligned to 6.2
+				{triggerInput{emNow: 6200}, true}, // fire
 				{triggerInput{emNow: 6201}, false},
 			},
 		}, {

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/strategy_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/strategy_test.go
@@ -514,6 +514,23 @@ func TestTriggers_isReady(t *testing.T) {
 				{triggerInput{emNow: 10000}, true}, // fire in the new window
 			},
 		}, {
+			name: "afterProcessingTime_Repeated_Composite", trig: &TriggerRepeatedly{
+				&TriggerAfterAny{SubTriggers: []Trigger{
+					&TriggerAfterProcessingTime{
+						Transforms: []TimestampTransform{
+							{Delay: 3 * time.Second},
+						},
+					},
+					&TriggerElementCount{ElementCount: 2},
+				}}},
+			inputs: []io{
+				{triggerInput{emNow: 0, newElementCount: 1}, false},    // ElmCount = 1, set AfterProcessingTime trigger firing time to 3s
+				{triggerInput{emNow: 1000, newElementCount: 1}, true},  // ElmCount = 2, fire ElmCount trigger and reset ElmCount and AfterProcessingTime firing time (4s)
+				{triggerInput{emNow: 4000, newElementCount: 1}, true},  // ElmCount = 1, fire AfterProcessingTime trigger and reset ElmCount and AfterProcessingTime firing time (7s)
+				{triggerInput{emNow: 5000, newElementCount: 1}, false}, // ElmCount = 1
+				{triggerInput{emNow: 5500, newElementCount: 1}, true},  // ElmCount = 2, fire ElmCount trigger
+			},
+		}, {
 			name: "default",
 			trig: &TriggerDefault{},
 			inputs: []io{

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/strategy_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/strategy_test.go
@@ -488,11 +488,30 @@ func TestTriggers_isReady(t *testing.T) {
 				{triggerInput{emNow: 0}, false},
 				{triggerInput{emNow: 1000}, false},
 				{triggerInput{emNow: 2000}, false},
-				{triggerInput{emNow: 3000}, true},  // first the first time
-				{triggerInput{emNow: 4000}, false}, // trigger firing time is set again
+				{triggerInput{emNow: 3000}, true}, // firing the first time, trigger set again
+				{triggerInput{emNow: 4000}, false},
 				{triggerInput{emNow: 5000}, false},
-				{triggerInput{emNow: 6000}, false},
-				{triggerInput{emNow: 7000}, true}, // trigger firing again
+				{triggerInput{emNow: 6000}, true}, // firing the second time
+			},
+		}, {
+			name: "afterProcessingTime_Repeated_AcrossWindows", trig: &TriggerRepeatedly{
+				&TriggerAfterProcessingTime{
+					Transforms: []TimestampTransform{
+						{Delay: 3 * time.Second},
+					}}},
+			inputs: []io{
+				{triggerInput{emNow: 0}, false},
+				{triggerInput{emNow: 1000}, false},
+				{triggerInput{emNow: 2000}, false},
+				{triggerInput{emNow: 3000}, true}, // fire the first time, trigger is set again
+				{triggerInput{emNow: 4000}, false},
+				{triggerInput{emNow: 5000}, false},
+				{triggerInput{emNow: 6000,
+					endOfWindowReached: true}, true}, // fire the second time, reach end of window and start over
+				{triggerInput{emNow: 7000}, false}, // trigger firing time is set to 7s + 3s = 10s
+				{triggerInput{emNow: 8000}, false},
+				{triggerInput{emNow: 9000}, false},
+				{triggerInput{emNow: 10000}, true}, // fire in the new window
 			},
 		}, {
 			name: "default",

--- a/sdks/go/pkg/beam/runners/prism/internal/execute.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/execute.go
@@ -461,7 +461,27 @@ func buildTrigger(tpb *pipepb.Trigger) engine.Trigger {
 		}
 	case *pipepb.Trigger_Repeat_:
 		return &engine.TriggerRepeatedly{Repeated: buildTrigger(at.Repeat.GetSubtrigger())}
-	case *pipepb.Trigger_AfterProcessingTime_, *pipepb.Trigger_AfterSynchronizedProcessingTime_:
+	case *pipepb.Trigger_AfterProcessingTime_:
+		var transforms []engine.TimestampTransform
+		for _, ts := range at.AfterProcessingTime.GetTimestampTransforms() {
+			var delay, period, offset time.Duration
+			if d := ts.GetDelay(); d != nil {
+				delay = time.Duration(d.GetDelayMillis()) * time.Millisecond
+			}
+			if align := ts.GetAlignTo(); align != nil {
+				period = time.Duration(align.GetPeriod()) * time.Millisecond
+				offset = time.Duration(align.GetOffset()) * time.Millisecond
+			}
+			transforms = append(transforms, engine.TimestampTransform{
+				Delay:         delay,
+				AlignToPeriod: period,
+				AlignToOffset: offset,
+			})
+		}
+		return &engine.TriggerAfterProcessingTime{
+			Transforms: transforms,
+		}
+	case *pipepb.Trigger_AfterSynchronizedProcessingTime_:
 		panic(fmt.Sprintf("unsupported trigger: %v", prototext.Format(tpb)))
 	default:
 		return &engine.TriggerDefault{}


### PR DESCRIPTION
Construct after-processing-time trigger from proto and define trigger callbacks.

This is part of the original PR #36069, but with more tests and some changes to handle trigger reset.
