### PR TITLE
Return inputwatermarkAdvanced signal and use it in bundleReady

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/engine/teststream.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/teststream.go
@@ -252,7 +252,7 @@ type tsFinalEvent struct {
 func (ev tsFinalEvent) Execute(em *ElementManager) {
 	em.testStreamHandler.UpdateHold(em, mtime.MaxTimestamp)
 	ss := em.stages[ev.stageID]
-	kickSet := ss.updateWatermarks(em)
+	kickSet, _ := ss.updateWatermarks(em)
 	kickSet.insert(ev.stageID)
 	em.changedStages.merge(kickSet)
 }


### PR DESCRIPTION
address #36128

Change was suggested in https://github.com/apache/beam/pull/36069#discussion_r2342072221