### PR TITLE
[Prism] Avoid firing on-time pane for some triggers.

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/engine/strategy_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/strategy_test.go
@@ -364,8 +364,8 @@ func TestTriggers_isReady(t *testing.T) {
 				{triggerInput{newElementCount: 1}, false},
 				{triggerInput{newElementCount: 1}, true}, // Early is ready
 				{triggerInput{newElementCount: 1}, false},
-				{triggerInput{newElementCount: 1}, true},                            // Early is ready
-				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false}, // End of window
+				{triggerInput{newElementCount: 1}, true},                           // Early is ready
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, true}, // End of window
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
@@ -381,12 +381,12 @@ func TestTriggers_isReady(t *testing.T) {
 				{triggerInput{newElementCount: 1}, false},
 				{triggerInput{newElementCount: 1}, false},
 				{triggerInput{newElementCount: 1}, false},
-				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false}, // End of window
-				{triggerInput{newElementCount: 1, endOfWindowReached: true}, true},  // Late
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, true}, // End of window
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, true}, // Late
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, true}, // Late
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
 			},
 		}, {
 			name: "afterEndOfWindow_NeitherSet",
@@ -396,12 +396,12 @@ func TestTriggers_isReady(t *testing.T) {
 				{triggerInput{newElementCount: 1}, false},
 				{triggerInput{newElementCount: 1}, false},
 				{triggerInput{newElementCount: 1}, false},
-				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false}, // End of window
-				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false}, // Late
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, true}, // End of window
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
-				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false}, // Late
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
-				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false}, // Late
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
 			},
 		}, {
 			name: "afterEndOfWindow_EarlyUnset_Late2",
@@ -413,12 +413,12 @@ func TestTriggers_isReady(t *testing.T) {
 				{triggerInput{newElementCount: 1}, false},
 				{triggerInput{newElementCount: 1}, false},
 				{triggerInput{newElementCount: 1}, false},
-				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false}, // End of window
-				{triggerInput{newElementCount: 1, endOfWindowReached: true}, true},  // Late
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, true}, // End of window
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, true}, // Late
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
 				{triggerInput{newElementCount: 1, endOfWindowReached: true}, true}, // Late
+				{triggerInput{newElementCount: 1, endOfWindowReached: true}, false},
 			},
 		}, {
 			name: "default",

--- a/sdks/go/pkg/beam/runners/prism/internal/unimplemented_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/unimplemented_test.go
@@ -43,13 +43,6 @@ func TestUnimplemented(t *testing.T) {
 	}{
 		// {pipeline: primitives.Drain}, // Can't test drain automatically yet.
 
-		// Implemented but the Go SDK doesn't fully handle panes and
-		// their associated valid behaviors for these triggers, leading
-		// to variable results.
-		// See https://github.com/apache/beam/issues/31153.
-		{pipeline: primitives.TriggerElementCount},
-		{pipeline: primitives.TriggerOrFinally},
-
 		// Currently unimplemented triggers.
 		// https://github.com/apache/beam/issues/31438
 		{pipeline: primitives.TriggerAfterSynchronizedProcessingTime},
@@ -93,6 +86,8 @@ func TestImplemented(t *testing.T) {
 		{pipeline: primitives.TriggerAfterEach},
 		{pipeline: primitives.TriggerAfterEndOfWindow},
 		{pipeline: primitives.TriggerRepeat},
+		{pipeline: primitives.TriggerOrFinally},
+		{pipeline: primitives.TriggerElementCount},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The current implementation in Prism unconditionally fires an on-time pane for all trigger types. This is [incorrect](https://beam.apache.org/releases/javadoc/2.67.0/org/apache/beam/sdk/transforms/windowing/PaneInfo.Timing.html) for triggers like `ElementCount` and `AfterProcessingTime` which should only fire when their specific conditions are met.

- `TriggerElementCount`:   
  - Proto definition: https://github.com/apache/beam/blob/575df4e89ee91f0135d03f8e5fa2b9e3fa02a5b7/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/beam_runner_api.proto#L1327-L1330
  - Java doc: https://beam.apache.org/releases/javadoc/2.67.0/org/apache/beam/sdk/transforms/windowing/AfterPane.html
- `TriggerAfterProcessingTime`:
  - Proto definition: https://github.com/apache/beam/blob/575df4e89ee91f0135d03f8e5fa2b9e3fa02a5b7/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/beam_runner_api.proto#L1311-L1312
  - Java doc: https://beam.apache.org/releases/javadoc/2.67.0/org/apache/beam/sdk/transforms/windowing/AfterProcessingTime.html

This PR corrects this behavior by introducing a call to `IsTriggerReady` at the end of the window. This ensures that a trigger only fires if it is ready, preventing the premature firing of on-time panes. A simple skip is not sufficient, as these triggers can be nested within composite triggers.

This change also requires modifications to existing triggers that relied on the previous assumption of on-time panes always firing. `TriggerNever` and `TriggerAfterEndOfWindow` have been updated to ensure their `IsTriggerReady()` method returns true at the end of the window.

Additionally, this PR includes the following fixes:
- Resolves two failing integration tests for `TriggerElementCount` and `TriggerOrFinally`.
- Updates the `TriggerAfterEndOfWindow` test to cover late data scenarios.

---

## The Unsolved Problem: Inaccurate isLast flag for Early Panes
- The `isLast` field in pane info could be inaccurately determined right now. 
- Here is the dilemma:
  - We want to fire early pane as soon as it is ready.
  - However, to definitively know if an early pane is the last pane for a given window, the system would need to know if another early pane or an on-time pane will fire later. This information is not available when the first early pane is ready to be fired.

To guarantee the isLast field is always correct, we would have to postpone firing an early pane until a subsequent pane arrives or the watermark passes the end of the window. This delay would counteract the primary benefit of using early panes.