### PR TITLE
[Prism] Disable combiner lifting for TriggerAlways

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/unimplemented_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/unimplemented_test.go
@@ -49,7 +49,6 @@ func TestUnimplemented(t *testing.T) {
 		// See https://github.com/apache/beam/issues/31153.
 		{pipeline: primitives.TriggerElementCount},
 		{pipeline: primitives.TriggerOrFinally},
-		{pipeline: primitives.TriggerAlways},
 
 		// Currently unimplemented triggers.
 		// https://github.com/apache/beam/issues/31438
@@ -87,6 +86,7 @@ func TestImplemented(t *testing.T) {
 		{pipeline: primitives.ParDoProcessElementBundleFinalizer},
 
 		{pipeline: primitives.TriggerNever},
+		{pipeline: primitives.TriggerAlways},
 		{pipeline: primitives.Panes},
 		{pipeline: primitives.TriggerAfterAll},
 		{pipeline: primitives.TriggerAfterAny},


### PR DESCRIPTION
Same as TriggerElementCount, TriggerAlways does not work well with combiner lifting. Therefore, we disable if there is such a trigger in the window strategy.

With this fix, the TriggerAlways integration test passed.

fixes #36145