### PR TITLE
[Prism] Fix potential side-effect in TriggerAfterEach.onFire.

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/engine/strategy.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/strategy.go
@@ -302,15 +302,23 @@ func (t *TriggerAfterEach) onFire(state *StateData) {
 	if !t.shouldFire(state) {
 		return
 	}
-	for _, sub := range t.SubTriggers {
+	for i, sub := range t.SubTriggers {
 		if state.getTriggerState(sub).finished {
 			continue
 		}
 		sub.onFire(state)
+		// If the sub-trigger didn't finish, we return, waiting for it to finish on a subsequent call.
 		if !state.getTriggerState(sub).finished {
 			return
 		}
+
+		// If the sub-trigger finished, we check if it's the last one.
+		// If it's not the last one, we return, waiting for the next onFire call to advance to the next sub-trigger.
+		if i < len(t.SubTriggers)-1 {
+			return
+		}
 	}
+	// clear and reset when all sub-triggers have fired.
 	triggerClearAndFinish(t, state)
 }
 


### PR DESCRIPTION
The current implementation of the `onFire` method for the `TriggerAfterEach` trigger in `strategy.go` has a side-effect that can cause multiple sub-triggers to be marked as finished within a single invocation.

https://github.com/apache/beam/blob/d0e48e202403c2b1b96d8b170a6e575682332a31/sdks/go/pkg/beam/runners/prism/internal/engine/strategy.go#L305-L314

The `onFire` function iterates through its sub-triggers. When a sub-trigger (let's call it A) fires and completes, the loop continues to the next sub-trigger (B) and calls `B.onFire()` within the same execution. This is incorrect, as the `TriggerAfterEach` should only advance to the next sub-trigger on a subsequent onFire call.

This behavior is not detected by the existing test suite because the sub-triggers used in the tests have conditions that prevent them from firing immediately. For example, TriggerElementCounts (below) will not fire if its element count has not been reached.
https://github.com/apache/beam/blob/d0e48e202403c2b1b96d8b170a6e575682332a31/sdks/go/pkg/beam/runners/prism/internal/engine/strategy.go#L358-L366.

However, there is an edge case if B is `TriggerAny{TriggerAlways{}}`. In this case, the call of `B.onFire()` will marked B as finished. 

This results in both A and B being marked as finished in one onFire call to the parent `TriggerAfterEach`, which is not the intended behavior