### PR TITLE
[Dataflow Streaming Java] Fix possible IllegalStateException when grpc streams have deadline exceeded.

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/ResettableThrowingStreamObserver.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/ResettableThrowingStreamObserver.java
@@ -115,33 +115,48 @@ final class ResettableThrowingStreamObserver<T> {
           logger.debug("Stream was shutdown during send.", cancellationException);
           return;
         }
-      }
+        if (delegateStreamObserver == delegate) {
+          if (isCurrentStreamClosed) {
+            logger.debug("Stream is already closed when encountering error with send.");
+            return;
+          }
+          isCurrentStreamClosed = true;
+        }
 
-      try {
-        delegate.onError(cancellationException);
-      } catch (IllegalStateException onErrorException) {
-        // The delegate above was already terminated via onError or onComplete.
-        // Fallthrough since this is possibly due to queued onNext() calls that are being made from
-        // previously blocked threads.
-      } catch (RuntimeException onErrorException) {
-        logger.warn(
-            "Encountered unexpected error {} when cancelling due to error.",
-            onErrorException,
-            cancellationException);
+        // Either the no longer active observer which we attempt a reset and handle errors
+        // or the current observer that still requires closing.
+        try {
+          delegate.onError(cancellationException);
+        } catch (IllegalStateException onErrorException) {
+          // The delegate above was already terminated via onError or onComplete.
+          // Fallthrough since this is possibly due to queued onNext() calls that are being made
+          // from previously blocked threads.
+        } catch (RuntimeException onErrorException) {
+          logger.warn(
+              "Encountered unexpected error {} when cancelling due to error.",
+              onErrorException,
+              cancellationException);
+        }
       }
     }
   }
 
   public synchronized void onError(Throwable throwable)
       throws StreamClosedException, WindmillStreamShutdownException {
-    delegate().onError(throwable);
-    isCurrentStreamClosed = true;
+    try {
+      delegate().onError(throwable);
+    } finally {
+      isCurrentStreamClosed = true;
+    }
   }
 
   public synchronized void onCompleted()
       throws StreamClosedException, WindmillStreamShutdownException {
-    delegate().onCompleted();
-    isCurrentStreamClosed = true;
+    try {
+      delegate().onCompleted();
+    } finally {
+      isCurrentStreamClosed = true;
+    }
   }
 
   synchronized boolean isClosed() {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/ResettableThrowingStreamObserver.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/ResettableThrowingStreamObserver.java
@@ -122,21 +122,22 @@ final class ResettableThrowingStreamObserver<T> {
           }
           isCurrentStreamClosed = true;
         }
+      }
 
-        // Either the no longer active observer which we attempt a reset and handle errors
-        // or the current observer that still requires closing.
-        try {
-          delegate.onError(cancellationException);
-        } catch (IllegalStateException onErrorException) {
-          // The delegate above was already terminated via onError or onComplete.
-          // Fallthrough since this is possibly due to queued onNext() calls that are being made
-          // from previously blocked threads.
-        } catch (RuntimeException onErrorException) {
-          logger.warn(
-              "Encountered unexpected error {} when cancelling due to error.",
-              onErrorException,
-              cancellationException);
-        }
+      // Either this was the active observer the current observer that requires closing, or this was
+      // a previous
+      // observer which we attempt to close and ignore possible exceptions.
+      try {
+        delegate.onError(cancellationException);
+      } catch (IllegalStateException onErrorException) {
+        // The delegate above was already terminated via onError or onComplete.
+        // Fallthrough since this is possibly due to queued onNext() calls that are being made
+        // from previously blocked threads.
+      } catch (RuntimeException onErrorException) {
+        logger.warn(
+            "Encountered unexpected error {} when cancelling due to error.",
+            onErrorException,
+            cancellationException);
       }
     }
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/observers/DirectStreamObserver.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/observers/DirectStreamObserver.java
@@ -182,8 +182,8 @@ final class DirectStreamObserver<T> implements TerminatingStreamObserver<T> {
       Preconditions.checkState(!isUserClosed);
       isUserClosed = true;
       if (!isOutboundObserverClosed) {
-        outboundObserver.onError(t);
         isOutboundObserverClosed = true;
+        outboundObserver.onError(t);
       }
     }
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/observers/StreamObserverCancelledException.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/observers/StreamObserverCancelledException.java
@@ -21,15 +21,15 @@ import org.apache.beam.sdk.annotations.Internal;
 
 @Internal
 public final class StreamObserverCancelledException extends RuntimeException {
-  StreamObserverCancelledException(Throwable cause) {
+  public StreamObserverCancelledException(Throwable cause) {
     super(cause);
   }
 
-  StreamObserverCancelledException(String message, Throwable cause) {
+  public StreamObserverCancelledException(String message, Throwable cause) {
     super(message, cause);
   }
 
-  StreamObserverCancelledException(String message) {
+  public StreamObserverCancelledException(String message) {
     super(message);
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/ResettableThrowingStreamObserverTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/ResettableThrowingStreamObserverTest.java
@@ -162,7 +162,7 @@ public class ResettableThrowingStreamObserverTest {
   }
 
   @Test
-  public void testOnNext_streamCancelledException_onErrorThrows() throws Exception {
+  public void testOnNext_streamCancelledException_closesStream() throws Exception {
     ResettableThrowingStreamObserver<Integer> observer = newStreamObserver();
     TerminatingStreamObserver<Integer> spiedDelegate = newDelegate();
     StreamObserverCancelledException streamObserverCancelledException =
@@ -175,19 +175,6 @@ public class ResettableThrowingStreamObserverTest {
     assertThrows(
         ResettableThrowingStreamObserver.StreamClosedException.class,
         () -> observer.onError(new Exception()));
-  }
-
-  @Test
-  public void testOnNext_streamCancelledException_onCompletedThrows() throws Exception {
-    ResettableThrowingStreamObserver<Integer> observer = newStreamObserver();
-    TerminatingStreamObserver<Integer> spiedDelegate = newDelegate();
-    StreamObserverCancelledException streamObserverCancelledException =
-        new StreamObserverCancelledException("Test error");
-    doThrow(streamObserverCancelledException).when(spiedDelegate).onNext(any());
-    observer.reset(spiedDelegate);
-    observer.onNext(1);
-
-    verify(spiedDelegate).onError(eq(streamObserverCancelledException));
     assertThrows(
         ResettableThrowingStreamObserver.StreamClosedException.class, observer::onCompleted);
   }


### PR DESCRIPTION
Example error that could be observed previously when onComplete was called on ResettableThrowingStreamObserver which already called delegate.onError within onNext.

```json
{
  "jsonPayload": {
    "exception": "java.lang.IllegalStateException\n    at com.google.common.base.Preconditions.checkState(Preconditions.java:527)\n    at org.apache.beam.runners.dataflow.worker.windmill.client.grpc.observers.DirectStreamObserver.onCompleted(DirectStreamObserver.java:198)\n    at org.apache.beam.runners.dataflow.worker.windmill.client.ResettableThrowingStreamObserver.onCompleted(ResettableThrowingStreamObserver.java:143)\n    at org.apache.beam.runners.dataflow.worker.windmill.client.AbstractWindmillStream.halfClose(AbstractWindmillStream.java:450)\n    at org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStreamPool.getStream(WindmillStreamPool.java:131)\n    at org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStreamPool.getCloseableStream(WindmillStreamPool.java:137)\n    at org.apache.beam.runners.dataflow.worker.windmill.client.commits.StreamingEngineWorkCommitter.streamingCommitLoop(StreamingEngineWorkCommitter.java:178)\n    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)\n    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)\n    at java.base/java.lang.Thread.run(Thread.java:1583)",
    "job": "2025-09-12_13_56_55-8555386915480239630",
    "logger": "org.apache.beam.runners.dataflow.worker.windmill.client.grpc.GrpcCommitWorkStream",
    "message": "Unexpected error when trying to close stream",
    "thread": "49",
  }
}
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
