### PR TITLE
[Go SDK] Propagate paneInfo correctly.

### DIFF
--- a/sdks/go/pkg/beam/beam.shims.go
+++ b/sdks/go/pkg/beam/beam.shims.go
@@ -25,6 +25,7 @@ import (
 	// Library imports
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime/exec"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime/graphx/schema"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/sdf"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/typex"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/util/reflectx"
@@ -43,121 +44,104 @@ func init() {
 	runtime.RegisterFunction(schemaDec)
 	runtime.RegisterFunction(schemaEnc)
 	runtime.RegisterFunction(swapKVFn)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(reflect.Type, []byte) (typex.T, error))(nil)).Elem(), funcMakerReflect۰TypeSliceOfByteГTypex۰TError)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(reflect.Type, typex.T) ([]byte, error))(nil)).Elem(), funcMakerReflect۰TypeTypex۰TГSliceOfByteError)
-	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte, func(typex.T)) error)(nil)).Elem(), funcMakerSliceOfByteEmitTypex۰TГError)
-	reflectx.RegisterFunc(reflect.TypeOf((*func([]typex.T, func(typex.T)))(nil)).Elem(), funcMakerSliceOfTypex۰TEmitTypex۰TГ)
+	runtime.RegisterType(reflect.TypeOf((*T)(nil)).Elem())
+	schema.RegisterType(reflect.TypeOf((*T)(nil)).Elem())
+	runtime.RegisterType(reflect.TypeOf((*X)(nil)).Elem())
+	schema.RegisterType(reflect.TypeOf((*X)(nil)).Elem())
+	runtime.RegisterType(reflect.TypeOf((*Y)(nil)).Elem())
+	schema.RegisterType(reflect.TypeOf((*Y)(nil)).Elem())
+	runtime.RegisterType(reflect.TypeOf((*reflect.Type)(nil)).Elem())
+	schema.RegisterType(reflect.TypeOf((*reflect.Type)(nil)).Elem())
+	runtime.RegisterType(reflect.TypeOf((*reflectx.Func)(nil)).Elem())
+	schema.RegisterType(reflect.TypeOf((*reflectx.Func)(nil)).Elem())
+	reflectx.RegisterFunc(reflect.TypeOf((*func(reflect.Type, []byte) (T, error))(nil)).Elem(), funcMakerReflect۰TypeSliceOfByteГTError)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(reflect.Type, T) ([]byte, error))(nil)).Elem(), funcMakerReflect۰TypeTГSliceOfByteError)
+	reflectx.RegisterFunc(reflect.TypeOf((*func([]T, func(T)))(nil)).Elem(), funcMakerSliceOfTEmitTГ)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(string, reflect.Type, []byte) reflectx.Func)(nil)).Elem(), funcMakerStringReflect۰TypeSliceOfByteГReflectx۰Func)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.T) (int, typex.T))(nil)).Elem(), funcMakerTypex۰TГIntTypex۰T)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.T) ([]byte, error))(nil)).Elem(), funcMakerTypex۰TГSliceOfByteError)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.X, typex.Y) typex.X)(nil)).Elem(), funcMakerTypex۰XTypex۰YГTypex۰X)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.X, typex.Y) typex.Y)(nil)).Elem(), funcMakerTypex۰XTypex۰YГTypex۰Y)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.X, typex.Y) (typex.Y, typex.X))(nil)).Elem(), funcMakerTypex۰XTypex۰YГTypex۰YTypex۰X)
-	exec.RegisterEmitter(reflect.TypeOf((*func(typex.T))(nil)).Elem(), emitMakerTypex۰T)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(T) (int, T))(nil)).Elem(), funcMakerTГIntT)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(T) ([]byte, error))(nil)).Elem(), funcMakerTГSliceOfByteError)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(X, Y) X)(nil)).Elem(), funcMakerXYГX)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(X, Y) Y)(nil)).Elem(), funcMakerXYГY)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(X, Y) (Y, X))(nil)).Elem(), funcMakerXYГYX)
+	exec.RegisterEmitter(reflect.TypeOf((*func(T))(nil)).Elem(), emitMakerT)
 }
 
-type callerReflect۰TypeSliceOfByteГTypex۰TError struct {
-	fn func(reflect.Type, []byte) (typex.T, error)
+type callerReflect۰TypeSliceOfByteГTError struct {
+	fn func(reflect.Type, []byte) (T, error)
 }
 
-func funcMakerReflect۰TypeSliceOfByteГTypex۰TError(fn any) reflectx.Func {
-	f := fn.(func(reflect.Type, []byte) (typex.T, error))
-	return &callerReflect۰TypeSliceOfByteГTypex۰TError{fn: f}
+func funcMakerReflect۰TypeSliceOfByteГTError(fn any) reflectx.Func {
+	f := fn.(func(reflect.Type, []byte) (T, error))
+	return &callerReflect۰TypeSliceOfByteГTError{fn: f}
 }
 
-func (c *callerReflect۰TypeSliceOfByteГTypex۰TError) Name() string {
+func (c *callerReflect۰TypeSliceOfByteГTError) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerReflect۰TypeSliceOfByteГTypex۰TError) Type() reflect.Type {
+func (c *callerReflect۰TypeSliceOfByteГTError) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerReflect۰TypeSliceOfByteГTypex۰TError) Call(args []any) []any {
+func (c *callerReflect۰TypeSliceOfByteГTError) Call(args []any) []any {
 	out0, out1 := c.fn(args[0].(reflect.Type), args[1].([]byte))
 	return []any{out0, out1}
 }
 
-func (c *callerReflect۰TypeSliceOfByteГTypex۰TError) Call2x2(arg0, arg1 any) (any, any) {
+func (c *callerReflect۰TypeSliceOfByteГTError) Call2x2(arg0, arg1 any) (any, any) {
 	return c.fn(arg0.(reflect.Type), arg1.([]byte))
 }
 
-type callerReflect۰TypeTypex۰TГSliceOfByteError struct {
-	fn func(reflect.Type, typex.T) ([]byte, error)
+type callerReflect۰TypeTГSliceOfByteError struct {
+	fn func(reflect.Type, T) ([]byte, error)
 }
 
-func funcMakerReflect۰TypeTypex۰TГSliceOfByteError(fn any) reflectx.Func {
-	f := fn.(func(reflect.Type, typex.T) ([]byte, error))
-	return &callerReflect۰TypeTypex۰TГSliceOfByteError{fn: f}
+func funcMakerReflect۰TypeTГSliceOfByteError(fn any) reflectx.Func {
+	f := fn.(func(reflect.Type, T) ([]byte, error))
+	return &callerReflect۰TypeTГSliceOfByteError{fn: f}
 }
 
-func (c *callerReflect۰TypeTypex۰TГSliceOfByteError) Name() string {
+func (c *callerReflect۰TypeTГSliceOfByteError) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerReflect۰TypeTypex۰TГSliceOfByteError) Type() reflect.Type {
+func (c *callerReflect۰TypeTГSliceOfByteError) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerReflect۰TypeTypex۰TГSliceOfByteError) Call(args []any) []any {
-	out0, out1 := c.fn(args[0].(reflect.Type), args[1].(typex.T))
+func (c *callerReflect۰TypeTГSliceOfByteError) Call(args []any) []any {
+	out0, out1 := c.fn(args[0].(reflect.Type), args[1].(T))
 	return []any{out0, out1}
 }
 
-func (c *callerReflect۰TypeTypex۰TГSliceOfByteError) Call2x2(arg0, arg1 any) (any, any) {
-	return c.fn(arg0.(reflect.Type), arg1.(typex.T))
+func (c *callerReflect۰TypeTГSliceOfByteError) Call2x2(arg0, arg1 any) (any, any) {
+	return c.fn(arg0.(reflect.Type), arg1.(T))
 }
 
-type callerSliceOfByteEmitTypex۰TГError struct {
-	fn func([]byte, func(typex.T)) error
+type callerSliceOfTEmitTГ struct {
+	fn func([]T, func(T))
 }
 
-func funcMakerSliceOfByteEmitTypex۰TГError(fn any) reflectx.Func {
-	f := fn.(func([]byte, func(typex.T)) error)
-	return &callerSliceOfByteEmitTypex۰TГError{fn: f}
+func funcMakerSliceOfTEmitTГ(fn any) reflectx.Func {
+	f := fn.(func([]T, func(T)))
+	return &callerSliceOfTEmitTГ{fn: f}
 }
 
-func (c *callerSliceOfByteEmitTypex۰TГError) Name() string {
+func (c *callerSliceOfTEmitTГ) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerSliceOfByteEmitTypex۰TГError) Type() reflect.Type {
+func (c *callerSliceOfTEmitTГ) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerSliceOfByteEmitTypex۰TГError) Call(args []any) []any {
-	out0 := c.fn(args[0].([]byte), args[1].(func(typex.T)))
-	return []any{out0}
-}
-
-func (c *callerSliceOfByteEmitTypex۰TГError) Call2x1(arg0, arg1 any) any {
-	return c.fn(arg0.([]byte), arg1.(func(typex.T)))
-}
-
-type callerSliceOfTypex۰TEmitTypex۰TГ struct {
-	fn func([]typex.T, func(typex.T))
-}
-
-func funcMakerSliceOfTypex۰TEmitTypex۰TГ(fn any) reflectx.Func {
-	f := fn.(func([]typex.T, func(typex.T)))
-	return &callerSliceOfTypex۰TEmitTypex۰TГ{fn: f}
-}
-
-func (c *callerSliceOfTypex۰TEmitTypex۰TГ) Name() string {
-	return reflectx.FunctionName(c.fn)
-}
-
-func (c *callerSliceOfTypex۰TEmitTypex۰TГ) Type() reflect.Type {
-	return reflect.TypeOf(c.fn)
-}
-
-func (c *callerSliceOfTypex۰TEmitTypex۰TГ) Call(args []any) []any {
-	c.fn(args[0].([]typex.T), args[1].(func(typex.T)))
+func (c *callerSliceOfTEmitTГ) Call(args []any) []any {
+	c.fn(args[0].([]T), args[1].(func(T)))
 	return []any{}
 }
 
-func (c *callerSliceOfTypex۰TEmitTypex۰TГ) Call2x0(arg0, arg1 any) {
-	c.fn(arg0.([]typex.T), arg1.(func(typex.T)))
+func (c *callerSliceOfTEmitTГ) Call2x0(arg0, arg1 any) {
+	c.fn(arg0.([]T), arg1.(func(T)))
 }
 
 type callerStringReflect۰TypeSliceOfByteГReflectx۰Func struct {
@@ -186,134 +170,134 @@ func (c *callerStringReflect۰TypeSliceOfByteГReflectx۰Func) Call3x1(arg0, arg
 	return c.fn(arg0.(string), arg1.(reflect.Type), arg2.([]byte))
 }
 
-type callerTypex۰TГIntTypex۰T struct {
-	fn func(typex.T) (int, typex.T)
+type callerTГIntT struct {
+	fn func(T) (int, T)
 }
 
-func funcMakerTypex۰TГIntTypex۰T(fn any) reflectx.Func {
-	f := fn.(func(typex.T) (int, typex.T))
-	return &callerTypex۰TГIntTypex۰T{fn: f}
+func funcMakerTГIntT(fn any) reflectx.Func {
+	f := fn.(func(T) (int, T))
+	return &callerTГIntT{fn: f}
 }
 
-func (c *callerTypex۰TГIntTypex۰T) Name() string {
+func (c *callerTГIntT) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerTypex۰TГIntTypex۰T) Type() reflect.Type {
+func (c *callerTГIntT) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerTypex۰TГIntTypex۰T) Call(args []any) []any {
-	out0, out1 := c.fn(args[0].(typex.T))
+func (c *callerTГIntT) Call(args []any) []any {
+	out0, out1 := c.fn(args[0].(T))
 	return []any{out0, out1}
 }
 
-func (c *callerTypex۰TГIntTypex۰T) Call1x2(arg0 any) (any, any) {
-	return c.fn(arg0.(typex.T))
+func (c *callerTГIntT) Call1x2(arg0 any) (any, any) {
+	return c.fn(arg0.(T))
 }
 
-type callerTypex۰TГSliceOfByteError struct {
-	fn func(typex.T) ([]byte, error)
+type callerTГSliceOfByteError struct {
+	fn func(T) ([]byte, error)
 }
 
-func funcMakerTypex۰TГSliceOfByteError(fn any) reflectx.Func {
-	f := fn.(func(typex.T) ([]byte, error))
-	return &callerTypex۰TГSliceOfByteError{fn: f}
+func funcMakerTГSliceOfByteError(fn any) reflectx.Func {
+	f := fn.(func(T) ([]byte, error))
+	return &callerTГSliceOfByteError{fn: f}
 }
 
-func (c *callerTypex۰TГSliceOfByteError) Name() string {
+func (c *callerTГSliceOfByteError) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerTypex۰TГSliceOfByteError) Type() reflect.Type {
+func (c *callerTГSliceOfByteError) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerTypex۰TГSliceOfByteError) Call(args []any) []any {
-	out0, out1 := c.fn(args[0].(typex.T))
+func (c *callerTГSliceOfByteError) Call(args []any) []any {
+	out0, out1 := c.fn(args[0].(T))
 	return []any{out0, out1}
 }
 
-func (c *callerTypex۰TГSliceOfByteError) Call1x2(arg0 any) (any, any) {
-	return c.fn(arg0.(typex.T))
+func (c *callerTГSliceOfByteError) Call1x2(arg0 any) (any, any) {
+	return c.fn(arg0.(T))
 }
 
-type callerTypex۰XTypex۰YГTypex۰X struct {
-	fn func(typex.X, typex.Y) typex.X
+type callerXYГX struct {
+	fn func(X, Y) X
 }
 
-func funcMakerTypex۰XTypex۰YГTypex۰X(fn any) reflectx.Func {
-	f := fn.(func(typex.X, typex.Y) typex.X)
-	return &callerTypex۰XTypex۰YГTypex۰X{fn: f}
+func funcMakerXYГX(fn any) reflectx.Func {
+	f := fn.(func(X, Y) X)
+	return &callerXYГX{fn: f}
 }
 
-func (c *callerTypex۰XTypex۰YГTypex۰X) Name() string {
+func (c *callerXYГX) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerTypex۰XTypex۰YГTypex۰X) Type() reflect.Type {
+func (c *callerXYГX) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerTypex۰XTypex۰YГTypex۰X) Call(args []any) []any {
-	out0 := c.fn(args[0].(typex.X), args[1].(typex.Y))
+func (c *callerXYГX) Call(args []any) []any {
+	out0 := c.fn(args[0].(X), args[1].(Y))
 	return []any{out0}
 }
 
-func (c *callerTypex۰XTypex۰YГTypex۰X) Call2x1(arg0, arg1 any) any {
-	return c.fn(arg0.(typex.X), arg1.(typex.Y))
+func (c *callerXYГX) Call2x1(arg0, arg1 any) any {
+	return c.fn(arg0.(X), arg1.(Y))
 }
 
-type callerTypex۰XTypex۰YГTypex۰Y struct {
-	fn func(typex.X, typex.Y) typex.Y
+type callerXYГY struct {
+	fn func(X, Y) Y
 }
 
-func funcMakerTypex۰XTypex۰YГTypex۰Y(fn any) reflectx.Func {
-	f := fn.(func(typex.X, typex.Y) typex.Y)
-	return &callerTypex۰XTypex۰YГTypex۰Y{fn: f}
+func funcMakerXYГY(fn any) reflectx.Func {
+	f := fn.(func(X, Y) Y)
+	return &callerXYГY{fn: f}
 }
 
-func (c *callerTypex۰XTypex۰YГTypex۰Y) Name() string {
+func (c *callerXYГY) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerTypex۰XTypex۰YГTypex۰Y) Type() reflect.Type {
+func (c *callerXYГY) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerTypex۰XTypex۰YГTypex۰Y) Call(args []any) []any {
-	out0 := c.fn(args[0].(typex.X), args[1].(typex.Y))
+func (c *callerXYГY) Call(args []any) []any {
+	out0 := c.fn(args[0].(X), args[1].(Y))
 	return []any{out0}
 }
 
-func (c *callerTypex۰XTypex۰YГTypex۰Y) Call2x1(arg0, arg1 any) any {
-	return c.fn(arg0.(typex.X), arg1.(typex.Y))
+func (c *callerXYГY) Call2x1(arg0, arg1 any) any {
+	return c.fn(arg0.(X), arg1.(Y))
 }
 
-type callerTypex۰XTypex۰YГTypex۰YTypex۰X struct {
-	fn func(typex.X, typex.Y) (typex.Y, typex.X)
+type callerXYГYX struct {
+	fn func(X, Y) (Y, X)
 }
 
-func funcMakerTypex۰XTypex۰YГTypex۰YTypex۰X(fn any) reflectx.Func {
-	f := fn.(func(typex.X, typex.Y) (typex.Y, typex.X))
-	return &callerTypex۰XTypex۰YГTypex۰YTypex۰X{fn: f}
+func funcMakerXYГYX(fn any) reflectx.Func {
+	f := fn.(func(X, Y) (Y, X))
+	return &callerXYГYX{fn: f}
 }
 
-func (c *callerTypex۰XTypex۰YГTypex۰YTypex۰X) Name() string {
+func (c *callerXYГYX) Name() string {
 	return reflectx.FunctionName(c.fn)
 }
 
-func (c *callerTypex۰XTypex۰YГTypex۰YTypex۰X) Type() reflect.Type {
+func (c *callerXYГYX) Type() reflect.Type {
 	return reflect.TypeOf(c.fn)
 }
 
-func (c *callerTypex۰XTypex۰YГTypex۰YTypex۰X) Call(args []any) []any {
-	out0, out1 := c.fn(args[0].(typex.X), args[1].(typex.Y))
+func (c *callerXYГYX) Call(args []any) []any {
+	out0, out1 := c.fn(args[0].(X), args[1].(Y))
 	return []any{out0, out1}
 }
 
-func (c *callerTypex۰XTypex۰YГTypex۰YTypex۰X) Call2x2(arg0, arg1 any) (any, any) {
-	return c.fn(arg0.(typex.X), arg1.(typex.Y))
+func (c *callerXYГYX) Call2x2(arg0, arg1 any) (any, any) {
+	return c.fn(arg0.(X), arg1.(Y))
 }
 
 type emitNative struct {
@@ -322,13 +306,15 @@ type emitNative struct {
 	est *sdf.WatermarkEstimator
 
 	ctx   context.Context
+	pn    typex.PaneInfo
 	ws    []typex.Window
 	et    typex.EventTime
 	value exec.FullValue
 }
 
-func (e *emitNative) Init(ctx context.Context, ws []typex.Window, et typex.EventTime) error {
+func (e *emitNative) Init(ctx context.Context, pn typex.PaneInfo, ws []typex.Window, et typex.EventTime) error {
 	e.ctx = ctx
+	e.pn = pn
 	e.ws = ws
 	e.et = et
 	return nil
@@ -342,14 +328,14 @@ func (e *emitNative) AttachEstimator(est *sdf.WatermarkEstimator) {
 	e.est = est
 }
 
-func emitMakerTypex۰T(n exec.ElementProcessor) exec.ReusableEmitter {
+func emitMakerT(n exec.ElementProcessor) exec.ReusableEmitter {
 	ret := &emitNative{n: n}
-	ret.fn = ret.invokeTypex۰T
+	ret.fn = ret.invokeT
 	return ret
 }
 
-func (e *emitNative) invokeTypex۰T(val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: val}
+func (e *emitNative) invokeT(val T) {
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}

--- a/sdks/go/pkg/beam/core/runtime/exec/emit.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/emit.go
@@ -30,7 +30,7 @@ import (
 // emit event time.
 type ReusableEmitter interface {
 	// Init resets the value. Can be called multiple times.
-	Init(ctx context.Context, ws []typex.Window, t typex.EventTime) error
+	Init(ctx context.Context, pn typex.PaneInfo, ws []typex.Window, t typex.EventTime) error
 	// Value returns the side input value. Constant value.
 	Value() any
 }
@@ -96,12 +96,14 @@ type emitValue struct {
 	est   *sdf.WatermarkEstimator
 
 	ctx context.Context
+	pn  typex.PaneInfo
 	ws  []typex.Window
 	et  typex.EventTime
 }
 
-func (e *emitValue) Init(ctx context.Context, ws []typex.Window, et typex.EventTime) error {
+func (e *emitValue) Init(ctx context.Context, pn typex.PaneInfo, ws []typex.Window, et typex.EventTime) error {
 	e.ctx = ctx
+	e.pn = pn
 	e.ws = ws
 	e.et = et
 	return nil
@@ -116,7 +118,7 @@ func (e *emitValue) AttachEstimator(est *sdf.WatermarkEstimator) {
 }
 
 func (e *emitValue) invoke(args []reflect.Value) []reflect.Value {
-	value := &FullValue{Windows: e.ws, Timestamp: e.et}
+	value := &FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et}
 	isKey := true
 	for i, t := range e.types {
 		switch {

--- a/sdks/go/pkg/beam/core/runtime/exec/optimized/emitters.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/optimized/emitters.go
@@ -1047,13 +1047,15 @@ type emitNative struct {
 	est *sdf.WatermarkEstimator
 
 	ctx   context.Context
+	pn    typex.PaneInfo
 	ws    []typex.Window
 	et    typex.EventTime
 	value exec.FullValue
 }
 
-func (e *emitNative) Init(ctx context.Context, ws []typex.Window, et typex.EventTime) error {
+func (e *emitNative) Init(ctx context.Context, pn typex.PaneInfo, ws []typex.Window, et typex.EventTime) error {
 	e.ctx = ctx
+	e.pn = pn
 	e.ws = ws
 	e.et = et
 	return nil
@@ -1074,7 +1076,7 @@ func emitMakerByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSlice(elm []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1090,7 +1092,7 @@ func emitMakerETByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSlice(t typex.EventTime, elm []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1106,7 +1108,7 @@ func emitMakerByteSliceByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceByteSlice(key []byte, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1122,7 +1124,7 @@ func emitMakerETByteSliceByteSlice(n exec.ElementProcessor) exec.ReusableEmitter
 }
 
 func (e *emitNative) invokeETByteSliceByteSlice(t typex.EventTime, key []byte, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1138,7 +1140,7 @@ func emitMakerByteSliceBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceBool(key []byte, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1154,7 +1156,7 @@ func emitMakerETByteSliceBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceBool(t typex.EventTime, key []byte, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1170,7 +1172,7 @@ func emitMakerByteSliceString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceString(key []byte, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1186,7 +1188,7 @@ func emitMakerETByteSliceString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceString(t typex.EventTime, key []byte, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1202,7 +1204,7 @@ func emitMakerByteSliceInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceInt(key []byte, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1218,7 +1220,7 @@ func emitMakerETByteSliceInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceInt(t typex.EventTime, key []byte, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1234,7 +1236,7 @@ func emitMakerByteSliceInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceInt8(key []byte, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1250,7 +1252,7 @@ func emitMakerETByteSliceInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceInt8(t typex.EventTime, key []byte, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1266,7 +1268,7 @@ func emitMakerByteSliceInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceInt16(key []byte, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1282,7 +1284,7 @@ func emitMakerETByteSliceInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceInt16(t typex.EventTime, key []byte, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1298,7 +1300,7 @@ func emitMakerByteSliceInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceInt32(key []byte, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1314,7 +1316,7 @@ func emitMakerETByteSliceInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceInt32(t typex.EventTime, key []byte, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1330,7 +1332,7 @@ func emitMakerByteSliceInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceInt64(key []byte, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1346,7 +1348,7 @@ func emitMakerETByteSliceInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceInt64(t typex.EventTime, key []byte, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1362,7 +1364,7 @@ func emitMakerByteSliceUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceUint(key []byte, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1378,7 +1380,7 @@ func emitMakerETByteSliceUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceUint(t typex.EventTime, key []byte, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1394,7 +1396,7 @@ func emitMakerByteSliceUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceUint8(key []byte, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1410,7 +1412,7 @@ func emitMakerETByteSliceUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceUint8(t typex.EventTime, key []byte, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1426,7 +1428,7 @@ func emitMakerByteSliceUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceUint16(key []byte, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1442,7 +1444,7 @@ func emitMakerETByteSliceUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceUint16(t typex.EventTime, key []byte, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1458,7 +1460,7 @@ func emitMakerByteSliceUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceUint32(key []byte, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1474,7 +1476,7 @@ func emitMakerETByteSliceUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceUint32(t typex.EventTime, key []byte, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1490,7 +1492,7 @@ func emitMakerByteSliceUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceUint64(key []byte, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1506,7 +1508,7 @@ func emitMakerETByteSliceUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceUint64(t typex.EventTime, key []byte, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1522,7 +1524,7 @@ func emitMakerByteSliceFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceFloat32(key []byte, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1538,7 +1540,7 @@ func emitMakerETByteSliceFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceFloat32(t typex.EventTime, key []byte, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1554,7 +1556,7 @@ func emitMakerByteSliceFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceFloat64(key []byte, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1570,7 +1572,7 @@ func emitMakerETByteSliceFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceFloat64(t typex.EventTime, key []byte, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1586,7 +1588,7 @@ func emitMakerByteSliceTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceTypex_T(key []byte, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1602,7 +1604,7 @@ func emitMakerETByteSliceTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceTypex_T(t typex.EventTime, key []byte, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1618,7 +1620,7 @@ func emitMakerByteSliceTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceTypex_U(key []byte, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1634,7 +1636,7 @@ func emitMakerETByteSliceTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceTypex_U(t typex.EventTime, key []byte, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1650,7 +1652,7 @@ func emitMakerByteSliceTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceTypex_V(key []byte, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1666,7 +1668,7 @@ func emitMakerETByteSliceTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceTypex_V(t typex.EventTime, key []byte, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1682,7 +1684,7 @@ func emitMakerByteSliceTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceTypex_W(key []byte, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1698,7 +1700,7 @@ func emitMakerETByteSliceTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceTypex_W(t typex.EventTime, key []byte, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1714,7 +1716,7 @@ func emitMakerByteSliceTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceTypex_X(key []byte, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1730,7 +1732,7 @@ func emitMakerETByteSliceTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceTypex_X(t typex.EventTime, key []byte, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1746,7 +1748,7 @@ func emitMakerByteSliceTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceTypex_Y(key []byte, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1762,7 +1764,7 @@ func emitMakerETByteSliceTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceTypex_Y(t typex.EventTime, key []byte, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1778,7 +1780,7 @@ func emitMakerByteSliceTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeByteSliceTypex_Z(key []byte, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1794,7 +1796,7 @@ func emitMakerETByteSliceTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETByteSliceTypex_Z(t typex.EventTime, key []byte, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1810,7 +1812,7 @@ func emitMakerBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBool(elm bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1826,7 +1828,7 @@ func emitMakerETBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBool(t typex.EventTime, elm bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1842,7 +1844,7 @@ func emitMakerBoolByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolByteSlice(key bool, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1858,7 +1860,7 @@ func emitMakerETBoolByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolByteSlice(t typex.EventTime, key bool, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1874,7 +1876,7 @@ func emitMakerBoolBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolBool(key bool, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1890,7 +1892,7 @@ func emitMakerETBoolBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolBool(t typex.EventTime, key bool, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1906,7 +1908,7 @@ func emitMakerBoolString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolString(key bool, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1922,7 +1924,7 @@ func emitMakerETBoolString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolString(t typex.EventTime, key bool, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1938,7 +1940,7 @@ func emitMakerBoolInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolInt(key bool, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1954,7 +1956,7 @@ func emitMakerETBoolInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolInt(t typex.EventTime, key bool, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -1970,7 +1972,7 @@ func emitMakerBoolInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolInt8(key bool, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -1986,7 +1988,7 @@ func emitMakerETBoolInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolInt8(t typex.EventTime, key bool, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2002,7 +2004,7 @@ func emitMakerBoolInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolInt16(key bool, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2018,7 +2020,7 @@ func emitMakerETBoolInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolInt16(t typex.EventTime, key bool, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2034,7 +2036,7 @@ func emitMakerBoolInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolInt32(key bool, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2050,7 +2052,7 @@ func emitMakerETBoolInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolInt32(t typex.EventTime, key bool, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2066,7 +2068,7 @@ func emitMakerBoolInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolInt64(key bool, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2082,7 +2084,7 @@ func emitMakerETBoolInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolInt64(t typex.EventTime, key bool, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2098,7 +2100,7 @@ func emitMakerBoolUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolUint(key bool, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2114,7 +2116,7 @@ func emitMakerETBoolUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolUint(t typex.EventTime, key bool, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2130,7 +2132,7 @@ func emitMakerBoolUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolUint8(key bool, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2146,7 +2148,7 @@ func emitMakerETBoolUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolUint8(t typex.EventTime, key bool, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2162,7 +2164,7 @@ func emitMakerBoolUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolUint16(key bool, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2178,7 +2180,7 @@ func emitMakerETBoolUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolUint16(t typex.EventTime, key bool, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2194,7 +2196,7 @@ func emitMakerBoolUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolUint32(key bool, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2210,7 +2212,7 @@ func emitMakerETBoolUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolUint32(t typex.EventTime, key bool, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2226,7 +2228,7 @@ func emitMakerBoolUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolUint64(key bool, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2242,7 +2244,7 @@ func emitMakerETBoolUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolUint64(t typex.EventTime, key bool, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2258,7 +2260,7 @@ func emitMakerBoolFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolFloat32(key bool, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2274,7 +2276,7 @@ func emitMakerETBoolFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolFloat32(t typex.EventTime, key bool, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2290,7 +2292,7 @@ func emitMakerBoolFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolFloat64(key bool, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2306,7 +2308,7 @@ func emitMakerETBoolFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolFloat64(t typex.EventTime, key bool, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2322,7 +2324,7 @@ func emitMakerBoolTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolTypex_T(key bool, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2338,7 +2340,7 @@ func emitMakerETBoolTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolTypex_T(t typex.EventTime, key bool, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2354,7 +2356,7 @@ func emitMakerBoolTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolTypex_U(key bool, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2370,7 +2372,7 @@ func emitMakerETBoolTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolTypex_U(t typex.EventTime, key bool, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2386,7 +2388,7 @@ func emitMakerBoolTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolTypex_V(key bool, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2402,7 +2404,7 @@ func emitMakerETBoolTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolTypex_V(t typex.EventTime, key bool, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2418,7 +2420,7 @@ func emitMakerBoolTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolTypex_W(key bool, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2434,7 +2436,7 @@ func emitMakerETBoolTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolTypex_W(t typex.EventTime, key bool, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2450,7 +2452,7 @@ func emitMakerBoolTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolTypex_X(key bool, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2466,7 +2468,7 @@ func emitMakerETBoolTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolTypex_X(t typex.EventTime, key bool, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2482,7 +2484,7 @@ func emitMakerBoolTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolTypex_Y(key bool, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2498,7 +2500,7 @@ func emitMakerETBoolTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolTypex_Y(t typex.EventTime, key bool, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2514,7 +2516,7 @@ func emitMakerBoolTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeBoolTypex_Z(key bool, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2530,7 +2532,7 @@ func emitMakerETBoolTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETBoolTypex_Z(t typex.EventTime, key bool, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2546,7 +2548,7 @@ func emitMakerString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeString(elm string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2562,7 +2564,7 @@ func emitMakerETString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETString(t typex.EventTime, elm string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2578,7 +2580,7 @@ func emitMakerStringByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringByteSlice(key string, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2594,7 +2596,7 @@ func emitMakerETStringByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringByteSlice(t typex.EventTime, key string, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2610,7 +2612,7 @@ func emitMakerStringBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringBool(key string, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2626,7 +2628,7 @@ func emitMakerETStringBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringBool(t typex.EventTime, key string, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2642,7 +2644,7 @@ func emitMakerStringString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringString(key string, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2658,7 +2660,7 @@ func emitMakerETStringString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringString(t typex.EventTime, key string, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2674,7 +2676,7 @@ func emitMakerStringInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringInt(key string, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2690,7 +2692,7 @@ func emitMakerETStringInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringInt(t typex.EventTime, key string, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2706,7 +2708,7 @@ func emitMakerStringInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringInt8(key string, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2722,7 +2724,7 @@ func emitMakerETStringInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringInt8(t typex.EventTime, key string, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2738,7 +2740,7 @@ func emitMakerStringInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringInt16(key string, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2754,7 +2756,7 @@ func emitMakerETStringInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringInt16(t typex.EventTime, key string, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2770,7 +2772,7 @@ func emitMakerStringInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringInt32(key string, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2786,7 +2788,7 @@ func emitMakerETStringInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringInt32(t typex.EventTime, key string, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2802,7 +2804,7 @@ func emitMakerStringInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringInt64(key string, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2818,7 +2820,7 @@ func emitMakerETStringInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringInt64(t typex.EventTime, key string, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2834,7 +2836,7 @@ func emitMakerStringUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringUint(key string, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2850,7 +2852,7 @@ func emitMakerETStringUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringUint(t typex.EventTime, key string, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2866,7 +2868,7 @@ func emitMakerStringUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringUint8(key string, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2882,7 +2884,7 @@ func emitMakerETStringUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringUint8(t typex.EventTime, key string, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2898,7 +2900,7 @@ func emitMakerStringUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringUint16(key string, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2914,7 +2916,7 @@ func emitMakerETStringUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringUint16(t typex.EventTime, key string, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2930,7 +2932,7 @@ func emitMakerStringUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringUint32(key string, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2946,7 +2948,7 @@ func emitMakerETStringUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringUint32(t typex.EventTime, key string, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2962,7 +2964,7 @@ func emitMakerStringUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringUint64(key string, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -2978,7 +2980,7 @@ func emitMakerETStringUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringUint64(t typex.EventTime, key string, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -2994,7 +2996,7 @@ func emitMakerStringFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringFloat32(key string, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3010,7 +3012,7 @@ func emitMakerETStringFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringFloat32(t typex.EventTime, key string, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3026,7 +3028,7 @@ func emitMakerStringFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringFloat64(key string, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3042,7 +3044,7 @@ func emitMakerETStringFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringFloat64(t typex.EventTime, key string, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3058,7 +3060,7 @@ func emitMakerStringTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringTypex_T(key string, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3074,7 +3076,7 @@ func emitMakerETStringTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringTypex_T(t typex.EventTime, key string, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3090,7 +3092,7 @@ func emitMakerStringTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringTypex_U(key string, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3106,7 +3108,7 @@ func emitMakerETStringTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringTypex_U(t typex.EventTime, key string, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3122,7 +3124,7 @@ func emitMakerStringTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringTypex_V(key string, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3138,7 +3140,7 @@ func emitMakerETStringTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringTypex_V(t typex.EventTime, key string, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3154,7 +3156,7 @@ func emitMakerStringTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringTypex_W(key string, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3170,7 +3172,7 @@ func emitMakerETStringTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringTypex_W(t typex.EventTime, key string, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3186,7 +3188,7 @@ func emitMakerStringTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringTypex_X(key string, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3202,7 +3204,7 @@ func emitMakerETStringTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringTypex_X(t typex.EventTime, key string, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3218,7 +3220,7 @@ func emitMakerStringTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringTypex_Y(key string, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3234,7 +3236,7 @@ func emitMakerETStringTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringTypex_Y(t typex.EventTime, key string, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3250,7 +3252,7 @@ func emitMakerStringTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringTypex_Z(key string, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3266,7 +3268,7 @@ func emitMakerETStringTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETStringTypex_Z(t typex.EventTime, key string, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3282,7 +3284,7 @@ func emitMakerInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt(elm int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3298,7 +3300,7 @@ func emitMakerETInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt(t typex.EventTime, elm int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3314,7 +3316,7 @@ func emitMakerIntByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntByteSlice(key int, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3330,7 +3332,7 @@ func emitMakerETIntByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntByteSlice(t typex.EventTime, key int, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3346,7 +3348,7 @@ func emitMakerIntBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntBool(key int, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3362,7 +3364,7 @@ func emitMakerETIntBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntBool(t typex.EventTime, key int, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3378,7 +3380,7 @@ func emitMakerIntString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntString(key int, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3394,7 +3396,7 @@ func emitMakerETIntString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntString(t typex.EventTime, key int, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3410,7 +3412,7 @@ func emitMakerIntInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntInt(key int, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3426,7 +3428,7 @@ func emitMakerETIntInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntInt(t typex.EventTime, key int, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3442,7 +3444,7 @@ func emitMakerIntInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntInt8(key int, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3458,7 +3460,7 @@ func emitMakerETIntInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntInt8(t typex.EventTime, key int, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3474,7 +3476,7 @@ func emitMakerIntInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntInt16(key int, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3490,7 +3492,7 @@ func emitMakerETIntInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntInt16(t typex.EventTime, key int, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3506,7 +3508,7 @@ func emitMakerIntInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntInt32(key int, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3522,7 +3524,7 @@ func emitMakerETIntInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntInt32(t typex.EventTime, key int, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3538,7 +3540,7 @@ func emitMakerIntInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntInt64(key int, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3554,7 +3556,7 @@ func emitMakerETIntInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntInt64(t typex.EventTime, key int, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3570,7 +3572,7 @@ func emitMakerIntUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntUint(key int, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3586,7 +3588,7 @@ func emitMakerETIntUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntUint(t typex.EventTime, key int, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3602,7 +3604,7 @@ func emitMakerIntUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntUint8(key int, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3618,7 +3620,7 @@ func emitMakerETIntUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntUint8(t typex.EventTime, key int, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3634,7 +3636,7 @@ func emitMakerIntUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntUint16(key int, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3650,7 +3652,7 @@ func emitMakerETIntUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntUint16(t typex.EventTime, key int, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3666,7 +3668,7 @@ func emitMakerIntUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntUint32(key int, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3682,7 +3684,7 @@ func emitMakerETIntUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntUint32(t typex.EventTime, key int, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3698,7 +3700,7 @@ func emitMakerIntUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntUint64(key int, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3714,7 +3716,7 @@ func emitMakerETIntUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntUint64(t typex.EventTime, key int, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3730,7 +3732,7 @@ func emitMakerIntFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntFloat32(key int, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3746,7 +3748,7 @@ func emitMakerETIntFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntFloat32(t typex.EventTime, key int, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3762,7 +3764,7 @@ func emitMakerIntFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntFloat64(key int, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3778,7 +3780,7 @@ func emitMakerETIntFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntFloat64(t typex.EventTime, key int, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3794,7 +3796,7 @@ func emitMakerIntTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntTypex_T(key int, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3810,7 +3812,7 @@ func emitMakerETIntTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntTypex_T(t typex.EventTime, key int, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3826,7 +3828,7 @@ func emitMakerIntTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntTypex_U(key int, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3842,7 +3844,7 @@ func emitMakerETIntTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntTypex_U(t typex.EventTime, key int, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3858,7 +3860,7 @@ func emitMakerIntTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntTypex_V(key int, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3874,7 +3876,7 @@ func emitMakerETIntTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntTypex_V(t typex.EventTime, key int, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3890,7 +3892,7 @@ func emitMakerIntTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntTypex_W(key int, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3906,7 +3908,7 @@ func emitMakerETIntTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntTypex_W(t typex.EventTime, key int, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3922,7 +3924,7 @@ func emitMakerIntTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntTypex_X(key int, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3938,7 +3940,7 @@ func emitMakerETIntTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntTypex_X(t typex.EventTime, key int, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3954,7 +3956,7 @@ func emitMakerIntTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntTypex_Y(key int, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -3970,7 +3972,7 @@ func emitMakerETIntTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntTypex_Y(t typex.EventTime, key int, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -3986,7 +3988,7 @@ func emitMakerIntTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeIntTypex_Z(key int, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4002,7 +4004,7 @@ func emitMakerETIntTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETIntTypex_Z(t typex.EventTime, key int, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4018,7 +4020,7 @@ func emitMakerInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8(elm int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4034,7 +4036,7 @@ func emitMakerETInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8(t typex.EventTime, elm int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4050,7 +4052,7 @@ func emitMakerInt8ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8ByteSlice(key int8, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4066,7 +4068,7 @@ func emitMakerETInt8ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8ByteSlice(t typex.EventTime, key int8, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4082,7 +4084,7 @@ func emitMakerInt8Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Bool(key int8, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4098,7 +4100,7 @@ func emitMakerETInt8Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Bool(t typex.EventTime, key int8, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4114,7 +4116,7 @@ func emitMakerInt8String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8String(key int8, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4130,7 +4132,7 @@ func emitMakerETInt8String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8String(t typex.EventTime, key int8, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4146,7 +4148,7 @@ func emitMakerInt8Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Int(key int8, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4162,7 +4164,7 @@ func emitMakerETInt8Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Int(t typex.EventTime, key int8, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4178,7 +4180,7 @@ func emitMakerInt8Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Int8(key int8, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4194,7 +4196,7 @@ func emitMakerETInt8Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Int8(t typex.EventTime, key int8, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4210,7 +4212,7 @@ func emitMakerInt8Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Int16(key int8, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4226,7 +4228,7 @@ func emitMakerETInt8Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Int16(t typex.EventTime, key int8, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4242,7 +4244,7 @@ func emitMakerInt8Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Int32(key int8, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4258,7 +4260,7 @@ func emitMakerETInt8Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Int32(t typex.EventTime, key int8, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4274,7 +4276,7 @@ func emitMakerInt8Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Int64(key int8, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4290,7 +4292,7 @@ func emitMakerETInt8Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Int64(t typex.EventTime, key int8, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4306,7 +4308,7 @@ func emitMakerInt8Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Uint(key int8, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4322,7 +4324,7 @@ func emitMakerETInt8Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Uint(t typex.EventTime, key int8, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4338,7 +4340,7 @@ func emitMakerInt8Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Uint8(key int8, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4354,7 +4356,7 @@ func emitMakerETInt8Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Uint8(t typex.EventTime, key int8, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4370,7 +4372,7 @@ func emitMakerInt8Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Uint16(key int8, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4386,7 +4388,7 @@ func emitMakerETInt8Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Uint16(t typex.EventTime, key int8, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4402,7 +4404,7 @@ func emitMakerInt8Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Uint32(key int8, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4418,7 +4420,7 @@ func emitMakerETInt8Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Uint32(t typex.EventTime, key int8, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4434,7 +4436,7 @@ func emitMakerInt8Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Uint64(key int8, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4450,7 +4452,7 @@ func emitMakerETInt8Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Uint64(t typex.EventTime, key int8, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4466,7 +4468,7 @@ func emitMakerInt8Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Float32(key int8, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4482,7 +4484,7 @@ func emitMakerETInt8Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Float32(t typex.EventTime, key int8, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4498,7 +4500,7 @@ func emitMakerInt8Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Float64(key int8, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4514,7 +4516,7 @@ func emitMakerETInt8Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Float64(t typex.EventTime, key int8, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4530,7 +4532,7 @@ func emitMakerInt8Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Typex_T(key int8, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4546,7 +4548,7 @@ func emitMakerETInt8Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Typex_T(t typex.EventTime, key int8, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4562,7 +4564,7 @@ func emitMakerInt8Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Typex_U(key int8, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4578,7 +4580,7 @@ func emitMakerETInt8Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Typex_U(t typex.EventTime, key int8, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4594,7 +4596,7 @@ func emitMakerInt8Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Typex_V(key int8, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4610,7 +4612,7 @@ func emitMakerETInt8Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Typex_V(t typex.EventTime, key int8, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4626,7 +4628,7 @@ func emitMakerInt8Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Typex_W(key int8, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4642,7 +4644,7 @@ func emitMakerETInt8Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Typex_W(t typex.EventTime, key int8, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4658,7 +4660,7 @@ func emitMakerInt8Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Typex_X(key int8, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4674,7 +4676,7 @@ func emitMakerETInt8Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Typex_X(t typex.EventTime, key int8, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4690,7 +4692,7 @@ func emitMakerInt8Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Typex_Y(key int8, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4706,7 +4708,7 @@ func emitMakerETInt8Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Typex_Y(t typex.EventTime, key int8, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4722,7 +4724,7 @@ func emitMakerInt8Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt8Typex_Z(key int8, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4738,7 +4740,7 @@ func emitMakerETInt8Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt8Typex_Z(t typex.EventTime, key int8, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4754,7 +4756,7 @@ func emitMakerInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16(elm int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4770,7 +4772,7 @@ func emitMakerETInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16(t typex.EventTime, elm int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4786,7 +4788,7 @@ func emitMakerInt16ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16ByteSlice(key int16, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4802,7 +4804,7 @@ func emitMakerETInt16ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16ByteSlice(t typex.EventTime, key int16, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4818,7 +4820,7 @@ func emitMakerInt16Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Bool(key int16, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4834,7 +4836,7 @@ func emitMakerETInt16Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Bool(t typex.EventTime, key int16, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4850,7 +4852,7 @@ func emitMakerInt16String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16String(key int16, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4866,7 +4868,7 @@ func emitMakerETInt16String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16String(t typex.EventTime, key int16, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4882,7 +4884,7 @@ func emitMakerInt16Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Int(key int16, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4898,7 +4900,7 @@ func emitMakerETInt16Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Int(t typex.EventTime, key int16, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4914,7 +4916,7 @@ func emitMakerInt16Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Int8(key int16, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4930,7 +4932,7 @@ func emitMakerETInt16Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Int8(t typex.EventTime, key int16, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4946,7 +4948,7 @@ func emitMakerInt16Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Int16(key int16, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4962,7 +4964,7 @@ func emitMakerETInt16Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Int16(t typex.EventTime, key int16, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -4978,7 +4980,7 @@ func emitMakerInt16Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Int32(key int16, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -4994,7 +4996,7 @@ func emitMakerETInt16Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Int32(t typex.EventTime, key int16, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5010,7 +5012,7 @@ func emitMakerInt16Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Int64(key int16, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5026,7 +5028,7 @@ func emitMakerETInt16Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Int64(t typex.EventTime, key int16, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5042,7 +5044,7 @@ func emitMakerInt16Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Uint(key int16, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5058,7 +5060,7 @@ func emitMakerETInt16Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Uint(t typex.EventTime, key int16, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5074,7 +5076,7 @@ func emitMakerInt16Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Uint8(key int16, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5090,7 +5092,7 @@ func emitMakerETInt16Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Uint8(t typex.EventTime, key int16, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5106,7 +5108,7 @@ func emitMakerInt16Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Uint16(key int16, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5122,7 +5124,7 @@ func emitMakerETInt16Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Uint16(t typex.EventTime, key int16, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5138,7 +5140,7 @@ func emitMakerInt16Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Uint32(key int16, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5154,7 +5156,7 @@ func emitMakerETInt16Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Uint32(t typex.EventTime, key int16, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5170,7 +5172,7 @@ func emitMakerInt16Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Uint64(key int16, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5186,7 +5188,7 @@ func emitMakerETInt16Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Uint64(t typex.EventTime, key int16, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5202,7 +5204,7 @@ func emitMakerInt16Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Float32(key int16, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5218,7 +5220,7 @@ func emitMakerETInt16Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Float32(t typex.EventTime, key int16, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5234,7 +5236,7 @@ func emitMakerInt16Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Float64(key int16, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5250,7 +5252,7 @@ func emitMakerETInt16Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Float64(t typex.EventTime, key int16, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5266,7 +5268,7 @@ func emitMakerInt16Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Typex_T(key int16, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5282,7 +5284,7 @@ func emitMakerETInt16Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Typex_T(t typex.EventTime, key int16, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5298,7 +5300,7 @@ func emitMakerInt16Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Typex_U(key int16, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5314,7 +5316,7 @@ func emitMakerETInt16Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Typex_U(t typex.EventTime, key int16, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5330,7 +5332,7 @@ func emitMakerInt16Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Typex_V(key int16, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5346,7 +5348,7 @@ func emitMakerETInt16Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Typex_V(t typex.EventTime, key int16, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5362,7 +5364,7 @@ func emitMakerInt16Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Typex_W(key int16, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5378,7 +5380,7 @@ func emitMakerETInt16Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Typex_W(t typex.EventTime, key int16, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5394,7 +5396,7 @@ func emitMakerInt16Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Typex_X(key int16, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5410,7 +5412,7 @@ func emitMakerETInt16Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Typex_X(t typex.EventTime, key int16, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5426,7 +5428,7 @@ func emitMakerInt16Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Typex_Y(key int16, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5442,7 +5444,7 @@ func emitMakerETInt16Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Typex_Y(t typex.EventTime, key int16, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5458,7 +5460,7 @@ func emitMakerInt16Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt16Typex_Z(key int16, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5474,7 +5476,7 @@ func emitMakerETInt16Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt16Typex_Z(t typex.EventTime, key int16, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5490,7 +5492,7 @@ func emitMakerInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32(elm int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5506,7 +5508,7 @@ func emitMakerETInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32(t typex.EventTime, elm int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5522,7 +5524,7 @@ func emitMakerInt32ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32ByteSlice(key int32, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5538,7 +5540,7 @@ func emitMakerETInt32ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32ByteSlice(t typex.EventTime, key int32, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5554,7 +5556,7 @@ func emitMakerInt32Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Bool(key int32, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5570,7 +5572,7 @@ func emitMakerETInt32Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Bool(t typex.EventTime, key int32, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5586,7 +5588,7 @@ func emitMakerInt32String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32String(key int32, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5602,7 +5604,7 @@ func emitMakerETInt32String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32String(t typex.EventTime, key int32, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5618,7 +5620,7 @@ func emitMakerInt32Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Int(key int32, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5634,7 +5636,7 @@ func emitMakerETInt32Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Int(t typex.EventTime, key int32, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5650,7 +5652,7 @@ func emitMakerInt32Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Int8(key int32, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5666,7 +5668,7 @@ func emitMakerETInt32Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Int8(t typex.EventTime, key int32, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5682,7 +5684,7 @@ func emitMakerInt32Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Int16(key int32, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5698,7 +5700,7 @@ func emitMakerETInt32Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Int16(t typex.EventTime, key int32, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5714,7 +5716,7 @@ func emitMakerInt32Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Int32(key int32, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5730,7 +5732,7 @@ func emitMakerETInt32Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Int32(t typex.EventTime, key int32, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5746,7 +5748,7 @@ func emitMakerInt32Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Int64(key int32, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5762,7 +5764,7 @@ func emitMakerETInt32Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Int64(t typex.EventTime, key int32, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5778,7 +5780,7 @@ func emitMakerInt32Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Uint(key int32, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5794,7 +5796,7 @@ func emitMakerETInt32Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Uint(t typex.EventTime, key int32, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5810,7 +5812,7 @@ func emitMakerInt32Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Uint8(key int32, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5826,7 +5828,7 @@ func emitMakerETInt32Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Uint8(t typex.EventTime, key int32, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5842,7 +5844,7 @@ func emitMakerInt32Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Uint16(key int32, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5858,7 +5860,7 @@ func emitMakerETInt32Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Uint16(t typex.EventTime, key int32, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5874,7 +5876,7 @@ func emitMakerInt32Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Uint32(key int32, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5890,7 +5892,7 @@ func emitMakerETInt32Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Uint32(t typex.EventTime, key int32, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5906,7 +5908,7 @@ func emitMakerInt32Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Uint64(key int32, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5922,7 +5924,7 @@ func emitMakerETInt32Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Uint64(t typex.EventTime, key int32, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5938,7 +5940,7 @@ func emitMakerInt32Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Float32(key int32, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5954,7 +5956,7 @@ func emitMakerETInt32Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Float32(t typex.EventTime, key int32, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -5970,7 +5972,7 @@ func emitMakerInt32Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Float64(key int32, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -5986,7 +5988,7 @@ func emitMakerETInt32Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Float64(t typex.EventTime, key int32, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6002,7 +6004,7 @@ func emitMakerInt32Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Typex_T(key int32, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6018,7 +6020,7 @@ func emitMakerETInt32Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Typex_T(t typex.EventTime, key int32, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6034,7 +6036,7 @@ func emitMakerInt32Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Typex_U(key int32, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6050,7 +6052,7 @@ func emitMakerETInt32Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Typex_U(t typex.EventTime, key int32, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6066,7 +6068,7 @@ func emitMakerInt32Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Typex_V(key int32, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6082,7 +6084,7 @@ func emitMakerETInt32Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Typex_V(t typex.EventTime, key int32, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6098,7 +6100,7 @@ func emitMakerInt32Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Typex_W(key int32, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6114,7 +6116,7 @@ func emitMakerETInt32Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Typex_W(t typex.EventTime, key int32, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6130,7 +6132,7 @@ func emitMakerInt32Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Typex_X(key int32, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6146,7 +6148,7 @@ func emitMakerETInt32Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Typex_X(t typex.EventTime, key int32, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6162,7 +6164,7 @@ func emitMakerInt32Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Typex_Y(key int32, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6178,7 +6180,7 @@ func emitMakerETInt32Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Typex_Y(t typex.EventTime, key int32, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6194,7 +6196,7 @@ func emitMakerInt32Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt32Typex_Z(key int32, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6210,7 +6212,7 @@ func emitMakerETInt32Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt32Typex_Z(t typex.EventTime, key int32, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6226,7 +6228,7 @@ func emitMakerInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64(elm int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6242,7 +6244,7 @@ func emitMakerETInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64(t typex.EventTime, elm int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6258,7 +6260,7 @@ func emitMakerInt64ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64ByteSlice(key int64, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6274,7 +6276,7 @@ func emitMakerETInt64ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64ByteSlice(t typex.EventTime, key int64, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6290,7 +6292,7 @@ func emitMakerInt64Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Bool(key int64, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6306,7 +6308,7 @@ func emitMakerETInt64Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Bool(t typex.EventTime, key int64, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6322,7 +6324,7 @@ func emitMakerInt64String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64String(key int64, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6338,7 +6340,7 @@ func emitMakerETInt64String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64String(t typex.EventTime, key int64, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6354,7 +6356,7 @@ func emitMakerInt64Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Int(key int64, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6370,7 +6372,7 @@ func emitMakerETInt64Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Int(t typex.EventTime, key int64, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6386,7 +6388,7 @@ func emitMakerInt64Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Int8(key int64, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6402,7 +6404,7 @@ func emitMakerETInt64Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Int8(t typex.EventTime, key int64, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6418,7 +6420,7 @@ func emitMakerInt64Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Int16(key int64, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6434,7 +6436,7 @@ func emitMakerETInt64Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Int16(t typex.EventTime, key int64, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6450,7 +6452,7 @@ func emitMakerInt64Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Int32(key int64, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6466,7 +6468,7 @@ func emitMakerETInt64Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Int32(t typex.EventTime, key int64, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6482,7 +6484,7 @@ func emitMakerInt64Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Int64(key int64, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6498,7 +6500,7 @@ func emitMakerETInt64Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Int64(t typex.EventTime, key int64, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6514,7 +6516,7 @@ func emitMakerInt64Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Uint(key int64, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6530,7 +6532,7 @@ func emitMakerETInt64Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Uint(t typex.EventTime, key int64, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6546,7 +6548,7 @@ func emitMakerInt64Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Uint8(key int64, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6562,7 +6564,7 @@ func emitMakerETInt64Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Uint8(t typex.EventTime, key int64, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6578,7 +6580,7 @@ func emitMakerInt64Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Uint16(key int64, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6594,7 +6596,7 @@ func emitMakerETInt64Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Uint16(t typex.EventTime, key int64, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6610,7 +6612,7 @@ func emitMakerInt64Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Uint32(key int64, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6626,7 +6628,7 @@ func emitMakerETInt64Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Uint32(t typex.EventTime, key int64, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6642,7 +6644,7 @@ func emitMakerInt64Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Uint64(key int64, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6658,7 +6660,7 @@ func emitMakerETInt64Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Uint64(t typex.EventTime, key int64, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6674,7 +6676,7 @@ func emitMakerInt64Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Float32(key int64, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6690,7 +6692,7 @@ func emitMakerETInt64Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Float32(t typex.EventTime, key int64, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6706,7 +6708,7 @@ func emitMakerInt64Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Float64(key int64, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6722,7 +6724,7 @@ func emitMakerETInt64Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Float64(t typex.EventTime, key int64, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6738,7 +6740,7 @@ func emitMakerInt64Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Typex_T(key int64, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6754,7 +6756,7 @@ func emitMakerETInt64Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Typex_T(t typex.EventTime, key int64, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6770,7 +6772,7 @@ func emitMakerInt64Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Typex_U(key int64, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6786,7 +6788,7 @@ func emitMakerETInt64Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Typex_U(t typex.EventTime, key int64, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6802,7 +6804,7 @@ func emitMakerInt64Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Typex_V(key int64, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6818,7 +6820,7 @@ func emitMakerETInt64Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Typex_V(t typex.EventTime, key int64, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6834,7 +6836,7 @@ func emitMakerInt64Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Typex_W(key int64, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6850,7 +6852,7 @@ func emitMakerETInt64Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Typex_W(t typex.EventTime, key int64, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6866,7 +6868,7 @@ func emitMakerInt64Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Typex_X(key int64, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6882,7 +6884,7 @@ func emitMakerETInt64Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Typex_X(t typex.EventTime, key int64, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6898,7 +6900,7 @@ func emitMakerInt64Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Typex_Y(key int64, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6914,7 +6916,7 @@ func emitMakerETInt64Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Typex_Y(t typex.EventTime, key int64, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6930,7 +6932,7 @@ func emitMakerInt64Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeInt64Typex_Z(key int64, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6946,7 +6948,7 @@ func emitMakerETInt64Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETInt64Typex_Z(t typex.EventTime, key int64, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6962,7 +6964,7 @@ func emitMakerUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint(elm uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -6978,7 +6980,7 @@ func emitMakerETUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint(t typex.EventTime, elm uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -6994,7 +6996,7 @@ func emitMakerUintByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintByteSlice(key uint, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7010,7 +7012,7 @@ func emitMakerETUintByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintByteSlice(t typex.EventTime, key uint, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7026,7 +7028,7 @@ func emitMakerUintBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintBool(key uint, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7042,7 +7044,7 @@ func emitMakerETUintBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintBool(t typex.EventTime, key uint, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7058,7 +7060,7 @@ func emitMakerUintString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintString(key uint, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7074,7 +7076,7 @@ func emitMakerETUintString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintString(t typex.EventTime, key uint, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7090,7 +7092,7 @@ func emitMakerUintInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintInt(key uint, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7106,7 +7108,7 @@ func emitMakerETUintInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintInt(t typex.EventTime, key uint, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7122,7 +7124,7 @@ func emitMakerUintInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintInt8(key uint, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7138,7 +7140,7 @@ func emitMakerETUintInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintInt8(t typex.EventTime, key uint, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7154,7 +7156,7 @@ func emitMakerUintInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintInt16(key uint, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7170,7 +7172,7 @@ func emitMakerETUintInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintInt16(t typex.EventTime, key uint, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7186,7 +7188,7 @@ func emitMakerUintInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintInt32(key uint, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7202,7 +7204,7 @@ func emitMakerETUintInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintInt32(t typex.EventTime, key uint, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7218,7 +7220,7 @@ func emitMakerUintInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintInt64(key uint, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7234,7 +7236,7 @@ func emitMakerETUintInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintInt64(t typex.EventTime, key uint, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7250,7 +7252,7 @@ func emitMakerUintUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintUint(key uint, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7266,7 +7268,7 @@ func emitMakerETUintUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintUint(t typex.EventTime, key uint, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7282,7 +7284,7 @@ func emitMakerUintUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintUint8(key uint, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7298,7 +7300,7 @@ func emitMakerETUintUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintUint8(t typex.EventTime, key uint, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7314,7 +7316,7 @@ func emitMakerUintUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintUint16(key uint, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7330,7 +7332,7 @@ func emitMakerETUintUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintUint16(t typex.EventTime, key uint, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7346,7 +7348,7 @@ func emitMakerUintUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintUint32(key uint, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7362,7 +7364,7 @@ func emitMakerETUintUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintUint32(t typex.EventTime, key uint, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7378,7 +7380,7 @@ func emitMakerUintUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintUint64(key uint, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7394,7 +7396,7 @@ func emitMakerETUintUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintUint64(t typex.EventTime, key uint, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7410,7 +7412,7 @@ func emitMakerUintFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintFloat32(key uint, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7426,7 +7428,7 @@ func emitMakerETUintFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintFloat32(t typex.EventTime, key uint, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7442,7 +7444,7 @@ func emitMakerUintFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintFloat64(key uint, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7458,7 +7460,7 @@ func emitMakerETUintFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintFloat64(t typex.EventTime, key uint, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7474,7 +7476,7 @@ func emitMakerUintTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintTypex_T(key uint, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7490,7 +7492,7 @@ func emitMakerETUintTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintTypex_T(t typex.EventTime, key uint, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7506,7 +7508,7 @@ func emitMakerUintTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintTypex_U(key uint, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7522,7 +7524,7 @@ func emitMakerETUintTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintTypex_U(t typex.EventTime, key uint, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7538,7 +7540,7 @@ func emitMakerUintTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintTypex_V(key uint, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7554,7 +7556,7 @@ func emitMakerETUintTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintTypex_V(t typex.EventTime, key uint, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7570,7 +7572,7 @@ func emitMakerUintTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintTypex_W(key uint, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7586,7 +7588,7 @@ func emitMakerETUintTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintTypex_W(t typex.EventTime, key uint, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7602,7 +7604,7 @@ func emitMakerUintTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintTypex_X(key uint, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7618,7 +7620,7 @@ func emitMakerETUintTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintTypex_X(t typex.EventTime, key uint, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7634,7 +7636,7 @@ func emitMakerUintTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintTypex_Y(key uint, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7650,7 +7652,7 @@ func emitMakerETUintTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintTypex_Y(t typex.EventTime, key uint, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7666,7 +7668,7 @@ func emitMakerUintTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUintTypex_Z(key uint, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7682,7 +7684,7 @@ func emitMakerETUintTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUintTypex_Z(t typex.EventTime, key uint, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7698,7 +7700,7 @@ func emitMakerUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8(elm uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7714,7 +7716,7 @@ func emitMakerETUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8(t typex.EventTime, elm uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7730,7 +7732,7 @@ func emitMakerUint8ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8ByteSlice(key uint8, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7746,7 +7748,7 @@ func emitMakerETUint8ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8ByteSlice(t typex.EventTime, key uint8, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7762,7 +7764,7 @@ func emitMakerUint8Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Bool(key uint8, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7778,7 +7780,7 @@ func emitMakerETUint8Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Bool(t typex.EventTime, key uint8, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7794,7 +7796,7 @@ func emitMakerUint8String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8String(key uint8, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7810,7 +7812,7 @@ func emitMakerETUint8String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8String(t typex.EventTime, key uint8, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7826,7 +7828,7 @@ func emitMakerUint8Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Int(key uint8, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7842,7 +7844,7 @@ func emitMakerETUint8Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Int(t typex.EventTime, key uint8, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7858,7 +7860,7 @@ func emitMakerUint8Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Int8(key uint8, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7874,7 +7876,7 @@ func emitMakerETUint8Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Int8(t typex.EventTime, key uint8, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7890,7 +7892,7 @@ func emitMakerUint8Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Int16(key uint8, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7906,7 +7908,7 @@ func emitMakerETUint8Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Int16(t typex.EventTime, key uint8, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7922,7 +7924,7 @@ func emitMakerUint8Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Int32(key uint8, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7938,7 +7940,7 @@ func emitMakerETUint8Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Int32(t typex.EventTime, key uint8, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7954,7 +7956,7 @@ func emitMakerUint8Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Int64(key uint8, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -7970,7 +7972,7 @@ func emitMakerETUint8Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Int64(t typex.EventTime, key uint8, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -7986,7 +7988,7 @@ func emitMakerUint8Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Uint(key uint8, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8002,7 +8004,7 @@ func emitMakerETUint8Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Uint(t typex.EventTime, key uint8, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8018,7 +8020,7 @@ func emitMakerUint8Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Uint8(key uint8, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8034,7 +8036,7 @@ func emitMakerETUint8Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Uint8(t typex.EventTime, key uint8, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8050,7 +8052,7 @@ func emitMakerUint8Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Uint16(key uint8, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8066,7 +8068,7 @@ func emitMakerETUint8Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Uint16(t typex.EventTime, key uint8, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8082,7 +8084,7 @@ func emitMakerUint8Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Uint32(key uint8, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8098,7 +8100,7 @@ func emitMakerETUint8Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Uint32(t typex.EventTime, key uint8, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8114,7 +8116,7 @@ func emitMakerUint8Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Uint64(key uint8, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8130,7 +8132,7 @@ func emitMakerETUint8Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Uint64(t typex.EventTime, key uint8, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8146,7 +8148,7 @@ func emitMakerUint8Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Float32(key uint8, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8162,7 +8164,7 @@ func emitMakerETUint8Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Float32(t typex.EventTime, key uint8, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8178,7 +8180,7 @@ func emitMakerUint8Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Float64(key uint8, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8194,7 +8196,7 @@ func emitMakerETUint8Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Float64(t typex.EventTime, key uint8, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8210,7 +8212,7 @@ func emitMakerUint8Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Typex_T(key uint8, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8226,7 +8228,7 @@ func emitMakerETUint8Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Typex_T(t typex.EventTime, key uint8, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8242,7 +8244,7 @@ func emitMakerUint8Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Typex_U(key uint8, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8258,7 +8260,7 @@ func emitMakerETUint8Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Typex_U(t typex.EventTime, key uint8, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8274,7 +8276,7 @@ func emitMakerUint8Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Typex_V(key uint8, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8290,7 +8292,7 @@ func emitMakerETUint8Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Typex_V(t typex.EventTime, key uint8, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8306,7 +8308,7 @@ func emitMakerUint8Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Typex_W(key uint8, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8322,7 +8324,7 @@ func emitMakerETUint8Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Typex_W(t typex.EventTime, key uint8, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8338,7 +8340,7 @@ func emitMakerUint8Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Typex_X(key uint8, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8354,7 +8356,7 @@ func emitMakerETUint8Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Typex_X(t typex.EventTime, key uint8, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8370,7 +8372,7 @@ func emitMakerUint8Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Typex_Y(key uint8, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8386,7 +8388,7 @@ func emitMakerETUint8Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Typex_Y(t typex.EventTime, key uint8, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8402,7 +8404,7 @@ func emitMakerUint8Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint8Typex_Z(key uint8, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8418,7 +8420,7 @@ func emitMakerETUint8Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint8Typex_Z(t typex.EventTime, key uint8, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8434,7 +8436,7 @@ func emitMakerUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16(elm uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8450,7 +8452,7 @@ func emitMakerETUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16(t typex.EventTime, elm uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8466,7 +8468,7 @@ func emitMakerUint16ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16ByteSlice(key uint16, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8482,7 +8484,7 @@ func emitMakerETUint16ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16ByteSlice(t typex.EventTime, key uint16, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8498,7 +8500,7 @@ func emitMakerUint16Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Bool(key uint16, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8514,7 +8516,7 @@ func emitMakerETUint16Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Bool(t typex.EventTime, key uint16, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8530,7 +8532,7 @@ func emitMakerUint16String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16String(key uint16, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8546,7 +8548,7 @@ func emitMakerETUint16String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16String(t typex.EventTime, key uint16, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8562,7 +8564,7 @@ func emitMakerUint16Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Int(key uint16, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8578,7 +8580,7 @@ func emitMakerETUint16Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Int(t typex.EventTime, key uint16, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8594,7 +8596,7 @@ func emitMakerUint16Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Int8(key uint16, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8610,7 +8612,7 @@ func emitMakerETUint16Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Int8(t typex.EventTime, key uint16, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8626,7 +8628,7 @@ func emitMakerUint16Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Int16(key uint16, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8642,7 +8644,7 @@ func emitMakerETUint16Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Int16(t typex.EventTime, key uint16, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8658,7 +8660,7 @@ func emitMakerUint16Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Int32(key uint16, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8674,7 +8676,7 @@ func emitMakerETUint16Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Int32(t typex.EventTime, key uint16, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8690,7 +8692,7 @@ func emitMakerUint16Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Int64(key uint16, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8706,7 +8708,7 @@ func emitMakerETUint16Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Int64(t typex.EventTime, key uint16, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8722,7 +8724,7 @@ func emitMakerUint16Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Uint(key uint16, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8738,7 +8740,7 @@ func emitMakerETUint16Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Uint(t typex.EventTime, key uint16, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8754,7 +8756,7 @@ func emitMakerUint16Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Uint8(key uint16, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8770,7 +8772,7 @@ func emitMakerETUint16Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Uint8(t typex.EventTime, key uint16, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8786,7 +8788,7 @@ func emitMakerUint16Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Uint16(key uint16, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8802,7 +8804,7 @@ func emitMakerETUint16Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Uint16(t typex.EventTime, key uint16, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8818,7 +8820,7 @@ func emitMakerUint16Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Uint32(key uint16, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8834,7 +8836,7 @@ func emitMakerETUint16Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Uint32(t typex.EventTime, key uint16, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8850,7 +8852,7 @@ func emitMakerUint16Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Uint64(key uint16, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8866,7 +8868,7 @@ func emitMakerETUint16Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Uint64(t typex.EventTime, key uint16, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8882,7 +8884,7 @@ func emitMakerUint16Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Float32(key uint16, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8898,7 +8900,7 @@ func emitMakerETUint16Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Float32(t typex.EventTime, key uint16, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8914,7 +8916,7 @@ func emitMakerUint16Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Float64(key uint16, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8930,7 +8932,7 @@ func emitMakerETUint16Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Float64(t typex.EventTime, key uint16, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8946,7 +8948,7 @@ func emitMakerUint16Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Typex_T(key uint16, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8962,7 +8964,7 @@ func emitMakerETUint16Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Typex_T(t typex.EventTime, key uint16, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -8978,7 +8980,7 @@ func emitMakerUint16Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Typex_U(key uint16, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -8994,7 +8996,7 @@ func emitMakerETUint16Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Typex_U(t typex.EventTime, key uint16, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9010,7 +9012,7 @@ func emitMakerUint16Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Typex_V(key uint16, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9026,7 +9028,7 @@ func emitMakerETUint16Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Typex_V(t typex.EventTime, key uint16, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9042,7 +9044,7 @@ func emitMakerUint16Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Typex_W(key uint16, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9058,7 +9060,7 @@ func emitMakerETUint16Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Typex_W(t typex.EventTime, key uint16, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9074,7 +9076,7 @@ func emitMakerUint16Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Typex_X(key uint16, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9090,7 +9092,7 @@ func emitMakerETUint16Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Typex_X(t typex.EventTime, key uint16, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9106,7 +9108,7 @@ func emitMakerUint16Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Typex_Y(key uint16, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9122,7 +9124,7 @@ func emitMakerETUint16Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Typex_Y(t typex.EventTime, key uint16, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9138,7 +9140,7 @@ func emitMakerUint16Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint16Typex_Z(key uint16, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9154,7 +9156,7 @@ func emitMakerETUint16Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint16Typex_Z(t typex.EventTime, key uint16, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9170,7 +9172,7 @@ func emitMakerUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32(elm uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9186,7 +9188,7 @@ func emitMakerETUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32(t typex.EventTime, elm uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9202,7 +9204,7 @@ func emitMakerUint32ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32ByteSlice(key uint32, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9218,7 +9220,7 @@ func emitMakerETUint32ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32ByteSlice(t typex.EventTime, key uint32, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9234,7 +9236,7 @@ func emitMakerUint32Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Bool(key uint32, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9250,7 +9252,7 @@ func emitMakerETUint32Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Bool(t typex.EventTime, key uint32, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9266,7 +9268,7 @@ func emitMakerUint32String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32String(key uint32, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9282,7 +9284,7 @@ func emitMakerETUint32String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32String(t typex.EventTime, key uint32, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9298,7 +9300,7 @@ func emitMakerUint32Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Int(key uint32, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9314,7 +9316,7 @@ func emitMakerETUint32Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Int(t typex.EventTime, key uint32, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9330,7 +9332,7 @@ func emitMakerUint32Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Int8(key uint32, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9346,7 +9348,7 @@ func emitMakerETUint32Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Int8(t typex.EventTime, key uint32, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9362,7 +9364,7 @@ func emitMakerUint32Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Int16(key uint32, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9378,7 +9380,7 @@ func emitMakerETUint32Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Int16(t typex.EventTime, key uint32, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9394,7 +9396,7 @@ func emitMakerUint32Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Int32(key uint32, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9410,7 +9412,7 @@ func emitMakerETUint32Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Int32(t typex.EventTime, key uint32, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9426,7 +9428,7 @@ func emitMakerUint32Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Int64(key uint32, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9442,7 +9444,7 @@ func emitMakerETUint32Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Int64(t typex.EventTime, key uint32, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9458,7 +9460,7 @@ func emitMakerUint32Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Uint(key uint32, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9474,7 +9476,7 @@ func emitMakerETUint32Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Uint(t typex.EventTime, key uint32, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9490,7 +9492,7 @@ func emitMakerUint32Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Uint8(key uint32, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9506,7 +9508,7 @@ func emitMakerETUint32Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Uint8(t typex.EventTime, key uint32, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9522,7 +9524,7 @@ func emitMakerUint32Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Uint16(key uint32, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9538,7 +9540,7 @@ func emitMakerETUint32Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Uint16(t typex.EventTime, key uint32, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9554,7 +9556,7 @@ func emitMakerUint32Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Uint32(key uint32, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9570,7 +9572,7 @@ func emitMakerETUint32Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Uint32(t typex.EventTime, key uint32, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9586,7 +9588,7 @@ func emitMakerUint32Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Uint64(key uint32, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9602,7 +9604,7 @@ func emitMakerETUint32Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Uint64(t typex.EventTime, key uint32, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9618,7 +9620,7 @@ func emitMakerUint32Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Float32(key uint32, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9634,7 +9636,7 @@ func emitMakerETUint32Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Float32(t typex.EventTime, key uint32, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9650,7 +9652,7 @@ func emitMakerUint32Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Float64(key uint32, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9666,7 +9668,7 @@ func emitMakerETUint32Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Float64(t typex.EventTime, key uint32, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9682,7 +9684,7 @@ func emitMakerUint32Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Typex_T(key uint32, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9698,7 +9700,7 @@ func emitMakerETUint32Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Typex_T(t typex.EventTime, key uint32, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9714,7 +9716,7 @@ func emitMakerUint32Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Typex_U(key uint32, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9730,7 +9732,7 @@ func emitMakerETUint32Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Typex_U(t typex.EventTime, key uint32, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9746,7 +9748,7 @@ func emitMakerUint32Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Typex_V(key uint32, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9762,7 +9764,7 @@ func emitMakerETUint32Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Typex_V(t typex.EventTime, key uint32, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9778,7 +9780,7 @@ func emitMakerUint32Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Typex_W(key uint32, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9794,7 +9796,7 @@ func emitMakerETUint32Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Typex_W(t typex.EventTime, key uint32, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9810,7 +9812,7 @@ func emitMakerUint32Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Typex_X(key uint32, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9826,7 +9828,7 @@ func emitMakerETUint32Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Typex_X(t typex.EventTime, key uint32, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9842,7 +9844,7 @@ func emitMakerUint32Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Typex_Y(key uint32, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9858,7 +9860,7 @@ func emitMakerETUint32Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Typex_Y(t typex.EventTime, key uint32, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9874,7 +9876,7 @@ func emitMakerUint32Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint32Typex_Z(key uint32, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9890,7 +9892,7 @@ func emitMakerETUint32Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint32Typex_Z(t typex.EventTime, key uint32, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9906,7 +9908,7 @@ func emitMakerUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64(elm uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9922,7 +9924,7 @@ func emitMakerETUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64(t typex.EventTime, elm uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9938,7 +9940,7 @@ func emitMakerUint64ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64ByteSlice(key uint64, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9954,7 +9956,7 @@ func emitMakerETUint64ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64ByteSlice(t typex.EventTime, key uint64, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -9970,7 +9972,7 @@ func emitMakerUint64Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Bool(key uint64, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -9986,7 +9988,7 @@ func emitMakerETUint64Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Bool(t typex.EventTime, key uint64, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10002,7 +10004,7 @@ func emitMakerUint64String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64String(key uint64, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10018,7 +10020,7 @@ func emitMakerETUint64String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64String(t typex.EventTime, key uint64, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10034,7 +10036,7 @@ func emitMakerUint64Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Int(key uint64, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10050,7 +10052,7 @@ func emitMakerETUint64Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Int(t typex.EventTime, key uint64, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10066,7 +10068,7 @@ func emitMakerUint64Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Int8(key uint64, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10082,7 +10084,7 @@ func emitMakerETUint64Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Int8(t typex.EventTime, key uint64, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10098,7 +10100,7 @@ func emitMakerUint64Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Int16(key uint64, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10114,7 +10116,7 @@ func emitMakerETUint64Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Int16(t typex.EventTime, key uint64, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10130,7 +10132,7 @@ func emitMakerUint64Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Int32(key uint64, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10146,7 +10148,7 @@ func emitMakerETUint64Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Int32(t typex.EventTime, key uint64, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10162,7 +10164,7 @@ func emitMakerUint64Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Int64(key uint64, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10178,7 +10180,7 @@ func emitMakerETUint64Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Int64(t typex.EventTime, key uint64, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10194,7 +10196,7 @@ func emitMakerUint64Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Uint(key uint64, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10210,7 +10212,7 @@ func emitMakerETUint64Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Uint(t typex.EventTime, key uint64, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10226,7 +10228,7 @@ func emitMakerUint64Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Uint8(key uint64, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10242,7 +10244,7 @@ func emitMakerETUint64Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Uint8(t typex.EventTime, key uint64, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10258,7 +10260,7 @@ func emitMakerUint64Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Uint16(key uint64, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10274,7 +10276,7 @@ func emitMakerETUint64Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Uint16(t typex.EventTime, key uint64, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10290,7 +10292,7 @@ func emitMakerUint64Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Uint32(key uint64, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10306,7 +10308,7 @@ func emitMakerETUint64Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Uint32(t typex.EventTime, key uint64, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10322,7 +10324,7 @@ func emitMakerUint64Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Uint64(key uint64, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10338,7 +10340,7 @@ func emitMakerETUint64Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Uint64(t typex.EventTime, key uint64, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10354,7 +10356,7 @@ func emitMakerUint64Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Float32(key uint64, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10370,7 +10372,7 @@ func emitMakerETUint64Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Float32(t typex.EventTime, key uint64, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10386,7 +10388,7 @@ func emitMakerUint64Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Float64(key uint64, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10402,7 +10404,7 @@ func emitMakerETUint64Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Float64(t typex.EventTime, key uint64, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10418,7 +10420,7 @@ func emitMakerUint64Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Typex_T(key uint64, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10434,7 +10436,7 @@ func emitMakerETUint64Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Typex_T(t typex.EventTime, key uint64, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10450,7 +10452,7 @@ func emitMakerUint64Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Typex_U(key uint64, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10466,7 +10468,7 @@ func emitMakerETUint64Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Typex_U(t typex.EventTime, key uint64, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10482,7 +10484,7 @@ func emitMakerUint64Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Typex_V(key uint64, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10498,7 +10500,7 @@ func emitMakerETUint64Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Typex_V(t typex.EventTime, key uint64, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10514,7 +10516,7 @@ func emitMakerUint64Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Typex_W(key uint64, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10530,7 +10532,7 @@ func emitMakerETUint64Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Typex_W(t typex.EventTime, key uint64, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10546,7 +10548,7 @@ func emitMakerUint64Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Typex_X(key uint64, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10562,7 +10564,7 @@ func emitMakerETUint64Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Typex_X(t typex.EventTime, key uint64, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10578,7 +10580,7 @@ func emitMakerUint64Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Typex_Y(key uint64, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10594,7 +10596,7 @@ func emitMakerETUint64Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Typex_Y(t typex.EventTime, key uint64, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10610,7 +10612,7 @@ func emitMakerUint64Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeUint64Typex_Z(key uint64, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10626,7 +10628,7 @@ func emitMakerETUint64Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETUint64Typex_Z(t typex.EventTime, key uint64, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10642,7 +10644,7 @@ func emitMakerFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32(elm float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10658,7 +10660,7 @@ func emitMakerETFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32(t typex.EventTime, elm float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10674,7 +10676,7 @@ func emitMakerFloat32ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32ByteSlice(key float32, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10690,7 +10692,7 @@ func emitMakerETFloat32ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32ByteSlice(t typex.EventTime, key float32, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10706,7 +10708,7 @@ func emitMakerFloat32Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Bool(key float32, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10722,7 +10724,7 @@ func emitMakerETFloat32Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Bool(t typex.EventTime, key float32, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10738,7 +10740,7 @@ func emitMakerFloat32String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32String(key float32, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10754,7 +10756,7 @@ func emitMakerETFloat32String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32String(t typex.EventTime, key float32, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10770,7 +10772,7 @@ func emitMakerFloat32Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Int(key float32, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10786,7 +10788,7 @@ func emitMakerETFloat32Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Int(t typex.EventTime, key float32, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10802,7 +10804,7 @@ func emitMakerFloat32Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Int8(key float32, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10818,7 +10820,7 @@ func emitMakerETFloat32Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Int8(t typex.EventTime, key float32, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10834,7 +10836,7 @@ func emitMakerFloat32Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Int16(key float32, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10850,7 +10852,7 @@ func emitMakerETFloat32Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Int16(t typex.EventTime, key float32, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10866,7 +10868,7 @@ func emitMakerFloat32Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Int32(key float32, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10882,7 +10884,7 @@ func emitMakerETFloat32Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Int32(t typex.EventTime, key float32, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10898,7 +10900,7 @@ func emitMakerFloat32Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Int64(key float32, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10914,7 +10916,7 @@ func emitMakerETFloat32Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Int64(t typex.EventTime, key float32, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10930,7 +10932,7 @@ func emitMakerFloat32Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Uint(key float32, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10946,7 +10948,7 @@ func emitMakerETFloat32Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Uint(t typex.EventTime, key float32, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10962,7 +10964,7 @@ func emitMakerFloat32Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Uint8(key float32, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -10978,7 +10980,7 @@ func emitMakerETFloat32Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Uint8(t typex.EventTime, key float32, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -10994,7 +10996,7 @@ func emitMakerFloat32Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Uint16(key float32, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11010,7 +11012,7 @@ func emitMakerETFloat32Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Uint16(t typex.EventTime, key float32, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11026,7 +11028,7 @@ func emitMakerFloat32Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Uint32(key float32, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11042,7 +11044,7 @@ func emitMakerETFloat32Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Uint32(t typex.EventTime, key float32, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11058,7 +11060,7 @@ func emitMakerFloat32Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Uint64(key float32, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11074,7 +11076,7 @@ func emitMakerETFloat32Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Uint64(t typex.EventTime, key float32, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11090,7 +11092,7 @@ func emitMakerFloat32Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Float32(key float32, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11106,7 +11108,7 @@ func emitMakerETFloat32Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Float32(t typex.EventTime, key float32, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11122,7 +11124,7 @@ func emitMakerFloat32Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Float64(key float32, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11138,7 +11140,7 @@ func emitMakerETFloat32Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Float64(t typex.EventTime, key float32, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11154,7 +11156,7 @@ func emitMakerFloat32Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Typex_T(key float32, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11170,7 +11172,7 @@ func emitMakerETFloat32Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Typex_T(t typex.EventTime, key float32, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11186,7 +11188,7 @@ func emitMakerFloat32Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Typex_U(key float32, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11202,7 +11204,7 @@ func emitMakerETFloat32Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Typex_U(t typex.EventTime, key float32, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11218,7 +11220,7 @@ func emitMakerFloat32Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Typex_V(key float32, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11234,7 +11236,7 @@ func emitMakerETFloat32Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Typex_V(t typex.EventTime, key float32, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11250,7 +11252,7 @@ func emitMakerFloat32Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Typex_W(key float32, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11266,7 +11268,7 @@ func emitMakerETFloat32Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Typex_W(t typex.EventTime, key float32, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11282,7 +11284,7 @@ func emitMakerFloat32Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Typex_X(key float32, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11298,7 +11300,7 @@ func emitMakerETFloat32Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Typex_X(t typex.EventTime, key float32, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11314,7 +11316,7 @@ func emitMakerFloat32Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Typex_Y(key float32, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11330,7 +11332,7 @@ func emitMakerETFloat32Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Typex_Y(t typex.EventTime, key float32, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11346,7 +11348,7 @@ func emitMakerFloat32Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat32Typex_Z(key float32, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11362,7 +11364,7 @@ func emitMakerETFloat32Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat32Typex_Z(t typex.EventTime, key float32, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11378,7 +11380,7 @@ func emitMakerFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64(elm float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11394,7 +11396,7 @@ func emitMakerETFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64(t typex.EventTime, elm float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11410,7 +11412,7 @@ func emitMakerFloat64ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64ByteSlice(key float64, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11426,7 +11428,7 @@ func emitMakerETFloat64ByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64ByteSlice(t typex.EventTime, key float64, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11442,7 +11444,7 @@ func emitMakerFloat64Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Bool(key float64, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11458,7 +11460,7 @@ func emitMakerETFloat64Bool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Bool(t typex.EventTime, key float64, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11474,7 +11476,7 @@ func emitMakerFloat64String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64String(key float64, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11490,7 +11492,7 @@ func emitMakerETFloat64String(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64String(t typex.EventTime, key float64, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11506,7 +11508,7 @@ func emitMakerFloat64Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Int(key float64, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11522,7 +11524,7 @@ func emitMakerETFloat64Int(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Int(t typex.EventTime, key float64, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11538,7 +11540,7 @@ func emitMakerFloat64Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Int8(key float64, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11554,7 +11556,7 @@ func emitMakerETFloat64Int8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Int8(t typex.EventTime, key float64, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11570,7 +11572,7 @@ func emitMakerFloat64Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Int16(key float64, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11586,7 +11588,7 @@ func emitMakerETFloat64Int16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Int16(t typex.EventTime, key float64, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11602,7 +11604,7 @@ func emitMakerFloat64Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Int32(key float64, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11618,7 +11620,7 @@ func emitMakerETFloat64Int32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Int32(t typex.EventTime, key float64, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11634,7 +11636,7 @@ func emitMakerFloat64Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Int64(key float64, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11650,7 +11652,7 @@ func emitMakerETFloat64Int64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Int64(t typex.EventTime, key float64, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11666,7 +11668,7 @@ func emitMakerFloat64Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Uint(key float64, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11682,7 +11684,7 @@ func emitMakerETFloat64Uint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Uint(t typex.EventTime, key float64, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11698,7 +11700,7 @@ func emitMakerFloat64Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Uint8(key float64, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11714,7 +11716,7 @@ func emitMakerETFloat64Uint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Uint8(t typex.EventTime, key float64, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11730,7 +11732,7 @@ func emitMakerFloat64Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Uint16(key float64, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11746,7 +11748,7 @@ func emitMakerETFloat64Uint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Uint16(t typex.EventTime, key float64, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11762,7 +11764,7 @@ func emitMakerFloat64Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Uint32(key float64, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11778,7 +11780,7 @@ func emitMakerETFloat64Uint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Uint32(t typex.EventTime, key float64, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11794,7 +11796,7 @@ func emitMakerFloat64Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Uint64(key float64, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11810,7 +11812,7 @@ func emitMakerETFloat64Uint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Uint64(t typex.EventTime, key float64, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11826,7 +11828,7 @@ func emitMakerFloat64Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Float32(key float64, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11842,7 +11844,7 @@ func emitMakerETFloat64Float32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Float32(t typex.EventTime, key float64, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11858,7 +11860,7 @@ func emitMakerFloat64Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Float64(key float64, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11874,7 +11876,7 @@ func emitMakerETFloat64Float64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Float64(t typex.EventTime, key float64, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11890,7 +11892,7 @@ func emitMakerFloat64Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Typex_T(key float64, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11906,7 +11908,7 @@ func emitMakerETFloat64Typex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Typex_T(t typex.EventTime, key float64, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11922,7 +11924,7 @@ func emitMakerFloat64Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Typex_U(key float64, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11938,7 +11940,7 @@ func emitMakerETFloat64Typex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Typex_U(t typex.EventTime, key float64, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11954,7 +11956,7 @@ func emitMakerFloat64Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Typex_V(key float64, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -11970,7 +11972,7 @@ func emitMakerETFloat64Typex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Typex_V(t typex.EventTime, key float64, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -11986,7 +11988,7 @@ func emitMakerFloat64Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Typex_W(key float64, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12002,7 +12004,7 @@ func emitMakerETFloat64Typex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Typex_W(t typex.EventTime, key float64, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12018,7 +12020,7 @@ func emitMakerFloat64Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Typex_X(key float64, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12034,7 +12036,7 @@ func emitMakerETFloat64Typex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Typex_X(t typex.EventTime, key float64, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12050,7 +12052,7 @@ func emitMakerFloat64Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Typex_Y(key float64, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12066,7 +12068,7 @@ func emitMakerETFloat64Typex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Typex_Y(t typex.EventTime, key float64, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12082,7 +12084,7 @@ func emitMakerFloat64Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeFloat64Typex_Z(key float64, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12098,7 +12100,7 @@ func emitMakerETFloat64Typex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETFloat64Typex_Z(t typex.EventTime, key float64, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12114,7 +12116,7 @@ func emitMakerTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_T(elm typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12130,7 +12132,7 @@ func emitMakerETTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_T(t typex.EventTime, elm typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12146,7 +12148,7 @@ func emitMakerTypex_TByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TByteSlice(key typex.T, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12162,7 +12164,7 @@ func emitMakerETTypex_TByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TByteSlice(t typex.EventTime, key typex.T, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12178,7 +12180,7 @@ func emitMakerTypex_TBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TBool(key typex.T, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12194,7 +12196,7 @@ func emitMakerETTypex_TBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TBool(t typex.EventTime, key typex.T, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12210,7 +12212,7 @@ func emitMakerTypex_TString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TString(key typex.T, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12226,7 +12228,7 @@ func emitMakerETTypex_TString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TString(t typex.EventTime, key typex.T, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12242,7 +12244,7 @@ func emitMakerTypex_TInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TInt(key typex.T, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12258,7 +12260,7 @@ func emitMakerETTypex_TInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TInt(t typex.EventTime, key typex.T, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12274,7 +12276,7 @@ func emitMakerTypex_TInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TInt8(key typex.T, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12290,7 +12292,7 @@ func emitMakerETTypex_TInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TInt8(t typex.EventTime, key typex.T, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12306,7 +12308,7 @@ func emitMakerTypex_TInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TInt16(key typex.T, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12322,7 +12324,7 @@ func emitMakerETTypex_TInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TInt16(t typex.EventTime, key typex.T, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12338,7 +12340,7 @@ func emitMakerTypex_TInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TInt32(key typex.T, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12354,7 +12356,7 @@ func emitMakerETTypex_TInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TInt32(t typex.EventTime, key typex.T, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12370,7 +12372,7 @@ func emitMakerTypex_TInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TInt64(key typex.T, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12386,7 +12388,7 @@ func emitMakerETTypex_TInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TInt64(t typex.EventTime, key typex.T, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12402,7 +12404,7 @@ func emitMakerTypex_TUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TUint(key typex.T, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12418,7 +12420,7 @@ func emitMakerETTypex_TUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TUint(t typex.EventTime, key typex.T, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12434,7 +12436,7 @@ func emitMakerTypex_TUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TUint8(key typex.T, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12450,7 +12452,7 @@ func emitMakerETTypex_TUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TUint8(t typex.EventTime, key typex.T, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12466,7 +12468,7 @@ func emitMakerTypex_TUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TUint16(key typex.T, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12482,7 +12484,7 @@ func emitMakerETTypex_TUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TUint16(t typex.EventTime, key typex.T, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12498,7 +12500,7 @@ func emitMakerTypex_TUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TUint32(key typex.T, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12514,7 +12516,7 @@ func emitMakerETTypex_TUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TUint32(t typex.EventTime, key typex.T, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12530,7 +12532,7 @@ func emitMakerTypex_TUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TUint64(key typex.T, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12546,7 +12548,7 @@ func emitMakerETTypex_TUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TUint64(t typex.EventTime, key typex.T, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12562,7 +12564,7 @@ func emitMakerTypex_TFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TFloat32(key typex.T, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12578,7 +12580,7 @@ func emitMakerETTypex_TFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TFloat32(t typex.EventTime, key typex.T, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12594,7 +12596,7 @@ func emitMakerTypex_TFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TFloat64(key typex.T, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12610,7 +12612,7 @@ func emitMakerETTypex_TFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TFloat64(t typex.EventTime, key typex.T, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12626,7 +12628,7 @@ func emitMakerTypex_TTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TTypex_T(key typex.T, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12642,7 +12644,7 @@ func emitMakerETTypex_TTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TTypex_T(t typex.EventTime, key typex.T, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12658,7 +12660,7 @@ func emitMakerTypex_TTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TTypex_U(key typex.T, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12674,7 +12676,7 @@ func emitMakerETTypex_TTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TTypex_U(t typex.EventTime, key typex.T, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12690,7 +12692,7 @@ func emitMakerTypex_TTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TTypex_V(key typex.T, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12706,7 +12708,7 @@ func emitMakerETTypex_TTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TTypex_V(t typex.EventTime, key typex.T, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12722,7 +12724,7 @@ func emitMakerTypex_TTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TTypex_W(key typex.T, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12738,7 +12740,7 @@ func emitMakerETTypex_TTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TTypex_W(t typex.EventTime, key typex.T, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12754,7 +12756,7 @@ func emitMakerTypex_TTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TTypex_X(key typex.T, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12770,7 +12772,7 @@ func emitMakerETTypex_TTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TTypex_X(t typex.EventTime, key typex.T, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12786,7 +12788,7 @@ func emitMakerTypex_TTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TTypex_Y(key typex.T, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12802,7 +12804,7 @@ func emitMakerETTypex_TTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TTypex_Y(t typex.EventTime, key typex.T, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12818,7 +12820,7 @@ func emitMakerTypex_TTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_TTypex_Z(key typex.T, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12834,7 +12836,7 @@ func emitMakerETTypex_TTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_TTypex_Z(t typex.EventTime, key typex.T, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12850,7 +12852,7 @@ func emitMakerTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_U(elm typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12866,7 +12868,7 @@ func emitMakerETTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_U(t typex.EventTime, elm typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12882,7 +12884,7 @@ func emitMakerTypex_UByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UByteSlice(key typex.U, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12898,7 +12900,7 @@ func emitMakerETTypex_UByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UByteSlice(t typex.EventTime, key typex.U, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12914,7 +12916,7 @@ func emitMakerTypex_UBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UBool(key typex.U, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12930,7 +12932,7 @@ func emitMakerETTypex_UBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UBool(t typex.EventTime, key typex.U, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12946,7 +12948,7 @@ func emitMakerTypex_UString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UString(key typex.U, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12962,7 +12964,7 @@ func emitMakerETTypex_UString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UString(t typex.EventTime, key typex.U, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -12978,7 +12980,7 @@ func emitMakerTypex_UInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UInt(key typex.U, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -12994,7 +12996,7 @@ func emitMakerETTypex_UInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UInt(t typex.EventTime, key typex.U, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13010,7 +13012,7 @@ func emitMakerTypex_UInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UInt8(key typex.U, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13026,7 +13028,7 @@ func emitMakerETTypex_UInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UInt8(t typex.EventTime, key typex.U, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13042,7 +13044,7 @@ func emitMakerTypex_UInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UInt16(key typex.U, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13058,7 +13060,7 @@ func emitMakerETTypex_UInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UInt16(t typex.EventTime, key typex.U, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13074,7 +13076,7 @@ func emitMakerTypex_UInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UInt32(key typex.U, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13090,7 +13092,7 @@ func emitMakerETTypex_UInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UInt32(t typex.EventTime, key typex.U, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13106,7 +13108,7 @@ func emitMakerTypex_UInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UInt64(key typex.U, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13122,7 +13124,7 @@ func emitMakerETTypex_UInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UInt64(t typex.EventTime, key typex.U, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13138,7 +13140,7 @@ func emitMakerTypex_UUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UUint(key typex.U, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13154,7 +13156,7 @@ func emitMakerETTypex_UUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UUint(t typex.EventTime, key typex.U, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13170,7 +13172,7 @@ func emitMakerTypex_UUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UUint8(key typex.U, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13186,7 +13188,7 @@ func emitMakerETTypex_UUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UUint8(t typex.EventTime, key typex.U, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13202,7 +13204,7 @@ func emitMakerTypex_UUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UUint16(key typex.U, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13218,7 +13220,7 @@ func emitMakerETTypex_UUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UUint16(t typex.EventTime, key typex.U, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13234,7 +13236,7 @@ func emitMakerTypex_UUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UUint32(key typex.U, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13250,7 +13252,7 @@ func emitMakerETTypex_UUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UUint32(t typex.EventTime, key typex.U, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13266,7 +13268,7 @@ func emitMakerTypex_UUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UUint64(key typex.U, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13282,7 +13284,7 @@ func emitMakerETTypex_UUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UUint64(t typex.EventTime, key typex.U, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13298,7 +13300,7 @@ func emitMakerTypex_UFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UFloat32(key typex.U, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13314,7 +13316,7 @@ func emitMakerETTypex_UFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UFloat32(t typex.EventTime, key typex.U, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13330,7 +13332,7 @@ func emitMakerTypex_UFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UFloat64(key typex.U, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13346,7 +13348,7 @@ func emitMakerETTypex_UFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UFloat64(t typex.EventTime, key typex.U, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13362,7 +13364,7 @@ func emitMakerTypex_UTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UTypex_T(key typex.U, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13378,7 +13380,7 @@ func emitMakerETTypex_UTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UTypex_T(t typex.EventTime, key typex.U, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13394,7 +13396,7 @@ func emitMakerTypex_UTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UTypex_U(key typex.U, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13410,7 +13412,7 @@ func emitMakerETTypex_UTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UTypex_U(t typex.EventTime, key typex.U, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13426,7 +13428,7 @@ func emitMakerTypex_UTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UTypex_V(key typex.U, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13442,7 +13444,7 @@ func emitMakerETTypex_UTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UTypex_V(t typex.EventTime, key typex.U, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13458,7 +13460,7 @@ func emitMakerTypex_UTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UTypex_W(key typex.U, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13474,7 +13476,7 @@ func emitMakerETTypex_UTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UTypex_W(t typex.EventTime, key typex.U, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13490,7 +13492,7 @@ func emitMakerTypex_UTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UTypex_X(key typex.U, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13506,7 +13508,7 @@ func emitMakerETTypex_UTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UTypex_X(t typex.EventTime, key typex.U, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13522,7 +13524,7 @@ func emitMakerTypex_UTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UTypex_Y(key typex.U, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13538,7 +13540,7 @@ func emitMakerETTypex_UTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UTypex_Y(t typex.EventTime, key typex.U, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13554,7 +13556,7 @@ func emitMakerTypex_UTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_UTypex_Z(key typex.U, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13570,7 +13572,7 @@ func emitMakerETTypex_UTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_UTypex_Z(t typex.EventTime, key typex.U, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13586,7 +13588,7 @@ func emitMakerTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_V(elm typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13602,7 +13604,7 @@ func emitMakerETTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_V(t typex.EventTime, elm typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13618,7 +13620,7 @@ func emitMakerTypex_VByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VByteSlice(key typex.V, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13634,7 +13636,7 @@ func emitMakerETTypex_VByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VByteSlice(t typex.EventTime, key typex.V, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13650,7 +13652,7 @@ func emitMakerTypex_VBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VBool(key typex.V, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13666,7 +13668,7 @@ func emitMakerETTypex_VBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VBool(t typex.EventTime, key typex.V, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13682,7 +13684,7 @@ func emitMakerTypex_VString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VString(key typex.V, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13698,7 +13700,7 @@ func emitMakerETTypex_VString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VString(t typex.EventTime, key typex.V, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13714,7 +13716,7 @@ func emitMakerTypex_VInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VInt(key typex.V, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13730,7 +13732,7 @@ func emitMakerETTypex_VInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VInt(t typex.EventTime, key typex.V, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13746,7 +13748,7 @@ func emitMakerTypex_VInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VInt8(key typex.V, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13762,7 +13764,7 @@ func emitMakerETTypex_VInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VInt8(t typex.EventTime, key typex.V, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13778,7 +13780,7 @@ func emitMakerTypex_VInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VInt16(key typex.V, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13794,7 +13796,7 @@ func emitMakerETTypex_VInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VInt16(t typex.EventTime, key typex.V, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13810,7 +13812,7 @@ func emitMakerTypex_VInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VInt32(key typex.V, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13826,7 +13828,7 @@ func emitMakerETTypex_VInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VInt32(t typex.EventTime, key typex.V, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13842,7 +13844,7 @@ func emitMakerTypex_VInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VInt64(key typex.V, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13858,7 +13860,7 @@ func emitMakerETTypex_VInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VInt64(t typex.EventTime, key typex.V, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13874,7 +13876,7 @@ func emitMakerTypex_VUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VUint(key typex.V, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13890,7 +13892,7 @@ func emitMakerETTypex_VUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VUint(t typex.EventTime, key typex.V, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13906,7 +13908,7 @@ func emitMakerTypex_VUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VUint8(key typex.V, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13922,7 +13924,7 @@ func emitMakerETTypex_VUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VUint8(t typex.EventTime, key typex.V, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13938,7 +13940,7 @@ func emitMakerTypex_VUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VUint16(key typex.V, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13954,7 +13956,7 @@ func emitMakerETTypex_VUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VUint16(t typex.EventTime, key typex.V, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -13970,7 +13972,7 @@ func emitMakerTypex_VUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VUint32(key typex.V, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -13986,7 +13988,7 @@ func emitMakerETTypex_VUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VUint32(t typex.EventTime, key typex.V, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14002,7 +14004,7 @@ func emitMakerTypex_VUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VUint64(key typex.V, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14018,7 +14020,7 @@ func emitMakerETTypex_VUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VUint64(t typex.EventTime, key typex.V, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14034,7 +14036,7 @@ func emitMakerTypex_VFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VFloat32(key typex.V, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14050,7 +14052,7 @@ func emitMakerETTypex_VFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VFloat32(t typex.EventTime, key typex.V, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14066,7 +14068,7 @@ func emitMakerTypex_VFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VFloat64(key typex.V, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14082,7 +14084,7 @@ func emitMakerETTypex_VFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VFloat64(t typex.EventTime, key typex.V, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14098,7 +14100,7 @@ func emitMakerTypex_VTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VTypex_T(key typex.V, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14114,7 +14116,7 @@ func emitMakerETTypex_VTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VTypex_T(t typex.EventTime, key typex.V, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14130,7 +14132,7 @@ func emitMakerTypex_VTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VTypex_U(key typex.V, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14146,7 +14148,7 @@ func emitMakerETTypex_VTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VTypex_U(t typex.EventTime, key typex.V, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14162,7 +14164,7 @@ func emitMakerTypex_VTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VTypex_V(key typex.V, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14178,7 +14180,7 @@ func emitMakerETTypex_VTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VTypex_V(t typex.EventTime, key typex.V, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14194,7 +14196,7 @@ func emitMakerTypex_VTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VTypex_W(key typex.V, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14210,7 +14212,7 @@ func emitMakerETTypex_VTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VTypex_W(t typex.EventTime, key typex.V, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14226,7 +14228,7 @@ func emitMakerTypex_VTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VTypex_X(key typex.V, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14242,7 +14244,7 @@ func emitMakerETTypex_VTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VTypex_X(t typex.EventTime, key typex.V, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14258,7 +14260,7 @@ func emitMakerTypex_VTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VTypex_Y(key typex.V, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14274,7 +14276,7 @@ func emitMakerETTypex_VTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VTypex_Y(t typex.EventTime, key typex.V, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14290,7 +14292,7 @@ func emitMakerTypex_VTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_VTypex_Z(key typex.V, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14306,7 +14308,7 @@ func emitMakerETTypex_VTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_VTypex_Z(t typex.EventTime, key typex.V, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14322,7 +14324,7 @@ func emitMakerTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_W(elm typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14338,7 +14340,7 @@ func emitMakerETTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_W(t typex.EventTime, elm typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14354,7 +14356,7 @@ func emitMakerTypex_WByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WByteSlice(key typex.W, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14370,7 +14372,7 @@ func emitMakerETTypex_WByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WByteSlice(t typex.EventTime, key typex.W, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14386,7 +14388,7 @@ func emitMakerTypex_WBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WBool(key typex.W, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14402,7 +14404,7 @@ func emitMakerETTypex_WBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WBool(t typex.EventTime, key typex.W, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14418,7 +14420,7 @@ func emitMakerTypex_WString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WString(key typex.W, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14434,7 +14436,7 @@ func emitMakerETTypex_WString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WString(t typex.EventTime, key typex.W, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14450,7 +14452,7 @@ func emitMakerTypex_WInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WInt(key typex.W, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14466,7 +14468,7 @@ func emitMakerETTypex_WInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WInt(t typex.EventTime, key typex.W, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14482,7 +14484,7 @@ func emitMakerTypex_WInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WInt8(key typex.W, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14498,7 +14500,7 @@ func emitMakerETTypex_WInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WInt8(t typex.EventTime, key typex.W, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14514,7 +14516,7 @@ func emitMakerTypex_WInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WInt16(key typex.W, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14530,7 +14532,7 @@ func emitMakerETTypex_WInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WInt16(t typex.EventTime, key typex.W, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14546,7 +14548,7 @@ func emitMakerTypex_WInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WInt32(key typex.W, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14562,7 +14564,7 @@ func emitMakerETTypex_WInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WInt32(t typex.EventTime, key typex.W, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14578,7 +14580,7 @@ func emitMakerTypex_WInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WInt64(key typex.W, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14594,7 +14596,7 @@ func emitMakerETTypex_WInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WInt64(t typex.EventTime, key typex.W, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14610,7 +14612,7 @@ func emitMakerTypex_WUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WUint(key typex.W, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14626,7 +14628,7 @@ func emitMakerETTypex_WUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WUint(t typex.EventTime, key typex.W, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14642,7 +14644,7 @@ func emitMakerTypex_WUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WUint8(key typex.W, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14658,7 +14660,7 @@ func emitMakerETTypex_WUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WUint8(t typex.EventTime, key typex.W, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14674,7 +14676,7 @@ func emitMakerTypex_WUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WUint16(key typex.W, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14690,7 +14692,7 @@ func emitMakerETTypex_WUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WUint16(t typex.EventTime, key typex.W, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14706,7 +14708,7 @@ func emitMakerTypex_WUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WUint32(key typex.W, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14722,7 +14724,7 @@ func emitMakerETTypex_WUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WUint32(t typex.EventTime, key typex.W, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14738,7 +14740,7 @@ func emitMakerTypex_WUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WUint64(key typex.W, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14754,7 +14756,7 @@ func emitMakerETTypex_WUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WUint64(t typex.EventTime, key typex.W, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14770,7 +14772,7 @@ func emitMakerTypex_WFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WFloat32(key typex.W, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14786,7 +14788,7 @@ func emitMakerETTypex_WFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WFloat32(t typex.EventTime, key typex.W, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14802,7 +14804,7 @@ func emitMakerTypex_WFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WFloat64(key typex.W, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14818,7 +14820,7 @@ func emitMakerETTypex_WFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WFloat64(t typex.EventTime, key typex.W, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14834,7 +14836,7 @@ func emitMakerTypex_WTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WTypex_T(key typex.W, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14850,7 +14852,7 @@ func emitMakerETTypex_WTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WTypex_T(t typex.EventTime, key typex.W, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14866,7 +14868,7 @@ func emitMakerTypex_WTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WTypex_U(key typex.W, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14882,7 +14884,7 @@ func emitMakerETTypex_WTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WTypex_U(t typex.EventTime, key typex.W, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14898,7 +14900,7 @@ func emitMakerTypex_WTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WTypex_V(key typex.W, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14914,7 +14916,7 @@ func emitMakerETTypex_WTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WTypex_V(t typex.EventTime, key typex.W, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14930,7 +14932,7 @@ func emitMakerTypex_WTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WTypex_W(key typex.W, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14946,7 +14948,7 @@ func emitMakerETTypex_WTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WTypex_W(t typex.EventTime, key typex.W, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14962,7 +14964,7 @@ func emitMakerTypex_WTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WTypex_X(key typex.W, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -14978,7 +14980,7 @@ func emitMakerETTypex_WTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WTypex_X(t typex.EventTime, key typex.W, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -14994,7 +14996,7 @@ func emitMakerTypex_WTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WTypex_Y(key typex.W, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15010,7 +15012,7 @@ func emitMakerETTypex_WTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WTypex_Y(t typex.EventTime, key typex.W, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15026,7 +15028,7 @@ func emitMakerTypex_WTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_WTypex_Z(key typex.W, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15042,7 +15044,7 @@ func emitMakerETTypex_WTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_WTypex_Z(t typex.EventTime, key typex.W, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15058,7 +15060,7 @@ func emitMakerTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_X(elm typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15074,7 +15076,7 @@ func emitMakerETTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_X(t typex.EventTime, elm typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15090,7 +15092,7 @@ func emitMakerTypex_XByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XByteSlice(key typex.X, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15106,7 +15108,7 @@ func emitMakerETTypex_XByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XByteSlice(t typex.EventTime, key typex.X, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15122,7 +15124,7 @@ func emitMakerTypex_XBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XBool(key typex.X, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15138,7 +15140,7 @@ func emitMakerETTypex_XBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XBool(t typex.EventTime, key typex.X, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15154,7 +15156,7 @@ func emitMakerTypex_XString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XString(key typex.X, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15170,7 +15172,7 @@ func emitMakerETTypex_XString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XString(t typex.EventTime, key typex.X, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15186,7 +15188,7 @@ func emitMakerTypex_XInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XInt(key typex.X, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15202,7 +15204,7 @@ func emitMakerETTypex_XInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XInt(t typex.EventTime, key typex.X, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15218,7 +15220,7 @@ func emitMakerTypex_XInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XInt8(key typex.X, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15234,7 +15236,7 @@ func emitMakerETTypex_XInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XInt8(t typex.EventTime, key typex.X, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15250,7 +15252,7 @@ func emitMakerTypex_XInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XInt16(key typex.X, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15266,7 +15268,7 @@ func emitMakerETTypex_XInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XInt16(t typex.EventTime, key typex.X, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15282,7 +15284,7 @@ func emitMakerTypex_XInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XInt32(key typex.X, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15298,7 +15300,7 @@ func emitMakerETTypex_XInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XInt32(t typex.EventTime, key typex.X, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15314,7 +15316,7 @@ func emitMakerTypex_XInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XInt64(key typex.X, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15330,7 +15332,7 @@ func emitMakerETTypex_XInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XInt64(t typex.EventTime, key typex.X, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15346,7 +15348,7 @@ func emitMakerTypex_XUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XUint(key typex.X, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15362,7 +15364,7 @@ func emitMakerETTypex_XUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XUint(t typex.EventTime, key typex.X, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15378,7 +15380,7 @@ func emitMakerTypex_XUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XUint8(key typex.X, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15394,7 +15396,7 @@ func emitMakerETTypex_XUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XUint8(t typex.EventTime, key typex.X, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15410,7 +15412,7 @@ func emitMakerTypex_XUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XUint16(key typex.X, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15426,7 +15428,7 @@ func emitMakerETTypex_XUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XUint16(t typex.EventTime, key typex.X, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15442,7 +15444,7 @@ func emitMakerTypex_XUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XUint32(key typex.X, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15458,7 +15460,7 @@ func emitMakerETTypex_XUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XUint32(t typex.EventTime, key typex.X, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15474,7 +15476,7 @@ func emitMakerTypex_XUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XUint64(key typex.X, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15490,7 +15492,7 @@ func emitMakerETTypex_XUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XUint64(t typex.EventTime, key typex.X, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15506,7 +15508,7 @@ func emitMakerTypex_XFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XFloat32(key typex.X, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15522,7 +15524,7 @@ func emitMakerETTypex_XFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XFloat32(t typex.EventTime, key typex.X, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15538,7 +15540,7 @@ func emitMakerTypex_XFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XFloat64(key typex.X, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15554,7 +15556,7 @@ func emitMakerETTypex_XFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XFloat64(t typex.EventTime, key typex.X, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15570,7 +15572,7 @@ func emitMakerTypex_XTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XTypex_T(key typex.X, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15586,7 +15588,7 @@ func emitMakerETTypex_XTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XTypex_T(t typex.EventTime, key typex.X, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15602,7 +15604,7 @@ func emitMakerTypex_XTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XTypex_U(key typex.X, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15618,7 +15620,7 @@ func emitMakerETTypex_XTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XTypex_U(t typex.EventTime, key typex.X, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15634,7 +15636,7 @@ func emitMakerTypex_XTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XTypex_V(key typex.X, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15650,7 +15652,7 @@ func emitMakerETTypex_XTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XTypex_V(t typex.EventTime, key typex.X, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15666,7 +15668,7 @@ func emitMakerTypex_XTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XTypex_W(key typex.X, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15682,7 +15684,7 @@ func emitMakerETTypex_XTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XTypex_W(t typex.EventTime, key typex.X, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15698,7 +15700,7 @@ func emitMakerTypex_XTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XTypex_X(key typex.X, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15714,7 +15716,7 @@ func emitMakerETTypex_XTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XTypex_X(t typex.EventTime, key typex.X, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15730,7 +15732,7 @@ func emitMakerTypex_XTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XTypex_Y(key typex.X, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15746,7 +15748,7 @@ func emitMakerETTypex_XTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XTypex_Y(t typex.EventTime, key typex.X, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15762,7 +15764,7 @@ func emitMakerTypex_XTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_XTypex_Z(key typex.X, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15778,7 +15780,7 @@ func emitMakerETTypex_XTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_XTypex_Z(t typex.EventTime, key typex.X, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15794,7 +15796,7 @@ func emitMakerTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_Y(elm typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15810,7 +15812,7 @@ func emitMakerETTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_Y(t typex.EventTime, elm typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15826,7 +15828,7 @@ func emitMakerTypex_YByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YByteSlice(key typex.Y, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15842,7 +15844,7 @@ func emitMakerETTypex_YByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YByteSlice(t typex.EventTime, key typex.Y, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15858,7 +15860,7 @@ func emitMakerTypex_YBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YBool(key typex.Y, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15874,7 +15876,7 @@ func emitMakerETTypex_YBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YBool(t typex.EventTime, key typex.Y, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15890,7 +15892,7 @@ func emitMakerTypex_YString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YString(key typex.Y, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15906,7 +15908,7 @@ func emitMakerETTypex_YString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YString(t typex.EventTime, key typex.Y, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15922,7 +15924,7 @@ func emitMakerTypex_YInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YInt(key typex.Y, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15938,7 +15940,7 @@ func emitMakerETTypex_YInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YInt(t typex.EventTime, key typex.Y, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15954,7 +15956,7 @@ func emitMakerTypex_YInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YInt8(key typex.Y, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -15970,7 +15972,7 @@ func emitMakerETTypex_YInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YInt8(t typex.EventTime, key typex.Y, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -15986,7 +15988,7 @@ func emitMakerTypex_YInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YInt16(key typex.Y, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16002,7 +16004,7 @@ func emitMakerETTypex_YInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YInt16(t typex.EventTime, key typex.Y, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16018,7 +16020,7 @@ func emitMakerTypex_YInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YInt32(key typex.Y, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16034,7 +16036,7 @@ func emitMakerETTypex_YInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YInt32(t typex.EventTime, key typex.Y, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16050,7 +16052,7 @@ func emitMakerTypex_YInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YInt64(key typex.Y, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16066,7 +16068,7 @@ func emitMakerETTypex_YInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YInt64(t typex.EventTime, key typex.Y, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16082,7 +16084,7 @@ func emitMakerTypex_YUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YUint(key typex.Y, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16098,7 +16100,7 @@ func emitMakerETTypex_YUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YUint(t typex.EventTime, key typex.Y, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16114,7 +16116,7 @@ func emitMakerTypex_YUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YUint8(key typex.Y, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16130,7 +16132,7 @@ func emitMakerETTypex_YUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YUint8(t typex.EventTime, key typex.Y, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16146,7 +16148,7 @@ func emitMakerTypex_YUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YUint16(key typex.Y, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16162,7 +16164,7 @@ func emitMakerETTypex_YUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YUint16(t typex.EventTime, key typex.Y, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16178,7 +16180,7 @@ func emitMakerTypex_YUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YUint32(key typex.Y, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16194,7 +16196,7 @@ func emitMakerETTypex_YUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YUint32(t typex.EventTime, key typex.Y, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16210,7 +16212,7 @@ func emitMakerTypex_YUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YUint64(key typex.Y, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16226,7 +16228,7 @@ func emitMakerETTypex_YUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YUint64(t typex.EventTime, key typex.Y, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16242,7 +16244,7 @@ func emitMakerTypex_YFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YFloat32(key typex.Y, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16258,7 +16260,7 @@ func emitMakerETTypex_YFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YFloat32(t typex.EventTime, key typex.Y, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16274,7 +16276,7 @@ func emitMakerTypex_YFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YFloat64(key typex.Y, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16290,7 +16292,7 @@ func emitMakerETTypex_YFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YFloat64(t typex.EventTime, key typex.Y, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16306,7 +16308,7 @@ func emitMakerTypex_YTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YTypex_T(key typex.Y, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16322,7 +16324,7 @@ func emitMakerETTypex_YTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YTypex_T(t typex.EventTime, key typex.Y, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16338,7 +16340,7 @@ func emitMakerTypex_YTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YTypex_U(key typex.Y, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16354,7 +16356,7 @@ func emitMakerETTypex_YTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YTypex_U(t typex.EventTime, key typex.Y, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16370,7 +16372,7 @@ func emitMakerTypex_YTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YTypex_V(key typex.Y, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16386,7 +16388,7 @@ func emitMakerETTypex_YTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YTypex_V(t typex.EventTime, key typex.Y, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16402,7 +16404,7 @@ func emitMakerTypex_YTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YTypex_W(key typex.Y, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16418,7 +16420,7 @@ func emitMakerETTypex_YTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YTypex_W(t typex.EventTime, key typex.Y, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16434,7 +16436,7 @@ func emitMakerTypex_YTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YTypex_X(key typex.Y, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16450,7 +16452,7 @@ func emitMakerETTypex_YTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YTypex_X(t typex.EventTime, key typex.Y, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16466,7 +16468,7 @@ func emitMakerTypex_YTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YTypex_Y(key typex.Y, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16482,7 +16484,7 @@ func emitMakerETTypex_YTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YTypex_Y(t typex.EventTime, key typex.Y, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16498,7 +16500,7 @@ func emitMakerTypex_YTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_YTypex_Z(key typex.Y, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16514,7 +16516,7 @@ func emitMakerETTypex_YTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_YTypex_Z(t typex.EventTime, key typex.Y, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16530,7 +16532,7 @@ func emitMakerTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_Z(elm typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16546,7 +16548,7 @@ func emitMakerETTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_Z(t typex.EventTime, elm typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16562,7 +16564,7 @@ func emitMakerTypex_ZByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZByteSlice(key typex.Z, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16578,7 +16580,7 @@ func emitMakerETTypex_ZByteSlice(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZByteSlice(t typex.EventTime, key typex.Z, val []byte) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16594,7 +16596,7 @@ func emitMakerTypex_ZBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZBool(key typex.Z, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16610,7 +16612,7 @@ func emitMakerETTypex_ZBool(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZBool(t typex.EventTime, key typex.Z, val bool) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16626,7 +16628,7 @@ func emitMakerTypex_ZString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZString(key typex.Z, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16642,7 +16644,7 @@ func emitMakerETTypex_ZString(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZString(t typex.EventTime, key typex.Z, val string) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16658,7 +16660,7 @@ func emitMakerTypex_ZInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZInt(key typex.Z, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16674,7 +16676,7 @@ func emitMakerETTypex_ZInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZInt(t typex.EventTime, key typex.Z, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16690,7 +16692,7 @@ func emitMakerTypex_ZInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZInt8(key typex.Z, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16706,7 +16708,7 @@ func emitMakerETTypex_ZInt8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZInt8(t typex.EventTime, key typex.Z, val int8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16722,7 +16724,7 @@ func emitMakerTypex_ZInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZInt16(key typex.Z, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16738,7 +16740,7 @@ func emitMakerETTypex_ZInt16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZInt16(t typex.EventTime, key typex.Z, val int16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16754,7 +16756,7 @@ func emitMakerTypex_ZInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZInt32(key typex.Z, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16770,7 +16772,7 @@ func emitMakerETTypex_ZInt32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZInt32(t typex.EventTime, key typex.Z, val int32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16786,7 +16788,7 @@ func emitMakerTypex_ZInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZInt64(key typex.Z, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16802,7 +16804,7 @@ func emitMakerETTypex_ZInt64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZInt64(t typex.EventTime, key typex.Z, val int64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16818,7 +16820,7 @@ func emitMakerTypex_ZUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZUint(key typex.Z, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16834,7 +16836,7 @@ func emitMakerETTypex_ZUint(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZUint(t typex.EventTime, key typex.Z, val uint) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16850,7 +16852,7 @@ func emitMakerTypex_ZUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZUint8(key typex.Z, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16866,7 +16868,7 @@ func emitMakerETTypex_ZUint8(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZUint8(t typex.EventTime, key typex.Z, val uint8) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16882,7 +16884,7 @@ func emitMakerTypex_ZUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZUint16(key typex.Z, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16898,7 +16900,7 @@ func emitMakerETTypex_ZUint16(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZUint16(t typex.EventTime, key typex.Z, val uint16) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16914,7 +16916,7 @@ func emitMakerTypex_ZUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZUint32(key typex.Z, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16930,7 +16932,7 @@ func emitMakerETTypex_ZUint32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZUint32(t typex.EventTime, key typex.Z, val uint32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16946,7 +16948,7 @@ func emitMakerTypex_ZUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZUint64(key typex.Z, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16962,7 +16964,7 @@ func emitMakerETTypex_ZUint64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZUint64(t typex.EventTime, key typex.Z, val uint64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -16978,7 +16980,7 @@ func emitMakerTypex_ZFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZFloat32(key typex.Z, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -16994,7 +16996,7 @@ func emitMakerETTypex_ZFloat32(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZFloat32(t typex.EventTime, key typex.Z, val float32) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -17010,7 +17012,7 @@ func emitMakerTypex_ZFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZFloat64(key typex.Z, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -17026,7 +17028,7 @@ func emitMakerETTypex_ZFloat64(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZFloat64(t typex.EventTime, key typex.Z, val float64) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -17042,7 +17044,7 @@ func emitMakerTypex_ZTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZTypex_T(key typex.Z, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -17058,7 +17060,7 @@ func emitMakerETTypex_ZTypex_T(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZTypex_T(t typex.EventTime, key typex.Z, val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -17074,7 +17076,7 @@ func emitMakerTypex_ZTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZTypex_U(key typex.Z, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -17090,7 +17092,7 @@ func emitMakerETTypex_ZTypex_U(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZTypex_U(t typex.EventTime, key typex.Z, val typex.U) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -17106,7 +17108,7 @@ func emitMakerTypex_ZTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZTypex_V(key typex.Z, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -17122,7 +17124,7 @@ func emitMakerETTypex_ZTypex_V(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZTypex_V(t typex.EventTime, key typex.Z, val typex.V) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -17138,7 +17140,7 @@ func emitMakerTypex_ZTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZTypex_W(key typex.Z, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -17154,7 +17156,7 @@ func emitMakerETTypex_ZTypex_W(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZTypex_W(t typex.EventTime, key typex.Z, val typex.W) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -17170,7 +17172,7 @@ func emitMakerTypex_ZTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZTypex_X(key typex.Z, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -17186,7 +17188,7 @@ func emitMakerETTypex_ZTypex_X(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZTypex_X(t typex.EventTime, key typex.Z, val typex.X) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -17202,7 +17204,7 @@ func emitMakerTypex_ZTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZTypex_Y(key typex.Z, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -17218,7 +17220,7 @@ func emitMakerETTypex_ZTypex_Y(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZTypex_Y(t typex.EventTime, key typex.Z, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -17234,7 +17236,7 @@ func emitMakerTypex_ZTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeTypex_ZTypex_Z(key typex.Z, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -17250,7 +17252,7 @@ func emitMakerETTypex_ZTypex_Z(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeETTypex_ZTypex_Z(t typex.EventTime, key typex.Z, val typex.Z) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}

--- a/sdks/go/pkg/beam/core/runtime/exec/optimized/emitters.tmpl
+++ b/sdks/go/pkg/beam/core/runtime/exec/optimized/emitters.tmpl
@@ -44,13 +44,15 @@ type emitNative struct {
 	est   *sdf.WatermarkEstimator
 
 	ctx context.Context
+  pn  typex.PaneInfo
 	ws  []typex.Window
 	et  typex.EventTime
 	value exec.FullValue
 }
 
-func (e *emitNative) Init(ctx context.Context, ws  []typex.Window, et typex.EventTime) error {
+func (e *emitNative) Init(ctx context.Context, pn typex.PaneInfo, ws  []typex.Window, et typex.EventTime) error {
 	e.ctx = ctx
+  e.pn = pn
 	e.ws = ws
 	e.et = et
 	return nil
@@ -72,7 +74,7 @@ func emitMaker{{$x.Name}}(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invoke{{$x.Name}}(elm {{$x.Type}}) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: elm }
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: elm }
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -88,7 +90,7 @@ func emitMakerET{{$x.Name}}(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeET{{$x.Name}}(t typex.EventTime, elm {{$x.Type}}) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: elm }
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: elm }
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}
@@ -105,7 +107,7 @@ func emitMaker{{$x.Name}}{{$y.Name}}(n exec.ElementProcessor) exec.ReusableEmitt
 }
 
 func (e *emitNative) invoke{{$x.Name}}{{$y.Name}}(key {{$x.Type}}, val {{$y.Type}}) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val }
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val }
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -121,7 +123,7 @@ func emitMakerET{{$x.Name}}{{$y.Name}}(n exec.ElementProcessor) exec.ReusableEmi
 }
 
 func (e *emitNative) invokeET{{$x.Name}}{{$y.Name}}(t typex.EventTime, key {{$x.Type}}, val {{$y.Type}}) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: t, Elm: key, Elm2: val }
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: t, Elm: key, Elm2: val }
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(t.ToTime())
 	}

--- a/sdks/go/pkg/beam/core/runtime/exec/pardo.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/pardo.go
@@ -474,7 +474,7 @@ func (n *ParDo) processTimer(timerFamilyID string, singleWindow []typex.Window, 
 			err = postErr
 		}
 	}()
-	if err := n.preInvoke(n.ctx, typex.PaneInfo{}, singleWindow, tmap.HoldTimestamp); err != nil {
+	if err := n.preInvoke(n.ctx, typex.NoFiringPane(), singleWindow, tmap.HoldTimestamp); err != nil {
 		return err
 	}
 

--- a/sdks/go/pkg/beam/core/runtime/exec/pardo.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/pardo.go
@@ -360,7 +360,7 @@ func (n *ParDo) invokeDataFn(ctx context.Context, pn typex.PaneInfo, ws []typex.
 			err = postErr
 		}
 	}()
-	if err := n.preInvoke(ctx, ws, ts); err != nil {
+	if err := n.preInvoke(ctx, pn, ws, ts); err != nil {
 		return nil, err
 	}
 	val, err = Invoke(ctx, pn, ws, ts, fn, opt, n.bf, n.we, n.UState, n.reader, n.cache.extra...)
@@ -474,7 +474,7 @@ func (n *ParDo) processTimer(timerFamilyID string, singleWindow []typex.Window, 
 			err = postErr
 		}
 	}()
-	if err := n.preInvoke(n.ctx, singleWindow, tmap.HoldTimestamp); err != nil {
+	if err := n.preInvoke(n.ctx, typex.PaneInfo{}, singleWindow, tmap.HoldTimestamp); err != nil {
 		return err
 	}
 
@@ -502,7 +502,7 @@ func (n *ParDo) invokeProcessFn(ctx context.Context, pn typex.PaneInfo, ws []typ
 			err = postErr
 		}
 	}()
-	if err := n.preInvoke(ctx, ws, ts); err != nil {
+	if err := n.preInvoke(ctx, pn, ws, ts); err != nil {
 		return nil, err
 	}
 	val, err = n.inv.invokeWithOpts(ctx, pn, ws, ts, InvokeOpts{opt: opt, bf: n.bf, we: n.we, sa: n.UState, sr: n.reader, ta: n.TimerTracker, tm: n.timerManager, extra: n.cache.extra})
@@ -512,9 +512,9 @@ func (n *ParDo) invokeProcessFn(ctx context.Context, pn typex.PaneInfo, ws []typ
 	return val, nil
 }
 
-func (n *ParDo) preInvoke(ctx context.Context, ws []typex.Window, ts typex.EventTime) error {
+func (n *ParDo) preInvoke(ctx context.Context, pn typex.PaneInfo, ws []typex.Window, ts typex.EventTime) error {
 	for _, e := range n.emitters {
-		if err := e.Init(ctx, ws, ts); err != nil {
+		if err := e.Init(ctx, pn, ws, ts); err != nil {
 			return err
 		}
 	}

--- a/sdks/go/pkg/beam/register/emitter.go
+++ b/sdks/go/pkg/beam/register/emitter.go
@@ -28,13 +28,15 @@ type emit struct {
 	est *sdf.WatermarkEstimator
 
 	ctx   context.Context
+	pn    typex.PaneInfo
 	ws    []typex.Window
 	et    typex.EventTime
 	value exec.FullValue
 }
 
-func (e *emit) Init(ctx context.Context, ws []typex.Window, et typex.EventTime) error {
+func (e *emit) Init(ctx context.Context, pn typex.PaneInfo, ws []typex.Window, et typex.EventTime) error {
 	e.ctx = ctx
+	e.pn = pn
 	e.ws = ws
 	e.et = et
 	return nil
@@ -54,7 +56,7 @@ func (e *emit1[T]) Value() any {
 }
 
 func (e *emit1[T]) invoke(val T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}

--- a/sdks/go/pkg/beam/register/emitter.go
+++ b/sdks/go/pkg/beam/register/emitter.go
@@ -75,7 +75,7 @@ func (e *emit2[T1, T2]) Value() any {
 }
 
 func (e *emit2[T1, T2]) invoke(key T1, val T2) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -94,7 +94,7 @@ func (e *emit1WithTimestamp[T]) Value() any {
 }
 
 func (e *emit1WithTimestamp[T]) invoke(et typex.EventTime, val T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: et, Elm: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: et, Elm: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(et.ToTime())
 	}
@@ -113,7 +113,7 @@ func (e *emit2WithTimestamp[T1, T2]) Value() any {
 }
 
 func (e *emit2WithTimestamp[T1, T2]) invoke(et typex.EventTime, key T1, val T2) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(et.ToTime())
 	}

--- a/sdks/go/pkg/beam/register/emitter_test.go
+++ b/sdks/go/pkg/beam/register/emitter_test.go
@@ -103,7 +103,7 @@ func TestEmitter3(t *testing.T) {
 
 func TestEmit1(t *testing.T) {
 	e := &emit1[int]{n: &elementProcessor{}}
-	e.Init(context.Background(), []typex.Window{}, mtime.ZeroTimestamp)
+	e.Init(context.Background(), typex.NoFiringPane(), []typex.Window{}, mtime.ZeroTimestamp)
 	fn := e.Value().(func(int))
 	fn(3)
 	if got, want := e.n.(*elementProcessor).inFV.Elm, 3; got != want {
@@ -119,7 +119,7 @@ func TestEmit1(t *testing.T) {
 
 func TestEmit2(t *testing.T) {
 	e := &emit2[int, string]{n: &elementProcessor{}}
-	e.Init(context.Background(), []typex.Window{}, mtime.ZeroTimestamp)
+	e.Init(context.Background(), typex.NoFiringPane(), []typex.Window{}, mtime.ZeroTimestamp)
 	fn := e.Value().(func(int, string))
 	fn(3, "hello")
 	if got, want := e.n.(*elementProcessor).inFV.Elm, 3; got != want {
@@ -135,7 +135,7 @@ func TestEmit2(t *testing.T) {
 
 func TestEmit1WithTimestamp(t *testing.T) {
 	e := &emit1WithTimestamp[int]{n: &elementProcessor{}}
-	e.Init(context.Background(), []typex.Window{}, mtime.ZeroTimestamp)
+	e.Init(context.Background(), typex.NoFiringPane(), []typex.Window{}, mtime.ZeroTimestamp)
 	fn := e.Value().(func(typex.EventTime, int))
 	fn(mtime.MaxTimestamp, 3)
 	if got, want := e.n.(*elementProcessor).inFV.Elm, 3; got != want {
@@ -151,7 +151,7 @@ func TestEmit1WithTimestamp(t *testing.T) {
 
 func TestEmit2WithTimestamp(t *testing.T) {
 	e := &emit2WithTimestamp[int, string]{n: &elementProcessor{}}
-	e.Init(context.Background(), []typex.Window{}, mtime.ZeroTimestamp)
+	e.Init(context.Background(), typex.NoFiringPane(), []typex.Window{}, mtime.ZeroTimestamp)
 	fn := e.Value().(func(typex.EventTime, int, string))
 	fn(mtime.MaxTimestamp, 3, "hello")
 	if got, want := e.n.(*elementProcessor).inFV.Elm, 3; got != want {

--- a/sdks/go/pkg/beam/runners/vet/testpipeline/testpipeline.shims.go
+++ b/sdks/go/pkg/beam/runners/vet/testpipeline/testpipeline.shims.go
@@ -162,13 +162,15 @@ type emitNative struct {
 	est *sdf.WatermarkEstimator
 
 	ctx   context.Context
+	pn    typex.PaneInfo
 	ws    []typex.Window
 	et    typex.EventTime
 	value exec.FullValue
 }
 
-func (e *emitNative) Init(ctx context.Context, ws []typex.Window, et typex.EventTime) error {
+func (e *emitNative) Init(ctx context.Context, pn typex.PaneInfo, ws []typex.Window, et typex.EventTime) error {
 	e.ctx = ctx
+	e.pn = pn
 	e.ws = ws
 	e.et = et
 	return nil
@@ -189,7 +191,7 @@ func emitMakerStringInt(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invokeStringInt(key string, val int) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}

--- a/sdks/go/pkg/beam/testing/passert/passert.shims.go
+++ b/sdks/go/pkg/beam/testing/passert/passert.shims.go
@@ -25,6 +25,7 @@ import (
 	"reflect"
 
 	// Library imports
+	"github.com/apache/beam/sdks/v2/go/pkg/beam"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime/exec"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime/graphx/schema"
@@ -65,28 +66,28 @@ func init() {
 	reflectx.RegisterFunc(reflect.TypeOf((*func(int, int) int)(nil)).Elem(), funcMakerIntIntГInt)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(int, func(*int) bool) error)(nil)).Elem(), funcMakerIntIterIntГError)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(int, func(*string) bool) error)(nil)).Elem(), funcMakerIntIterStringГError)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(int, typex.T) int)(nil)).Elem(), funcMakerIntTypex۰TГInt)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(int, beam.T) int)(nil)).Elem(), funcMakerIntTypex۰TГInt)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(int) error)(nil)).Elem(), funcMakerIntГError)
 	reflectx.RegisterFunc(reflect.TypeOf((*func(int) int)(nil)).Elem(), funcMakerIntГInt)
-	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte, func(*typex.T) bool, func(*typex.T) bool, func(t typex.T), func(t typex.T), func(t typex.T)) error)(nil)).Elem(), funcMakerSliceOfByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError)
-	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte, func(*typex.T) bool, func(*typex.T) bool, func(*typex.T) bool) error)(nil)).Elem(), funcMakerSliceOfByteIterTypex۰TIterTypex۰TIterTypex۰TГError)
-	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte, func(*typex.Z) bool) error)(nil)).Elem(), funcMakerSliceOfByteIterTypex۰ZГError)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.X, func(*typex.Y) bool) error)(nil)).Elem(), funcMakerTypex۰XIterTypex۰YГError)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.X, typex.Y) error)(nil)).Elem(), funcMakerTypex۰XTypex۰YГError)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.X) error)(nil)).Elem(), funcMakerTypex۰XГError)
+	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte, func(*beam.T) bool, func(*beam.T) bool, func(t beam.T), func(t beam.T), func(t beam.T)) error)(nil)).Elem(), funcMakerSliceOfByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError)
+	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte, func(*beam.T) bool, func(*beam.T) bool, func(*beam.T) bool) error)(nil)).Elem(), funcMakerSliceOfByteIterTypex۰TIterTypex۰TIterTypex۰TГError)
+	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte, func(*beam.Z) bool) error)(nil)).Elem(), funcMakerSliceOfByteIterTypex۰ZГError)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(beam.X, func(*beam.Y) bool) error)(nil)).Elem(), funcMakerTypex۰XIterTypex۰YГError)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(beam.X, beam.Y) error)(nil)).Elem(), funcMakerTypex۰XTypex۰YГError)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(beam.X) error)(nil)).Elem(), funcMakerTypex۰XГError)
 	reflectx.RegisterFunc(reflect.TypeOf((*func() int)(nil)).Elem(), funcMakerГInt)
-	exec.RegisterEmitter(reflect.TypeOf((*func(typex.T))(nil)).Elem(), emitMakerTypex۰T)
+	exec.RegisterEmitter(reflect.TypeOf((*func(beam.T))(nil)).Elem(), emitMakerTypex۰T)
 	exec.RegisterInput(reflect.TypeOf((*func(*int) bool)(nil)).Elem(), iterMakerInt)
 	exec.RegisterInput(reflect.TypeOf((*func(*string) bool)(nil)).Elem(), iterMakerString)
-	exec.RegisterInput(reflect.TypeOf((*func(*typex.T) bool)(nil)).Elem(), iterMakerTypex۰T)
-	exec.RegisterInput(reflect.TypeOf((*func(*typex.Y) bool)(nil)).Elem(), iterMakerTypex۰Y)
-	exec.RegisterInput(reflect.TypeOf((*func(*typex.Z) bool)(nil)).Elem(), iterMakerTypex۰Z)
+	exec.RegisterInput(reflect.TypeOf((*func(*beam.T) bool)(nil)).Elem(), iterMakerTypex۰T)
+	exec.RegisterInput(reflect.TypeOf((*func(*beam.Y) bool)(nil)).Elem(), iterMakerTypex۰Y)
+	exec.RegisterInput(reflect.TypeOf((*func(*beam.Z) bool)(nil)).Elem(), iterMakerTypex۰Z)
 }
 
 func wrapMakerDiffFn(fn any) map[string]reflectx.Func {
 	dfn := fn.(*diffFn)
 	return map[string]reflectx.Func{
-		"ProcessElement": reflectx.MakeFunc(func(a0 []byte, a1 func(*typex.T) bool, a2 func(*typex.T) bool, a3 func(t typex.T), a4 func(t typex.T), a5 func(t typex.T)) error {
+		"ProcessElement": reflectx.MakeFunc(func(a0 []byte, a1 func(*beam.T) bool, a2 func(*beam.T) bool, a3 func(t beam.T), a4 func(t beam.T), a5 func(t beam.T)) error {
 			return dfn.ProcessElement(a0, a1, a2, a3, a4, a5)
 		}),
 	}
@@ -95,7 +96,7 @@ func wrapMakerDiffFn(fn any) map[string]reflectx.Func {
 func wrapMakerElmCountCombineFn(fn any) map[string]reflectx.Func {
 	dfn := fn.(*elmCountCombineFn)
 	return map[string]reflectx.Func{
-		"AddInput":          reflectx.MakeFunc(func(a0 int, a1 typex.T) int { return dfn.AddInput(a0, a1) }),
+		"AddInput":          reflectx.MakeFunc(func(a0 int, a1 beam.T) int { return dfn.AddInput(a0, a1) }),
 		"CreateAccumulator": reflectx.MakeFunc(func() int { return dfn.CreateAccumulator() }),
 		"ExtractOutput":     reflectx.MakeFunc(func(a0 int) int { return dfn.ExtractOutput(a0) }),
 		"MergeAccumulators": reflectx.MakeFunc(func(a0 int, a1 int) int { return dfn.MergeAccumulators(a0, a1) }),
@@ -112,21 +113,21 @@ func wrapMakerErrFn(fn any) map[string]reflectx.Func {
 func wrapMakerFailFn(fn any) map[string]reflectx.Func {
 	dfn := fn.(*failFn)
 	return map[string]reflectx.Func{
-		"ProcessElement": reflectx.MakeFunc(func(a0 typex.X) error { return dfn.ProcessElement(a0) }),
+		"ProcessElement": reflectx.MakeFunc(func(a0 beam.X) error { return dfn.ProcessElement(a0) }),
 	}
 }
 
 func wrapMakerFailGBKFn(fn any) map[string]reflectx.Func {
 	dfn := fn.(*failGBKFn)
 	return map[string]reflectx.Func{
-		"ProcessElement": reflectx.MakeFunc(func(a0 typex.X, a1 func(*typex.Y) bool) error { return dfn.ProcessElement(a0, a1) }),
+		"ProcessElement": reflectx.MakeFunc(func(a0 beam.X, a1 func(*beam.Y) bool) error { return dfn.ProcessElement(a0, a1) }),
 	}
 }
 
 func wrapMakerFailKVFn(fn any) map[string]reflectx.Func {
 	dfn := fn.(*failKVFn)
 	return map[string]reflectx.Func{
-		"ProcessElement": reflectx.MakeFunc(func(a0 typex.X, a1 typex.Y) error { return dfn.ProcessElement(a0, a1) }),
+		"ProcessElement": reflectx.MakeFunc(func(a0 beam.X, a1 beam.Y) error { return dfn.ProcessElement(a0, a1) }),
 	}
 }
 
@@ -140,7 +141,7 @@ func wrapMakerHashFn(fn any) map[string]reflectx.Func {
 func wrapMakerNonEmptyFn(fn any) map[string]reflectx.Func {
 	dfn := fn.(*nonEmptyFn)
 	return map[string]reflectx.Func{
-		"ProcessElement": reflectx.MakeFunc(func(a0 []byte, a1 func(*typex.Z) bool) error { return dfn.ProcessElement(a0, a1) }),
+		"ProcessElement": reflectx.MakeFunc(func(a0 []byte, a1 func(*beam.Z) bool) error { return dfn.ProcessElement(a0, a1) }),
 	}
 }
 
@@ -230,11 +231,11 @@ func (c *callerIntIterStringГError) Call2x1(arg0, arg1 any) any {
 }
 
 type callerIntTypex۰TГInt struct {
-	fn func(int, typex.T) int
+	fn func(int, beam.T) int
 }
 
 func funcMakerIntTypex۰TГInt(fn any) reflectx.Func {
-	f := fn.(func(int, typex.T) int)
+	f := fn.(func(int, beam.T) int)
 	return &callerIntTypex۰TГInt{fn: f}
 }
 
@@ -247,12 +248,12 @@ func (c *callerIntTypex۰TГInt) Type() reflect.Type {
 }
 
 func (c *callerIntTypex۰TГInt) Call(args []any) []any {
-	out0 := c.fn(args[0].(int), args[1].(typex.T))
+	out0 := c.fn(args[0].(int), args[1].(beam.T))
 	return []any{out0}
 }
 
 func (c *callerIntTypex۰TГInt) Call2x1(arg0, arg1 any) any {
-	return c.fn(arg0.(int), arg1.(typex.T))
+	return c.fn(arg0.(int), arg1.(beam.T))
 }
 
 type callerIntГError struct {
@@ -308,11 +309,11 @@ func (c *callerIntГInt) Call1x1(arg0 any) any {
 }
 
 type callerSliceOfByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError struct {
-	fn func([]byte, func(*typex.T) bool, func(*typex.T) bool, func(t typex.T), func(t typex.T), func(t typex.T)) error
+	fn func([]byte, func(*beam.T) bool, func(*beam.T) bool, func(t beam.T), func(t beam.T), func(t beam.T)) error
 }
 
 func funcMakerSliceOfByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError(fn any) reflectx.Func {
-	f := fn.(func([]byte, func(*typex.T) bool, func(*typex.T) bool, func(t typex.T), func(t typex.T), func(t typex.T)) error)
+	f := fn.(func([]byte, func(*beam.T) bool, func(*beam.T) bool, func(t beam.T), func(t beam.T), func(t beam.T)) error)
 	return &callerSliceOfByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError{fn: f}
 }
 
@@ -325,20 +326,20 @@ func (c *callerSliceOfByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTy
 }
 
 func (c *callerSliceOfByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError) Call(args []any) []any {
-	out0 := c.fn(args[0].([]byte), args[1].(func(*typex.T) bool), args[2].(func(*typex.T) bool), args[3].(func(t typex.T)), args[4].(func(t typex.T)), args[5].(func(t typex.T)))
+	out0 := c.fn(args[0].([]byte), args[1].(func(*beam.T) bool), args[2].(func(*beam.T) bool), args[3].(func(t beam.T)), args[4].(func(t beam.T)), args[5].(func(t beam.T)))
 	return []any{out0}
 }
 
 func (c *callerSliceOfByteIterTypex۰TIterTypex۰TEmitTypex۰TEmitTypex۰TEmitTypex۰TГError) Call6x1(arg0, arg1, arg2, arg3, arg4, arg5 any) any {
-	return c.fn(arg0.([]byte), arg1.(func(*typex.T) bool), arg2.(func(*typex.T) bool), arg3.(func(t typex.T)), arg4.(func(t typex.T)), arg5.(func(t typex.T)))
+	return c.fn(arg0.([]byte), arg1.(func(*beam.T) bool), arg2.(func(*beam.T) bool), arg3.(func(t beam.T)), arg4.(func(t beam.T)), arg5.(func(t beam.T)))
 }
 
 type callerSliceOfByteIterTypex۰TIterTypex۰TIterTypex۰TГError struct {
-	fn func([]byte, func(*typex.T) bool, func(*typex.T) bool, func(*typex.T) bool) error
+	fn func([]byte, func(*beam.T) bool, func(*beam.T) bool, func(*beam.T) bool) error
 }
 
 func funcMakerSliceOfByteIterTypex۰TIterTypex۰TIterTypex۰TГError(fn any) reflectx.Func {
-	f := fn.(func([]byte, func(*typex.T) bool, func(*typex.T) bool, func(*typex.T) bool) error)
+	f := fn.(func([]byte, func(*beam.T) bool, func(*beam.T) bool, func(*beam.T) bool) error)
 	return &callerSliceOfByteIterTypex۰TIterTypex۰TIterTypex۰TГError{fn: f}
 }
 
@@ -351,20 +352,20 @@ func (c *callerSliceOfByteIterTypex۰TIterTypex۰TIterTypex۰TГError) Type() re
 }
 
 func (c *callerSliceOfByteIterTypex۰TIterTypex۰TIterTypex۰TГError) Call(args []any) []any {
-	out0 := c.fn(args[0].([]byte), args[1].(func(*typex.T) bool), args[2].(func(*typex.T) bool), args[3].(func(*typex.T) bool))
+	out0 := c.fn(args[0].([]byte), args[1].(func(*beam.T) bool), args[2].(func(*beam.T) bool), args[3].(func(*beam.T) bool))
 	return []any{out0}
 }
 
 func (c *callerSliceOfByteIterTypex۰TIterTypex۰TIterTypex۰TГError) Call4x1(arg0, arg1, arg2, arg3 any) any {
-	return c.fn(arg0.([]byte), arg1.(func(*typex.T) bool), arg2.(func(*typex.T) bool), arg3.(func(*typex.T) bool))
+	return c.fn(arg0.([]byte), arg1.(func(*beam.T) bool), arg2.(func(*beam.T) bool), arg3.(func(*beam.T) bool))
 }
 
 type callerSliceOfByteIterTypex۰ZГError struct {
-	fn func([]byte, func(*typex.Z) bool) error
+	fn func([]byte, func(*beam.Z) bool) error
 }
 
 func funcMakerSliceOfByteIterTypex۰ZГError(fn any) reflectx.Func {
-	f := fn.(func([]byte, func(*typex.Z) bool) error)
+	f := fn.(func([]byte, func(*beam.Z) bool) error)
 	return &callerSliceOfByteIterTypex۰ZГError{fn: f}
 }
 
@@ -377,20 +378,20 @@ func (c *callerSliceOfByteIterTypex۰ZГError) Type() reflect.Type {
 }
 
 func (c *callerSliceOfByteIterTypex۰ZГError) Call(args []any) []any {
-	out0 := c.fn(args[0].([]byte), args[1].(func(*typex.Z) bool))
+	out0 := c.fn(args[0].([]byte), args[1].(func(*beam.Z) bool))
 	return []any{out0}
 }
 
 func (c *callerSliceOfByteIterTypex۰ZГError) Call2x1(arg0, arg1 any) any {
-	return c.fn(arg0.([]byte), arg1.(func(*typex.Z) bool))
+	return c.fn(arg0.([]byte), arg1.(func(*beam.Z) bool))
 }
 
 type callerTypex۰XIterTypex۰YГError struct {
-	fn func(typex.X, func(*typex.Y) bool) error
+	fn func(beam.X, func(*beam.Y) bool) error
 }
 
 func funcMakerTypex۰XIterTypex۰YГError(fn any) reflectx.Func {
-	f := fn.(func(typex.X, func(*typex.Y) bool) error)
+	f := fn.(func(beam.X, func(*beam.Y) bool) error)
 	return &callerTypex۰XIterTypex۰YГError{fn: f}
 }
 
@@ -403,20 +404,20 @@ func (c *callerTypex۰XIterTypex۰YГError) Type() reflect.Type {
 }
 
 func (c *callerTypex۰XIterTypex۰YГError) Call(args []any) []any {
-	out0 := c.fn(args[0].(typex.X), args[1].(func(*typex.Y) bool))
+	out0 := c.fn(args[0].(beam.X), args[1].(func(*beam.Y) bool))
 	return []any{out0}
 }
 
 func (c *callerTypex۰XIterTypex۰YГError) Call2x1(arg0, arg1 any) any {
-	return c.fn(arg0.(typex.X), arg1.(func(*typex.Y) bool))
+	return c.fn(arg0.(beam.X), arg1.(func(*beam.Y) bool))
 }
 
 type callerTypex۰XTypex۰YГError struct {
-	fn func(typex.X, typex.Y) error
+	fn func(beam.X, beam.Y) error
 }
 
 func funcMakerTypex۰XTypex۰YГError(fn any) reflectx.Func {
-	f := fn.(func(typex.X, typex.Y) error)
+	f := fn.(func(beam.X, beam.Y) error)
 	return &callerTypex۰XTypex۰YГError{fn: f}
 }
 
@@ -429,20 +430,20 @@ func (c *callerTypex۰XTypex۰YГError) Type() reflect.Type {
 }
 
 func (c *callerTypex۰XTypex۰YГError) Call(args []any) []any {
-	out0 := c.fn(args[0].(typex.X), args[1].(typex.Y))
+	out0 := c.fn(args[0].(beam.X), args[1].(beam.Y))
 	return []any{out0}
 }
 
 func (c *callerTypex۰XTypex۰YГError) Call2x1(arg0, arg1 any) any {
-	return c.fn(arg0.(typex.X), arg1.(typex.Y))
+	return c.fn(arg0.(beam.X), arg1.(beam.Y))
 }
 
 type callerTypex۰XГError struct {
-	fn func(typex.X) error
+	fn func(beam.X) error
 }
 
 func funcMakerTypex۰XГError(fn any) reflectx.Func {
-	f := fn.(func(typex.X) error)
+	f := fn.(func(beam.X) error)
 	return &callerTypex۰XГError{fn: f}
 }
 
@@ -455,12 +456,12 @@ func (c *callerTypex۰XГError) Type() reflect.Type {
 }
 
 func (c *callerTypex۰XГError) Call(args []any) []any {
-	out0 := c.fn(args[0].(typex.X))
+	out0 := c.fn(args[0].(beam.X))
 	return []any{out0}
 }
 
 func (c *callerTypex۰XГError) Call1x1(arg0 any) any {
-	return c.fn(arg0.(typex.X))
+	return c.fn(arg0.(beam.X))
 }
 
 type callerГInt struct {
@@ -495,13 +496,15 @@ type emitNative struct {
 	est *sdf.WatermarkEstimator
 
 	ctx   context.Context
+	pn    typex.PaneInfo
 	ws    []typex.Window
 	et    typex.EventTime
 	value exec.FullValue
 }
 
-func (e *emitNative) Init(ctx context.Context, ws []typex.Window, et typex.EventTime) error {
+func (e *emitNative) Init(ctx context.Context, pn typex.PaneInfo, ws []typex.Window, et typex.EventTime) error {
 	e.ctx = ctx
+	e.pn = pn
 	e.ws = ws
 	e.et = et
 	return nil
@@ -521,8 +524,8 @@ func emitMakerTypex۰T(n exec.ElementProcessor) exec.ReusableEmitter {
 	return ret
 }
 
-func (e *emitNative) invokeTypex۰T(val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: val}
+func (e *emitNative) invokeTypex۰T(val beam.T) {
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -602,7 +605,7 @@ func iterMakerTypex۰T(s exec.ReStream) exec.ReusableInput {
 	return ret
 }
 
-func (v *iterNative) readTypex۰T(value *typex.T) bool {
+func (v *iterNative) readTypex۰T(value *beam.T) bool {
 	elm, err := v.cur.Read()
 	if err != nil {
 		if err == io.EOF {
@@ -610,7 +613,7 @@ func (v *iterNative) readTypex۰T(value *typex.T) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*value = elm.Elm.(typex.T)
+	*value = elm.Elm.(beam.T)
 	return true
 }
 
@@ -620,7 +623,7 @@ func iterMakerTypex۰Y(s exec.ReStream) exec.ReusableInput {
 	return ret
 }
 
-func (v *iterNative) readTypex۰Y(value *typex.Y) bool {
+func (v *iterNative) readTypex۰Y(value *beam.Y) bool {
 	elm, err := v.cur.Read()
 	if err != nil {
 		if err == io.EOF {
@@ -628,7 +631,7 @@ func (v *iterNative) readTypex۰Y(value *typex.Y) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*value = elm.Elm.(typex.Y)
+	*value = elm.Elm.(beam.Y)
 	return true
 }
 
@@ -638,7 +641,7 @@ func iterMakerTypex۰Z(s exec.ReStream) exec.ReusableInput {
 	return ret
 }
 
-func (v *iterNative) readTypex۰Z(value *typex.Z) bool {
+func (v *iterNative) readTypex۰Z(value *beam.Z) bool {
 	elm, err := v.cur.Read()
 	if err != nil {
 		if err == io.EOF {
@@ -646,7 +649,7 @@ func (v *iterNative) readTypex۰Z(value *typex.Z) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*value = elm.Elm.(typex.Z)
+	*value = elm.Elm.(beam.Z)
 	return true
 }
 

--- a/sdks/go/pkg/beam/util/shimx/generate.go
+++ b/sdks/go/pkg/beam/util/shimx/generate.go
@@ -328,13 +328,15 @@ type emitNative struct {
 	est   *sdf.WatermarkEstimator
 
 	ctx context.Context
+	pn typex.PaneInfo
 	ws  []typex.Window
 	et  typex.EventTime
 	value exec.FullValue
 }
 
-func (e *emitNative) Init(ctx context.Context, ws []typex.Window, et typex.EventTime) error {
+func (e *emitNative) Init(ctx context.Context, pn typex.PaneInfo, ws []typex.Window, et typex.EventTime) error {
 	e.ctx = ctx
+	e.pn = pn
 	e.ws = ws
 	e.et = et
 	return nil
@@ -357,7 +359,7 @@ func emitMaker{{$x.Name}}(n exec.ElementProcessor) exec.ReusableEmitter {
 }
 
 func (e *emitNative) invoke{{$x.Name}}({{if $x.Time -}} t typex.EventTime, {{end}}{{if $x.Key}}key {{$x.Key}}, {{end}}val {{$x.Val}}) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: {{- if $x.Time}} t{{else}} e.et{{end}}, {{- if $x.Key}} Elm: key, Elm2: val {{else}} Elm: val{{end -}} }
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: {{- if $x.Time}} t{{else}} e.et{{end}}, {{- if $x.Key}} Elm: key, Elm2: val {{else}} Elm: val{{end -}} }
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp({{- if $x.Time}} t.ToTime(){{else}} e.et.ToTime(){{end}})
 	}

--- a/sdks/go/pkg/beam/x/debug/debug.shims.go
+++ b/sdks/go/pkg/beam/x/debug/debug.shims.go
@@ -25,6 +25,7 @@ import (
 	"reflect"
 
 	// Library imports
+	"github.com/apache/beam/sdks/v2/go/pkg/beam"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime/exec"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime/graphx/schema"
@@ -52,30 +53,30 @@ func init() {
 	reflectx.RegisterStructWrapper(reflect.TypeOf((*printFn)(nil)).Elem(), wrapMakerPrintFn)
 	reflectx.RegisterStructWrapper(reflect.TypeOf((*printGBKFn)(nil)).Elem(), wrapMakerPrintGBKFn)
 	reflectx.RegisterStructWrapper(reflect.TypeOf((*printKVFn)(nil)).Elem(), wrapMakerPrintKVFn)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(context.Context, typex.T) typex.T)(nil)).Elem(), funcMakerContext۰ContextTypex۰TГTypex۰T)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(context.Context, typex.X, func(*typex.Y) bool) typex.X)(nil)).Elem(), funcMakerContext۰ContextTypex۰XIterTypex۰YГTypex۰X)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(context.Context, typex.X, typex.Y) (typex.X, typex.Y))(nil)).Elem(), funcMakerContext۰ContextTypex۰XTypex۰YГTypex۰XTypex۰Y)
-	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte, func(*typex.T) bool, func(typex.T)))(nil)).Elem(), funcMakerSliceOfByteIterTypex۰TEmitTypex۰TГ)
-	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte, func(*typex.X, *typex.Y) bool, func(typex.X, typex.Y)))(nil)).Elem(), funcMakerSliceOfByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ)
-	reflectx.RegisterFunc(reflect.TypeOf((*func(typex.T))(nil)).Elem(), funcMakerTypex۰TГ)
-	exec.RegisterEmitter(reflect.TypeOf((*func(typex.T))(nil)).Elem(), emitMakerTypex۰T)
-	exec.RegisterEmitter(reflect.TypeOf((*func(typex.X, typex.Y))(nil)).Elem(), emitMakerTypex۰XTypex۰Y)
-	exec.RegisterInput(reflect.TypeOf((*func(*typex.T) bool)(nil)).Elem(), iterMakerTypex۰T)
-	exec.RegisterInput(reflect.TypeOf((*func(*typex.X, *typex.Y) bool)(nil)).Elem(), iterMakerTypex۰XTypex۰Y)
-	exec.RegisterInput(reflect.TypeOf((*func(*typex.Y) bool)(nil)).Elem(), iterMakerTypex۰Y)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(context.Context, beam.T) beam.T)(nil)).Elem(), funcMakerContext۰ContextTypex۰TГTypex۰T)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(context.Context, beam.X, func(*beam.Y) bool) beam.X)(nil)).Elem(), funcMakerContext۰ContextTypex۰XIterTypex۰YГTypex۰X)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(context.Context, beam.X, beam.Y) (beam.X, beam.Y))(nil)).Elem(), funcMakerContext۰ContextTypex۰XTypex۰YГTypex۰XTypex۰Y)
+	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte, func(*beam.T) bool, func(beam.T)))(nil)).Elem(), funcMakerSliceOfByteIterTypex۰TEmitTypex۰TГ)
+	reflectx.RegisterFunc(reflect.TypeOf((*func([]byte, func(*beam.X, *beam.Y) bool, func(beam.X, beam.Y)))(nil)).Elem(), funcMakerSliceOfByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ)
+	reflectx.RegisterFunc(reflect.TypeOf((*func(beam.T))(nil)).Elem(), funcMakerTypex۰TГ)
+	exec.RegisterEmitter(reflect.TypeOf((*func(beam.T))(nil)).Elem(), emitMakerTypex۰T)
+	exec.RegisterEmitter(reflect.TypeOf((*func(beam.X, beam.Y))(nil)).Elem(), emitMakerTypex۰XTypex۰Y)
+	exec.RegisterInput(reflect.TypeOf((*func(*beam.T) bool)(nil)).Elem(), iterMakerTypex۰T)
+	exec.RegisterInput(reflect.TypeOf((*func(*beam.X, *beam.Y) bool)(nil)).Elem(), iterMakerTypex۰XTypex۰Y)
+	exec.RegisterInput(reflect.TypeOf((*func(*beam.Y) bool)(nil)).Elem(), iterMakerTypex۰Y)
 }
 
 func wrapMakerHeadFn(fn any) map[string]reflectx.Func {
 	dfn := fn.(*headFn)
 	return map[string]reflectx.Func{
-		"ProcessElement": reflectx.MakeFunc(func(a0 []byte, a1 func(*typex.T) bool, a2 func(typex.T)) { dfn.ProcessElement(a0, a1, a2) }),
+		"ProcessElement": reflectx.MakeFunc(func(a0 []byte, a1 func(*beam.T) bool, a2 func(beam.T)) { dfn.ProcessElement(a0, a1, a2) }),
 	}
 }
 
 func wrapMakerHeadKVFn(fn any) map[string]reflectx.Func {
 	dfn := fn.(*headKVFn)
 	return map[string]reflectx.Func{
-		"ProcessElement": reflectx.MakeFunc(func(a0 []byte, a1 func(*typex.X, *typex.Y) bool, a2 func(typex.X, typex.Y)) {
+		"ProcessElement": reflectx.MakeFunc(func(a0 []byte, a1 func(*beam.X, *beam.Y) bool, a2 func(beam.X, beam.Y)) {
 			dfn.ProcessElement(a0, a1, a2)
 		}),
 	}
@@ -84,14 +85,14 @@ func wrapMakerHeadKVFn(fn any) map[string]reflectx.Func {
 func wrapMakerPrintFn(fn any) map[string]reflectx.Func {
 	dfn := fn.(*printFn)
 	return map[string]reflectx.Func{
-		"ProcessElement": reflectx.MakeFunc(func(a0 context.Context, a1 typex.T) typex.T { return dfn.ProcessElement(a0, a1) }),
+		"ProcessElement": reflectx.MakeFunc(func(a0 context.Context, a1 beam.T) beam.T { return dfn.ProcessElement(a0, a1) }),
 	}
 }
 
 func wrapMakerPrintGBKFn(fn any) map[string]reflectx.Func {
 	dfn := fn.(*printGBKFn)
 	return map[string]reflectx.Func{
-		"ProcessElement": reflectx.MakeFunc(func(a0 context.Context, a1 typex.X, a2 func(*typex.Y) bool) typex.X {
+		"ProcessElement": reflectx.MakeFunc(func(a0 context.Context, a1 beam.X, a2 func(*beam.Y) bool) beam.X {
 			return dfn.ProcessElement(a0, a1, a2)
 		}),
 	}
@@ -100,18 +101,16 @@ func wrapMakerPrintGBKFn(fn any) map[string]reflectx.Func {
 func wrapMakerPrintKVFn(fn any) map[string]reflectx.Func {
 	dfn := fn.(*printKVFn)
 	return map[string]reflectx.Func{
-		"ProcessElement": reflectx.MakeFunc(func(a0 context.Context, a1 typex.X, a2 typex.Y) (typex.X, typex.Y) {
-			return dfn.ProcessElement(a0, a1, a2)
-		}),
+		"ProcessElement": reflectx.MakeFunc(func(a0 context.Context, a1 beam.X, a2 beam.Y) (beam.X, beam.Y) { return dfn.ProcessElement(a0, a1, a2) }),
 	}
 }
 
 type callerContext۰ContextTypex۰TГTypex۰T struct {
-	fn func(context.Context, typex.T) typex.T
+	fn func(context.Context, beam.T) beam.T
 }
 
 func funcMakerContext۰ContextTypex۰TГTypex۰T(fn any) reflectx.Func {
-	f := fn.(func(context.Context, typex.T) typex.T)
+	f := fn.(func(context.Context, beam.T) beam.T)
 	return &callerContext۰ContextTypex۰TГTypex۰T{fn: f}
 }
 
@@ -124,20 +123,20 @@ func (c *callerContext۰ContextTypex۰TГTypex۰T) Type() reflect.Type {
 }
 
 func (c *callerContext۰ContextTypex۰TГTypex۰T) Call(args []any) []any {
-	out0 := c.fn(args[0].(context.Context), args[1].(typex.T))
+	out0 := c.fn(args[0].(context.Context), args[1].(beam.T))
 	return []any{out0}
 }
 
 func (c *callerContext۰ContextTypex۰TГTypex۰T) Call2x1(arg0, arg1 any) any {
-	return c.fn(arg0.(context.Context), arg1.(typex.T))
+	return c.fn(arg0.(context.Context), arg1.(beam.T))
 }
 
 type callerContext۰ContextTypex۰XIterTypex۰YГTypex۰X struct {
-	fn func(context.Context, typex.X, func(*typex.Y) bool) typex.X
+	fn func(context.Context, beam.X, func(*beam.Y) bool) beam.X
 }
 
 func funcMakerContext۰ContextTypex۰XIterTypex۰YГTypex۰X(fn any) reflectx.Func {
-	f := fn.(func(context.Context, typex.X, func(*typex.Y) bool) typex.X)
+	f := fn.(func(context.Context, beam.X, func(*beam.Y) bool) beam.X)
 	return &callerContext۰ContextTypex۰XIterTypex۰YГTypex۰X{fn: f}
 }
 
@@ -150,20 +149,20 @@ func (c *callerContext۰ContextTypex۰XIterTypex۰YГTypex۰X) Type() reflect.Ty
 }
 
 func (c *callerContext۰ContextTypex۰XIterTypex۰YГTypex۰X) Call(args []any) []any {
-	out0 := c.fn(args[0].(context.Context), args[1].(typex.X), args[2].(func(*typex.Y) bool))
+	out0 := c.fn(args[0].(context.Context), args[1].(beam.X), args[2].(func(*beam.Y) bool))
 	return []any{out0}
 }
 
 func (c *callerContext۰ContextTypex۰XIterTypex۰YГTypex۰X) Call3x1(arg0, arg1, arg2 any) any {
-	return c.fn(arg0.(context.Context), arg1.(typex.X), arg2.(func(*typex.Y) bool))
+	return c.fn(arg0.(context.Context), arg1.(beam.X), arg2.(func(*beam.Y) bool))
 }
 
 type callerContext۰ContextTypex۰XTypex۰YГTypex۰XTypex۰Y struct {
-	fn func(context.Context, typex.X, typex.Y) (typex.X, typex.Y)
+	fn func(context.Context, beam.X, beam.Y) (beam.X, beam.Y)
 }
 
 func funcMakerContext۰ContextTypex۰XTypex۰YГTypex۰XTypex۰Y(fn any) reflectx.Func {
-	f := fn.(func(context.Context, typex.X, typex.Y) (typex.X, typex.Y))
+	f := fn.(func(context.Context, beam.X, beam.Y) (beam.X, beam.Y))
 	return &callerContext۰ContextTypex۰XTypex۰YГTypex۰XTypex۰Y{fn: f}
 }
 
@@ -176,20 +175,20 @@ func (c *callerContext۰ContextTypex۰XTypex۰YГTypex۰XTypex۰Y) Type() reflec
 }
 
 func (c *callerContext۰ContextTypex۰XTypex۰YГTypex۰XTypex۰Y) Call(args []any) []any {
-	out0, out1 := c.fn(args[0].(context.Context), args[1].(typex.X), args[2].(typex.Y))
+	out0, out1 := c.fn(args[0].(context.Context), args[1].(beam.X), args[2].(beam.Y))
 	return []any{out0, out1}
 }
 
 func (c *callerContext۰ContextTypex۰XTypex۰YГTypex۰XTypex۰Y) Call3x2(arg0, arg1, arg2 any) (any, any) {
-	return c.fn(arg0.(context.Context), arg1.(typex.X), arg2.(typex.Y))
+	return c.fn(arg0.(context.Context), arg1.(beam.X), arg2.(beam.Y))
 }
 
 type callerSliceOfByteIterTypex۰TEmitTypex۰TГ struct {
-	fn func([]byte, func(*typex.T) bool, func(typex.T))
+	fn func([]byte, func(*beam.T) bool, func(beam.T))
 }
 
 func funcMakerSliceOfByteIterTypex۰TEmitTypex۰TГ(fn any) reflectx.Func {
-	f := fn.(func([]byte, func(*typex.T) bool, func(typex.T)))
+	f := fn.(func([]byte, func(*beam.T) bool, func(beam.T)))
 	return &callerSliceOfByteIterTypex۰TEmitTypex۰TГ{fn: f}
 }
 
@@ -202,20 +201,20 @@ func (c *callerSliceOfByteIterTypex۰TEmitTypex۰TГ) Type() reflect.Type {
 }
 
 func (c *callerSliceOfByteIterTypex۰TEmitTypex۰TГ) Call(args []any) []any {
-	c.fn(args[0].([]byte), args[1].(func(*typex.T) bool), args[2].(func(typex.T)))
+	c.fn(args[0].([]byte), args[1].(func(*beam.T) bool), args[2].(func(beam.T)))
 	return []any{}
 }
 
 func (c *callerSliceOfByteIterTypex۰TEmitTypex۰TГ) Call3x0(arg0, arg1, arg2 any) {
-	c.fn(arg0.([]byte), arg1.(func(*typex.T) bool), arg2.(func(typex.T)))
+	c.fn(arg0.([]byte), arg1.(func(*beam.T) bool), arg2.(func(beam.T)))
 }
 
 type callerSliceOfByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ struct {
-	fn func([]byte, func(*typex.X, *typex.Y) bool, func(typex.X, typex.Y))
+	fn func([]byte, func(*beam.X, *beam.Y) bool, func(beam.X, beam.Y))
 }
 
 func funcMakerSliceOfByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ(fn any) reflectx.Func {
-	f := fn.(func([]byte, func(*typex.X, *typex.Y) bool, func(typex.X, typex.Y)))
+	f := fn.(func([]byte, func(*beam.X, *beam.Y) bool, func(beam.X, beam.Y)))
 	return &callerSliceOfByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ{fn: f}
 }
 
@@ -228,20 +227,20 @@ func (c *callerSliceOfByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ) Type() ref
 }
 
 func (c *callerSliceOfByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ) Call(args []any) []any {
-	c.fn(args[0].([]byte), args[1].(func(*typex.X, *typex.Y) bool), args[2].(func(typex.X, typex.Y)))
+	c.fn(args[0].([]byte), args[1].(func(*beam.X, *beam.Y) bool), args[2].(func(beam.X, beam.Y)))
 	return []any{}
 }
 
 func (c *callerSliceOfByteIterTypex۰XTypex۰YEmitTypex۰XTypex۰YГ) Call3x0(arg0, arg1, arg2 any) {
-	c.fn(arg0.([]byte), arg1.(func(*typex.X, *typex.Y) bool), arg2.(func(typex.X, typex.Y)))
+	c.fn(arg0.([]byte), arg1.(func(*beam.X, *beam.Y) bool), arg2.(func(beam.X, beam.Y)))
 }
 
 type callerTypex۰TГ struct {
-	fn func(typex.T)
+	fn func(beam.T)
 }
 
 func funcMakerTypex۰TГ(fn any) reflectx.Func {
-	f := fn.(func(typex.T))
+	f := fn.(func(beam.T))
 	return &callerTypex۰TГ{fn: f}
 }
 
@@ -254,12 +253,12 @@ func (c *callerTypex۰TГ) Type() reflect.Type {
 }
 
 func (c *callerTypex۰TГ) Call(args []any) []any {
-	c.fn(args[0].(typex.T))
+	c.fn(args[0].(beam.T))
 	return []any{}
 }
 
 func (c *callerTypex۰TГ) Call1x0(arg0 any) {
-	c.fn(arg0.(typex.T))
+	c.fn(arg0.(beam.T))
 }
 
 type emitNative struct {
@@ -268,13 +267,15 @@ type emitNative struct {
 	est *sdf.WatermarkEstimator
 
 	ctx   context.Context
+	pn    typex.PaneInfo
 	ws    []typex.Window
 	et    typex.EventTime
 	value exec.FullValue
 }
 
-func (e *emitNative) Init(ctx context.Context, ws []typex.Window, et typex.EventTime) error {
+func (e *emitNative) Init(ctx context.Context, pn typex.PaneInfo, ws []typex.Window, et typex.EventTime) error {
 	e.ctx = ctx
+	e.pn = pn
 	e.ws = ws
 	e.et = et
 	return nil
@@ -294,8 +295,8 @@ func emitMakerTypex۰T(n exec.ElementProcessor) exec.ReusableEmitter {
 	return ret
 }
 
-func (e *emitNative) invokeTypex۰T(val typex.T) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: val}
+func (e *emitNative) invokeTypex۰T(val beam.T) {
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -310,8 +311,8 @@ func emitMakerTypex۰XTypex۰Y(n exec.ElementProcessor) exec.ReusableEmitter {
 	return ret
 }
 
-func (e *emitNative) invokeTypex۰XTypex۰Y(key typex.X, val typex.Y) {
-	e.value = exec.FullValue{Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
+func (e *emitNative) invokeTypex۰XTypex۰Y(key beam.X, val beam.Y) {
+	e.value = exec.FullValue{Pane: e.pn, Windows: e.ws, Timestamp: e.et, Elm: key, Elm2: val}
 	if e.est != nil {
 		(*e.est).(sdf.TimestampObservingEstimator).ObserveTimestamp(e.et.ToTime())
 	}
@@ -355,7 +356,7 @@ func iterMakerTypex۰T(s exec.ReStream) exec.ReusableInput {
 	return ret
 }
 
-func (v *iterNative) readTypex۰T(value *typex.T) bool {
+func (v *iterNative) readTypex۰T(value *beam.T) bool {
 	elm, err := v.cur.Read()
 	if err != nil {
 		if err == io.EOF {
@@ -363,7 +364,7 @@ func (v *iterNative) readTypex۰T(value *typex.T) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*value = elm.Elm.(typex.T)
+	*value = elm.Elm.(beam.T)
 	return true
 }
 
@@ -373,7 +374,7 @@ func iterMakerTypex۰XTypex۰Y(s exec.ReStream) exec.ReusableInput {
 	return ret
 }
 
-func (v *iterNative) readTypex۰XTypex۰Y(key *typex.X, value *typex.Y) bool {
+func (v *iterNative) readTypex۰XTypex۰Y(key *beam.X, value *beam.Y) bool {
 	elm, err := v.cur.Read()
 	if err != nil {
 		if err == io.EOF {
@@ -381,8 +382,8 @@ func (v *iterNative) readTypex۰XTypex۰Y(key *typex.X, value *typex.Y) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*key = elm.Elm.(typex.X)
-	*value = elm.Elm2.(typex.Y)
+	*key = elm.Elm.(beam.X)
+	*value = elm.Elm2.(beam.Y)
 	return true
 }
 
@@ -392,7 +393,7 @@ func iterMakerTypex۰Y(s exec.ReStream) exec.ReusableInput {
 	return ret
 }
 
-func (v *iterNative) readTypex۰Y(value *typex.Y) bool {
+func (v *iterNative) readTypex۰Y(value *beam.Y) bool {
 	elm, err := v.cur.Read()
 	if err != nil {
 		if err == io.EOF {
@@ -400,7 +401,7 @@ func (v *iterNative) readTypex۰Y(value *typex.Y) bool {
 		}
 		panic(fmt.Sprintf("broken stream: %v", err))
 	}
-	*value = elm.Elm.(typex.Y)
+	*value = elm.Elm.(beam.Y)
 	return true
 }
 


### PR DESCRIPTION
fixes #31153

Rather the default pane mentioned in the bug (also shown below), 
```
got pane {Timing:0 IsFirst:false IsLast:false Index:0 NonSpeculativeIndex:0}
```

we get the [NoFiringPane](https://github.com/apache/beam/blob/master/sdks/go/pkg/beam/core/typex/fulltype.go#L439) after the fix.
```
"got pane {Timing:unknown IsFirst:true IsLast:true Index:0 NonSpeculativeIndex:0}"
```