### PR TITLE
Add missing format strings to logging calls in the Go SDK

### DIFF
--- a/sdks/go/container/tools/buffered_logging.go
+++ b/sdks/go/container/tools/buffered_logging.go
@@ -78,7 +78,7 @@ func (b *BufferedLogger) FlushAtError(ctx context.Context) {
 		return
 	}
 	for _, message := range b.logs {
-		b.logger.Errorf(ctx, message)
+		b.logger.Errorf(ctx, "%s", message)
 	}
 	b.logs = nil
 	b.lastFlush = time.Now()
@@ -91,7 +91,7 @@ func (b *BufferedLogger) FlushAtDebug(ctx context.Context) {
 		return
 	}
 	for _, message := range b.logs {
-		b.logger.Printf(ctx, message)
+		b.logger.Printf(ctx, "%s", message)
 	}
 	b.logs = nil
 	b.lastFlush = time.Now()

--- a/sdks/go/container/tools/logging_test.go
+++ b/sdks/go/container/tools/logging_test.go
@@ -85,7 +85,7 @@ func TestLogger(t *testing.T) {
 
 		catcher.err = errors.New("test error")
 		wantMsg := "checking for error?"
-		l.Printf(ctx, wantMsg)
+		l.Printf(ctx, "%s", wantMsg)
 
 		line, err := buf.ReadString('\n')
 		if err != nil {

--- a/sdks/go/pkg/beam/runners/dataflow/dataflowlib/job.go
+++ b/sdks/go/pkg/beam/runners/dataflow/dataflowlib/job.go
@@ -262,7 +262,7 @@ func WaitForCompletion(ctx context.Context, client *df.Service, project, region,
 		if err != nil {
 			return err
 		}
-		log.Infof(ctx, msg)
+		log.Infof(ctx, "%s", msg)
 		if terminal {
 			return nil
 		}

--- a/sdks/python/container/boot.go
+++ b/sdks/python/container/boot.go
@@ -188,7 +188,7 @@ func launchSDKProcess() error {
 	if err != nil {
 		fmtErr := fmt.Errorf("failed to retrieve staged files: %v", err)
 		// Send error message to logging service before returning up the call stack
-		logger.Errorf(ctx, fmtErr.Error())
+		logger.Errorf(ctx, "%s", fmtErr.Error())
 		// No need to fail the job if submission_environment_dependencies.txt cannot be loaded
 		if strings.Contains(fmtErr.Error(), "submission_environment_dependencies.txt") {
 			logger.Printf(ctx, "Ignore the error when loading submission_environment_dependencies.txt.")
@@ -214,7 +214,7 @@ func launchSDKProcess() error {
 	if setupErr := installSetupPackages(ctx, logger, fileNames, dir, requirementsFiles); setupErr != nil {
 		fmtErr := fmt.Errorf("failed to install required packages: %v", setupErr)
 		// Send error message to logging service before returning up the call stack
-		logger.Errorf(ctx, fmtErr.Error())
+		logger.Errorf(ctx, "%s", fmtErr.Error())
 		return fmtErr
 	}
 
@@ -500,6 +500,6 @@ func logSubmissionEnvDependencies(ctx context.Context, bufLogger *tools.Buffered
 	if err != nil {
 		return err
 	}
-	bufLogger.Printf(ctx, string(content))
+	bufLogger.Printf(ctx, "%s", string(content))
 	return nil
 }


### PR DESCRIPTION
Some errors in the Go Coverage runs started to surface around logging format calls missing a const format string, instead just dropping the output in. This works but can cause issues (and is now caught during testing) so adding some simple formatting strings solves that issue.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
