### PR TITLE
Allow parquet import to be None

### DIFF
--- a/sdks/python/apache_beam/io/parquetio.py
+++ b/sdks/python/apache_beam/io/parquetio.py
@@ -52,11 +52,13 @@ from apache_beam.utils.windowed_value import WindowedValue
 
 try:
   import pyarrow as pa
+  paTable = pa.Table
   import pyarrow.parquet as pq
   # pylint: disable=ungrouped-imports
   from apache_beam.typehints import arrow_type_compatibility
 except ImportError:
   pa = None
+  paTable = None
   pq = None
   ARROW_MAJOR_VERSION = None
   arrow_type_compatibility = None
@@ -176,7 +178,7 @@ class _ArrowTableToBeamRows(DoFn):
     self._beam_type = beam_type
 
   @DoFn.yields_batches
-  def process(self, element) -> Iterator[pa.Table]:
+  def process(self, element) -> Iterator[paTable]:
     yield element
 
   def infer_output_type(self, input_type):
@@ -185,7 +187,7 @@ class _ArrowTableToBeamRows(DoFn):
 
 class _BeamRowsToArrowTable(DoFn):
   @DoFn.yields_elements
-  def process_batch(self, element: pa.Table) -> Iterator[pa.Table]:
+  def process_batch(self, element: paTable) -> Iterator[paTable]:
     yield element
 
 
@@ -845,7 +847,7 @@ class _ParquetSink(filebasedsink.FileBasedSink):
         use_deprecated_int96_timestamps=self._use_deprecated_int96_timestamps,
         use_compliant_nested_type=self._use_compliant_nested_type)
 
-  def write_record(self, writer, table: pa.Table):
+  def write_record(self, writer, table: paTable):
     writer.write_table(table)
 
   def close(self, writer):


### PR DESCRIPTION
Installing pyarrow can be painful, especially on macs with M1s (I've run into this), and it isn't necessary for most python development. At the same time, doing anything involving conftest.py causes parquetio.py to be loaded[1], and this currently fails when pyarrow is not installed.

This is because even though pyarrow imports are guarded behind a try/except block, we assume that `pa` is defined later in the file when we enforce the `pa.Table` type. This works around that issue by creating a variable that holds `pa.Table` when it is defined, and None otherwise. Invoking these functions will still fail, but now you can load the file without issues.

[1] The dependency path that errors is:

```
ImportError while loading conftest '/Users/dannymccormick/beam/sdks/python/conftest.py'.
conftest.py:26: in <module>
    from apache_beam.options import pipeline_options
apache_beam/__init__.py:88: in <module>
    from apache_beam import io
apache_beam/io/__init__.py:28: in <module>
    from apache_beam.io.parquetio import *
apache_beam/io/parquetio.py:174: in <module>
    class _ArrowTableToBeamRows(DoFn):
apache_beam/io/parquetio.py:179: in _ArrowTableToBeamRows
    def process(self, element) -> Iterator[pa.Table]:
E   AttributeError: 'NoneType' object has no attribute 'Table'
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
