### PR TITLE
[python] Fix output pcollections of composite transforms that return DoOutputsTuple

### DIFF
--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -840,7 +840,9 @@ class Pipeline(HasDisplayData):
         # The DoOutputsTuple adds the PCollection to the outputs when accessed
         # except for the main tag. Add the main tag here.
         if isinstance(result, pvalue.DoOutputsTuple):
-          current.add_output(result, result._main_tag)
+          for tag, pc in list(result._pcolls.items()):
+            if tag not in current.outputs:
+              current.add_output(pc, tag)
           continue
 
         # If there is already a tag with the same name, increase a counter for

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -837,8 +837,6 @@ class Pipeline(HasDisplayData):
         self._infer_result_type(transform, tuple(inputs.values()), result)
 
         assert isinstance(result.producer.inputs, tuple)
-        # The DoOutputsTuple adds the PCollection to the outputs when accessed
-        # except for the main tag. Add the main tag here.
         if isinstance(result, pvalue.DoOutputsTuple):
           for tag, pc in list(result._pcolls.items()):
             if tag not in current.outputs:

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -1563,6 +1563,10 @@ class RunnerApiTest(unittest.TestCase):
     self.assertEqual(len(proto.components.environments), 6)
 
   def test_multiple_outputs_composite_ptransform(self):
+    """
+    Test that a composite PTransform with multiple outputs is represented
+    correctly in the pipeline proto.
+    """
     class SalesSplitter(beam.DoFn):
       def process(self, element):
         price = element['price']
@@ -1607,6 +1611,8 @@ class RunnerApiTest(unittest.TestCase):
       all_applied_transforms[xform.full_label] = xform
       current_transforms.extend(xform.parts)
     xform = all_applied_transforms['Split Sales']
+    # Confirm that Split Sales correctly has two outputs as specified by
+    #  ParDo.with_outputs in ParentSalesSplitter.
     assert len(xform.outputs) == 2
 
 

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -1563,12 +1563,6 @@ class RunnerApiTest(unittest.TestCase):
     self.assertEqual(len(proto.components.environments), 6)
 
   def test_multiple_outputs_composite_ptransform(self):
-    from apache_beam.runners.render import RenderRunner
-
-    class NoOpTransform(beam.PTransform):
-      def expand(self, pcoll):
-        return pcoll | 'No-Op' >> beam.Map(lambda x: x)
-
     class SalesSplitter(beam.DoFn):
       def process(self, element):
         price = element['price']
@@ -1579,8 +1573,8 @@ class RunnerApiTest(unittest.TestCase):
 
     class ParentSalesSplitter(beam.PTransform):
       def expand(self, pcoll):
-        return pcoll | 'Split Sales' >> beam.ParDo(
-            SalesSplitter()).with_outputs('premium_sales', 'standard_sales')
+        return pcoll | beam.ParDo(SalesSplitter()).with_outputs(
+            'premium_sales', 'standard_sales')
 
     sales_data = [
         {
@@ -1600,24 +1594,9 @@ class RunnerApiTest(unittest.TestCase):
         },
     ]
 
-    optsions = beam.options.pipeline_options.PipelineOptions(
-        "--render_output=./twopt.dot".split())
-    with beam.Pipeline(runner=RenderRunner(), options=optsions) as pipeline:
+    with beam.Pipeline() as pipeline:
       sales_records = pipeline | 'Create Sales' >> beam.Create(sales_data)
-
-      # Split the PCollection into two tagged outputs
-      split_collections = sales_records | 'Split Sales' >> ParentSalesSplitter()
-
-      premium_sales = split_collections.premium_sales
-      standard_sales = split_collections.standard_sales
-
-      # Apply the same composite transform to both PCollections
-      premium_sales_noop = premium_sales | 'Premium No-Op' >> NoOpTransform()
-      standard_sales_noop = standard_sales | 'Standard No-Op' >> NoOpTransform()
-
-      # Print the results to verify they are still there
-      _ = premium_sales_noop | 'Print Premium After No-Op' >> beam.Map(print)
-      _ = standard_sales_noop | 'Print Standard After No-Op' >> beam.Map(print)
+      _ = sales_records | 'Split Sales' >> ParentSalesSplitter()
     current_transforms = list(pipeline.transforms_stack)
     all_applied_transforms = {
         xform.full_label: xform


### PR DESCRIPTION
The pipeline proto generated by the python SDK for a composite transform that has multiple output pcollections was incorrect. It would _only_ specify the "main" pcollection of the DoOutputsTuple.

I think this has had no functional effect on runners since composite transforms are just an organizational container. I only happened to observe this from looking at visualizations of the pipeline. Here are before and after visualizations using the RenderRunner:
<img width="612" height="198" alt="twopt_before" src="https://github.com/user-attachments/assets/26f4dd89-20d6-4311-85ba-1ee7d7ff60c7" />

<img width="483" height="401" alt="twopt_after" src="https://github.com/user-attachments/assets/d0032840-38f8-45f3-817a-b738bca79a8e" />

Since the "main" pcollection is not consumed by anything, the pipeline ends up being made up of disjoint subgraphs.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
