### PR TITLE
Install go for python unit tests to use prism runner.

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -105,6 +105,7 @@ jobs:
         uses: ./.github/actions/setup-environment-action
         with:
           python-version: ${{ matrix.params.py_ver }}
+          go-version: default
       - name: Install tox
         run: pip install tox
       - name: Run tests basic linux


### PR DESCRIPTION
This PR resolves an `[Errno 2] No such file or directory: 'go' error` in Python unit tests by installing Go, which is a prerequisite for the Prism runner.

Previously, this issue was masked because the tests would silently fall back to the FnAPI runner. This change ensures that the Prism runner is used as intended when enabled as the default. This fixes the issue mentioned in https://github.com/apache/beam/pull/36219#issuecomment-3314983621