### PR TITLE
Revert "Install go for python unit tests to use prism runner."

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -105,7 +105,6 @@ jobs:
         uses: ./.github/actions/setup-environment-action
         with:
           python-version: ${{ matrix.params.py_ver }}
-          go-version: default
       - name: Install tox
         run: pip install tox
       - name: Run tests basic linux


### PR DESCRIPTION
Reverts apache/beam#36221 due to performance impact on Python unit tests.