### PR TITLE
[Prism] Fix panic in teststream

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
@@ -2056,7 +2056,7 @@ func (ss *stageState) String() string {
 	return fmt.Sprintf("[%v] IN: %v OUT: %v UP: %q %v, kind: %v", ss.ID, ss.input, ss.output, pcol, up, ss.kind)
 }
 
-// updateWatermarks performs the following operations:
+// updateWatermarks performs the following operations and returns a possible set of stages to refresh next or nil.
 //
 // Watermark_In'  = MAX(Watermark_In, MIN(U(TS_Pending), U(Watermark_InputPCollection)))
 // Watermark_Out' = MAX(Watermark_Out, MIN(Watermark_In', U(minWatermarkHold)))

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/teststream.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/teststream.go
@@ -253,6 +253,9 @@ func (ev tsFinalEvent) Execute(em *ElementManager) {
 	em.testStreamHandler.UpdateHold(em, mtime.MaxTimestamp)
 	ss := em.stages[ev.stageID]
 	kickSet := ss.updateWatermarks(em)
+	if kickSet == nil {
+		kickSet = make(set[string])
+	}
 	kickSet.insert(ev.stageID)
 	em.changedStages.merge(kickSet)
 }


### PR DESCRIPTION
I have seen the following panic in one of the precommit test logs (	https://github.com/apache/beam/actions/runs/17888682703/job/50866217521?pr=36226).

```
 0: panic in ElementManager.Bundles watermark evaluation goroutine: assignment to entry in nil map
goroutine 5592 [running]:
runtime/debug.Stack()
	/home/runner/sdk/go1.24.4/src/runtime/debug/stack.go:26 +0x5e
github.com/apache/beam/sdks/v2/go/pkg/beam/runners/prism/internal/engine.(*ElementManager).Bundles.func2.1()
	/runner/_work/beam/beam/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go:385 +0x39
panic({0x169b4c0?, 0x2d0a4a0?})
	/home/runner/sdk/go1.24.4/src/runtime/panic.go:792 +0x132
github.com/apache/beam/sdks/v2/go/pkg/beam/runners/prism/internal/engine.set[...].insert(...)
	/runner/_work/beam/beam/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go:1131
github.com/apache/beam/sdks/v2/go/pkg/beam/runners/prism/internal/engine.tsFinalEvent.Execute({{0xc153f7fc50?, 0x15c9f40?}}, 0xc212f6bd40)
	/runner/_work/beam/beam/sdks/go/pkg/beam/runners/prism/internal/engine/teststream.go:256 +0xa5
github.com/apache/beam/sdks/v2/go/pkg/beam/runners/prism/internal/engine.(*ElementManager).checkForQuiescence(0xc212f6bd40, 0xc212f6bd40?)
	/runner/_work/beam/beam/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go:542 +0x17b
github.com/apache/beam/sdks/v2/go/pkg/beam/runners/prism/internal/engine.(*ElementManager).Bundles.func2()
	/runner/_work/beam/beam/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go:497 +0x251
created by github.com/apache/beam/sdks/v2/go/pkg/beam/runners/prism/internal/engine.(*ElementManager).Bundles in goroutine 5582
	/runner/_work/beam/beam/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go:381 +0x156
```

Basically, there are a few cases where `updateWatermarks` will return a nil set(map). For example:
https://github.com/apache/beam/blob/36598323b10f7ec0df4bd5a02d4a07f9fcfc9018/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go#L2101

For most references of `updateWatermarks`, the returned map are read not written. The one in teststream, however, is an exception. Within there, we try to insert an element to this returned set(map), which leads to a panic if the set(map) is nil.
https://github.com/apache/beam/blob/36598323b10f7ec0df4bd5a02d4a07f9fcfc9018/sdks/go/pkg/beam/runners/prism/internal/engine/teststream.go#L255-L256

Here is a note from go blog (https://go.dev/blog/maps#declaration-and-initialization):
>  A nil map behaves like an empty map when reading, but attempts to write to a nil map will cause a runtime panic; don’t do that.
