### PR TITLE
Solution for #19968, python sdk justs stage up-to-date versions on the required files

### DIFF
--- a/sdks/python/apache_beam/runners/portability/stager.py
+++ b/sdks/python/apache_beam/runners/portability/stager.py
@@ -434,7 +434,7 @@ class Stager(object):
       temp_dir: Optional[str] = None,
       pypi_requirements: Optional[List[str]] = None,
       populate_requirements_cache: Optional[Callable[[str, str, bool],
-                                                     None]] = None,
+                                                     List[str]]] = None,
       staging_location: Optional[str] = None):
     """For internal use only; no backwards-compatibility guarantees.
 
@@ -738,7 +738,9 @@ class Stager(object):
   @retry.with_exponential_backoff(
       num_retries=4, retry_filter=retry_on_non_zero_exit)
   def _populate_requirements_cache(
-      requirements_file, cache_dir, populate_cache_with_sdists=False) -> List[str]:
+      requirements_file,
+      cache_dir,
+      populate_cache_with_sdists=False) -> List[str]:
     # The 'pip download' command will not download again if it finds the
     # tarball with the proper version already present.
     # It will get the packages downloaded in the order they are presented in

--- a/sdks/python/apache_beam/runners/portability/stager_test.py
+++ b/sdks/python/apache_beam/runners/portability/stager_test.py
@@ -100,8 +100,7 @@ class StagerTest(unittest.TestCase):
     _ = requirements_file
     _ = populate_cache_with_sdists
     pkgs = [
-      os.path.join(cache_dir, 'abc.txt'),
-      os.path.join(cache_dir, 'def.txt')
+        os.path.join(cache_dir, 'abc.txt'), os.path.join(cache_dir, 'def.txt')
     ]
     for pkg in pkgs:
       self.create_temp_file(pkg, 'nothing')


### PR DESCRIPTION
Refactor how Python package dependencies are staged and cached in the Apache Beam portability runner. The main change is to track and use the exact set of downloaded package files, rather than globbing all files in the cache directory. Also updated the tests accordingly.

- fixes #19968
