### PR TITLE
Increase expansion service connection timeout to 30 sec.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/process.go
+++ b/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/process.go
@@ -94,7 +94,7 @@ func (e *ExpansionServiceRunner) pingEndpoint(timeout time.Duration) error {
 	return nil
 }
 
-const connectionTimeout = 15 * time.Second
+const connectionTimeout = 30 * time.Second
 
 // StartService starts the expansion service for a given ExpansionServiceRunner. If this is
 // called and does not return an error, the expansion service will be running in the background


### PR DESCRIPTION
To reduce test flakiness for `TestAutomatedExpansionService` (https://github.com/apache/beam/actions/runs/17935293271/job/51000252392)

Error message:
```
--- FAIL: TestAutomatedExpansionService (19.16s)
    expansion_test.go:82: failed to start expansion service JAR, got context deadline exceeded
```


We can repeat the test with 
```
go test -v -count=10 github.com/apache/beam/sdks/v2/go/test/integration/xlang -run TestAutomatedExpansionService
```

