### PR TITLE
Revert "Update dill requirement from <0.3.2,>=0.3.1.1 to >=0.3.1.1,<0.4.1 in /sdks/python"

### DIFF
--- a/sdks/python/container/base_image_requirements_manual.txt
+++ b/sdks/python/container/base_image_requirements_manual.txt
@@ -42,4 +42,4 @@ scikit-learn
 build>=1.0,<2 # tool to build sdist from setup.py in stager.
 # Dill 0.3.1.1 is included as a base manual requirement so is avaiable to users
 # with pickle_library=dill, but apache-beam does not have a hard dependency.
-dill>=0.3.1.1,<0.4.1
+dill>=0.3.1.1,<0.3.2


### PR DESCRIPTION
Reverts apache/beam#36147

Only dill 0.3.1.1 should be installed in base containers by default.