### PR TITLE
[Java]Fix infinite retry issue in BigQuery getDatasetLocation() for non-existent datasets

### DIFF
--- a/sdks/java/io/debezium/src/main/java/org/apache/beam/io/debezium/DebeziumReadSchemaTransformProvider.java
+++ b/sdks/java/io/debezium/src/main/java/org/apache/beam/io/debezium/DebeziumReadSchemaTransformProvider.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.coders.RowCoder;
 import org.apache.beam.sdk.schemas.Schema;

--- a/sdks/java/io/debezium/src/main/java/org/apache/beam/io/debezium/DebeziumReadSchemaTransformProvider.java
+++ b/sdks/java/io/debezium/src/main/java/org/apache/beam/io/debezium/DebeziumReadSchemaTransformProvider.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.coders.RowCoder;
 import org.apache.beam.sdk.schemas.Schema;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpers.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpers.java
@@ -632,20 +632,17 @@ public class BigQueryHelpers {
   }
 
   static String getDatasetLocation(
-      DatasetService datasetService, String projectId, String datasetId) {
-    Dataset dataset;
+      DatasetService datasetService, String projectId, String datasetId)
+      throws IOException, InterruptedException {
     try {
-      dataset = datasetService.getDataset(projectId, datasetId);
-    } catch (Exception e) {
-      if (e instanceof InterruptedException) {
-        Thread.currentThread().interrupt();
-      }
-      throw new RuntimeException(
-          String.format(
-              "unable to obtain dataset for dataset %s in project %s", datasetId, projectId),
-          e);
+      Dataset dataset = datasetService.getDataset(projectId, datasetId);
+      return dataset.getLocation();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw e;
     }
-    return dataset.getLocation();
+    // Remove the catch (Exception e) block entirely
+    // Let IOException bubble up naturally without wrapping it in RuntimeException
   }
 
   static void verifyTablePresence(DatasetService datasetService, TableReference table) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpers.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpers.java
@@ -637,6 +637,21 @@ public class BigQueryHelpers {
     try {
       Dataset dataset = datasetService.getDataset(projectId, datasetId);
       return dataset.getLocation();
+    } catch (IOException e) {
+      ApiErrorExtractor errorExtractor = new ApiErrorExtractor();
+      if (errorExtractor.itemNotFound(e)
+          || e instanceof BigQueryServicesImpl.RetryExhaustedException) {
+        LOG.error(
+            "Terminal failure obtaining dataset {} in project {}. Resource missing or retries exhausted.",
+            datasetId,
+            projectId);
+        throw new IllegalStateException(
+            String.format(
+                "Dataset %s not found or inaccessible in project %s. Please ensure the dataset exists before running the pipeline.",
+                datasetId, projectId),
+            e);
+      }
+      throw e;
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw e;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpers.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpers.java
@@ -641,8 +641,6 @@ public class BigQueryHelpers {
       Thread.currentThread().interrupt();
       throw e;
     }
-    // Remove the catch (Exception e) block entirely
-    // Let IOException bubble up naturally without wrapping it in RuntimeException
   }
 
   static void verifyTablePresence(DatasetService datasetService, TableReference table) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java
@@ -200,6 +200,12 @@ public class BigQueryServicesImpl implements BigQueryServices {
   private static final Metadata.Key<RetryInfo> KEY_RETRY_INFO =
       ProtoUtils.keyForProto(RetryInfo.getDefaultInstance());
 
+  public static class RetryExhaustedException extends IOException {
+    public RetryExhaustedException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+
   @Override
   public JobService getJobService(BigQueryOptions options) {
     return new JobServiceImpl(options);
@@ -1688,7 +1694,7 @@ public class BigQueryServicesImpl implements BigQueryServices {
         LOG.info("Ignore the error and retry the request.", e);
       }
     } while (nextBackOff(sleeper, backoff));
-    throw new IOException(errorMessage, lastException);
+    throw new RetryExhaustedException(errorMessage, lastException);
   }
 
   /** Identical to {@link BackOffUtils#next} but without checked IOException. */

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/UpdateSchemaDestination.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/UpdateSchemaDestination.java
@@ -302,9 +302,14 @@ public class UpdateSchemaDestination<DestinationT>
         loadJobProjectId == null || loadJobProjectId.get() == null
             ? tableReference.getProjectId()
             : loadJobProjectId.get();
-    String bqLocation =
-        BigQueryHelpers.getDatasetLocation(
-            datasetService, tableReference.getProjectId(), tableReference.getDatasetId());
+    String bqLocation;
+    try {
+      bqLocation =
+          BigQueryHelpers.getDatasetLocation(
+              datasetService, tableReference.getProjectId(), tableReference.getDatasetId());
+    } catch (IOException | InterruptedException e) {
+      throw new RuntimeException(e);
+    }
 
     BigQueryHelpers.PendingJob retryJob =
         new BigQueryHelpers.PendingJob(

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/UpdateSchemaDestination.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/UpdateSchemaDestination.java
@@ -317,7 +317,7 @@ public class UpdateSchemaDestination<DestinationT>
                 tableReference.getDatasetId(), tableReference.getProjectId()),
             e);
       }
-      // For other IOExceptions, wrap and throw
+
       throw new RuntimeException(
           String.format(
               "Unable to get dataset location for dataset %s in project %s",

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/UpdateSchemaDestination.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/UpdateSchemaDestination.java
@@ -60,9 +60,9 @@ import org.slf4j.LoggerFactory;
  */
 @SuppressWarnings({"nullness"})
 public class UpdateSchemaDestination<DestinationT>
-  extends DoFn<
-  Iterable<KV<DestinationT, WriteTables.Result>>,
-  Iterable<KV<TableDestination, WriteTables.Result>>> {
+    extends DoFn<
+        Iterable<KV<DestinationT, WriteTables.Result>>,
+        Iterable<KV<TableDestination, WriteTables.Result>>> {
 
   private static final Logger LOG = LoggerFactory.getLogger(UpdateSchemaDestination.class);
   private final BigQueryServices bqServices;
@@ -83,9 +83,9 @@ public class UpdateSchemaDestination<DestinationT>
     final BoundedWindow window;
 
     public PendingJobData(
-      BigQueryHelpers.PendingJob retryJob,
-      TableDestination tableDestination,
-      BoundedWindow window) {
+        BigQueryHelpers.PendingJob retryJob,
+        TableDestination tableDestination,
+        BoundedWindow window) {
       this.retryJob = retryJob;
       this.tableDestination = tableDestination;
       this.window = window;
@@ -95,15 +95,15 @@ public class UpdateSchemaDestination<DestinationT>
   private final Map<DestinationT, PendingJobData> pendingJobs = Maps.newHashMap();
 
   public UpdateSchemaDestination(
-    BigQueryServices bqServices,
-    PCollectionView<String> zeroLoadJobIdPrefixView,
-    @Nullable ValueProvider<String> loadJobProjectId,
-    BigQueryIO.Write.WriteDisposition writeDisposition,
-    BigQueryIO.Write.CreateDisposition createDisposition,
-    int maxRetryJobs,
-    @Nullable String kmsKey,
-    Set<BigQueryIO.Write.SchemaUpdateOption> schemaUpdateOptions,
-    DynamicDestinations<?, DestinationT> dynamicDestinations) {
+      BigQueryServices bqServices,
+      PCollectionView<String> zeroLoadJobIdPrefixView,
+      @Nullable ValueProvider<String> loadJobProjectId,
+      BigQueryIO.Write.WriteDisposition writeDisposition,
+      BigQueryIO.Write.CreateDisposition createDisposition,
+      int maxRetryJobs,
+      @Nullable String kmsKey,
+      Set<BigQueryIO.Write.SchemaUpdateOption> schemaUpdateOptions,
+      DynamicDestinations<?, DestinationT> dynamicDestinations) {
     this.loadJobProjectId = loadJobProjectId;
     this.zeroLoadJobIdPrefixView = zeroLoadJobIdPrefixView;
     this.bqServices = bqServices;
@@ -123,8 +123,8 @@ public class UpdateSchemaDestination<DestinationT>
   TableDestination getTableWithDefaultProject(DestinationT destination) {
     if (dynamicDestinations.getPipelineOptions() == null) {
       throw new IllegalStateException(
-        "Unexpected null pipeline option for DynamicDestination object. "
-          + "Need to call setSideInputAccessorFromProcessContext(context) before use it.");
+          "Unexpected null pipeline option for DynamicDestination object. "
+              + "Need to call setSideInputAccessorFromProcessContext(context) before use it.");
     }
     BigQueryOptions options = dynamicDestinations.getPipelineOptions().as(BigQueryOptions.class);
     TableDestination tableDestination = dynamicDestinations.getTable(destination);
@@ -132,9 +132,9 @@ public class UpdateSchemaDestination<DestinationT>
 
     if (Strings.isNullOrEmpty(tableReference.getProjectId())) {
       tableReference.setProjectId(
-        options.getBigQueryProject() == null
-          ? options.getProject()
-          : options.getBigQueryProject());
+          options.getBigQueryProject() == null
+              ? options.getProject()
+              : options.getBigQueryProject());
       tableDestination = tableDestination.withTableReference(tableReference);
     }
 
@@ -143,10 +143,10 @@ public class UpdateSchemaDestination<DestinationT>
 
   @ProcessElement
   public void processElement(
-    @Element Iterable<KV<DestinationT, WriteTables.Result>> element,
-    ProcessContext context,
-    BoundedWindow window)
-    throws IOException {
+      @Element Iterable<KV<DestinationT, WriteTables.Result>> element,
+      ProcessContext context,
+      BoundedWindow window)
+      throws IOException {
     dynamicDestinations.setSideInputAccessorFromProcessContext(context);
     List<KV<TableDestination, WriteTables.Result>> outputs = Lists.newArrayList();
     for (KV<DestinationT, WriteTables.Result> entry : element) {
@@ -160,33 +160,33 @@ public class UpdateSchemaDestination<DestinationT>
       TableSchema schema = dynamicDestinations.getSchema(destination);
       TableReference tableReference = tableDestination.getTableReference();
       String jobIdPrefix =
-        BigQueryResourceNaming.createJobIdWithDestination(
-          context.sideInput(zeroLoadJobIdPrefixView),
-          tableDestination,
-          1,
-          context.pane().getIndex());
+          BigQueryResourceNaming.createJobIdWithDestination(
+              context.sideInput(zeroLoadJobIdPrefixView),
+              tableDestination,
+              1,
+              context.pane().getIndex());
       BigQueryHelpers.PendingJob updateSchemaDestinationJob =
-        startZeroLoadJob(
-          getJobService(context.getPipelineOptions().as(BigQueryOptions.class)),
-          getDatasetService(context.getPipelineOptions().as(BigQueryOptions.class)),
-          jobIdPrefix,
-          tableReference,
-          tableDestination.getTimePartitioning(),
-          tableDestination.getClustering(),
-          schema,
-          writeDisposition,
-          createDisposition,
-          schemaUpdateOptions);
+          startZeroLoadJob(
+              getJobService(context.getPipelineOptions().as(BigQueryOptions.class)),
+              getDatasetService(context.getPipelineOptions().as(BigQueryOptions.class)),
+              jobIdPrefix,
+              tableReference,
+              tableDestination.getTimePartitioning(),
+              tableDestination.getClustering(),
+              schema,
+              writeDisposition,
+              createDisposition,
+              schemaUpdateOptions);
       if (updateSchemaDestinationJob != null) {
         pendingJobs.put(
-          destination, new PendingJobData(updateSchemaDestinationJob, tableDestination, window));
+            destination, new PendingJobData(updateSchemaDestinationJob, tableDestination, window));
       }
     }
     if (!pendingJobs.isEmpty()) {
       LOG.info(
-        "Added {} pending jobs to update the schema for each destination before copying {} temp tables.",
-        pendingJobs.size(),
-        outputs.size());
+          "Added {} pending jobs to update the schema for each destination before copying {} temp tables.",
+          pendingJobs.size(),
+          outputs.size());
     }
     context.output(outputs);
   }
@@ -210,61 +210,61 @@ public class UpdateSchemaDestination<DestinationT>
   @FinishBundle
   public void finishBundle(FinishBundleContext context) throws Exception {
     DatasetService datasetService =
-      getDatasetService(context.getPipelineOptions().as(BigQueryOptions.class));
+        getDatasetService(context.getPipelineOptions().as(BigQueryOptions.class));
     BigQueryHelpers.PendingJobManager jobManager = new BigQueryHelpers.PendingJobManager();
     for (final PendingJobData pendingJobData : pendingJobs.values()) {
       jobManager =
-        jobManager.addPendingJob(
-          pendingJobData.retryJob,
-          j -> {
-            try {
-              if (pendingJobData.tableDestination.getTableDescription() != null) {
-                TableReference ref = pendingJobData.tableDestination.getTableReference();
-                datasetService.patchTableDescription(
-                  ref.clone()
-                    .setTableId(BigQueryHelpers.stripPartitionDecorator(ref.getTableId())),
-                  pendingJobData.tableDestination.getTableDescription());
-              }
-            } catch (IOException | InterruptedException e) {
-              return e;
-            }
-            return null;
-          });
+          jobManager.addPendingJob(
+              pendingJobData.retryJob,
+              j -> {
+                try {
+                  if (pendingJobData.tableDestination.getTableDescription() != null) {
+                    TableReference ref = pendingJobData.tableDestination.getTableReference();
+                    datasetService.patchTableDescription(
+                        ref.clone()
+                            .setTableId(BigQueryHelpers.stripPartitionDecorator(ref.getTableId())),
+                        pendingJobData.tableDestination.getTableDescription());
+                  }
+                } catch (IOException | InterruptedException e) {
+                  return e;
+                }
+                return null;
+              });
     }
     jobManager.waitForDone();
   }
 
   private BigQueryHelpers.PendingJob startZeroLoadJob(
-    BigQueryServices.JobService jobService,
-    DatasetService datasetService,
-    String jobIdPrefix,
-    TableReference tableReference,
-    TimePartitioning timePartitioning,
-    Clustering clustering,
-    @Nullable TableSchema schema,
-    BigQueryIO.Write.WriteDisposition writeDisposition,
-    BigQueryIO.Write.CreateDisposition createDisposition,
-    Set<BigQueryIO.Write.SchemaUpdateOption> schemaUpdateOptions) {
+      BigQueryServices.JobService jobService,
+      DatasetService datasetService,
+      String jobIdPrefix,
+      TableReference tableReference,
+      TimePartitioning timePartitioning,
+      Clustering clustering,
+      @Nullable TableSchema schema,
+      BigQueryIO.Write.WriteDisposition writeDisposition,
+      BigQueryIO.Write.CreateDisposition createDisposition,
+      Set<BigQueryIO.Write.SchemaUpdateOption> schemaUpdateOptions) {
     JobConfigurationLoad loadConfig =
-      new JobConfigurationLoad()
-        .setDestinationTable(tableReference)
-        .setSchema(schema)
-        .setWriteDisposition(writeDisposition.name())
-        .setCreateDisposition(createDisposition.name())
-        .setSourceFormat("NEWLINE_DELIMITED_JSON");
+        new JobConfigurationLoad()
+            .setDestinationTable(tableReference)
+            .setSchema(schema)
+            .setWriteDisposition(writeDisposition.name())
+            .setCreateDisposition(createDisposition.name())
+            .setSourceFormat("NEWLINE_DELIMITED_JSON");
     if (schemaUpdateOptions != null) {
       List<String> options =
-        schemaUpdateOptions.stream()
-          .map(BigQueryIO.Write.SchemaUpdateOption::name)
-          .collect(Collectors.toList());
+          schemaUpdateOptions.stream()
+              .map(BigQueryIO.Write.SchemaUpdateOption::name)
+              .collect(Collectors.toList());
       loadConfig.setSchemaUpdateOptions(options);
     }
     if (!loadConfig
-      .getWriteDisposition()
-      .equals(BigQueryIO.Write.WriteDisposition.WRITE_TRUNCATE.toString())
-      && !loadConfig
-      .getWriteDisposition()
-      .equals(BigQueryIO.Write.WriteDisposition.WRITE_APPEND.toString())) {
+            .getWriteDisposition()
+            .equals(BigQueryIO.Write.WriteDisposition.WRITE_TRUNCATE.toString())
+        && !loadConfig
+            .getWriteDisposition()
+            .equals(BigQueryIO.Write.WriteDisposition.WRITE_APPEND.toString())) {
       return null;
     }
     final Table destinationTable;
@@ -281,9 +281,9 @@ public class UpdateSchemaDestination<DestinationT>
     // or when destination schema is null (the write will set the schema)
     // or when provided schema is null (e.g. when using CREATE_NEVER disposition)
     if (destinationTable.getSchema() == null
-      || destinationTable.getSchema().isEmpty()
-      || destinationTable.getSchema().equals(schema)
-      || schema == null) {
+        || destinationTable.getSchema().isEmpty()
+        || destinationTable.getSchema().equals(schema)
+        || schema == null) {
       return null;
     }
     if (timePartitioning != null) {
@@ -296,67 +296,67 @@ public class UpdateSchemaDestination<DestinationT>
 
     if (kmsKey != null) {
       loadConfig.setDestinationEncryptionConfiguration(
-        new EncryptionConfiguration().setKmsKeyName(kmsKey));
+          new EncryptionConfiguration().setKmsKeyName(kmsKey));
     }
     String projectId =
-      loadJobProjectId == null || loadJobProjectId.get() == null
-        ? tableReference.getProjectId()
-        : loadJobProjectId.get();
+        loadJobProjectId == null || loadJobProjectId.get() == null
+            ? tableReference.getProjectId()
+            : loadJobProjectId.get();
     String bqLocation =
-      BigQueryHelpers.getDatasetLocation(
-        datasetService, tableReference.getProjectId(), tableReference.getDatasetId());
+        BigQueryHelpers.getDatasetLocation(
+            datasetService, tableReference.getProjectId(), tableReference.getDatasetId());
 
     BigQueryHelpers.PendingJob retryJob =
-      new BigQueryHelpers.PendingJob(
-        // Function to load the data.
-        jobId -> {
-          JobReference jobRef =
-            new JobReference()
-              .setProjectId(projectId)
-              .setJobId(jobId.getJobId())
-              .setLocation(bqLocation);
-          LOG.info(
-            "Loading zero rows using job {}, job id {} iteration {}",
-            tableReference,
-            jobRef,
-            jobId.getRetryIndex());
-          try {
-            jobService.startLoadJob(
-              jobRef, loadConfig, new ByteArrayContent("text/plain", new byte[0]));
-          } catch (IOException | InterruptedException e) {
-            LOG.warn("Schema update load job {} failed with {}", jobRef, e.toString());
-            throw new RuntimeException(e);
-          }
-          return null;
-        },
-        // Function to poll the result of a load job.
-        jobId -> {
-          JobReference jobRef =
-            new JobReference()
-              .setProjectId(projectId)
-              .setJobId(jobId.getJobId())
-              .setLocation(bqLocation);
-          try {
-            return jobService.pollJob(jobRef, BatchLoads.LOAD_JOB_POLL_MAX_RETRIES);
-          } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-          }
-        },
-        // Function to lookup a job.
-        jobId -> {
-          JobReference jobRef =
-            new JobReference()
-              .setProjectId(projectId)
-              .setJobId(jobId.getJobId())
-              .setLocation(bqLocation);
-          try {
-            return jobService.getJob(jobRef);
-          } catch (InterruptedException | IOException e) {
-            throw new RuntimeException(e);
-          }
-        },
-        maxRetryJobs,
-        jobIdPrefix);
+        new BigQueryHelpers.PendingJob(
+            // Function to load the data.
+            jobId -> {
+              JobReference jobRef =
+                  new JobReference()
+                      .setProjectId(projectId)
+                      .setJobId(jobId.getJobId())
+                      .setLocation(bqLocation);
+              LOG.info(
+                  "Loading zero rows using job {}, job id {} iteration {}",
+                  tableReference,
+                  jobRef,
+                  jobId.getRetryIndex());
+              try {
+                jobService.startLoadJob(
+                    jobRef, loadConfig, new ByteArrayContent("text/plain", new byte[0]));
+              } catch (IOException | InterruptedException e) {
+                LOG.warn("Schema update load job {} failed with {}", jobRef, e.toString());
+                throw new RuntimeException(e);
+              }
+              return null;
+            },
+            // Function to poll the result of a load job.
+            jobId -> {
+              JobReference jobRef =
+                  new JobReference()
+                      .setProjectId(projectId)
+                      .setJobId(jobId.getJobId())
+                      .setLocation(bqLocation);
+              try {
+                return jobService.pollJob(jobRef, BatchLoads.LOAD_JOB_POLL_MAX_RETRIES);
+              } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+              }
+            },
+            // Function to lookup a job.
+            jobId -> {
+              JobReference jobRef =
+                  new JobReference()
+                      .setProjectId(projectId)
+                      .setJobId(jobId.getJobId())
+                      .setLocation(bqLocation);
+              try {
+                return jobService.getJob(jobRef);
+              } catch (InterruptedException | IOException e) {
+                throw new RuntimeException(e);
+              }
+            },
+            maxRetryJobs,
+            jobIdPrefix);
     return retryJob;
   }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteRename.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteRename.java
@@ -331,7 +331,6 @@ class WriteRename
             new EncryptionConfiguration().setKmsKeyName(kmsKey));
       }
 
-      // Move dataset location lookup OUTSIDE the retry loop and handle failures immediately
       String bqLocation;
       try {
         bqLocation =
@@ -346,7 +345,6 @@ class WriteRename
                   ref.getDatasetId(), ref.getProjectId()),
               e);
         }
-        // For other IOExceptions, wrap and throw
         throw new RuntimeException(
             String.format(
                 "Unable to get dataset location for dataset %s in project %s",
@@ -373,7 +371,7 @@ class WriteRename
                     new JobReference()
                         .setProjectId(projectId)
                         .setJobId(jobId.getJobId())
-                        .setLocation(bqLocation); // Use pre-resolved location
+                        .setLocation(bqLocation);
                 LOG.info(
                     "Starting copy job for table {} using  {}, job id iteration {}",
                     ref,
@@ -393,7 +391,7 @@ class WriteRename
                     new JobReference()
                         .setProjectId(projectId)
                         .setJobId(jobId.getJobId())
-                        .setLocation(bqLocation); // Use pre-resolved location
+                        .setLocation(bqLocation);
                 try {
                   return jobService.pollJob(jobRef, BatchLoads.LOAD_JOB_POLL_MAX_RETRIES);
                 } catch (InterruptedException e) {
@@ -406,7 +404,7 @@ class WriteRename
                     new JobReference()
                         .setProjectId(projectId)
                         .setJobId(jobId.getJobId())
-                        .setLocation(bqLocation); // Use pre-resolved location
+                        .setLocation(bqLocation);
                 try {
                   return jobService.getJob(jobRef);
                 } catch (InterruptedException | IOException e) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteRename.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteRename.java
@@ -329,9 +329,14 @@ class WriteRename
             new EncryptionConfiguration().setKmsKeyName(kmsKey));
       }
 
-      String bqLocation =
-          BigQueryHelpers.getDatasetLocation(
-              datasetService, ref.getProjectId(), ref.getDatasetId());
+      String bqLocation;
+      try {
+        bqLocation =
+            BigQueryHelpers.getDatasetLocation(
+                datasetService, ref.getProjectId(), ref.getDatasetId());
+      } catch (IOException | InterruptedException e) {
+        throw new RuntimeException(e);
+      }
 
       String projectId =
           loadJobProjectId == null || loadJobProjectId.get() == null

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteTables.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteTables.java
@@ -505,8 +505,14 @@ class WriteTables<DestinationT extends @NonNull Object>
         loadJobProjectId == null || loadJobProjectId.get() == null
             ? ref.getProjectId()
             : loadJobProjectId.get();
-    String bqLocation =
-        BigQueryHelpers.getDatasetLocation(datasetService, ref.getProjectId(), ref.getDatasetId());
+    String bqLocation;
+    try {
+      bqLocation =
+          BigQueryHelpers.getDatasetLocation(
+              datasetService, ref.getProjectId(), ref.getDatasetId());
+    } catch (IOException | InterruptedException e) {
+      throw new RuntimeException(e);
+    }
 
     PendingJob retryJob =
         new PendingJob(

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteTables.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteTables.java
@@ -27,7 +27,6 @@ import com.google.api.services.bigquery.model.TableReference;
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.api.services.bigquery.model.TimePartitioning;
 import com.google.auto.value.AutoValue;
-import com.google.cloud.hadoop.util.ApiErrorExtractor;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -95,9 +94,9 @@ import org.slf4j.LoggerFactory;
  * {@link KV} maps the final table to itself.
  */
 class WriteTables<DestinationT extends @NonNull Object>
-    extends PTransform<
-        PCollection<KV<ShardedKey<DestinationT>, WritePartition.Result>>,
-        PCollection<KV<DestinationT, WriteTables.Result>>> {
+  extends PTransform<
+  PCollection<KV<ShardedKey<DestinationT>, WritePartition.Result>>,
+  PCollection<KV<DestinationT, WriteTables.Result>>> {
   @AutoValue
   abstract static class Result {
     abstract String getTableName();
@@ -117,7 +116,7 @@ class WriteTables<DestinationT extends @NonNull Object>
     @Override
     public Result decode(InputStream inStream) throws CoderException, IOException {
       return new AutoValue_WriteTables_Result(
-          StringUtf8Coder.of().decode(inStream), BooleanCoder.of().decode(inStream));
+        StringUtf8Coder.of().decode(inStream), BooleanCoder.of().decode(inStream));
     }
   }
 
@@ -144,7 +143,7 @@ class WriteTables<DestinationT extends @NonNull Object>
   private final @Nullable String tempDataset;
 
   private class WriteTablesDoFn
-      extends DoFn<KV<ShardedKey<DestinationT>, WritePartition.Result>, KV<DestinationT, Result>> {
+    extends DoFn<KV<ShardedKey<DestinationT>, WritePartition.Result>, KV<DestinationT, Result>> {
 
     private Map<DestinationT, String> jsonSchemas = Maps.newHashMap();
 
@@ -159,13 +158,13 @@ class WriteTables<DestinationT extends @NonNull Object>
       final boolean isFirstPane;
 
       public PendingJobData(
-          BoundedWindow window,
-          BigQueryHelpers.PendingJob retryJob,
-          List<String> partitionFiles,
-          TableDestination tableDestination,
-          TableReference tableReference,
-          DestinationT destinationT,
-          boolean isFirstPane) {
+        BoundedWindow window,
+        BigQueryHelpers.PendingJob retryJob,
+        List<String> partitionFiles,
+        TableDestination tableDestination,
+        TableReference tableReference,
+        DestinationT destinationT,
+        boolean isFirstPane) {
         this.window = window;
         this.retryJob = retryJob;
         this.partitionFiles = partitionFiles;
@@ -188,10 +187,10 @@ class WriteTables<DestinationT extends @NonNull Object>
 
     @ProcessElement
     public void processElement(
-        @Element KV<ShardedKey<DestinationT>, WritePartition.Result> element,
-        ProcessContext c,
-        BoundedWindow window)
-        throws Exception {
+      @Element KV<ShardedKey<DestinationT>, WritePartition.Result> element,
+      ProcessContext c,
+      BoundedWindow window)
+      throws Exception {
       dynamicDestinations.setSideInputAccessorFromProcessContext(c);
       DestinationT destination = c.element().getKey().getKey();
       TableSchema tableSchema;
@@ -200,54 +199,54 @@ class WriteTables<DestinationT extends @NonNull Object>
       } else if (jsonSchemas.containsKey(destination)) {
         // tableSchema for the destination stored in cache (jsonSchemas)
         tableSchema =
-            BigQueryHelpers.fromJsonString(jsonSchemas.get(destination), TableSchema.class);
+          BigQueryHelpers.fromJsonString(jsonSchemas.get(destination), TableSchema.class);
       } else {
         tableSchema = dynamicDestinations.getSchema(destination);
         Preconditions.checkArgumentNotNull(
-            tableSchema,
-            "Unless create disposition is %s, a schema must be specified, i.e. "
-                + "DynamicDestinations.getSchema() may not return null. "
-                + "However, create disposition is %s, and %s returned null for destination %s",
-            CreateDisposition.CREATE_NEVER,
-            firstPaneCreateDisposition,
-            dynamicDestinations,
-            destination);
+          tableSchema,
+          "Unless create disposition is %s, a schema must be specified, i.e. "
+            + "DynamicDestinations.getSchema() may not return null. "
+            + "However, create disposition is %s, and %s returned null for destination %s",
+          CreateDisposition.CREATE_NEVER,
+          firstPaneCreateDisposition,
+          dynamicDestinations,
+          destination);
         LOG.debug("Fetched TableSchema for table {}:\n\t{}", destination, tableSchema);
         jsonSchemas.put(destination, BigQueryHelpers.toJsonString(tableSchema));
       }
 
       TableDestination tableDestination = dynamicDestinations.getTable(destination);
       checkArgument(
-          tableDestination != null,
-          "DynamicDestinations.getTable() may not return null, "
-              + "but %s returned null for destination %s",
-          dynamicDestinations,
-          destination);
+        tableDestination != null,
+        "DynamicDestinations.getTable() may not return null, "
+          + "but %s returned null for destination %s",
+        dynamicDestinations,
+        destination);
       boolean destinationCoderSupportsClustering =
-          !(dynamicDestinations.getDestinationCoder() instanceof TableDestinationCoderV2);
+        !(dynamicDestinations.getDestinationCoder() instanceof TableDestinationCoderV2);
       checkArgument(
-          tableDestination.getClustering() == null || destinationCoderSupportsClustering,
-          "DynamicDestinations.getTable() may only return destinations with clustering configured"
-              + " if a destination coder is supplied that supports clustering, but %s is configured"
-              + " to use TableDestinationCoderV2. Set withClustering() on BigQueryIO.write() and, "
-              + " if you provided a custom DynamicDestinations instance, override"
-              + " getDestinationCoder() to return TableDestinationCoderV3.",
-          dynamicDestinations);
+        tableDestination.getClustering() == null || destinationCoderSupportsClustering,
+        "DynamicDestinations.getTable() may only return destinations with clustering configured"
+          + " if a destination coder is supplied that supports clustering, but %s is configured"
+          + " to use TableDestinationCoderV2. Set withClustering() on BigQueryIO.write() and, "
+          + " if you provided a custom DynamicDestinations instance, override"
+          + " getDestinationCoder() to return TableDestinationCoderV3.",
+        dynamicDestinations);
       TableReference tableReference = tableDestination.getTableReference();
       if (Strings.isNullOrEmpty(tableReference.getProjectId())) {
         BigQueryOptions options = c.getPipelineOptions().as(BigQueryOptions.class);
         tableReference.setProjectId(
-            options.getBigQueryProject() == null
-                ? options.getProject()
-                : options.getBigQueryProject());
+          options.getBigQueryProject() == null
+            ? options.getProject()
+            : options.getBigQueryProject());
         tableDestination = tableDestination.withTableReference(tableReference);
       }
 
       Integer partition = element.getKey().getShardNumber();
       List<String> partitionFiles = Lists.newArrayList(element.getValue().getFilenames());
       String jobIdPrefix =
-          BigQueryResourceNaming.createJobIdWithDestination(
-              c.sideInput(loadJobIdPrefixView), tableDestination, partition, c.pane().getIndex());
+        BigQueryResourceNaming.createJobIdWithDestination(
+          c.sideInput(loadJobIdPrefixView), tableDestination, partition, c.pane().getIndex());
 
       if (tempTable) {
         if (tempDataset != null) {
@@ -257,10 +256,10 @@ class WriteTables<DestinationT extends @NonNull Object>
         tableReference.setTableId(jobIdPrefix);
       } else {
         Lineage.getSinks()
-            .add(
-                "bigquery",
-                BigQueryHelpers.dataCatalogSegments(
-                    tableReference, c.getPipelineOptions().as(BigQueryOptions.class)));
+          .add(
+            "bigquery",
+            BigQueryHelpers.dataCatalogSegments(
+              tableReference, c.getPipelineOptions().as(BigQueryOptions.class)));
       }
 
       WriteDisposition writeDisposition = firstPaneWriteDisposition;
@@ -278,28 +277,28 @@ class WriteTables<DestinationT extends @NonNull Object>
       }
 
       BigQueryHelpers.PendingJob retryJob =
-          startLoad(
-              getJobService(c.getPipelineOptions().as(BigQueryOptions.class)),
-              getDatasetService(c.getPipelineOptions().as(BigQueryOptions.class)),
-              jobIdPrefix,
-              tableReference,
-              tableDestination.getTimePartitioning(),
-              tableDestination.getClustering(),
-              tableSchema,
-              partitionFiles,
-              writeDisposition,
-              createDisposition,
-              schemaUpdateOptions);
+        startLoad(
+          getJobService(c.getPipelineOptions().as(BigQueryOptions.class)),
+          getDatasetService(c.getPipelineOptions().as(BigQueryOptions.class)),
+          jobIdPrefix,
+          tableReference,
+          tableDestination.getTimePartitioning(),
+          tableDestination.getClustering(),
+          tableSchema,
+          partitionFiles,
+          writeDisposition,
+          createDisposition,
+          schemaUpdateOptions);
 
       pendingJobs.add(
-          new PendingJobData(
-              window,
-              retryJob,
-              partitionFiles,
-              tableDestination,
-              tableReference,
-              destination,
-              element.getValue().isFirstPane()));
+        new PendingJobData(
+          window,
+          retryJob,
+          partitionFiles,
+          tableDestination,
+          tableReference,
+          destination,
+          element.getValue().isFirstPane()));
     }
 
     @Teardown
@@ -335,52 +334,52 @@ class WriteTables<DestinationT extends @NonNull Object>
     @Override
     public void populateDisplayData(DisplayData.Builder builder) {
       builder.add(
-          DisplayData.item("launchesBigQueryJobs", true)
-              .withLabel("This transform launches BigQuery jobs to read/write elements."));
+        DisplayData.item("launchesBigQueryJobs", true)
+          .withLabel("This transform launches BigQuery jobs to read/write elements."));
     }
 
     @FinishBundle
     public void finishBundle(FinishBundleContext c) throws Exception {
       DatasetService datasetService =
-          getDatasetService(c.getPipelineOptions().as(BigQueryOptions.class));
+        getDatasetService(c.getPipelineOptions().as(BigQueryOptions.class));
 
       PendingJobManager jobManager = new PendingJobManager();
       for (final PendingJobData pendingJob : pendingJobs) {
         jobManager =
-            jobManager.addPendingJob(
-                pendingJob.retryJob,
-                // Lambda called when the job is done.
-                j -> {
-                  try {
-                    if (pendingJob.tableDestination.getTableDescription() != null) {
-                      TableReference ref = pendingJob.tableReference;
-                      datasetService.patchTableDescription(
-                          ref.clone()
-                              .setTableId(
-                                  BigQueryHelpers.stripPartitionDecorator(ref.getTableId())),
-                          pendingJob.tableDestination.getTableDescription());
-                    }
-                    Result result =
-                        new AutoValue_WriteTables_Result(
-                            BigQueryHelpers.toJsonString(pendingJob.tableReference),
-                            pendingJob.isFirstPane);
-                    c.output(
-                        mainOutputTag,
-                        KV.of(pendingJob.destinationT, result),
-                        pendingJob.window.maxTimestamp(),
-                        pendingJob.window);
-                    for (String file : pendingJob.partitionFiles) {
-                      c.output(
-                          temporaryFilesTag,
-                          file,
-                          pendingJob.window.maxTimestamp(),
-                          pendingJob.window);
-                    }
-                    return null;
-                  } catch (IOException | InterruptedException e) {
-                    return e;
-                  }
-                });
+          jobManager.addPendingJob(
+            pendingJob.retryJob,
+            // Lambda called when the job is done.
+            j -> {
+              try {
+                if (pendingJob.tableDestination.getTableDescription() != null) {
+                  TableReference ref = pendingJob.tableReference;
+                  datasetService.patchTableDescription(
+                    ref.clone()
+                      .setTableId(
+                        BigQueryHelpers.stripPartitionDecorator(ref.getTableId())),
+                    pendingJob.tableDestination.getTableDescription());
+                }
+                Result result =
+                  new AutoValue_WriteTables_Result(
+                    BigQueryHelpers.toJsonString(pendingJob.tableReference),
+                    pendingJob.isFirstPane);
+                c.output(
+                  mainOutputTag,
+                  KV.of(pendingJob.destinationT, result),
+                  pendingJob.window.maxTimestamp(),
+                  pendingJob.window);
+                for (String file : pendingJob.partitionFiles) {
+                  c.output(
+                    temporaryFilesTag,
+                    file,
+                    pendingJob.window.maxTimestamp(),
+                    pendingJob.window);
+                }
+                return null;
+              } catch (IOException | InterruptedException e) {
+                return e;
+              }
+            });
       }
       jobManager.waitForDone();
     }
@@ -394,21 +393,21 @@ class WriteTables<DestinationT extends @NonNull Object>
   }
 
   public WriteTables(
-      boolean tempTable,
-      BigQueryServices bqServices,
-      PCollectionView<String> loadJobIdPrefixView,
-      WriteDisposition writeDisposition,
-      CreateDisposition createDisposition,
-      List<PCollectionView<?>> sideInputs,
-      DynamicDestinations<?, DestinationT> dynamicDestinations,
-      @Nullable ValueProvider<String> loadJobProjectId,
-      int maxRetryJobs,
-      boolean ignoreUnknownValues,
-      @Nullable String kmsKey,
-      String sourceFormat,
-      boolean useAvroLogicalTypes,
-      Set<SchemaUpdateOption> schemaUpdateOptions,
-      @Nullable String tempDataset) {
+    boolean tempTable,
+    BigQueryServices bqServices,
+    PCollectionView<String> loadJobIdPrefixView,
+    WriteDisposition writeDisposition,
+    CreateDisposition createDisposition,
+    List<PCollectionView<?>> sideInputs,
+    DynamicDestinations<?, DestinationT> dynamicDestinations,
+    @Nullable ValueProvider<String> loadJobProjectId,
+    int maxRetryJobs,
+    boolean ignoreUnknownValues,
+    @Nullable String kmsKey,
+    String sourceFormat,
+    boolean useAvroLogicalTypes,
+    Set<SchemaUpdateOption> schemaUpdateOptions,
+    @Nullable String tempDataset) {
 
     this.tempTable = tempTable;
     this.bqServices = bqServices;
@@ -431,12 +430,12 @@ class WriteTables<DestinationT extends @NonNull Object>
 
   @Override
   public PCollection<KV<DestinationT, Result>> expand(
-      PCollection<KV<ShardedKey<DestinationT>, WritePartition.Result>> input) {
+    PCollection<KV<ShardedKey<DestinationT>, WritePartition.Result>> input) {
     PCollectionTuple writeTablesOutputs =
-        input.apply(
-            ParDo.of(new WriteTablesDoFn())
-                .withSideInputs(sideInputs)
-                .withOutputTags(mainOutputTag, TupleTagList.of(temporaryFilesTag)));
+      input.apply(
+        ParDo.of(new WriteTablesDoFn())
+          .withSideInputs(sideInputs)
+          .withOutputTags(mainOutputTag, TupleTagList.of(temporaryFilesTag)));
 
     // Garbage collect temporary files.
     // We mustn't start garbage collecting files until we are assured that the WriteTablesDoFn has
@@ -445,51 +444,51 @@ class WriteTables<DestinationT extends @NonNull Object>
     // to missing files, causing either the entire workflow to fail or get stuck (depending on how
     // the runner handles persistent failures).
     writeTablesOutputs
-        .get(temporaryFilesTag)
-        .setCoder(StringUtf8Coder.of())
-        .apply(WithKeys.of((Void) null))
-        .setCoder(KvCoder.of(VoidCoder.of(), StringUtf8Coder.of()))
-        .apply(
-            Window.<KV<Void, String>>into(new GlobalWindows())
-                .triggering(Repeatedly.forever(AfterPane.elementCountAtLeast(1)))
-                .discardingFiredPanes())
-        .apply(GroupByKey.create())
-        .apply(Values.create())
-        .apply(ParDo.of(new GarbageCollectTemporaryFiles()));
+      .get(temporaryFilesTag)
+      .setCoder(StringUtf8Coder.of())
+      .apply(WithKeys.of((Void) null))
+      .setCoder(KvCoder.of(VoidCoder.of(), StringUtf8Coder.of()))
+      .apply(
+        Window.<KV<Void, String>>into(new GlobalWindows())
+          .triggering(Repeatedly.forever(AfterPane.elementCountAtLeast(1)))
+          .discardingFiredPanes())
+      .apply(GroupByKey.create())
+      .apply(Values.create())
+      .apply(ParDo.of(new GarbageCollectTemporaryFiles()));
 
     return writeTablesOutputs.get(mainOutputTag);
   }
 
   private PendingJob startLoad(
-      JobService jobService,
-      DatasetService datasetService,
-      String jobIdPrefix,
-      TableReference ref,
-      @Nullable TimePartitioning timePartitioning,
-      @Nullable Clustering clustering,
-      @Nullable TableSchema schema,
-      List<String> gcsUris,
-      WriteDisposition writeDisposition,
-      CreateDisposition createDisposition,
-      Set<SchemaUpdateOption> schemaUpdateOptions) {
+    JobService jobService,
+    DatasetService datasetService,
+    String jobIdPrefix,
+    TableReference ref,
+    @Nullable TimePartitioning timePartitioning,
+    @Nullable Clustering clustering,
+    @Nullable TableSchema schema,
+    List<String> gcsUris,
+    WriteDisposition writeDisposition,
+    CreateDisposition createDisposition,
+    Set<SchemaUpdateOption> schemaUpdateOptions) {
     @SuppressWarnings({
       "nullness" // nulls allowed in most fields but API client not annotated
     })
     JobConfigurationLoad loadConfig =
-        new JobConfigurationLoad()
-            .setDestinationTable(ref)
-            .setSchema(schema)
-            .setSourceUris(gcsUris)
-            .setWriteDisposition(writeDisposition.name())
-            .setCreateDisposition(createDisposition.name())
-            .setSourceFormat(sourceFormat)
-            .setIgnoreUnknownValues(ignoreUnknownValues)
-            .setUseAvroLogicalTypes(useAvroLogicalTypes);
+      new JobConfigurationLoad()
+        .setDestinationTable(ref)
+        .setSchema(schema)
+        .setSourceUris(gcsUris)
+        .setWriteDisposition(writeDisposition.name())
+        .setCreateDisposition(createDisposition.name())
+        .setSourceFormat(sourceFormat)
+        .setIgnoreUnknownValues(ignoreUnknownValues)
+        .setUseAvroLogicalTypes(useAvroLogicalTypes);
     if (schemaUpdateOptions != null) {
       List<String> options =
-          schemaUpdateOptions.stream()
-              .map(Enum<SchemaUpdateOption>::name)
-              .collect(Collectors.toList());
+        schemaUpdateOptions.stream()
+          .map(Enum<SchemaUpdateOption>::name)
+          .collect(Collectors.toList());
       loadConfig.setSchemaUpdateOptions(options);
     }
     if (timePartitioning != null) {
@@ -500,93 +499,66 @@ class WriteTables<DestinationT extends @NonNull Object>
     }
     if (kmsKey != null) {
       loadConfig.setDestinationEncryptionConfiguration(
-          new EncryptionConfiguration().setKmsKeyName(kmsKey));
+        new EncryptionConfiguration().setKmsKeyName(kmsKey));
     }
     String projectId =
-        loadJobProjectId == null || loadJobProjectId.get() == null
-            ? ref.getProjectId()
-            : loadJobProjectId.get();
-
-    String bqLocation;
-    try {
-      bqLocation =
-          BigQueryHelpers.getDatasetLocation(
-              datasetService, ref.getProjectId(), ref.getDatasetId());
-    } catch (IOException e) {
-      ApiErrorExtractor errorExtractor = new ApiErrorExtractor();
-      if (errorExtractor.itemNotFound(e)) {
-        throw new RuntimeException(
-            String.format(
-                "Dataset %s not found in project %s. Please ensure the dataset exists before running the pipeline.",
-                ref.getDatasetId(), ref.getProjectId()),
-            e);
-      }
-      // For other IOExceptions, wrap and throw
-      throw new RuntimeException(
-          String.format(
-              "Unable to get dataset location for dataset %s in project %s",
-              ref.getDatasetId(), ref.getProjectId()),
-          e);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new RuntimeException(
-          String.format(
-              "Interrupted while getting dataset location for dataset %s in project %s",
-              ref.getDatasetId(), ref.getProjectId()),
-          e);
-    }
+      loadJobProjectId == null || loadJobProjectId.get() == null
+        ? ref.getProjectId()
+        : loadJobProjectId.get();
+    String bqLocation =
+      BigQueryHelpers.getDatasetLocation(datasetService, ref.getProjectId(), ref.getDatasetId());
 
     PendingJob retryJob =
-        new PendingJob(
-            // Function to load the data.
-            jobId -> {
-              JobReference jobRef =
-                  new JobReference()
-                      .setProjectId(projectId)
-                      .setJobId(jobId.getJobId())
-                      .setLocation(bqLocation);
-              LOG.info(
-                  "Loading {} files into {} using job {}, job id iteration {}",
-                  gcsUris.size(),
-                  ref,
-                  jobRef,
-                  jobId.getRetryIndex());
-              try {
-                jobService.startLoadJob(jobRef, loadConfig);
-              } catch (IOException | InterruptedException e) {
-                LOG.warn("Load job {} failed with {}", jobRef, e.toString());
-                throw new RuntimeException(e);
-              }
-              return null;
-            },
-            // Function to poll the result of a load job.
-            jobId -> {
-              JobReference jobRef =
-                  new JobReference()
-                      .setProjectId(projectId)
-                      .setJobId(jobId.getJobId())
-                      .setLocation(bqLocation);
-              try {
-                return jobService.pollJob(jobRef, BatchLoads.LOAD_JOB_POLL_MAX_RETRIES);
-              } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-              }
-            },
-            // Function to lookup a job.
-            jobId -> {
-              JobReference jobRef =
-                  new JobReference()
-                      .setProjectId(projectId)
-                      .setJobId(jobId.getJobId())
-                      .setLocation(bqLocation);
-              try {
-                return jobService.getJob(jobRef);
-              } catch (InterruptedException | IOException e) {
-                throw new RuntimeException(e);
-              }
-            },
-            maxRetryJobs,
-            jobIdPrefix);
+      new PendingJob(
+        // Function to load the data.
+        jobId -> {
+          JobReference jobRef =
+            new JobReference()
+              .setProjectId(projectId)
+              .setJobId(jobId.getJobId())
+              .setLocation(bqLocation);
+          LOG.info(
+            "Loading {} files into {} using job {}, job id iteration {}",
+            gcsUris.size(),
+            ref,
+            jobRef,
+            jobId.getRetryIndex());
+          try {
+            jobService.startLoadJob(jobRef, loadConfig);
+          } catch (IOException | InterruptedException e) {
+            LOG.warn("Load job {} failed with {}", jobRef, e.toString());
+            throw new RuntimeException(e);
+          }
+          return null;
+        },
+        // Function to poll the result of a load job.
+        jobId -> {
+          JobReference jobRef =
+            new JobReference()
+              .setProjectId(projectId)
+              .setJobId(jobId.getJobId())
+              .setLocation(bqLocation);
+          try {
+            return jobService.pollJob(jobRef, BatchLoads.LOAD_JOB_POLL_MAX_RETRIES);
+          } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+          }
+        },
+        // Function to lookup a job.
+        jobId -> {
+          JobReference jobRef =
+            new JobReference()
+              .setProjectId(projectId)
+              .setJobId(jobId.getJobId())
+              .setLocation(bqLocation);
+          try {
+            return jobService.getJob(jobRef);
+          } catch (InterruptedException | IOException e) {
+            throw new RuntimeException(e);
+          }
+        },
+        maxRetryJobs,
+        jobIdPrefix);
     return retryJob;
   }
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpersTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpersTest.java
@@ -25,7 +25,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.util.Data;
-import com.google.api.services.bigquery.model.*;
+import com.google.api.services.bigquery.model.Clustering;
+import com.google.api.services.bigquery.model.Dataset;
+import com.google.api.services.bigquery.model.ErrorProto;
+import com.google.api.services.bigquery.model.Job;
+import com.google.api.services.bigquery.model.JobReference;
+import com.google.api.services.bigquery.model.JobStatus;
+import com.google.api.services.bigquery.model.TableReference;
+import com.google.api.services.bigquery.model.TableRow;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Optional;

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpersTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpersTest.java
@@ -17,7 +17,9 @@
  */
 package org.apache.beam.sdk.io.gcp.bigquery;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
**Please** add a meaningful description for your change here

------------------------
This PR fixes #28438 where BigQuery operations would retry indefinitely when trying to access a non-existent dataset.

The `BigQueryHelpers.getDatasetLocation()` method was wrapping all exceptions (including IOException from dataset-not-found errors) in RuntimeException. This caused the retry mechanism in `PendingJob.runJob()` to treat dataset lookup failures as retryable job execution errors, leading to infinite retries that ignored the configured `MAX_RPC_RETRIES` limit of 9.

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
