### PR TITLE
Set latest tag based on branch in sdk and docker snapshots

### DIFF
--- a/.github/workflows/beam_Publish_Beam_SDK_Snapshots.yml
+++ b/.github/workflows/beam_Publish_Beam_SDK_Snapshots.yml
@@ -91,6 +91,9 @@ jobs:
         run: |
           BEAM_VERSION_LINE=$(cat gradle.properties | grep "sdk_version")
           echo "BEAM_VERSION=${BEAM_VERSION_LINE#*sdk_version=}" >> $GITHUB_ENV
+      - name: Set latest tag only on master branch
+        if: github.ref == 'refs/heads/master'
+        run: echo "LATEST_TAG=,latest" >> $GITHUB_ENV
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Authenticate on GCP
@@ -120,6 +123,6 @@ jobs:
           arguments: |
             -Pjava11Home=$JAVA_HOME_11_X64 \
             -Pdocker-repository-root=gcr.io/apache-beam-testing/beam-sdk \
-            -Pdocker-tag-list=${{ github.sha }},${BEAM_VERSION},latest \
+            -Pdocker-tag-list=${{ github.sha }},${BEAM_VERSION}${LATEST_TAG} \
             -Pcontainer-architecture-list=arm64,amd64 \
             -Ppush-containers \

--- a/.github/workflows/beam_Publish_Docker_Snapshots.yml
+++ b/.github/workflows/beam_Publish_Docker_Snapshots.yml
@@ -70,6 +70,13 @@ jobs:
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
       - name: Setup environment
         uses: ./.github/actions/setup-environment-action
+      - name: Set docker_tag_list
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
+            echo "DOCKER_TAG_LIST=${{ github.sha }},latest" >> $GITHUB_ENV
+          else
+            echo "DOCKER_TAG_LIST=${{ github.sha }}" >> $GITHUB_ENV
+          fi
       - name: GCloud Docker credential helper
         run: |
           gcloud auth configure-docker ${{ env.docker_registry }}
@@ -79,11 +86,11 @@ jobs:
           gradle-command: :runners:spark:3:job-server:container:dockerPush
           arguments: |
             -Pdocker-repository-root=gcr.io/apache-beam-testing/beam_portability \
-            -Pdocker-tag-list=latest \
+            -Pdocker-tag-list=${DOCKER_TAG_LIST}
       - name: run Publish Docker Snapshots script for Flink
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:
           gradle-command: :runners:flink:1.17:job-server-container:dockerPush
           arguments: |
             -Pdocker-repository-root=gcr.io/apache-beam-testing/beam_portability \
-            -Pdocker-tag-list=latest
+            -Pdocker-tag-list=${DOCKER_TAG_LIST}

--- a/.github/workflows/beam_Publish_Docker_Snapshots.yml
+++ b/.github/workflows/beam_Publish_Docker_Snapshots.yml
@@ -70,13 +70,9 @@ jobs:
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
       - name: Setup environment
         uses: ./.github/actions/setup-environment-action
-      - name: Set docker_tag_list
-        run: |
-          if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
-            echo "DOCKER_TAG_LIST=${{ github.sha }},latest" >> $GITHUB_ENV
-          else
-            echo "DOCKER_TAG_LIST=${{ github.sha }}" >> $GITHUB_ENV
-          fi
+      - name: Set latest tag only on master branch
+        if: github.ref == 'refs/heads/master'
+        run: echo "LATEST_TAG=,latest" >> $GITHUB_ENV
       - name: GCloud Docker credential helper
         run: |
           gcloud auth configure-docker ${{ env.docker_registry }}
@@ -86,11 +82,11 @@ jobs:
           gradle-command: :runners:spark:3:job-server:container:dockerPush
           arguments: |
             -Pdocker-repository-root=gcr.io/apache-beam-testing/beam_portability \
-            -Pdocker-tag-list=${DOCKER_TAG_LIST}
+            -Pdocker-tag-list=${{ github.sha }}${LATEST_TAG}
       - name: run Publish Docker Snapshots script for Flink
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:
           gradle-command: :runners:flink:1.17:job-server-container:dockerPush
           arguments: |
             -Pdocker-repository-root=gcr.io/apache-beam-testing/beam_portability \
-            -Pdocker-tag-list=${DOCKER_TAG_LIST}
+            -Pdocker-tag-list=${{ github.sha }}${LATEST_TAG}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows responsible for publishing Beam SDK and runner Docker images. The main goal is to ensure that the "latest" Docker tag is only applied when building from the `master` branch, preventing non-master branches from overwriting the "latest" tag, fixes #24130 .

A step was added to set the `LATEST_TAG` variable to `,latest` only when the workflow runs on the `master` branch, ensuring the "latest" tag is only used in that context. Outside of `master` it uses only the commit SHA.