### PR TITLE
Also check the existence of _fields in addition to__annotations__ for NamedTuple.

### DIFF
--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -164,8 +164,7 @@ def _match_is_exactly_sequence(user_type):
 def match_is_named_tuple(user_type):
   return (
       _safe_issubclass(user_type, typing.Tuple) and
-      hasattr(user_type, '__annotations__') and
-      hasattr(user_type, '_fields'))
+      hasattr(user_type, '__annotations__') and hasattr(user_type, '_fields'))
 
 
 def _match_is_optional(user_type):


### PR DESCRIPTION
Why? This addresses an issue in Python 3.13 where `typing.Tuple` _might_ gained an `__annotations__` attribute and this will fail to match NamedTuple. (Part of https://github.com/apache/beam/issues/34869.)

I'm not sure if this (the extra `__annotations__`) is a bug in CPython or not, but regardless I think it's safer to check the existence of `_fields`.

```
from typing import Annotated, Protocol, Tuple, runtime_checkable
@runtime_checkable
class MyProtocol(Protocol):
    def method(self) -> None: ...

print(f"Before, {hasattr(Tuple, '__annotations__')=}")

# After the following check, typing.Tuple.__annotations__ now exists.
isinstance(Annotated[float, 1], MyProtocol)

print(f"After, {hasattr(Tuple, '__annotations__')=}")
```

Once above code is run, `import apache_beam` will fail in Python 3.13:

```
    from apache_beam import metrics
apache_beam/__init__.py:88: in <module>
    from apache_beam import io
apache_beam/io/__init__.py:21: in <module>
    from apache_beam.io.avroio import *
apache_beam/io/avroio.py:59: in <module>
    from apache_beam.io import filebasedsink
apache_beam/io/filebasedsink.py:29: in <module>
    from apache_beam.io import iobase
apache_beam/io/iobase.py:55: in <module>
    from apache_beam.transforms import Impulse
apache_beam/transforms/__init__.py:27: in <module>
    from apache_beam.transforms.stats import *
apache_beam/transforms/stats.py:377: in init apache_beam.transforms.stats
    ???
apache_beam/typehints/typehints.py:611: in __getitem__
    return schemas.union_schema_type(params)
apache_beam/typehints/schemas.py:659: in union_schema_type
    for field in zip(*[named_fields_from_element_type(t) for t in element_types]):
apache_beam/typehints/schemas.py:649: in named_fields_from_element_type
    return named_fields_from_schema(schema_from_element_type(element_type))
apache_beam/typehints/schemas.py:639: in schema_from_element_type
    return named_tuple_to_schema(element_type)
apache_beam/typehints/schemas.py:622: in named_tuple_to_schema
    return typing_to_runner_api(named_tuple, schema_registry).row_type.schema
apache_beam/typehints/schemas.py:201: in typing_to_runner_api
    schema_registry=schema_registry).typing_to_runner_api(type_)
apache_beam/typehints/schemas.py:304: in typing_to_runner_api
    row_type_constraint = row_type.RowTypeConstraint.from_user_type(type_)
apache_beam/typehints/row_type.py:109: in from_user_type
    for name in user_type._fields]
/root/.pyenv/versions/3.13.7/lib/python3.13/typing.py:1365: in __getattr__
    return getattr(self.__origin__, attr)
E   AttributeError: type object 'tuple' has no attribute '_fields'
```

Tested with Python 3.13.7.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
