### PR TITLE
Remove temporary KafkaSourceDescriptor.create function

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaSourceDescriptor.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaSourceDescriptor.java
@@ -24,7 +24,6 @@ import java.io.Serializable;
 import java.util.List;
 import org.apache.beam.sdk.schemas.AutoValueSchema;
 import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
-import org.apache.beam.sdk.schemas.annotations.SchemaCreate;
 import org.apache.beam.sdk.schemas.annotations.SchemaFieldName;
 import org.apache.beam.sdk.schemas.annotations.SchemaIgnore;
 import org.apache.kafka.common.TopicPartition;
@@ -105,27 +104,5 @@ public abstract class KafkaSourceDescriptor implements Serializable {
     checkArgument(
         stopReadOffset == null || stopReadTime == null,
         "stopReadOffset and stopReadTime are optional but mutually exclusive. Please set only one of them.");
-  }
-
-  @SchemaCreate
-  @SuppressWarnings("all")
-  // TODO(BEAM-10677): Remove this function after AutoValueSchema is fixed.
-  static KafkaSourceDescriptor create(
-      String topic,
-      Integer partition,
-      Long start_read_offset,
-      Instant start_read_time,
-      Long stop_read_offset,
-      Instant stop_read_time,
-      List<String> bootstrap_servers) {
-    checkArguments(start_read_offset, start_read_time, stop_read_offset, stop_read_time);
-    return new AutoValue_KafkaSourceDescriptor(
-        topic,
-        partition,
-        start_read_offset,
-        start_read_time,
-        stop_read_offset,
-        stop_read_time,
-        bootstrap_servers);
   }
 }


### PR DESCRIPTION
In https://github.com/apache/beam/commit/b609aab9e2bd9e8d86c8e3a511c22a4402c5704e , it is added to make a workaround for bug in AutoValueSchema. It seems fixed now, so I suggest to remove this function.

I doubt this code changes are related to #36356

Feel free to close this PR if I got something wrong.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
