### PR TITLE
[Dataflow Streaming] Remove one wait for GetData

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetDataStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetDataStream.java
@@ -504,9 +504,6 @@ final class GrpcGetDataStream
       trySendBatch(batch);
       // Since the above send may not succeed, we fall through to block on sending or failure.
     }
-
-    // Wait for this batch to be sent before parsing the response.
-    batch.waitForSendOrFailNotification();
   }
 
   private synchronized void trySendBatch(QueuedBatch batch) throws WindmillStreamShutdownException {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetDataStreamRequests.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetDataStreamRequests.java
@@ -197,6 +197,9 @@ final class GrpcGetDataStreamRequests {
      */
     void notifyFailed() {
       failed = true;
+      for (QueuedRequest request : requests) {
+        request.getResponseStream().cancel();
+      }
       sent.countDown();
     }
 


### PR DESCRIPTION
Harness threads will no longer wait for sending threads directly. They'll wait on the responseStream and will observe failures when the responseStream is cancelled.

Reduces context switches and cpu usage under GetData

Before profile:  <img width="3456" height="1984" alt="image" src="https://github.com/user-attachments/assets/dbfaf430-05e6-4e87-9335-4e245062d9bf" />
After profile: 
<img width="3456" height="1984" alt="image" src="https://github.com/user-attachments/assets/949ce7ce-6115-468a-ad85-31ff747c8afe" />
