### PR TITLE
Fix issues in tableRowFromMessage

### DIFF
--- a/sdks/java/extensions/protobuf/src/test/proto/proto3_schema_messages.proto
+++ b/sdks/java/extensions/protobuf/src/test/proto/proto3_schema_messages.proto
@@ -33,6 +33,51 @@ import "proto3_schema_options.proto";
 
 option java_package = "org.apache.beam.sdk.extensions.protobuf";
 
+message PrimitiveEncodedFields {
+  int64 encoded_timestamp = 1;
+  int32 encoded_date = 2;
+  bytes encoded_numeric = 3;
+  bytes encoded_bignumeric = 4;
+  int64 encoded_packed_datetime = 5;
+  int64 encoded_packed_time = 6;
+}
+
+message NestedEncodedFields {
+  PrimitiveEncodedFields nested = 1;
+  repeated PrimitiveEncodedFields nested_list = 2;
+}
+
+message PrimitiveUnEncodedFields {
+  string timestamp = 1;
+  string date = 2;
+  string numeric = 3;
+  string bignumeric = 4;
+  string datetime = 5;
+  string time = 6;
+}
+
+message NestedUnEncodedFields {
+  PrimitiveUnEncodedFields nested = 1;
+  repeated PrimitiveUnEncodedFields nested_list = 2;
+}
+
+message WrapperUnEncodedFields {
+  google.protobuf.FloatValue float = 1;
+  google.protobuf.DoubleValue double = 2;
+  google.protobuf.BoolValue bool = 3;
+  google.protobuf.Int32Value int32 = 4;
+  google.protobuf.Int64Value int64 = 5;
+  google.protobuf.UInt32Value uint32 = 6;
+  google.protobuf.UInt64Value uint64 = 7;
+  google.protobuf.BytesValue bytes = 8;
+  google.protobuf.Timestamp timestamp = 9;
+}
+
+message NestedWrapperUnEncodedFields {
+  WrapperUnEncodedFields nested = 1;
+  repeated WrapperUnEncodedFields nested_list = 2;
+}
+
 message Primitive {
     double primitive_double = 1;
     float primitive_float = 2;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/AppendClientInfo.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/AppendClientInfo.java
@@ -182,6 +182,7 @@ abstract class AppendClientInfo {
   public TableRow toTableRow(ByteString protoBytes, Predicate<String> includeField) {
     try {
       return TableRowToStorageApiProto.tableRowFromMessage(
+          getSchemaInformation(),
           DynamicMessage.parseFrom(
               TableRowToStorageApiProto.wrapDescriptorProto(getDescriptor()), protoBytes),
           true,

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTranslation.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTranslation.java
@@ -20,7 +20,6 @@ package org.apache.beam.sdk.io.gcp.bigquery;
 import static org.apache.beam.sdk.util.construction.TransformUpgrader.fromByteArray;
 import static org.apache.beam.sdk.util.construction.TransformUpgrader.toByteArray;
 
-import com.google.api.services.bigquery.model.TableRow;
 import com.google.auto.service.AutoService;
 import com.google.cloud.bigquery.storage.v1.AppendRowsRequest.MissingValueInterpretation;
 import com.google.cloud.bigquery.storage.v1.DataFormat;
@@ -641,14 +640,14 @@ public class BigQueryIOTranslation {
         if (formatFunctionBytes != null) {
           builder =
               builder.setFormatFunction(
-                  (SerializableFunction<?, TableRow>) fromByteArray(formatFunctionBytes));
+                  (BigQueryIO.TableRowFormatFunction<?>) fromByteArray(formatFunctionBytes));
         }
         byte[] formatRecordOnFailureFunctionBytes =
             configRow.getBytes("format_record_on_failure_function");
         if (formatRecordOnFailureFunctionBytes != null) {
           builder =
               builder.setFormatRecordOnFailureFunction(
-                  (SerializableFunction<?, TableRow>)
+                  (BigQueryIO.TableRowFormatFunction<?>)
                       fromByteArray(formatRecordOnFailureFunctionBytes));
         }
         byte[] avroRowWriterFactoryBytes = configRow.getBytes("avro_row_writer_factory");

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
@@ -34,6 +34,8 @@ import java.nio.ByteBuffer;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -169,10 +171,45 @@ public class BigQueryUtils {
   }
 
   private static final String BIGQUERY_TIME_PATTERN = "HH:mm:ss[.SSSSSS]";
-  private static final java.time.format.DateTimeFormatter BIGQUERY_TIME_FORMATTER =
+  static final java.time.format.DateTimeFormatter BIGQUERY_TIME_FORMATTER =
       java.time.format.DateTimeFormatter.ofPattern(BIGQUERY_TIME_PATTERN);
-  private static final java.time.format.DateTimeFormatter BIGQUERY_DATETIME_FORMATTER =
+  static final java.time.format.DateTimeFormatter BIGQUERY_DATETIME_FORMATTER =
       java.time.format.DateTimeFormatter.ofPattern("uuuu-MM-dd'T'" + BIGQUERY_TIME_PATTERN);
+
+  // Custom formatter that accepts "2022-05-09 18:04:59.123456"
+  // The old dremel parser accepts this format, and so does insertall. We need to accept it
+  // for backwards compatibility, and it is based on UTC time.
+  static final java.time.format.DateTimeFormatter DATETIME_SPACE_FORMATTER =
+      new java.time.format.DateTimeFormatterBuilder()
+          .append(java.time.format.DateTimeFormatter.ISO_LOCAL_DATE)
+          .optionalStart()
+          .appendLiteral(' ')
+          .optionalEnd()
+          .optionalStart()
+          .appendLiteral('T')
+          .optionalEnd()
+          .append(java.time.format.DateTimeFormatter.ISO_LOCAL_TIME)
+          .toFormatter()
+          .withZone(ZoneOffset.UTC);
+
+  static final java.time.format.DateTimeFormatter TIMESTAMP_FORMATTER =
+      new java.time.format.DateTimeFormatterBuilder()
+          // 'yyyy-MM-dd(T| )HH:mm:ss.SSSSSSSSS'
+          .append(DATETIME_SPACE_FORMATTER)
+          // 'yyyy-MM-dd(T| )HH:mm:ss.SSSSSSSSS(+HH:mm:ss|Z)'
+          .optionalStart()
+          .appendOffsetId()
+          .optionalEnd()
+          .optionalStart()
+          .appendOffset("+HH:mm", "+00:00")
+          .optionalEnd()
+          // 'yyyy-MM-dd(T| )HH:mm:ss.SSSSSSSSS [time_zone]', time_zone -> UTC, Asia/Kolkata, etc
+          // if both an offset and a time zone are provided, the offset takes precedence
+          .optionalStart()
+          .appendLiteral(' ')
+          .parseCaseSensitive()
+          .appendZoneRegionId()
+          .toFormatter();
 
   private static final DateTimeFormatter BIGQUERY_TIMESTAMP_PRINTER;
 
@@ -747,7 +784,11 @@ public class BigQueryUtils {
           return CivilTimeEncoder.decodePacked64DatetimeMicrosAsJavaTime(value);
         } catch (NumberFormatException e) {
           // Handle as a String, ie. "2023-02-16 12:00:00"
-          return LocalDateTime.parse(jsonBQString, BIGQUERY_DATETIME_FORMATTER);
+          try {
+            return LocalDateTime.parse(jsonBQString);
+          } catch (DateTimeParseException e2) {
+            return LocalDateTime.parse(jsonBQString, DATETIME_SPACE_FORMATTER);
+          }
         }
       } else if (fieldType.isLogicalType(SqlTypes.DATE.getIdentifier())) {
         return LocalDate.parse(jsonBQString);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/RowWriterFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/RowWriterFactory.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.sdk.io.gcp.bigquery;
 
-import com.google.api.services.bigquery.model.TableRow;
 import com.google.api.services.bigquery.model.TableSchema;
 import java.io.Serializable;
 import org.apache.avro.Schema;
@@ -41,29 +40,29 @@ abstract class RowWriterFactory<ElementT, DestinationT> implements Serializable 
       String tempFilePrefix, DestinationT destination) throws Exception;
 
   static <ElementT, DestinationT> RowWriterFactory<ElementT, DestinationT> tableRows(
-      SerializableFunction<ElementT, TableRow> toRow,
-      SerializableFunction<ElementT, TableRow> toFailsafeRow) {
+      BigQueryIO.TableRowFormatFunction<ElementT> toRow,
+      BigQueryIO.TableRowFormatFunction<ElementT> toFailsafeRow) {
     return new TableRowWriterFactory<ElementT, DestinationT>(toRow, toFailsafeRow);
   }
 
   static final class TableRowWriterFactory<ElementT, DestinationT>
       extends RowWriterFactory<ElementT, DestinationT> {
 
-    private final SerializableFunction<ElementT, TableRow> toRow;
-    private final SerializableFunction<ElementT, TableRow> toFailsafeRow;
+    private final BigQueryIO.TableRowFormatFunction<ElementT> toRow;
+    private final BigQueryIO.TableRowFormatFunction<ElementT> toFailsafeRow;
 
     private TableRowWriterFactory(
-        SerializableFunction<ElementT, TableRow> toRow,
-        SerializableFunction<ElementT, TableRow> toFailsafeRow) {
+        BigQueryIO.TableRowFormatFunction<ElementT> toRow,
+        BigQueryIO.TableRowFormatFunction<ElementT> toFailsafeRow) {
       this.toRow = toRow;
       this.toFailsafeRow = toFailsafeRow;
     }
 
-    public SerializableFunction<ElementT, TableRow> getToRowFn() {
+    public BigQueryIO.TableRowFormatFunction<ElementT> getToRowFn() {
       return toRow;
     }
 
-    public SerializableFunction<ElementT, TableRow> getToFailsafeRowFn() {
+    public BigQueryIO.TableRowFormatFunction<ElementT> getToFailsafeRowFn() {
       if (toFailsafeRow == null) {
         return toRow;
       }
@@ -76,9 +75,10 @@ abstract class RowWriterFactory<ElementT, DestinationT> implements Serializable 
     }
 
     @Override
+    @SuppressWarnings("nullness")
     public BigQueryRowWriter<ElementT> createRowWriter(
         String tempFilePrefix, DestinationT destination) throws Exception {
-      return new TableRowWriter<>(tempFilePrefix, toRow);
+      return new TableRowWriter<>(tempFilePrefix, toRow.toSerializableFunction());
     }
 
     @Override

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiDynamicDestinationsGenericRecord.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiDynamicDestinationsGenericRecord.java
@@ -36,8 +36,7 @@ class StorageApiDynamicDestinationsGenericRecord<T, DestinationT extends @NonNul
 
   private final SerializableFunction<AvroWriteRequest<T>, GenericRecord> toGenericRecord;
   private final SerializableFunction<@Nullable TableSchema, Schema> schemaFactory;
-  private final @javax.annotation.Nullable SerializableFunction<T, TableRow>
-      formatRecordOnFailureFunction;
+  private final BigQueryIO.@Nullable TableRowFormatFunction<T> formatRecordOnFailureFunction;
 
   private boolean usesCdc;
 
@@ -45,7 +44,7 @@ class StorageApiDynamicDestinationsGenericRecord<T, DestinationT extends @NonNul
       DynamicDestinations<T, DestinationT> inner,
       SerializableFunction<@Nullable TableSchema, Schema> schemaFactory,
       SerializableFunction<AvroWriteRequest<T>, GenericRecord> toGenericRecord,
-      @Nullable SerializableFunction<T, TableRow> formatRecordOnFailureFunction,
+      BigQueryIO.@Nullable TableRowFormatFunction<T> formatRecordOnFailureFunction,
       boolean usesCdc) {
     super(inner);
     this.toGenericRecord = toGenericRecord;
@@ -110,7 +109,7 @@ class StorageApiDynamicDestinationsGenericRecord<T, DestinationT extends @NonNul
     @Override
     public TableRow toFailsafeTableRow(T element) {
       if (formatRecordOnFailureFunction != null) {
-        return formatRecordOnFailureFunction.apply(element);
+        return formatRecordOnFailureFunction.apply(null, element);
       } else {
         return BigQueryUtils.convertGenericRecordToTableRow(
             toGenericRecord.apply(new AvroWriteRequest<>(element, avroSchema)), bqTableSchema);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
@@ -655,11 +655,12 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
             @Nullable TableRow failedRow = failsafeTableRows.get(i);
             if (failedRow == null) {
               ByteString rowBytes = inserts.getSerializedRows(i);
+              AppendClientInfo aci = getAppendClientInfo(true, null);
               failedRow =
                   TableRowToStorageApiProto.tableRowFromMessage(
+                      aci.getSchemaInformation(),
                       DynamicMessage.parseFrom(
-                          TableRowToStorageApiProto.wrapDescriptorProto(
-                              getAppendClientInfo(true, null).getDescriptor()),
+                          TableRowToStorageApiProto.wrapDescriptorProto(aci.getDescriptor()),
                           rowBytes),
                       true,
                       successfulRowsPredicate);
@@ -739,12 +740,13 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
                     if (failedRow == null) {
                       ByteString protoBytes =
                           failedContext.protoRows.getSerializedRows(failedIndex);
+                      AppendClientInfo aci = Preconditions.checkStateNotNull(appendClientInfo);
                       failedRow =
                           TableRowToStorageApiProto.tableRowFromMessage(
+                              aci.getSchemaInformation(),
                               DynamicMessage.parseFrom(
                                   TableRowToStorageApiProto.wrapDescriptorProto(
-                                      Preconditions.checkStateNotNull(appendClientInfo)
-                                          .getDescriptor()),
+                                      aci.getDescriptor()),
                                   protoBytes),
                               true,
                               Predicates.alwaysTrue());
@@ -897,6 +899,8 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
                     try {
                       TableRow row =
                           TableRowToStorageApiProto.tableRowFromMessage(
+                              Preconditions.checkStateNotNull(appendClientInfo)
+                                  .getSchemaInformation(),
                               DynamicMessage.parseFrom(descriptor, rowBytes),
                               true,
                               successfulRowsPredicate);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TableRowToStorageApiProto.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TableRowToStorageApiProto.java
@@ -18,6 +18,8 @@
 package org.apache.beam.sdk.io.gcp.bigquery;
 
 import static java.util.stream.Collectors.toList;
+import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryUtils.DATETIME_SPACE_FORMATTER;
+import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryUtils.TIMESTAMP_FORMATTER;
 
 import com.google.api.services.bigquery.model.TableCell;
 import com.google.api.services.bigquery.model.TableRow;
@@ -44,14 +46,14 @@ import com.google.protobuf.Message;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
+import java.nio.charset.StandardCharsets;
+import java.text.DecimalFormat;
 import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -59,6 +61,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -71,6 +74,7 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Predicate
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Strings;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableSet;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Maps;
@@ -83,42 +87,6 @@ import org.joda.time.Days;
  * with the Storage write API.
  */
 public class TableRowToStorageApiProto {
-
-  // Custom formatter that accepts "2022-05-09 18:04:59.123456"
-  // The old dremel parser accepts this format, and so does insertall. We need to accept it
-  // for backwards compatibility, and it is based on UTC time.
-  private static final DateTimeFormatter DATETIME_SPACE_FORMATTER =
-      new DateTimeFormatterBuilder()
-          .append(DateTimeFormatter.ISO_LOCAL_DATE)
-          .optionalStart()
-          .appendLiteral(' ')
-          .optionalEnd()
-          .optionalStart()
-          .appendLiteral('T')
-          .optionalEnd()
-          .append(DateTimeFormatter.ISO_LOCAL_TIME)
-          .toFormatter()
-          .withZone(ZoneOffset.UTC);
-
-  private static final DateTimeFormatter TIMESTAMP_FORMATTER =
-      new DateTimeFormatterBuilder()
-          // 'yyyy-MM-dd(T| )HH:mm:ss.SSSSSSSSS'
-          .append(DATETIME_SPACE_FORMATTER)
-          // 'yyyy-MM-dd(T| )HH:mm:ss.SSSSSSSSS(+HH:mm:ss|Z)'
-          .optionalStart()
-          .appendOffsetId()
-          .optionalEnd()
-          .optionalStart()
-          .appendOffset("+HH:mm", "+00:00")
-          .optionalEnd()
-          // 'yyyy-MM-dd(T| )HH:mm:ss.SSSSSSSSS [time_zone]', time_zone -> UTC, Asia/Kolkata, etc
-          // if both an offset and a time zone are provided, the offset takes precedence
-          .optionalStart()
-          .appendLiteral(' ')
-          .parseCaseSensitive()
-          .appendZoneRegionId()
-          .toFormatter();
-
   abstract static class SchemaConversionException extends Exception {
     SchemaConversionException(String msg) {
       super(msg);
@@ -146,12 +114,13 @@ public class TableRowToStorageApiProto {
   }
 
   public static class SingleValueConversionException extends SchemaConversionException {
-    SingleValueConversionException(Object sourceValue, SchemaInformation schema, Exception e) {
+    SingleValueConversionException(
+        Object sourceValue, TableFieldSchema.Type type, String fullName, Exception e) {
       super(
           "Column: "
-              + getPrettyFieldName(schema)
+              + getPrettyFieldName(fullName)
               + " ("
-              + schema.getType()
+              + type
               + "). "
               + "Value: "
               + sourceValue
@@ -161,8 +130,7 @@ public class TableRowToStorageApiProto {
               + e);
     }
 
-    private static String getPrettyFieldName(SchemaInformation schema) {
-      String fullName = schema.getFullName();
+    private static String getPrettyFieldName(String fullName) {
       String rootPrefix = "root.";
       return fullName.startsWith(rootPrefix) ? fullName.substring(rootPrefix.length()) : fullName;
     }
@@ -220,6 +188,232 @@ public class TableRowToStorageApiProto {
           .put(TableFieldSchema.Type.TIMESTAMP, "TIMESTAMP")
           .put(TableFieldSchema.Type.JSON, "JSON")
           .build();
+
+  @FunctionalInterface
+  public interface ThrowingBiFunction<FirstInputT, SecondInputT, OutputT> {
+    OutputT apply(FirstInputT t, SecondInputT u) throws SchemaConversionException;
+  }
+
+  static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("0.0###############");
+
+  // Map of functions to convert json values into the value expected in the Vortex proto object.
+  static final Map<TableFieldSchema.Type, ThrowingBiFunction<String, Object, @Nullable Object>>
+      TYPE_MAP_PROTO_CONVERTERS =
+          ImmutableMap
+              .<TableFieldSchema.Type, ThrowingBiFunction<String, Object, @Nullable Object>>
+                  builder()
+              .put(
+                  TableFieldSchema.Type.INT64,
+                  (fullName, value) -> {
+                    if (value instanceof String) {
+                      try {
+                        return Long.valueOf((String) value);
+                      } catch (NumberFormatException e) {
+                        throw new SingleValueConversionException(
+                            value, TableFieldSchema.Type.INT64, fullName, e);
+                      }
+                    } else if (value instanceof Integer || value instanceof Long) {
+                      return ((Number) value).longValue();
+                    } else if (value instanceof BigDecimal) {
+                      try {
+                        return ((BigDecimal) value).longValueExact();
+                      } catch (ArithmeticException e) {
+                        throw new SingleValueConversionException(
+                            value, TableFieldSchema.Type.INT64, fullName, e);
+                      }
+                    } else if (value instanceof BigInteger) {
+                      try {
+                        return ((BigInteger) value).longValueExact();
+                      } catch (ArithmeticException e) {
+                        throw new SingleValueConversionException(
+                            value, TableFieldSchema.Type.INT64, fullName, e);
+                      }
+                    }
+                    return null;
+                  })
+              .put(
+                  TableFieldSchema.Type.DOUBLE,
+                  (schemaInformation, value) -> {
+                    if (value instanceof String) {
+                      return Double.valueOf((String) value);
+                    } else if (value instanceof Number) {
+                      return ((Number) value).doubleValue();
+                    }
+                    return null;
+                  })
+              .put(
+                  TableFieldSchema.Type.BOOL,
+                  (schemaInformation, value) -> {
+                    if (value instanceof String) {
+                      return Boolean.valueOf((String) value);
+                    } else if (value instanceof Boolean) {
+                      return value;
+                    }
+                    return null;
+                  })
+              .put(
+                  TableFieldSchema.Type.BYTES,
+                  (schemaInformation, value) -> {
+                    if (value instanceof String) {
+                      return ByteString.copyFrom(BaseEncoding.base64().decode((String) value));
+                    } else if (value instanceof byte[]) {
+                      return ByteString.copyFrom((byte[]) value);
+                    } else if (value instanceof ByteString) {
+                      return value;
+                    }
+                    return null;
+                  })
+              .put(
+                  TableFieldSchema.Type.TIMESTAMP,
+                  (schemaInformation, value) -> {
+                    if (value instanceof String) {
+                      try {
+                        // '2011-12-03T10:15:30Z', '2011-12-03 10:15:30+05:00'
+                        // '2011-12-03 10:15:30 UTC', '2011-12-03T10:15:30 America/New_York'
+                        Instant timestamp = Instant.from(TIMESTAMP_FORMATTER.parse((String) value));
+                        return toEpochMicros(timestamp);
+                      } catch (DateTimeException e) {
+                        try {
+                          // for backwards compatibility, default time zone is UTC for values with
+                          // no time-zone
+                          // '2011-12-03T10:15:30'
+                          Instant timestamp =
+                              Instant.from(
+                                  TIMESTAMP_FORMATTER
+                                      .withZone(ZoneOffset.UTC)
+                                      .parse((String) value));
+                          return toEpochMicros(timestamp);
+                        } catch (DateTimeParseException err) {
+                          // "12345667"
+                          Instant timestamp = Instant.ofEpochMilli(Long.parseLong((String) value));
+                          return toEpochMicros(timestamp);
+                        }
+                      }
+                    } else if (value instanceof Instant) {
+                      return toEpochMicros((Instant) value);
+                    } else if (value instanceof org.joda.time.Instant) {
+                      // joda instant precision is millisecond
+                      return ((org.joda.time.Instant) value).getMillis() * 1000L;
+                    } else if (value instanceof Integer || value instanceof Long) {
+                      return ((Number) value).longValue();
+                    } else if (value instanceof Double || value instanceof Float) {
+                      // assume value represents number of seconds since epoch
+                      return BigDecimal.valueOf(((Number) value).doubleValue())
+                          .scaleByPowerOfTen(6)
+                          .setScale(0, RoundingMode.HALF_UP)
+                          .longValue();
+                    }
+                    return null;
+                  })
+              .put(
+                  TableFieldSchema.Type.DATE,
+                  (schemaInformation, value) -> {
+                    if (value instanceof String) {
+                      return ((Long) LocalDate.parse((String) value).toEpochDay()).intValue();
+                    } else if (value instanceof LocalDate) {
+                      return ((Long) ((LocalDate) value).toEpochDay()).intValue();
+                    } else if (value instanceof org.joda.time.LocalDate) {
+                      return Days.daysBetween(
+                              org.joda.time.Instant.EPOCH.toDateTime().toLocalDate(),
+                              (org.joda.time.LocalDate) value)
+                          .getDays();
+                    } else if (value instanceof Integer || value instanceof Long) {
+                      return ((Number) value).intValue();
+                    }
+                    return null;
+                  })
+              .put(
+                  TableFieldSchema.Type.NUMERIC,
+                  (schemaInformation, value) -> {
+                    if (value instanceof String) {
+                      return BigDecimalByteStringEncoder.encodeToNumericByteString(
+                          new BigDecimal((String) value));
+                    } else if (value instanceof BigDecimal) {
+                      return BigDecimalByteStringEncoder.encodeToNumericByteString(
+                          ((BigDecimal) value));
+                    } else if (value instanceof Double || value instanceof Float) {
+                      return BigDecimalByteStringEncoder.encodeToNumericByteString(
+                          BigDecimal.valueOf(((Number) value).doubleValue()));
+                    } else if (value instanceof Short
+                        || value instanceof Integer
+                        || value instanceof Long) {
+                      return BigDecimalByteStringEncoder.encodeToNumericByteString(
+                          BigDecimal.valueOf(((Number) value).longValue()));
+                    }
+                    return null;
+                  })
+              .put(
+                  TableFieldSchema.Type.BIGNUMERIC,
+                  (schemaInformation, value) -> {
+                    if (value instanceof String) {
+                      return BigDecimalByteStringEncoder.encodeToBigNumericByteString(
+                          new BigDecimal((String) value));
+                    } else if (value instanceof BigDecimal) {
+                      return BigDecimalByteStringEncoder.encodeToBigNumericByteString(
+                          ((BigDecimal) value));
+                    } else if (value instanceof Double || value instanceof Float) {
+                      return BigDecimalByteStringEncoder.encodeToBigNumericByteString(
+                          BigDecimal.valueOf(((Number) value).doubleValue()));
+                    } else if (value instanceof Short
+                        || value instanceof Integer
+                        || value instanceof Long) {
+                      return BigDecimalByteStringEncoder.encodeToBigNumericByteString(
+                          BigDecimal.valueOf(((Number) value).longValue()));
+                    }
+                    return null;
+                  })
+              .put(
+                  TableFieldSchema.Type.DATETIME,
+                  (schemaInformation, value) -> {
+                    if (value instanceof String) {
+                      try {
+                        // '2011-12-03T10:15:30'
+                        return CivilTimeEncoder.encodePacked64DatetimeMicros(
+                            LocalDateTime.parse((String) value));
+                      } catch (DateTimeParseException e2) {
+                        // '2011-12-03 10:15:30'
+                        return CivilTimeEncoder.encodePacked64DatetimeMicros(
+                            LocalDateTime.parse((String) value, DATETIME_SPACE_FORMATTER));
+                      }
+                    } else if (value instanceof Number) {
+                      return ((Number) value).longValue();
+                    } else if (value instanceof LocalDateTime) {
+                      return CivilTimeEncoder.encodePacked64DatetimeMicros((LocalDateTime) value);
+                    } else if (value instanceof org.joda.time.LocalDateTime) {
+                      return CivilTimeEncoder.encodePacked64DatetimeMicros(
+                          (org.joda.time.LocalDateTime) value);
+                    }
+                    return null;
+                  })
+              .put(
+                  TableFieldSchema.Type.TIME,
+                  (schemaInformation, value) -> {
+                    if (value instanceof String) {
+                      return CivilTimeEncoder.encodePacked64TimeMicros(
+                          LocalTime.parse((String) value));
+                    } else if (value instanceof Number) {
+                      return ((Number) value).longValue();
+                    } else if (value instanceof LocalTime) {
+                      return CivilTimeEncoder.encodePacked64TimeMicros((LocalTime) value);
+                    } else if (value instanceof org.joda.time.LocalTime) {
+                      return CivilTimeEncoder.encodePacked64TimeMicros(
+                          (org.joda.time.LocalTime) value);
+                    }
+                    return null;
+                  })
+              .put(
+                  TableFieldSchema.Type.STRING,
+                  (schemaInformation, value) ->
+                      Preconditions.checkArgumentNotNull(value).toString())
+              .put(
+                  TableFieldSchema.Type.JSON,
+                  (schemaInformation, value) ->
+                      Preconditions.checkArgumentNotNull(value).toString())
+              .put(
+                  TableFieldSchema.Type.GEOGRAPHY,
+                  (schemaInformation, value) ->
+                      Preconditions.checkArgumentNotNull(value).toString())
+              .build();
 
   public static TableFieldSchema.Mode modeToProtoMode(
       @Nullable String defaultValueExpression, String mode) {
@@ -345,7 +539,7 @@ public class TableRowToStorageApiProto {
     return builder.build();
   }
 
-  static class SchemaInformation {
+  public static class SchemaInformation {
     private final TableFieldSchema tableFieldSchema;
     private final List<SchemaInformation> subFields;
     private final Map<String, SchemaInformation> subFieldsByName;
@@ -382,6 +576,14 @@ public class TableRowToStorageApiProto {
       return tableFieldSchema.getType();
     }
 
+    public boolean isNullable() {
+      return tableFieldSchema.getMode().equals(TableFieldSchema.Mode.NULLABLE);
+    }
+
+    public boolean isRepeated() {
+      return tableFieldSchema.getMode().equals(TableFieldSchema.Mode.REPEATED);
+    }
+
     public SchemaInformation getSchemaForField(String name) {
       SchemaInformation schemaInformation = subFieldsByName.get(name.toLowerCase());
       if (schemaInformation == null) {
@@ -398,7 +600,7 @@ public class TableRowToStorageApiProto {
       return schemaInformation;
     }
 
-    static SchemaInformation fromTableSchema(TableSchema tableSchema) {
+    public static SchemaInformation fromTableSchema(TableSchema tableSchema) {
       TableFieldSchema root =
           TableFieldSchema.newBuilder()
               .addAllFields(tableSchema.getFieldsList())
@@ -658,6 +860,9 @@ public class TableRowToStorageApiProto {
           final int finalIndex = i;
           Supplier<@Nullable TableRow> getNestedUnknown =
               () -> {
+                if (unknownFields == null) {
+                  return null;
+                }
                 TableRow localUnknownFields = Preconditions.checkStateNotNull(unknownFields);
                 @Nullable
                 TableRow nested = (TableRow) (localUnknownFields.getF().get(finalIndex).getV());
@@ -988,7 +1193,8 @@ public class TableRowToStorageApiProto {
       throw new RuntimeException(e);
     }
     TableRow original =
-        TableRowToStorageApiProto.tableRowFromMessage(message, true, Predicates.alwaysTrue());
+        TableRowToStorageApiProto.tableRowFromMessage(
+            schemaInformation, message, true, Predicates.alwaysTrue());
     Map<String, Descriptors.FieldDescriptor> fieldDescriptors =
         descriptor.getFields().stream()
             .collect(Collectors.toMap(Descriptors.FieldDescriptor::getName, Functions.identity()));
@@ -1061,7 +1267,7 @@ public class TableRowToStorageApiProto {
     return singularFieldToProtoValue(
         schemaInformation,
         fieldDescriptor,
-        bqValue,
+        Preconditions.checkStateNotNull(bqValue),
         ignoreUnknownValues,
         allowMissingRequiredFields,
         getUnknownNestedFields);
@@ -1071,208 +1277,60 @@ public class TableRowToStorageApiProto {
   static @Nullable Object singularFieldToProtoValue(
       SchemaInformation schemaInformation,
       FieldDescriptor fieldDescriptor,
-      @Nullable Object value,
+      Object value,
       boolean ignoreUnknownValues,
       boolean allowMissingRequiredFields,
       Supplier<@Nullable TableRow> getUnknownNestedFields)
       throws SchemaConversionException {
-    switch (schemaInformation.getType()) {
-      case INT64:
-        if (value instanceof String) {
-          try {
-            return Long.valueOf((String) value);
-          } catch (NumberFormatException e) {
-            throw new SingleValueConversionException(value, schemaInformation, e);
-          }
-        } else if (value instanceof Integer || value instanceof Long) {
-          return ((Number) value).longValue();
-        } else if (value instanceof BigDecimal) {
-          try {
-            return ((BigDecimal) value).longValueExact();
-          } catch (ArithmeticException e) {
-            throw new SingleValueConversionException(value, schemaInformation, e);
-          }
-        } else if (value instanceof BigInteger) {
-          try {
-            return ((BigInteger) value).longValueExact();
-          } catch (ArithmeticException e) {
-            throw new SingleValueConversionException(value, schemaInformation, e);
-          }
-        }
-        break;
-      case DOUBLE:
-        if (value instanceof String) {
-          return Double.valueOf((String) value);
-        } else if (value instanceof Number) {
-          return ((Number) value).doubleValue();
-        }
-        break;
-      case BOOL:
-        if (value instanceof String) {
-          return Boolean.valueOf((String) value);
-        } else if (value instanceof Boolean) {
-          return value;
-        }
-        break;
-      case BYTES:
-        if (value instanceof String) {
-          return ByteString.copyFrom(BaseEncoding.base64().decode((String) value));
-        } else if (value instanceof byte[]) {
-          return ByteString.copyFrom((byte[]) value);
-        } else if (value instanceof ByteString) {
-          return value;
-        }
-        break;
-      case TIMESTAMP:
-        if (value instanceof String) {
-          try {
-            // '2011-12-03T10:15:30Z', '2011-12-03 10:15:30+05:00'
-            // '2011-12-03 10:15:30 UTC', '2011-12-03T10:15:30 America/New_York'
-            Instant timestamp = Instant.from(TIMESTAMP_FORMATTER.parse((String) value));
-            return toEpochMicros(timestamp);
-          } catch (DateTimeException e) {
-            try {
-              // for backwards compatibility, default time zone is UTC for values with no time-zone
-              // '2011-12-03T10:15:30'
-              Instant timestamp =
-                  Instant.from(TIMESTAMP_FORMATTER.withZone(ZoneOffset.UTC).parse((String) value));
-              return toEpochMicros(timestamp);
-            } catch (DateTimeParseException err) {
-              // "12345667"
-              Instant timestamp = Instant.ofEpochMilli(Long.parseLong((String) value));
-              return toEpochMicros(timestamp);
-            }
-          }
-        } else if (value instanceof Instant) {
-          return toEpochMicros((Instant) value);
-        } else if (value instanceof org.joda.time.Instant) {
-          // joda instant precision is millisecond
-          return ((org.joda.time.Instant) value).getMillis() * 1000L;
-        } else if (value instanceof Integer || value instanceof Long) {
-          return ((Number) value).longValue();
-        } else if (value instanceof Double || value instanceof Float) {
-          // assume value represents number of seconds since epoch
-          return BigDecimal.valueOf(((Number) value).doubleValue())
-              .scaleByPowerOfTen(6)
-              .setScale(0, RoundingMode.HALF_UP)
-              .longValue();
-        }
-        break;
-      case DATE:
-        if (value instanceof String) {
-          return ((Long) LocalDate.parse((String) value).toEpochDay()).intValue();
-        } else if (value instanceof LocalDate) {
-          return ((Long) ((LocalDate) value).toEpochDay()).intValue();
-        } else if (value instanceof org.joda.time.LocalDate) {
-          return Days.daysBetween(
-                  org.joda.time.Instant.EPOCH.toDateTime().toLocalDate(),
-                  (org.joda.time.LocalDate) value)
-              .getDays();
-        } else if (value instanceof Integer || value instanceof Long) {
-          return ((Number) value).intValue();
-        }
-        break;
-      case NUMERIC:
-        if (value instanceof String) {
-          return BigDecimalByteStringEncoder.encodeToNumericByteString(
-              new BigDecimal((String) value));
-        } else if (value instanceof BigDecimal) {
-          return BigDecimalByteStringEncoder.encodeToNumericByteString(((BigDecimal) value));
-        } else if (value instanceof Double || value instanceof Float) {
-          return BigDecimalByteStringEncoder.encodeToNumericByteString(
-              BigDecimal.valueOf(((Number) value).doubleValue()));
-        } else if (value instanceof Short || value instanceof Integer || value instanceof Long) {
-          return BigDecimalByteStringEncoder.encodeToNumericByteString(
-              BigDecimal.valueOf(((Number) value).longValue()));
-        }
-        break;
-      case BIGNUMERIC:
-        if (value instanceof String) {
-          return BigDecimalByteStringEncoder.encodeToBigNumericByteString(
-              new BigDecimal((String) value));
-        } else if (value instanceof BigDecimal) {
-          return BigDecimalByteStringEncoder.encodeToBigNumericByteString(((BigDecimal) value));
-        } else if (value instanceof Double || value instanceof Float) {
-          return BigDecimalByteStringEncoder.encodeToBigNumericByteString(
-              BigDecimal.valueOf(((Number) value).doubleValue()));
-        } else if (value instanceof Short || value instanceof Integer || value instanceof Long) {
-          return BigDecimalByteStringEncoder.encodeToBigNumericByteString(
-              BigDecimal.valueOf(((Number) value).longValue()));
-        }
-        break;
-      case DATETIME:
-        if (value instanceof String) {
-          try {
-            // '2011-12-03T10:15:30'
-            return CivilTimeEncoder.encodePacked64DatetimeMicros(
-                LocalDateTime.parse((String) value));
-          } catch (DateTimeParseException e2) {
-            // '2011-12-03 10:15:30'
-            return CivilTimeEncoder.encodePacked64DatetimeMicros(
-                LocalDateTime.parse((String) value, DATETIME_SPACE_FORMATTER));
-          }
-        } else if (value instanceof Number) {
-          return ((Number) value).longValue();
-        } else if (value instanceof LocalDateTime) {
-          return CivilTimeEncoder.encodePacked64DatetimeMicros((LocalDateTime) value);
-        } else if (value instanceof org.joda.time.LocalDateTime) {
-          return CivilTimeEncoder.encodePacked64DatetimeMicros((org.joda.time.LocalDateTime) value);
-        }
-        break;
-      case TIME:
-        if (value instanceof String) {
-          return CivilTimeEncoder.encodePacked64TimeMicros(LocalTime.parse((String) value));
-        } else if (value instanceof Number) {
-          return ((Number) value).longValue();
-        } else if (value instanceof LocalTime) {
-          return CivilTimeEncoder.encodePacked64TimeMicros((LocalTime) value);
-        } else if (value instanceof org.joda.time.LocalTime) {
-          return CivilTimeEncoder.encodePacked64TimeMicros((org.joda.time.LocalTime) value);
-        }
-        break;
-      case STRING:
-      case JSON:
-      case GEOGRAPHY:
-        return Preconditions.checkArgumentNotNull(value).toString();
-      case STRUCT:
-        if (value instanceof TableRow) {
-          TableRow tableRow = (TableRow) value;
-          return messageFromTableRow(
-              schemaInformation,
-              fieldDescriptor.getMessageType(),
-              tableRow,
-              ignoreUnknownValues,
-              allowMissingRequiredFields,
-              getUnknownNestedFields.get(),
-              null,
-              null);
-        } else if (value instanceof AbstractMap) {
-          // This will handle nested rows.
-          AbstractMap<String, Object> map = ((AbstractMap<String, Object>) value);
-          return messageFromMap(
-              schemaInformation,
-              fieldDescriptor.getMessageType(),
-              map,
-              ignoreUnknownValues,
-              allowMissingRequiredFields,
-              getUnknownNestedFields.get(),
-              null,
-              null);
-        }
-        break;
-      default:
+    @Nullable Object converted = null;
+    if (schemaInformation.getType() == TableFieldSchema.Type.STRUCT) {
+      if (value instanceof TableRow) {
+        TableRow tableRow = (TableRow) value;
+        converted =
+            messageFromTableRow(
+                schemaInformation,
+                fieldDescriptor.getMessageType(),
+                tableRow,
+                ignoreUnknownValues,
+                allowMissingRequiredFields,
+                getUnknownNestedFields.get(),
+                null,
+                null);
+      } else if (value instanceof AbstractMap) {
+        // This will handle nested rows.
+        AbstractMap<String, Object> map = ((AbstractMap<String, Object>) value);
+        converted =
+            messageFromMap(
+                schemaInformation,
+                fieldDescriptor.getMessageType(),
+                map,
+                ignoreUnknownValues,
+                allowMissingRequiredFields,
+                getUnknownNestedFields.get(),
+                null,
+                null);
+      }
+    } else {
+      @Nullable
+      ThrowingBiFunction<String, Object, @Nullable Object> converter =
+          TYPE_MAP_PROTO_CONVERTERS.get(schemaInformation.getType());
+      if (converter == null) {
         throw new RuntimeException("Unknown type " + schemaInformation.getType());
+      }
+      converted = converter.apply(schemaInformation.getFullName(), value);
     }
-
-    throw new SchemaDoesntMatchException(
-        "Unexpected value: "
-            + value
-            + ", type: "
-            + (value == null ? "null" : value.getClass())
-            + ". Table field name: "
-            + schemaInformation.getFullName()
-            + ", type: "
-            + schemaInformation.getType());
+    if (converted == null) {
+      throw new SchemaDoesntMatchException(
+          "Unexpected value: "
+              + value
+              + ", type: "
+              + (value == null ? "null" : value.getClass())
+              + ". Table field name: "
+              + schemaInformation.getFullName()
+              + ", type: "
+              + schemaInformation.getType());
+    }
+    return converted;
   }
 
   private static long toEpochMicros(Instant timestamp) {
@@ -1282,68 +1340,378 @@ public class TableRowToStorageApiProto {
 
   @VisibleForTesting
   public static TableRow tableRowFromMessage(
-      Message message, boolean includeCdcColumns, Predicate<String> includeField) {
-    return tableRowFromMessage(message, includeCdcColumns, includeField, "");
+      SchemaInformation schemaInformation,
+      Message message,
+      boolean includeCdcColumns,
+      Predicate<String> includeField) {
+    return tableRowFromMessage(schemaInformation, message, includeCdcColumns, includeField, "");
   }
 
   public static TableRow tableRowFromMessage(
+      SchemaInformation schemaInformation,
       Message message,
       boolean includeCdcColumns,
       Predicate<String> includeField,
       String namePrefix) {
-    // TODO: Would be more correct to generate TableRows using setF.
+    // We first try to create a map-style TableRow for backwards compatibility with existing usage.
+    // However this will
+    // fail if there is a column name "f". If it fails, we then instead create a list-style
+    // TableRow.
+    Optional<TableRow> tableRow =
+        tableRowFromMessageNoF(
+            schemaInformation, message, includeCdcColumns, includeField, namePrefix);
+    return tableRow.orElseGet(
+        () ->
+            tableRowFromMessageUseSetF(
+                schemaInformation, message, includeCdcColumns, includeField, ""));
+  }
+
+  private static Optional<TableRow> tableRowFromMessageNoF(
+      SchemaInformation schemaInformation,
+      Message message,
+      boolean includeCdcColumns,
+      Predicate<String> includeField,
+      String namePrefix) {
     TableRow tableRow = new TableRow();
     for (Map.Entry<FieldDescriptor, Object> field : message.getAllFields().entrySet()) {
       StringBuilder fullName = new StringBuilder();
       FieldDescriptor fieldDescriptor = field.getKey();
       String fieldName = fieldNameFromProtoFieldDescriptor(fieldDescriptor);
+      if ("f".equals(fieldName)) {
+        // TableRow.put won't work as expected if the fields in named "f." Fail the call, and force
+        // a retry using
+        // the setF codepath.
+        return Optional.empty();
+      }
       fullName = fullName.append(namePrefix).append(fieldName);
       Object fieldValue = field.getValue();
       if ((includeCdcColumns || !StorageApiCDC.COLUMNS.contains(fullName.toString()))
           && includeField.test(fieldName)) {
-        tableRow.put(
-            fieldName,
+        SchemaInformation fieldSchemaInformation = schemaInformation.getSchemaForField(fieldName);
+        Object convertedFieldValue =
             jsonValueFromMessageValue(
-                fieldDescriptor, fieldValue, true, includeField, fullName.append(".").toString()));
+                fieldSchemaInformation,
+                fieldDescriptor,
+                fieldValue,
+                true,
+                includeField,
+                fullName.append(".").toString(),
+                false);
+        if (convertedFieldValue instanceof Optional) {
+          Optional<?> optional = (Optional<?>) convertedFieldValue;
+          if (!optional.isPresent()) {
+            // Some nested message had a field named "f." Fail.
+            return Optional.empty();
+          } else {
+            convertedFieldValue = optional.get();
+          }
+        }
+        tableRow.put(fieldName, convertedFieldValue);
       }
     }
+    return Optional.of(tableRow);
+  }
+
+  public static TableRow tableRowFromMessageUseSetF(
+      SchemaInformation schemaInformation,
+      Message message,
+      boolean includeCdcColumns,
+      Predicate<String> includeField,
+      String namePrefix) {
+    List<TableCell> tableCells =
+        Lists.newArrayListWithCapacity(message.getDescriptorForType().getFields().size());
+
+    for (FieldDescriptor fieldDescriptor : message.getDescriptorForType().getFields()) {
+      TableCell tableCell = new TableCell();
+      boolean isPresent =
+          (fieldDescriptor.isRepeated() && message.getRepeatedFieldCount(fieldDescriptor) > 0)
+              || (!fieldDescriptor.isRepeated() && message.hasField(fieldDescriptor));
+      if (isPresent) {
+        StringBuilder fullName = new StringBuilder();
+        String fieldName = fieldNameFromProtoFieldDescriptor(fieldDescriptor);
+        fullName = fullName.append(namePrefix).append(fieldName);
+        if ((includeCdcColumns || !StorageApiCDC.COLUMNS.contains(fullName.toString()))
+            && includeField.test(fieldName)) {
+          SchemaInformation fieldSchemaInformation = schemaInformation.getSchemaForField(fieldName);
+          Object fieldValue = message.getField(fieldDescriptor);
+          Object converted =
+              jsonValueFromMessageValue(
+                  fieldSchemaInformation,
+                  fieldDescriptor,
+                  fieldValue,
+                  true,
+                  includeField,
+                  fullName.append(".").toString(),
+                  true);
+          tableCell.setV(converted);
+        }
+      }
+      tableCells.add(tableCell);
+    }
+
+    TableRow tableRow = new TableRow();
+    tableRow.setF(tableCells);
+
     return tableRow;
   }
 
+  // Our process for generating descriptors modifies the names of nested descriptors for wrapper
+  // types, so we record them here.
+  private static final Set<String> FLOAT_VALUE_DESCRIPTOR_NAMES =
+      ImmutableSet.of("google_protobuf_FloatValue", "FloatValue");
+  private static final Set<String> DOUBLE_VALUE_DESCRIPTOR_NAMES =
+      ImmutableSet.of("google_protobuf_DoubleValue", "DoubleValue");
+  private static final Set<String> BOOL_VALUE_DESCRIPTOR_NAMES =
+      ImmutableSet.of("google_protobuf_BoolValue", "BoolValue");
+  private static final Set<String> INT32_VALUE_DESCRIPTOR_NAMES =
+      ImmutableSet.of("google_protobuf_Int32Value", "Int32Value");
+  private static final Set<String> INT64_VALUE_DESCRIPTOR_NAMES =
+      ImmutableSet.of("google_protobuf_Int64Value", "Int64Value");
+  private static final Set<String> UINT32_VALUE_DESCRIPTOR_NAMES =
+      ImmutableSet.of("google_protobuf_UInt32Value", "UInt32Value");
+  private static final Set<String> UINT64_VALUE_DESCRIPTOR_NAMES =
+      ImmutableSet.of("google_protobuf_UInt64Value", "UInt64Value");
+  private static final Set<String> BYTES_VALUE_DESCRIPTOR_NAMES =
+      ImmutableSet.of("google_protobuf_BytesValue", "BytesValue");
+  private static final Set<String> TIMESTAMP_VALUE_DESCRIPTOR_NAMES =
+      ImmutableSet.of("google_protobuf_Timestamp", "Timestamp");
+
+  // Translate a proto message value into a json value. If useSetF==false, this will fail with
+  // Optional.empty() if
+  // any fields named "f" are found (due to restrictions on the TableRow class). In that case, the
+  // top level will retry
+  // with useSetF==true. We fallback this way in order to maintain backwards compatibility with
+  // existing users.
   public static Object jsonValueFromMessageValue(
+      SchemaInformation schemaInformation,
       FieldDescriptor fieldDescriptor,
       Object fieldValue,
       boolean expandRepeated,
       Predicate<String> includeField,
-      String prefix) {
+      String prefix,
+      boolean useSetF) {
     if (expandRepeated && fieldDescriptor.isRepeated()) {
       List<Object> valueList = (List<Object>) fieldValue;
-      return valueList.stream()
-          .map(v -> jsonValueFromMessageValue(fieldDescriptor, v, false, includeField, prefix))
-          .collect(toList());
+      List<Object> expanded = Lists.newArrayListWithCapacity(valueList.size());
+      for (Object value : valueList) {
+        Object translatedValue =
+            jsonValueFromMessageValue(
+                schemaInformation, fieldDescriptor, value, false, includeField, prefix, useSetF);
+        if (!useSetF && translatedValue instanceof Optional) {
+          Optional<?> optional = (Optional<?>) translatedValue;
+          if (!optional.isPresent()) {
+            // A nested element contained an "f" column. Fail the call.
+            return Optional.empty();
+          }
+          translatedValue = optional.get();
+        }
+        expanded.add(translatedValue);
+      }
+      return expanded;
     }
 
-    switch (fieldDescriptor.getType()) {
-      case GROUP:
-      case MESSAGE:
-        return tableRowFromMessage((Message) fieldValue, false, includeField, prefix);
-      case BYTES:
-        return BaseEncoding.base64().encode(((ByteString) fieldValue).toByteArray());
-      case ENUM:
-        throw new RuntimeException("Enumerations not supported");
-      case INT32:
-      case FLOAT:
-      case BOOL:
+    // BigQueryIO supports direct proto writes - i.e. we allow the user to pass in their own proto
+    // and skip our
+    // conversion layer, as long as the proto conforms to the types supported by the BigQuery
+    // Storage Write API.
+    // For many schema types, the Storage Write API supports different proto field types (often with
+    // different
+    // encodings), so the mapping of schema type -> proto type is one to many. To read the data out
+    // of the proto,
+    // we need to examine both the schema type and the proto field type.
+    switch (schemaInformation.getType()) {
       case DOUBLE:
+        switch (fieldDescriptor.getType()) {
+          case FLOAT:
+          case DOUBLE:
+          case STRING:
+            return DECIMAL_FORMAT.format(Double.parseDouble(fieldValue.toString()));
+          case MESSAGE:
+            // Handle the various number wrapper types.
+            Message doubleMessage = (Message) fieldValue;
+            if (FLOAT_VALUE_DESCRIPTOR_NAMES.contains(fieldDescriptor.getMessageType().getName())) {
+              float floatValue =
+                  (float)
+                      doubleMessage.getField(
+                          doubleMessage.getDescriptorForType().findFieldByName("value"));
+
+              return DECIMAL_FORMAT.format(floatValue);
+            } else if (DOUBLE_VALUE_DESCRIPTOR_NAMES.contains(
+                fieldDescriptor.getMessageType().getName())) {
+              double doubleValue =
+                  (double)
+                      doubleMessage.getField(
+                          doubleMessage.getDescriptorForType().findFieldByName("value"));
+              return DECIMAL_FORMAT.format(doubleValue);
+            } else {
+              throw new RuntimeException(
+                  "Not implemented yet " + fieldDescriptor.getMessageType().getName());
+            }
+          default:
+            return fieldValue.toString();
+        }
+      case BOOL:
+        // Wrapper type.
+        if (fieldDescriptor.getType().equals(FieldDescriptor.Type.MESSAGE)) {
+          Message boolMessage = (Message) fieldValue;
+          if (BOOL_VALUE_DESCRIPTOR_NAMES.contains(fieldDescriptor.getMessageType().getName())) {
+            return boolMessage
+                .getField(boolMessage.getDescriptorForType().findFieldByName("value"))
+                .toString();
+          } else {
+            throw new RuntimeException(
+                "Not implemented yet " + fieldDescriptor.getMessageType().getName());
+          }
+        }
+        return fieldValue.toString();
+      case JSON:
+      case GEOGRAPHY:
         // The above types have native representations in JSON for all their
         // possible values.
-        return fieldValue;
       case STRING:
-      case INT64:
-      default:
-        // The above types must be cast to string to be safely encoded in
-        // JSON (due to JSON's float-based representation of all numbers).
         return fieldValue.toString();
+      case INT64:
+        switch (fieldDescriptor.getType()) {
+          case MESSAGE:
+            // Wrapper types.
+            Message message = (Message) fieldValue;
+            if (INT32_VALUE_DESCRIPTOR_NAMES.contains(fieldDescriptor.getMessageType().getName())) {
+              return message
+                  .getField(message.getDescriptorForType().findFieldByName("value"))
+                  .toString();
+            } else if (INT64_VALUE_DESCRIPTOR_NAMES.contains(
+                fieldDescriptor.getMessageType().getName())) {
+              return message
+                  .getField(message.getDescriptorForType().findFieldByName("value"))
+                  .toString();
+            } else if (UINT32_VALUE_DESCRIPTOR_NAMES.contains(
+                fieldDescriptor.getMessageType().getName())) {
+              return message
+                  .getField(message.getDescriptorForType().findFieldByName("value"))
+                  .toString();
+            } else if (UINT64_VALUE_DESCRIPTOR_NAMES.contains(
+                fieldDescriptor.getMessageType().getName())) {
+              return message
+                  .getField(message.getDescriptorForType().findFieldByName("value"))
+                  .toString();
+            } else {
+              throw new RuntimeException(
+                  "Not implemented yet " + fieldDescriptor.getMessageType().getFullName());
+            }
+          default:
+            return fieldValue.toString();
+        }
+      case BYTES:
+        switch (fieldDescriptor.getType()) {
+          case BYTES:
+            return BaseEncoding.base64().encode(((ByteString) fieldValue).toByteArray());
+          case STRING:
+            return BaseEncoding.base64()
+                .encode(((String) fieldValue).getBytes(StandardCharsets.UTF_8));
+          case MESSAGE:
+            Message message = (Message) fieldValue;
+            if (BYTES_VALUE_DESCRIPTOR_NAMES.contains(fieldDescriptor.getMessageType().getName())) {
+              ByteString byteString =
+                  (ByteString)
+                      message.getField(message.getDescriptorForType().findFieldByName("value"));
+              return BaseEncoding.base64().encode(byteString.toByteArray());
+            }
+            throw new RuntimeException(
+                "Not implemented " + fieldDescriptor.getMessageType().getFullName());
+          default:
+            return fieldValue.toString();
+        }
+      case TIMESTAMP:
+        if (isProtoFieldTypeInteger(fieldDescriptor.getType())) {
+          long epochMicros = Long.valueOf(fieldValue.toString());
+          long epochSeconds = epochMicros / 1_000_000L;
+          long nanoAdjustment = (epochMicros % 1_000_000L) * 1_000L;
+          Instant instant = Instant.ofEpochSecond(epochSeconds, nanoAdjustment);
+          return LocalDateTime.ofInstant(instant, ZoneOffset.UTC).format(TIMESTAMP_FORMATTER);
+        } else if (fieldDescriptor.getType().equals(FieldDescriptor.Type.MESSAGE)) {
+          Message message = (Message) fieldValue;
+          if (TIMESTAMP_VALUE_DESCRIPTOR_NAMES.contains(
+              fieldDescriptor.getMessageType().getName())) {
+            Descriptor descriptor = message.getDescriptorForType();
+            long seconds = (long) message.getField(descriptor.findFieldByName("seconds"));
+            int nanos = (int) message.getField(descriptor.findFieldByName("nanos"));
+            Instant instant = Instant.ofEpochSecond(seconds, nanos);
+            return LocalDateTime.ofInstant(instant, ZoneOffset.UTC).format(TIMESTAMP_FORMATTER);
+          } else {
+            throw new RuntimeException(
+                "Not implemented yet " + fieldDescriptor.getMessageType().getFullName());
+          }
+        } else {
+          return fieldValue.toString();
+        }
+
+      case DATE:
+        if (isProtoFieldTypeInteger(fieldDescriptor.getType())) {
+          int intDate = Integer.parseInt(fieldValue.toString());
+          return LocalDate.ofEpochDay(intDate).toString();
+        } else {
+          return fieldValue.toString();
+        }
+      case NUMERIC:
+        switch (fieldDescriptor.getType()) {
+          case BYTES:
+            ByteString numericByteString = (ByteString) fieldValue;
+            return BigDecimalByteStringEncoder.decodeNumericByteString(numericByteString)
+                .stripTrailingZeros()
+                .toString();
+          default:
+            return fieldValue.toString();
+        }
+      case BIGNUMERIC:
+        switch (fieldDescriptor.getType()) {
+          case BYTES:
+            ByteString numericByteString = (ByteString) fieldValue;
+            return BigDecimalByteStringEncoder.decodeBigNumericByteString(numericByteString)
+                .stripTrailingZeros()
+                .toString();
+          default:
+            return fieldValue.toString();
+        }
+
+      case DATETIME:
+        if (isProtoFieldTypeInteger(fieldDescriptor.getType())) {
+          long packedDateTime = Long.valueOf(fieldValue.toString());
+          return CivilTimeEncoder.decodePacked64DatetimeMicrosAsJavaTime(packedDateTime)
+              .format(BigQueryUtils.BIGQUERY_DATETIME_FORMATTER);
+        } else {
+          return fieldValue.toString();
+        }
+
+      case TIME:
+        if (isProtoFieldTypeInteger(fieldDescriptor.getType())) {
+          long packedTime = Long.valueOf(fieldValue.toString());
+          return CivilTimeEncoder.decodePacked64TimeMicrosAsJavaTime(packedTime).toString();
+        } else {
+          return fieldValue.toString();
+        }
+      case STRUCT:
+        return useSetF
+            ? tableRowFromMessageUseSetF(
+                schemaInformation, (Message) fieldValue, false, includeField, prefix)
+            : tableRowFromMessageNoF(
+                schemaInformation, (Message) fieldValue, false, includeField, prefix);
+      default:
+        return fieldValue.toString();
+    }
+  }
+
+  private static boolean isProtoFieldTypeInteger(FieldDescriptor.Type type) {
+    switch (type) {
+      case INT32:
+      case INT64:
+      case UINT32:
+      case UINT64:
+      case SFIXED32:
+      case SFIXED64:
+      case SINT64:
+        return true;
+      default:
+        return false;
     }
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TableRowToStorageApiProto.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TableRowToStorageApiProto.java
@@ -48,6 +48,7 @@ import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -59,6 +60,7 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -194,7 +196,8 @@ public class TableRowToStorageApiProto {
     OutputT apply(FirstInputT t, SecondInputT u) throws SchemaConversionException;
   }
 
-  static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("0.0###############");
+  static final DecimalFormat DECIMAL_FORMAT =
+      new DecimalFormat("0.0###############", DecimalFormatSymbols.getInstance(Locale.ROOT));
 
   // Map of functions to convert json values into the value expected in the Vortex proto object.
   static final Map<TableFieldSchema.Type, ThrowingBiFunction<String, Object, @Nullable Object>>

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/testing/FakeDatasetService.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/testing/FakeDatasetService.java
@@ -613,6 +613,7 @@ public class FakeDatasetService implements DatasetService, WriteStreamService, S
       private Descriptor protoDescriptor;
       private TableSchema currentSchema;
       private @Nullable com.google.cloud.bigquery.storage.v1.TableSchema updatedSchema;
+      TableRowToStorageApiProto.SchemaInformation schemaInformation;
 
       private boolean usedForInsert = false;
       private boolean usedForUpdate = false;
@@ -627,6 +628,9 @@ public class FakeDatasetService implements DatasetService, WriteStreamService, S
             throw new ApiException(null, GrpcStatusCode.of(Status.Code.NOT_FOUND), false);
           }
           currentSchema = stream.tableContainer.getTable().getSchema();
+          schemaInformation =
+              TableRowToStorageApiProto.SchemaInformation.fromTableSchema(
+                  TableRowToStorageApiProto.schemaToProtoTableSchema(currentSchema));
         }
       }
 
@@ -650,6 +654,7 @@ public class FakeDatasetService implements DatasetService, WriteStreamService, S
             }
             TableRow tableRow =
                 TableRowToStorageApiProto.tableRowFromMessage(
+                    schemaInformation,
                     DynamicMessage.parseFrom(protoDescriptor, bytes),
                     false,
                     Predicates.alwaysTrue());
@@ -698,6 +703,8 @@ public class FakeDatasetService implements DatasetService, WriteStreamService, S
             responseBuilder.setUpdatedSchema(newSchema);
             if (this.updatedSchema == null) {
               this.updatedSchema = newSchema;
+              this.schemaInformation =
+                  TableRowToStorageApiProto.SchemaInformation.fromTableSchema((this.updatedSchema));
             }
           }
         }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.io.gcp.bigquery;
 
 import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.toJsonString;
+import static org.apache.beam.sdk.io.gcp.bigquery.TableRowToStorageApiProto.TYPE_MAP_PROTO_CONVERTERS;
 import static org.apache.beam.sdk.io.gcp.bigquery.WriteTables.ResultCoder.INSTANCE;
 import static org.apache.beam.sdk.io.gcp.bigquery.providers.BigQueryFileLoadsSchemaTransformProvider.BigQueryFileLoadsSchemaTransform;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
@@ -59,8 +60,17 @@ import com.google.cloud.bigquery.storage.v1.AppendRowsRequest;
 import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
 import com.google.cloud.bigquery.storage.v1.Exceptions;
 import com.google.cloud.bigquery.storage.v1.ProtoRows;
+import com.google.protobuf.BoolValue;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.DoubleValue;
+import com.google.protobuf.FloatValue;
+import com.google.protobuf.Int32Value;
+import com.google.protobuf.Int64Value;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.UInt32Value;
+import com.google.protobuf.UInt64Value;
+import com.google.protobuf.util.Timestamps;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -1288,7 +1298,7 @@ public class BigQueryIOWriteTest implements Serializable {
                       "CreateTableSchemaString",
                       Create.of(KV.of(tableName, BigQueryHelpers.toJsonString(tableSchema))))
                   .setCoder(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()))
-                  .apply(View.<String, String>asMap()));
+                  .apply(View.asMap()));
     } else {
       bqWrite = bqWrite.withSchema(tableSchema);
     }
@@ -1302,34 +1312,46 @@ public class BigQueryIOWriteTest implements Serializable {
 
     p.run();
 
+    // Convert values string before comparing.
+    List<TableRow> allRows =
+        fakeDatasetService.getAllRows("project-id", "dataset-id", "table-id").stream()
+            .map(
+                (TableRow tr) -> {
+                  Map<String, Object> stringed =
+                      tr.entrySet().stream()
+                          .collect(
+                              Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString()));
+
+                  TableRow tableRow = new TableRow();
+                  tableRow.putAll(stringed);
+                  return tableRow;
+                })
+            .collect(Collectors.toList());
     assertThat(
-        fakeDatasetService.getAllRows("project-id", "dataset-id", "table-id"),
+        allRows,
         containsInAnyOrder(
             new TableRow()
                 .set("strval", "test")
                 .set("longval", "1")
-                .set("doubleval", 1.0)
+                .set("doubleval", "1.0")
                 .set(
                     "instantval",
                     useStorageApi || useStorageApiApproximate
-                        ? String.valueOf(Instant.parse("2019-01-01T00:00:00Z").getMillis() * 1000)
+                        ? "2019-01-01 T00:00:00"
                         : "2019-01-01 00:00:00 UTC"),
             new TableRow()
                 .set("strval", "test2")
                 .set("longval", "2")
-                .set("doubleval", 2.0)
+                .set("doubleval", "2.0")
                 .set(
                     "instantval",
                     useStorageApi || useStorageApiApproximate
-                        ? String.valueOf(Instant.parse("2019-02-01T00:00:00Z").getMillis() * 1000)
+                        ? "2019-02-01 T00:00:00"
                         : "2019-02-01 00:00:00 UTC")));
   }
 
   @Test
   public void testWriteAvro() throws Exception {
-    // only streaming inserts don't support avro types
-    assumeTrue(!useStreaming);
-
     runTestWriteAvro(false);
   }
 
@@ -2843,7 +2865,10 @@ public class BigQueryIOWriteTest implements Serializable {
             multiPartitionsTag,
             singlePartitionTag,
             RowWriterFactory.tableRows(
-                SerializableFunctions.identity(), SerializableFunctions.identity()));
+                BigQueryIO.TableRowFormatFunction.fromSerializableFunction(
+                    SerializableFunctions.identity()),
+                BigQueryIO.TableRowFormatFunction.fromSerializableFunction(
+                    SerializableFunctions.identity())));
 
     DoFnTester<
             Iterable<WriteBundlesToFiles.Result<TableDestination>>,
@@ -3284,9 +3309,9 @@ public class BigQueryIOWriteTest implements Serializable {
     Function<Integer, TableRow> getPrimitiveRow =
         (Integer i) ->
             new TableRow()
-                .set("primitive_double", Double.valueOf(i))
-                .set("primitive_float", Float.valueOf(i).doubleValue())
-                .set("primitive_int32", i.intValue())
+                .set("primitive_double", TableRowToStorageApiProto.DECIMAL_FORMAT.format(i))
+                .set("primitive_float", TableRowToStorageApiProto.DECIMAL_FORMAT.format(i))
+                .set("primitive_int32", i.toString())
                 .set("primitive_int64", i.toString())
                 .set("primitive_uint32", i.toString())
                 .set("primitive_uint64", i.toString())
@@ -3294,7 +3319,7 @@ public class BigQueryIOWriteTest implements Serializable {
                 .set("primitive_sint64", i.toString())
                 .set("primitive_fixed32", i.toString())
                 .set("primitive_fixed64", i.toString())
-                .set("primitive_bool", true)
+                .set("primitive_bool", "true")
                 .set("primitive_string", i.toString())
                 .set(
                     "primitive_bytes",
@@ -3307,7 +3332,7 @@ public class BigQueryIOWriteTest implements Serializable {
         (Function<TableRow, Boolean> & Serializable)
             tr ->
                 tr.containsKey("primitive_int32")
-                    && (Integer) tr.get("primitive_int32") >= failFrom;
+                    && Integer.parseInt((String) tr.get("primitive_int32")) >= failFrom;
     fakeDatasetService.setShouldFailRow(shouldFailRow);
 
     SerializableFunction<Proto3SchemaMessages.Primitive, TableRow> formatRecordOnFailureFunction =
@@ -3566,7 +3591,14 @@ public class BigQueryIOWriteTest implements Serializable {
     TableSchema subSchema =
         new TableSchema()
             .setFields(
-                ImmutableList.of(new TableFieldSchema().setName("number").setType("INTEGER")));
+                ImmutableList.of(
+                    new TableFieldSchema().setName("number").setType("INTEGER"),
+                    new TableFieldSchema().setName("timestamp").setType("TIMESTAMP"),
+                    new TableFieldSchema().setName("time").setType("TIME"),
+                    new TableFieldSchema().setName("datetime").setType("DATETIME"),
+                    new TableFieldSchema().setName("date").setType("DATE"),
+                    new TableFieldSchema().setName("numeric").setType("NUMERIC"),
+                    new TableFieldSchema().setName("bignumeric").setType("BIGNUMERIC")));
 
     TableSchema tableSchema =
         new TableSchema()
@@ -3582,10 +3614,19 @@ public class BigQueryIOWriteTest implements Serializable {
                         .setType("RECORD")
                         .setFields(subSchema.getFields())));
 
-    TableRow goodNested = new TableRow().set("number", "42");
+    TableRow goodNested =
+        new TableRow()
+            .set("number", "42")
+            .set("timestamp", "1970-01-01 T00:00:00.000043")
+            .set("time", "00:52:07.123456")
+            .set("datetime", "2019-08-16T00:52:07.123456")
+            .set("date", "2019-08-16")
+            .set("numeric", "23.4")
+            .set("bignumeric", "123456789012345678");
     TableRow badNested = new TableRow().set("number", "nAn");
 
     final String failValue = "failme";
+
     List<TableRow> goodRows =
         ImmutableList.of(
             new TableRow().set("name", "n1").set("number", "1"),
@@ -3593,6 +3634,7 @@ public class BigQueryIOWriteTest implements Serializable {
             new TableRow().set("name", "n2").set("number", "2"),
             new TableRow().set("name", failValue).set("number", "2"),
             new TableRow().set("name", "parent1").set("nested", goodNested),
+            new TableRow().set("name", failValue).set("number", "2").set("nested", goodNested),
             new TableRow().set("name", failValue).set("number", "1"));
     List<TableRow> badRows =
         ImmutableList.of(
@@ -3625,22 +3667,6 @@ public class BigQueryIOWriteTest implements Serializable {
             tr -> tr.containsKey("name") && tr.get("name").equals(failValue);
     fakeDatasetService.setShouldFailRow(shouldFailRow);
 
-    SerializableFunction<TableRow, TableRow> formatRecordOnFailureFunction =
-        input -> {
-          TableRow failedTableRow = new TableRow().set("testFailureFunctionField", "testValue");
-          if (input != null) {
-            Object name = input.get("name");
-            if (name != null) {
-              failedTableRow.set("name", name);
-            }
-            Object number = input.get("number");
-            if (number != null) {
-              failedTableRow.set("number", number);
-            }
-          }
-          return failedTableRow;
-        };
-
     WriteResult result =
         p.apply(Create.of(Iterables.concat(goodRows, badRows)))
             .apply(
@@ -3652,7 +3678,6 @@ public class BigQueryIOWriteTest implements Serializable {
                     .withFailedInsertRetryPolicy(InsertRetryPolicy.retryTransientErrors())
                     .withPropagateSuccessfulStorageApiWrites(true)
                     .withTestServices(fakeBqServices)
-                    .withFormatRecordOnFailureFunction(formatRecordOnFailureFunction)
                     .withoutValidation());
 
     PCollection<TableRow> deadRows =
@@ -3663,13 +3688,10 @@ public class BigQueryIOWriteTest implements Serializable {
                     .via(BigQueryStorageApiInsertError::getRow));
     PCollection<TableRow> successfulRows = result.getSuccessfulStorageApiInserts();
 
-    List<TableRow> expectedFailedRows =
-        badRows.stream().map(formatRecordOnFailureFunction::apply).collect(Collectors.toList());
+    List<TableRow> expectedFailedRows = Lists.newArrayList(badRows);
     expectedFailedRows.addAll(
-        goodRows.stream()
-            .filter(shouldFailRow::apply)
-            .map(formatRecordOnFailureFunction::apply)
-            .collect(Collectors.toList()));
+        goodRows.stream().filter(shouldFailRow::apply).collect(Collectors.toList()));
+
     PAssert.that(deadRows).containsInAnyOrder(expectedFailedRows);
     PAssert.that(successfulRows)
         .containsInAnyOrder(
@@ -4029,9 +4051,9 @@ public class BigQueryIOWriteTest implements Serializable {
     Function<Integer, TableRow> getPrimitiveRow =
         (Integer i) ->
             new TableRow()
-                .set("primitive_double", Double.valueOf(i))
-                .set("primitive_float", Float.valueOf(i).doubleValue())
-                .set("primitive_int32", i.intValue())
+                .set("primitive_double", TableRowToStorageApiProto.DECIMAL_FORMAT.format(i))
+                .set("primitive_float", TableRowToStorageApiProto.DECIMAL_FORMAT.format(i))
+                .set("primitive_int32", i.toString())
                 .set("primitive_int64", i.toString())
                 .set("primitive_uint32", i.toString())
                 .set("primitive_uint64", i.toString())
@@ -4039,7 +4061,7 @@ public class BigQueryIOWriteTest implements Serializable {
                 .set("primitive_sint64", i.toString())
                 .set("primitive_fixed32", i.toString())
                 .set("primitive_fixed64", i.toString())
-                .set("primitive_bool", true)
+                .set("primitive_bool", "true")
                 .set("primitive_string", i.toString())
                 .set(
                     "primitive_bytes",
@@ -4077,6 +4099,440 @@ public class BigQueryIOWriteTest implements Serializable {
             .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED)
             .withMethod(method)
             .withoutValidation()
+            .withTestServices(fakeBqServices);
+
+    p.apply(Create.of(items)).apply("WriteToBQ", write);
+    p.run();
+
+    // Round trip through the coder to make sure the types match our expected types.
+    List<TableRow> allRows =
+        fakeDatasetService.getAllRows("project-id", "dataset-id", "table-id").stream()
+            .map(
+                tr -> {
+                  try {
+                    byte[] bytes = CoderUtils.encodeToByteArray(TableRowJsonCoder.of(), tr);
+                    return CoderUtils.decodeFromByteArray(TableRowJsonCoder.of(), bytes);
+                  } catch (Exception e) {
+                    throw new RuntimeException(e);
+                  }
+                })
+            .collect(Collectors.toList());
+    assertThat(allRows, containsInAnyOrder(Iterables.toArray(expectedItems, TableRow.class)));
+  }
+
+  // XXX Test string fields
+  // Test date numeric field
+  @Test
+  public void testWriteProtosEncodedValuesDirectWrite() throws Exception {
+    testWriteProtosEncodedValues(true);
+  }
+
+  @Test
+  public void testWriteProtosEncodedValuesNoDirectWrite() throws Exception {
+    testWriteProtosEncodedValues(false);
+  }
+
+  public void testWriteProtosEncodedValues(boolean directWrite) throws Exception {
+    assumeTrue(useStorageApi);
+
+    BigQueryIO.Write.Method method =
+        useStreaming
+            ? (useStorageApi
+                ? (useStorageApiApproximate
+                    ? Method.STORAGE_API_AT_LEAST_ONCE
+                    : Method.STORAGE_WRITE_API)
+                : Method.STREAMING_INSERTS)
+            : useStorageApi ? Method.STORAGE_WRITE_API : Method.FILE_LOADS;
+
+    final TableSchema tableSchema =
+        new TableSchema()
+            .setFields(
+                ImmutableList.of(
+                    new TableFieldSchema().setName("encoded_timestamp").setType("TIMESTAMP"),
+                    new TableFieldSchema().setName("encoded_date").setType("DATE"),
+                    new TableFieldSchema().setName("encoded_numeric").setType("NUMERIC"),
+                    new TableFieldSchema().setName("encoded_bignumeric").setType("BIGNUMERIC"),
+                    new TableFieldSchema().setName("encoded_packed_datetime").setType("DATETIME"),
+                    new TableFieldSchema().setName("encoded_packed_time").setType("TIME")));
+    final TableSchema nestedSchema =
+        new TableSchema()
+            .setFields(
+                ImmutableList.of(
+                    new TableFieldSchema()
+                        .setName("nested")
+                        .setType("STRUCT")
+                        .setFields(tableSchema.getFields()),
+                    new TableFieldSchema()
+                        .setName("nested_list")
+                        .setType("STRUCT")
+                        .setMode("REPEATED")
+                        .setFields(tableSchema.getFields())));
+
+    final String timestamp = "1970-01-01 T00:00:00.000043";
+    final String date = "2019-08-16";
+    final String numeric = "23";
+    final String bignumeric = "123456789012345678";
+    final String datetime = "2019-08-16T00:52:07.123456";
+    final String time = "00:52:07.123456";
+
+    Function<Integer, Proto3SchemaMessages.PrimitiveEncodedFields> getPrimitive =
+        (Integer i) -> {
+          try {
+            return Proto3SchemaMessages.PrimitiveEncodedFields.newBuilder()
+                .setEncodedTimestamp(
+                    (long)
+                        TYPE_MAP_PROTO_CONVERTERS
+                            .get(
+                                com.google.cloud.bigquery.storage.v1.TableFieldSchema.Type
+                                    .TIMESTAMP)
+                            .apply("", timestamp))
+                .setEncodedDate(
+                    (int)
+                        TYPE_MAP_PROTO_CONVERTERS
+                            .get(com.google.cloud.bigquery.storage.v1.TableFieldSchema.Type.DATE)
+                            .apply("", date))
+                .setEncodedNumeric(
+                    (ByteString)
+                        TYPE_MAP_PROTO_CONVERTERS
+                            .get(com.google.cloud.bigquery.storage.v1.TableFieldSchema.Type.NUMERIC)
+                            .apply("", numeric))
+                .setEncodedBignumeric(
+                    (ByteString)
+                        TYPE_MAP_PROTO_CONVERTERS
+                            .get(
+                                com.google.cloud.bigquery.storage.v1.TableFieldSchema.Type
+                                    .BIGNUMERIC)
+                            .apply("", bignumeric))
+                .setEncodedPackedDatetime(
+                    (long)
+                        TYPE_MAP_PROTO_CONVERTERS
+                            .get(
+                                com.google.cloud.bigquery.storage.v1.TableFieldSchema.Type.DATETIME)
+                            .apply("", datetime))
+                .setEncodedPackedTime(
+                    (long)
+                        TYPE_MAP_PROTO_CONVERTERS
+                            .get(com.google.cloud.bigquery.storage.v1.TableFieldSchema.Type.TIME)
+                            .apply("", time))
+                .build();
+          } catch (TableRowToStorageApiProto.SchemaConversionException e) {
+            throw new RuntimeException(e);
+          }
+        };
+
+    Function<Integer, TableRow> getPrimitiveRow =
+        (Integer i) ->
+            new TableRow()
+                .set("encoded_timestamp", timestamp)
+                .set("encoded_date", date)
+                .set("encoded_numeric", numeric)
+                .set("encoded_bignumeric", bignumeric)
+                .set("encoded_packed_datetime", datetime)
+                .set("encoded_packed_time", time);
+
+    List<Proto3SchemaMessages.PrimitiveEncodedFields> nestedItems =
+        Lists.newArrayList(getPrimitive.apply(1), getPrimitive.apply(2), getPrimitive.apply(3));
+
+    Iterable<Proto3SchemaMessages.NestedEncodedFields> items =
+        nestedItems.stream()
+            .map(
+                p ->
+                    Proto3SchemaMessages.NestedEncodedFields.newBuilder()
+                        .setNested(p)
+                        .addAllNestedList(Lists.newArrayList(p, p, p))
+                        .build())
+            .collect(Collectors.toList());
+
+    List<TableRow> expectedNestedTableRows =
+        Lists.newArrayList(
+            getPrimitiveRow.apply(1), getPrimitiveRow.apply(2), getPrimitiveRow.apply(3));
+    Iterable<TableRow> expectedItems =
+        expectedNestedTableRows.stream()
+            .map(
+                p ->
+                    new TableRow().set("nested", p).set("nested_list", Lists.newArrayList(p, p, p)))
+            .collect(Collectors.toList());
+
+    BigQueryIO.Write<Proto3SchemaMessages.NestedEncodedFields> write =
+        BigQueryIO.writeProtos(Proto3SchemaMessages.NestedEncodedFields.class)
+            .to("dataset-id.table-id")
+            .withSchema(nestedSchema)
+            .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED)
+            .withMethod(method)
+            .withoutValidation()
+            .withDirectWriteProtos(directWrite)
+            .withTestServices(fakeBqServices);
+
+    p.apply(Create.of(items)).apply("WriteToBQ", write);
+    p.run();
+
+    // Round trip through the coder to make sure the types match our expected types.
+    List<TableRow> allRows =
+        fakeDatasetService.getAllRows("project-id", "dataset-id", "table-id").stream()
+            .map(
+                tr -> {
+                  try {
+                    byte[] bytes = CoderUtils.encodeToByteArray(TableRowJsonCoder.of(), tr);
+                    return CoderUtils.decodeFromByteArray(TableRowJsonCoder.of(), bytes);
+                  } catch (Exception e) {
+                    throw new RuntimeException(e);
+                  }
+                })
+            .collect(Collectors.toList());
+    assertThat(allRows, containsInAnyOrder(Iterables.toArray(expectedItems, TableRow.class)));
+  }
+
+  @Test
+  public void testWriteProtosUnEncodedValuesDirectWrite() throws Exception {
+    testWriteProtosUnEncodedValues(true);
+  }
+
+  @Test
+  public void testWriteProtosUnEncodedValuesNoDirectWrite() throws Exception {
+    testWriteProtosUnEncodedValues(false);
+  }
+
+  public void testWriteProtosUnEncodedValues(boolean directWrite) throws Exception {
+    BigQueryIO.Write.Method method =
+        useStreaming
+            ? (useStorageApi
+                ? (useStorageApiApproximate
+                    ? Method.STORAGE_API_AT_LEAST_ONCE
+                    : Method.STORAGE_WRITE_API)
+                : Method.STREAMING_INSERTS)
+            : useStorageApi ? Method.STORAGE_WRITE_API : Method.FILE_LOADS;
+
+    final TableSchema tableSchema =
+        new TableSchema()
+            .setFields(
+                ImmutableList.of(
+                    new TableFieldSchema().setName("timestamp").setType("TIMESTAMP"),
+                    new TableFieldSchema().setName("date").setType("DATE"),
+                    new TableFieldSchema().setName("numeric").setType("NUMERIC"),
+                    new TableFieldSchema().setName("bignumeric").setType("BIGNUMERIC"),
+                    new TableFieldSchema().setName("datetime").setType("DATETIME"),
+                    new TableFieldSchema().setName("time").setType("TIME")));
+    final TableSchema nestedSchema =
+        new TableSchema()
+            .setFields(
+                ImmutableList.of(
+                    new TableFieldSchema()
+                        .setName("nested")
+                        .setType("STRUCT")
+                        .setFields(tableSchema.getFields()),
+                    new TableFieldSchema()
+                        .setName("nested_list")
+                        .setType("STRUCT")
+                        .setMode("REPEATED")
+                        .setFields(tableSchema.getFields())));
+
+    final String timestamp = "1970-01-01 T00:00:00.000043";
+    final String date = "2019-08-16";
+    final String numeric = "23";
+    final String bignumeric = "123456789012345678";
+    final String datetime = "2019-08-16T00:52:07.123456";
+    final String time = "00:52:07.123456";
+
+    Function<Integer, Proto3SchemaMessages.PrimitiveUnEncodedFields> getPrimitive =
+        (Integer i) -> {
+          return Proto3SchemaMessages.PrimitiveUnEncodedFields.newBuilder()
+              .setTimestamp(timestamp)
+              .setDate(date)
+              .setNumeric(numeric)
+              .setBignumeric(bignumeric)
+              .setDatetime(datetime)
+              .setTime(time)
+              .build();
+        };
+
+    Function<Integer, TableRow> getPrimitiveRow =
+        (Integer i) ->
+            new TableRow()
+                .set("timestamp", timestamp)
+                .set("date", date)
+                .set("numeric", numeric)
+                .set("bignumeric", bignumeric)
+                .set("datetime", datetime)
+                .set("time", time);
+
+    List<Proto3SchemaMessages.PrimitiveUnEncodedFields> nestedItems =
+        Lists.newArrayList(getPrimitive.apply(1), getPrimitive.apply(2), getPrimitive.apply(3));
+
+    Iterable<Proto3SchemaMessages.NestedUnEncodedFields> items =
+        nestedItems.stream()
+            .map(
+                p ->
+                    Proto3SchemaMessages.NestedUnEncodedFields.newBuilder()
+                        .setNested(p)
+                        .addAllNestedList(Lists.newArrayList(p, p, p))
+                        .build())
+            .collect(Collectors.toList());
+
+    List<TableRow> expectedNestedTableRows =
+        Lists.newArrayList(
+            getPrimitiveRow.apply(1), getPrimitiveRow.apply(2), getPrimitiveRow.apply(3));
+    Iterable<TableRow> expectedItems =
+        expectedNestedTableRows.stream()
+            .map(
+                p ->
+                    new TableRow().set("nested", p).set("nested_list", Lists.newArrayList(p, p, p)))
+            .collect(Collectors.toList());
+
+    BigQueryIO.Write<Proto3SchemaMessages.NestedUnEncodedFields> write =
+        BigQueryIO.writeProtos(Proto3SchemaMessages.NestedUnEncodedFields.class)
+            .to("dataset-id.table-id")
+            .withSchema(nestedSchema)
+            .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED)
+            .withMethod(method)
+            .withoutValidation()
+            .withDirectWriteProtos(directWrite)
+            .withTestServices(fakeBqServices);
+
+    p.apply(Create.of(items)).apply("WriteToBQ", write);
+    p.run();
+
+    // Round trip through the coder to make sure the types match our expected types.
+    List<TableRow> allRows =
+        fakeDatasetService.getAllRows("project-id", "dataset-id", "table-id").stream()
+            .map(
+                tr -> {
+                  try {
+                    byte[] bytes = CoderUtils.encodeToByteArray(TableRowJsonCoder.of(), tr);
+                    return CoderUtils.decodeFromByteArray(TableRowJsonCoder.of(), bytes);
+                  } catch (Exception e) {
+                    throw new RuntimeException(e);
+                  }
+                })
+            .collect(Collectors.toList());
+    assertThat(allRows, containsInAnyOrder(Iterables.toArray(expectedItems, TableRow.class)));
+  }
+
+  @Test
+  public void testWriteProtosWrappedValuesDirectWrite() throws Exception {
+    testWriteProtosWrappedValues(true);
+  }
+
+  @Test
+  public void testWriteProtosWrappedValuesNoDirectWrite() throws Exception {
+    testWriteProtosWrappedValues(false);
+  }
+
+  public void testWriteProtosWrappedValues(boolean directWrite) throws Exception {
+    assumeTrue(useStorageApi);
+    BigQueryIO.Write.Method method =
+        useStreaming
+            ? (useStorageApi
+                ? (useStorageApiApproximate
+                    ? Method.STORAGE_API_AT_LEAST_ONCE
+                    : Method.STORAGE_WRITE_API)
+                : Method.STREAMING_INSERTS)
+            : useStorageApi ? Method.STORAGE_WRITE_API : Method.FILE_LOADS;
+
+    final TableSchema tableSchema =
+        new TableSchema()
+            .setFields(
+                ImmutableList.of(
+                    new TableFieldSchema().setName("float").setType("FLOAT"),
+                    new TableFieldSchema().setName("double").setType("FLOAT"),
+                    new TableFieldSchema().setName("bool").setType("BOOL"),
+                    new TableFieldSchema().setName("int32").setType("INTEGER"),
+                    new TableFieldSchema().setName("int64").setType("INT64"),
+                    new TableFieldSchema().setName("uint32").setType("INTEGER"),
+                    new TableFieldSchema().setName("uint64").setType("INT64"),
+                    new TableFieldSchema().setName("bytes").setType("BYTES"),
+                    new TableFieldSchema().setName("timestamp").setType("TIMESTAMP")));
+
+    final TableSchema nestedSchema =
+        new TableSchema()
+            .setFields(
+                ImmutableList.of(
+                    new TableFieldSchema()
+                        .setName("nested")
+                        .setType("STRUCT")
+                        .setFields(tableSchema.getFields()),
+                    new TableFieldSchema()
+                        .setName("nested_list")
+                        .setType("STRUCT")
+                        .setMode("REPEATED")
+                        .setFields(tableSchema.getFields())));
+
+    final String timestamp = "1970-01-01 T00:00:00.000043";
+    long timestampMicros =
+        (long)
+            TYPE_MAP_PROTO_CONVERTERS
+                .get(com.google.cloud.bigquery.storage.v1.TableFieldSchema.Type.TIMESTAMP)
+                .apply("", timestamp);
+
+    final FloatValue floatValue = FloatValue.newBuilder().setValue(42.4F).build();
+    final DoubleValue doubleValue = DoubleValue.newBuilder().setValue(3.14D).build();
+    final BoolValue boolValue = BoolValue.newBuilder().setValue(true).build();
+    final Int32Value int32Value = Int32Value.newBuilder().setValue(1234).build();
+    final Int64Value int64Value = Int64Value.newBuilder().setValue(12345L).build();
+    final UInt32Value uint32Value = UInt32Value.newBuilder().setValue(345).build();
+    final UInt64Value uint64Value = UInt64Value.newBuilder().setValue(34567L).build();
+    final Timestamp timestampValue = Timestamps.fromMicros(timestampMicros);
+
+    Function<Integer, Proto3SchemaMessages.WrapperUnEncodedFields> getPrimitive =
+        (Integer i) -> {
+          return Proto3SchemaMessages.WrapperUnEncodedFields.newBuilder()
+              .setFloat(floatValue)
+              .setDouble(doubleValue)
+              .setBool(boolValue)
+              .setInt32(int32Value)
+              .setInt64(int64Value)
+              .setUint32(uint32Value)
+              .setUint64(uint64Value)
+              .setTimestamp(timestampValue)
+              .build();
+        };
+
+    Function<Integer, TableRow> getPrimitiveRow =
+        (Integer i) ->
+            new TableRow()
+                .set(
+                    "float", TableRowToStorageApiProto.DECIMAL_FORMAT.format(floatValue.getValue()))
+                .set(
+                    "double",
+                    TableRowToStorageApiProto.DECIMAL_FORMAT.format(doubleValue.getValue()))
+                .set("bool", Boolean.toString(boolValue.getValue()))
+                .set("int32", Integer.toString(int32Value.getValue()))
+                .set("int64", Long.toString(int64Value.getValue()))
+                .set("uint32", Integer.toString(uint32Value.getValue()))
+                .set("uint64", Long.toString(uint64Value.getValue()))
+                .set("timestamp", timestamp);
+    ;
+
+    List<Proto3SchemaMessages.WrapperUnEncodedFields> nestedItems =
+        Lists.newArrayList(getPrimitive.apply(1), getPrimitive.apply(2), getPrimitive.apply(3));
+
+    Iterable<Proto3SchemaMessages.NestedWrapperUnEncodedFields> items =
+        nestedItems.stream()
+            .map(
+                p ->
+                    Proto3SchemaMessages.NestedWrapperUnEncodedFields.newBuilder()
+                        .setNested(p)
+                        .addAllNestedList(Lists.newArrayList(p, p, p))
+                        .build())
+            .collect(Collectors.toList());
+
+    List<TableRow> expectedNestedTableRows =
+        Lists.newArrayList(
+            getPrimitiveRow.apply(1), getPrimitiveRow.apply(2), getPrimitiveRow.apply(3));
+    Iterable<TableRow> expectedItems =
+        expectedNestedTableRows.stream()
+            .map(
+                p ->
+                    new TableRow().set("nested", p).set("nested_list", Lists.newArrayList(p, p, p)))
+            .collect(Collectors.toList());
+
+    BigQueryIO.Write<Proto3SchemaMessages.NestedWrapperUnEncodedFields> write =
+        BigQueryIO.writeProtos(Proto3SchemaMessages.NestedWrapperUnEncodedFields.class)
+            .to("dataset-id.table-id")
+            .withSchema(nestedSchema)
+            .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED)
+            .withMethod(method)
+            .withoutValidation()
+            .withDirectWriteProtos(directWrite)
             .withTestServices(fakeBqServices);
 
     p.apply(Create.of(items)).apply("WriteToBQ", write);


### PR DESCRIPTION
This PR fixes multiple fundamental issues in tableRowFromMessage. This function is usually used in the dead-letter output from BigQueryIO, though it has other uses as well.
  - If the BigQuery table has a column named "f" the existing code throws an exception. This is because the TableRow class has an implicit field named "f" which conflicts. The fix is to detect this case and format the TableRow using setF instead. We do this only if an "f" column is detected to maintain backwards compatibility with existing usage.
  -  When converting a TableRow to a protocol buffer, specific field types (e.g. DATE, DATETIME) are encoded using an efficient encoding structure. The existing tableRowFromMessage function didn't know about these encodings, so when converting back to TableRow it simply copied the raw encoded data back. Users of TableRow don't know how to deal with these encodings, so this effectively corrupted the result. In order to properly decode these types, we had to extend the internal format function to take extra information about the BigQuery schema.
 
In addition to fixing these bugs, many tests were added.