### PR TITLE
Revert "Bump actions/setup-python from 4 to 6"

### DIFF
--- a/.github/workflows/beam_Infrastructure_PolicyEnforcer.yml
+++ b/.github/workflows/beam_Infrastructure_PolicyEnforcer.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v4
         with:
           python-version: '3.13'
           

--- a/.github/workflows/beam_Infrastructure_SecurityLogging.yml
+++ b/.github/workflows/beam_Infrastructure_SecurityLogging.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v4
         with:
           python-version: '3.13'
 

--- a/.github/workflows/beam_Infrastructure_ServiceAccountKeys.yml
+++ b/.github/workflows/beam_Infrastructure_ServiceAccountKeys.yml
@@ -53,7 +53,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v4
         with:
           python-version: '3.13'
 

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -281,7 +281,7 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
       - name: Install Python 3.9
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - name: Set up Docker Buildx
@@ -327,7 +327,7 @@ jobs:
           token: ${{ github.event.inputs.REPO_TOKEN }}
           ref: release-docs
       - name: Install Python 3.9
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - name: Install node
@@ -566,7 +566,7 @@ jobs:
           token: ${{ github.event.inputs.REPO_TOKEN }}
           persist-credentials: false
       - name: Install Python 3.9
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - name: Install Java 11

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Get tag
@@ -244,7 +244,7 @@ jobs:
         name: source_rc${{ needs.build_source.outputs.rc_num }}
         path: apache-beam-source-rc
     - name: Install Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
     - uses: docker/setup-qemu-action@v3

--- a/.github/workflows/dask_runner_tests.yml
+++ b/.github/workflows/dask_runner_tests.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Build source
@@ -72,7 +72,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.params.py_ver }}
       - name: Install tox

--- a/.github/workflows/flaky_test_detection.yml
+++ b/.github/workflows/flaky_test_detection.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: [self-hosted, ubuntu-20.04, main]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v5
         with: 
           python-version: 3.11
       - run: pip install PyGithub

--- a/.github/workflows/python_dependency_tests.yml
+++ b/.github/workflows/python_dependency_tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install libsnappy-dev
         run: sudo apt-get update && sudo apt-get install -y libsnappy-dev
       - name: Install python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.params.py_ver }}
       - name: Install base_image_requirements.txt

--- a/.github/workflows/refresh_looker_metrics.yml
+++ b/.github/workflows/refresh_looker_metrics.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: [self-hosted, ubuntu-20.04, main]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.11
       - run: pip install requests google-cloud-storage looker-sdk

--- a/.github/workflows/republish_released_docker_containers.yml
+++ b/.github/workflows/republish_released_docker_containers.yml
@@ -68,7 +68,7 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
       - name: Install Python 3.9
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - name: Authenticate on GCP

--- a/.github/workflows/run_perf_alert_tool.yml
+++ b/.github/workflows/run_perf_alert_tool.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Install Apache Beam

--- a/.github/workflows/run_rc_validation_python_mobile_gaming.yml
+++ b/.github/workflows/run_rc_validation_python_mobile_gaming.yml
@@ -104,7 +104,7 @@ jobs:
           java-version: 11
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/run_rc_validation_python_yaml.yml
+++ b/.github/workflows/run_rc_validation_python_yaml.yml
@@ -91,7 +91,7 @@ jobs:
           java-version: 11 # Keep Java setup for now, might be needed by gcloud/Dataflow
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/typescript_tests.yml
+++ b/.github/workflows/typescript_tests.yml
@@ -108,7 +108,7 @@ jobs:
         run: npm exec -y -- pacote extract @gradle-tech/develocity-agent@2.0.2 ~/.node_libraries/@gradle-tech/develocity-agent
         working-directory: ./sdks/typescript
       - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Setup Beam Python
@@ -171,7 +171,7 @@ jobs:
         run: npm exec -y -- pacote extract @gradle-tech/develocity-agent@2.0.2 ~/.node_libraries/@gradle-tech/develocity-agent
         working-directory: ./sdks/typescript
       - name: Install python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Setup Beam Python


### PR DESCRIPTION
Reverts apache/beam#36277

Causing failures like https://github.com/apache/beam/actions/runs/18325592266/job/52189151483?pr=36426