### PR TITLE
[Dataflow Streaming] Fix outstanding bundle metric reporting

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/StreamingWorkerStatusReporter.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/StreamingWorkerStatusReporter.java
@@ -328,7 +328,7 @@ public final class StreamingWorkerStatusReporter {
     StreamingScalingReport activeThreadsReport =
         new StreamingScalingReport()
             .setActiveThreadCount(workExecutor.activeCount())
-            .setActiveBundleCount(workExecutor.elementsOutstanding())
+            .setOutstandingBundleCount(workExecutor.elementsOutstanding())
             .setOutstandingBytes(workExecutor.bytesOutstanding())
             .setMaximumThreadCount(workExecutor.getMaximumPoolSize())
             .setMaximumBundleCount(workExecutor.maximumElementsOutstanding())


### PR DESCRIPTION
The value was getting set in setActiveBundleCount instead of in setOutstandingBundleCount.