### PR TITLE
Implement the member_type on the users.yml

### DIFF
--- a/infra/enforcement/iam.py
+++ b/infra/enforcement/iam.py
@@ -113,6 +113,7 @@ class IAMPolicyComplianceChecker:
                     members_data[member_str] = {
                         "username": username,
                         "email": email_address,
+                        "member_type": member_type,
                         "permissions": []
                     }
 
@@ -131,6 +132,7 @@ class IAMPolicyComplianceChecker:
             output_list.append({
                 "username": data["username"],
                 "email": data["email"],
+                "member_type": data["member_type"],
                 "permissions": data["permissions"]
             })
 
@@ -225,6 +227,8 @@ class IAMPolicyComplianceChecker:
             elif not current_user and existing_user:
                 differences.append(f"User {email} found in policy file but not in GCP.")
             elif current_user and existing_user:
+                if current_user.get("member_type") != existing_user.get("member_type"):
+                    differences.append(f"User {email} has different member type. In GCP: {current_user.get('member_type')}, in file: {existing_user.get('member_type')}")
                 if current_user["permissions"] != existing_user["permissions"]:
                     msg = f"\nPermissions for user {email} differ."
                     msg += f"\nIn GCP: {current_user['permissions']}"

--- a/infra/iam/README.md
+++ b/infra/iam/README.md
@@ -33,6 +33,7 @@ To manage user roles, edit the `users.yml` file. Add or modify entries under the
 users:
   - username: <username>
     email: <email>
+    member_type: <user|serviceAccount|group>
     permissions:
       - role: <role>
         title: <title> (optional)

--- a/infra/iam/users.tf
+++ b/infra/iam/users.tf
@@ -28,6 +28,7 @@ locals {
         {
           username              = user.username
           email                 = user.email
+          member_type           = user.member_type
           role                  = replace(perm.role, "PROJECT-ID", var.project_id)
           title                 = lookup(perm, "title", null)
           description           = lookup(perm, "description", null)
@@ -46,7 +47,7 @@ resource "google_project_iam_member" "project_members" {
   }
   project = var.project_id
   role    = each.value.role
-  member = can(regex(".*\\.gserviceaccount\\.com$", each.value.email)) ? "serviceAccount:${each.value.email}" : "user:${each.value.email}"
+  member  = "${each.value.member_type}:${each.value.email}"
 
   dynamic "condition" {
     # Condition is only created if expiry_date is set

--- a/infra/iam/users.yml
+++ b/infra/iam/users.yml
@@ -12,24 +12,39 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+    
 # IAM policy for project apache-beam-testing
-# Generated on 2025-10-07 16:00:39 UTC
+# Generated on 2025-10-09 19:30:30 UTC
 
 - username: WhatWouldAustinDo
   email: WhatWouldAustinDo@gmail.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: aaronleeiv
   email: aaronleeiv@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: abbymotley
   email: abbymotley@google.com
+  member_type: user
   permissions:
   - role: roles/viewer
+- username: abdelrahman.ibrahim
+  email: abdelrahman.ibrahim@akvelon.us
+  member_type: user
+  permissions:
+  - role: roles/bigquery.admin
+  - role: roles/container.admin
+  - role: roles/editor
+  - role: roles/iam.serviceAccountUser
+  - role: roles/secretmanager.admin
+  - role: roles/storage.objectAdmin
+  - role: roles/storage.objectCreator
 - username: adudko-runner-gke-sa
   email: adudko-runner-gke-sa@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/container.admin
   - role: roles/container.clusterAdmin
@@ -38,12 +53,14 @@
   - role: roles/iam.serviceAccountUser
 - username: ahmedabualsaud
   email: ahmedabualsaud@google.com
+  member_type: user
   permissions:
   - role: roles/biglake.admin
   - role: roles/editor
   - role: roles/owner
 - username: akarys.akvelon
   email: akarys.akvelon@gmail.com
+  member_type: user
   permissions:
   - role: roles/bigquery.admin
   - role: roles/container.admin
@@ -51,23 +68,28 @@
   - role: roles/secretmanager.secretAccessor
 - username: aleks-vm-sa
   email: aleks-vm-sa@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/artifactregistry.writer
   - role: roles/bigquery.admin
 - username: aleksandr.dudko
   email: aleksandr.dudko@akvelon.com
+  member_type: user
   permissions:
   - role: roles/viewer
 - username: alex.kosolapov
   email: alex.kosolapov@akvelon.com
+  member_type: user
   permissions:
   - role: roles/viewer
 - username: alexey.inkin
   email: alexey.inkin@akvelon.com
+  member_type: user
   permissions:
   - role: roles/viewer
 - username: allows-impersonation
   email: allows-impersonation@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: organizations/433637338589/roles/GceStorageAdmin
   - role: organizations/433637338589/roles/GcsBucketOwner
@@ -80,6 +102,7 @@
   - role: roles/viewer
 - username: allows-impersonation-new
   email: allows-impersonation-new@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: organizations/433637338589/roles/GcsBucketOwner
   - role: roles/dataflow.admin
@@ -87,23 +110,28 @@
   - role: roles/iam.serviceAccountUser
 - username: altay
   email: altay@google.com
+  member_type: user
   permissions:
   - role: roles/owner
   - role: roles/viewer
 - username: anandinguva
   email: anandinguva@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/dataflow.admin
 - username: anandinguva
   email: anandinguva@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: andres.vervaecke
   email: andres.vervaecke@ml6.eu
+  member_type: user
   permissions:
   - role: roles/viewer
 - username: andrey.devyatkin
   email: andrey.devyatkin@akvelon.com
+  member_type: user
   permissions:
   - role: roles/cloudsql.instanceUser
   - role: roles/dataflow.admin
@@ -112,6 +140,7 @@
   - role: roles/storage.admin
 - username: andreydevyatkin-runner-gke-sa
   email: andreydevyatkin-runner-gke-sa@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/container.admin
   - role: roles/dataflow.admin
@@ -119,54 +148,67 @@
   - role: roles/iam.serviceAccountUser
 - username: anikin
   email: anikin@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: apache-beam-testing
   email: apache-beam-testing@appspot.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/editor
 - username: apache-beam-testing-klk
   email: apache-beam-testing-klk@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/editor
 - username: apache-beam-testing-looker-admins
   email: apache-beam-testing-looker-admins@google.com
+  member_type: group
   permissions:
   - role: roles/looker.admin
 - username: apache-beam-testing-looker-users
   email: apache-beam-testing-looker-users@google.com
+  member_type: group
   permissions:
   - role: roles/looker.instanceUser
 - username: apanich
   email: apanich@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: archbtw
   email: archbtw@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: arne.vandendorpe
   email: arne.vandendorpe@ml6.eu
+  member_type: user
   permissions:
   - role: roles/viewer
 - username: aroraarnav
   email: aroraarnav@google.com
+  member_type: user
   permissions:
   - role: roles/owner
 - username: asfgnome
   email: asfgnome@gmail.com
+  member_type: user
   permissions:
   - role: roles/owner
 - username: ashokrd2
   email: ashokrd2@gmail.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: auth-example
   email: auth-example@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/artifactregistry.reader
 - username: beam-github-actions
   email: beam-github-actions@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/artifactregistry.createOnPushWriter
   - role: roles/artifactregistry.reader
@@ -182,6 +224,7 @@
   - role: roles/editor
   - role: roles/healthcare.fhirResourceEditor
   - role: roles/healthcare.fhirStoreAdmin
+  - role: roles/iam.roleAdmin
   - role: roles/iam.serviceAccountTokenCreator
   - role: roles/iam.serviceAccountUser
   - role: roles/logging.logWriter
@@ -190,18 +233,21 @@
   - role: roles/managedkafka.schemaRegistryEditor
   - role: roles/monitoring.metricWriter
   - role: roles/monitoring.viewer
+  - role: roles/resourcemanager.projectIamAdmin
   - role: roles/secretmanager.admin
   - role: roles/spanner.databaseAdmin
   - role: roles/stackdriver.resourceMetadata.writer
   - role: roles/storage.admin
 - username: beam-github-actions-k8-nodes
   email: beam-github-actions-k8-nodes@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/artifactregistry.reader
   - role: roles/container.nodeServiceAccount
   - role: roles/storage.objectViewer
 - username: beam-interns
   email: beam-interns@google.com
+  member_type: group
   permissions:
   - role: roles/bigquery.jobUser
   - role: roles/dataflow.developer
@@ -209,14 +255,17 @@
   - role: roles/serviceusage.serviceUsageConsumer
 - username: beam-metrics-posgresql-kube
   email: beam-metrics-posgresql-kube@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/cloudsql.client
 - username: beam-testing-dmartin-api-token
   email: beam-testing-dmartin-api-token@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/cloudfunctions.invoker
 - username: beam-wheels-github
   email: beam-wheels-github@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/aiplatform.user
   - role: roles/artifactregistry.admin
@@ -239,39 +288,48 @@
   - role: roles/viewer
 - username: bigquery-admin
   email: bigquery-admin@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/bigquery.admin
 - username: bigquery-reader
   email: bigquery-reader@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/bigquery.dataViewer
   - role: roles/bigquery.jobUser
 - username: bjornpedersen
   email: bjornpedersen@google.com
+  member_type: user
   permissions:
   - role: roles/viewer
 - username: bvolpato
   email: bvolpato@google.com
+  member_type: user
   permissions:
   - role: roles/viewer
 - username: byronellis
   email: byronellis@google.com
+  member_type: user
   permissions:
   - role: roles/viewer
 - username: ccychenzo
   email: ccychenzo@gmail.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: chamikara
   email: chamikara@google.com
+  member_type: user
   permissions:
   - role: roles/owner
 - username: chamikara-sa
   email: chamikara-sa@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/editor
 - username: cloud-data-workflow-dev
   email: cloud-data-workflow-dev@prod.google.com
+  member_type: user
   permissions:
   - role: roles/compute.instanceAdmin.v1
   - role: roles/compute.networkViewer
@@ -280,21 +338,25 @@
   - role: roles/trafficdirector.client
 - username: cloud-dataflow-templates-team
   email: cloud-dataflow-templates-team@twosync.google.com
+  member_type: group
   permissions:
   - role: roles/managedkafka.admin
   - role: roles/viewer
 - username: cvandermerwe
   email: cvandermerwe@google.com
+  member_type: user
   permissions:
   - role: roles/compute.networkAdmin
   - role: roles/editor
 - username: damondouglas
   email: damondouglas@google.com
+  member_type: user
   permissions:
   - role: roles/editor
   - role: roles/owner
 - username: dannymccormick
   email: dannymccormick@google.com
+  member_type: user
   permissions:
   - role: roles/bigquery.dataOwner
   - role: roles/container.admin
@@ -303,52 +365,63 @@
   - role: roles/resourcemanager.projectIamAdmin
 - username: dataflow-ml-starter
   email: dataflow-ml-starter@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/editor
   - role: roles/iam.serviceAccountTokenCreator
 - username: datapls-plat-team
   email: datapls-plat-team@google.com
+  member_type: group
   permissions:
   - role: roles/looker.instanceUser
   - role: roles/viewer
 - username: datapls-team
   email: datapls-team@google.com
+  member_type: group
   permissions:
   - role: roles/looker.instanceUser
 - username: datapls-unified-worker
   email: datapls-unified-worker@google.com
+  member_type: group
   permissions:
   - role: roles/looker.instanceUser
 - username: dcrhodes
   email: dcrhodes@google.com
+  member_type: user
   permissions:
   - role: roles/bigquery.dataViewer
   - role: roles/bigquery.user
 - username: deepchowdhury
   email: deepchowdhury@google.com
+  member_type: user
   permissions:
   - role: roles/viewer
 - username: derrickaw
   email: derrickaw@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: dippatel
   email: dippatel@google.com
+  member_type: user
   permissions:
   - role: roles/editor
   - role: roles/resourcemanager.projectIamAdmin
   - role: roles/spanner.admin
 - username: dippatel
   email: dippatel@prod.google.com
+  member_type: user
   permissions:
   - role: roles/editor
   - role: roles/iam.serviceAccountTokenCreator
 - username: djagaluru
   email: djagaluru@google.com
+  member_type: user
   permissions:
   - role: roles/viewer
 - username: djerek.vlado6
   email: djerek.vlado6@gmail.com
+  member_type: user
   permissions:
   - role: organizations/433637338589/roles/GceStorageAdmin
   - role: roles/cloudfunctions.admin
@@ -358,34 +431,41 @@
   - role: roles/secretmanager.secretAccessor
 - username: dpcollins
   email: dpcollins@google.com
+  member_type: user
   permissions:
   - role: roles/viewer
 - username: ellading
   email: ellading@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: enriquecaol04
   email: enriquecaol04@gmail.com
+  member_type: user
   permissions:
   - role: roles/viewer
 - username: eventarc-workflow-sa
   email: eventarc-workflow-sa@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/eventarc.eventReceiver
   - role: roles/pubsub.publisher
   - role: roles/workflows.invoker
 - username: firebase-adminsdk-dpfsw
   email: firebase-adminsdk-dpfsw@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/firebase.sdkAdminServiceAgent
   - role: roles/firebaseauth.admin
   - role: roles/iam.serviceAccountTokenCreator
 - username: fozzie
   email: fozzie@google.com
+  member_type: user
   permissions:
   - role: roles/owner
 - username: francisohara
   email: francisohara@google.com
+  member_type: user
   permissions:
   - role: roles/bigquery.user
   - role: roles/dataflow.admin
@@ -393,10 +473,12 @@
   - role: roles/iam.serviceAccountUser
 - username: giomar.osorio
   email: giomar.osorio@wizeline.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: github-self-hosted-runners
   email: github-self-hosted-runners@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/artifactregistry.reader
   - role: roles/cloudfunctions.invoker
@@ -404,21 +486,25 @@
   - role: roles/storage.objectViewer
 - username: harrisonlim
   email: harrisonlim@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: hejia
   email: hejia@google.com
+  member_type: user
   permissions:
   - role: roles/iam.securityReviewer
   - role: roles/viewer
 - username: impersonation-dataflow-worker
   email: impersonation-dataflow-worker@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: organizations/433637338589/roles/GcsBucketOwner
   - role: roles/dataflow.admin
   - role: roles/dataflow.worker
 - username: infra-pipelines-worker
   email: infra-pipelines-worker@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/artifactregistry.reader
   - role: roles/bigquery.readSessionUser
@@ -431,41 +517,50 @@
   - role: roles/storage.admin
 - username: jasper.van.den.bossche
   email: jasper.van.den.bossche@ml6.eu
+  member_type: user
   permissions:
   - role: roles/editor
 - username: jeffreylwang
   email: jeffreylwang@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: jkinard
   email: jkinard@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: johnjcasey
   email: johnjcasey@google.com
+  member_type: user
   permissions:
   - role: roles/editor
   - role: roles/owner
 - username: joseinigo
   email: joseinigo@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: jrmccluskey
   email: jrmccluskey@google.com
+  member_type: user
   permissions:
   - role: roles/editor
   - role: roles/owner
 - username: k.loyola.gutierrez
   email: k.loyola.gutierrez@akvelon.com
+  member_type: user
   permissions:
   - role: roles/container.admin
   - role: roles/editor
 - username: kenn
   email: kenn@apache.org
+  member_type: user
   permissions:
   - role: roles/owner
 - username: kerrydc
   email: kerrydc@google.com
+  member_type: user
   permissions:
   - role: roles/cloudasset.owner
   - role: roles/dataflow.admin
@@ -473,15 +568,18 @@
   - role: roles/resourcemanager.projectIamAdmin
 - username: klk
   email: klk@google.com
+  member_type: user
   permissions:
   - role: roles/editor
   - role: roles/owner
 - username: kmj
   email: kmj@google.com
+  member_type: user
   permissions:
   - role: roles/bigquery.user
 - username: lahariguduru
   email: lahariguduru@google.com
+  member_type: user
   permissions:
   - role: roles/bigquery.user
   - role: roles/dataflow.admin
@@ -489,34 +587,42 @@
   - role: roles/iam.serviceAccountUser
 - username: limatthew
   email: limatthew@google.com
+  member_type: user
   permissions:
   - role: roles/viewer
 - username: maggiejz
   email: maggiejz@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: manavgarg
   email: manavgarg@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: meetsea
   email: meetsea@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: mock-apis-64xjw9
   email: mock-apis-64xjw9@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/logging.logWriter
 - username: naireenhussain
   email: naireenhussain@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: nickllx
   email: nickllx@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: oleg.borisevich
   email: oleg.borisevich@akvelon.com
+  member_type: user
   permissions:
   - role: roles/cloudbuild.builds.editor
   - role: roles/cloudfunctions.admin
@@ -536,19 +642,23 @@
   - role: roles/storage.admin
 - username: pabloem
   email: pabloem@google.com
+  member_type: user
   permissions:
   - role: roles/iap.tunnelResourceAccessor
   - role: roles/owner
 - username: pandey.ayu
   email: pandey.ayu@gmail.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: pandiana
   email: pandiana@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: phucnh402
   email: phucnh402@gmail.com
+  member_type: user
   permissions:
   - role: roles/biglake.admin
   - role: roles/container.admin
@@ -560,15 +670,18 @@
   - role: roles/storage.admin
 - username: playground-cd-cb
   email: playground-cd-cb@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/datastore.user
   - role: roles/storage.insightsCollectorService
 - username: playground-ci-cb
   email: playground-ci-cb@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/storage.insightsCollectorService
 - username: playground-deploy-cb
   email: playground-deploy-cb@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/appengine.appAdmin
   - role: roles/appengine.appCreator
@@ -589,6 +702,7 @@
   - role: roles/storage.admin
 - username: playground-update-cb
   email: playground-update-cb@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/appengine.appAdmin
   - role: roles/artifactregistry.admin
@@ -605,15 +719,18 @@
   - role: roles/storage.admin
 - username: polecito.em
   email: polecito.em@gmail.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: pranavbhandari
   email: pranavbhandari@google.com
+  member_type: user
   permissions:
   - role: roles/bigquery.admin
   - role: roles/editor
 - username: prod-playground-sa
   email: prod-playground-sa@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/artifactregistry.reader
   - role: roles/bigquery.dataViewer
@@ -626,20 +743,24 @@
   - role: roles/stackdriver.resourceMetadata.writer
 - username: prod-playground-sa-cf
   email: prod-playground-sa-cf@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/cloudfunctions.invoker
   - role: roles/datastore.user
   - role: roles/storage.objectViewer
 - username: rajkumargupta
   email: rajkumargupta@google.com
+  member_type: user
   permissions:
   - role: roles/owner
 - username: rebo
   email: rebo@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: reebaq212
   email: reebaq212@gmail.com
+  member_type: user
   permissions:
   - role: roles/bigquery.admin
   - role: roles/editor
@@ -649,10 +770,12 @@
   - role: roles/storage.objectViewer
 - username: relax
   email: relax@google.com
+  member_type: user
   permissions:
   - role: roles/owner
 - username: rezarokni
   email: rezarokni@google.com
+  member_type: user
   permissions:
   - role: roles/bigquery.admin
   - role: roles/dataflow.admin
@@ -660,24 +783,29 @@
   - role: roles/storage.objectAdmin
 - username: riteshghorse
   email: riteshghorse@google.com
+  member_type: user
   permissions:
   - role: roles/editor
   - role: roles/owner
 - username: robbe.sneyders
   email: robbe.sneyders@ml6.eu
+  member_type: user
   permissions:
   - role: roles/editor
 - username: robertwb
   email: robertwb@google.com
+  member_type: user
   permissions:
   - role: roles/owner
   - role: roles/viewer
 - username: rosinha
   email: rosinha@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: rrio-2hag2q
   email: rrio-2hag2q@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/autoscaling.metricsWriter
   - role: roles/logging.logWriter
@@ -686,15 +814,18 @@
   - role: roles/stackdriver.resourceMetadata.writer
 - username: rrio-tests-63de9ae8
   email: rrio-tests-63de9ae8@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/dataflow.worker
   - role: roles/storage.admin
 - username: ruilongjiang
   email: ruilongjiang@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: ruslan.shamunov
   email: ruslan.shamunov@akvelon.com
+  member_type: user
   permissions:
   - role: roles/artifactregistry.admin
   - role: roles/compute.admin
@@ -712,29 +843,35 @@
   - role: roles/storage.admin
 - username: ryanmadden
   email: ryanmadden@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: saadatssu
   email: saadatssu@gmail.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: samuelw
   email: samuelw@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: secrets-manager-40
   email: secrets-manager-40@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/compute.instanceAdmin.v1
   - role: roles/secretmanager.secretAccessor
 - username: sergey.makarkin
   email: sergey.makarkin@akvelon.com
+  member_type: user
   permissions:
   - role: roles/editor
   - role: roles/iam.workloadIdentityPoolAdmin
   - role: roles/secretmanager.admin
 - username: shunping
   email: shunping@google.com
+  member_type: user
   permissions:
   - role: roles/editor
   - role: roles/iam.serviceAccountTokenCreator
@@ -742,19 +879,23 @@
   - role: roles/owner
 - username: siyuez
   email: siyuez@google.com
+  member_type: user
   permissions:
   - role: roles/editor
   - role: roles/viewer
 - username: skp
   email: skp@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: sniemitz
   email: sniemitz@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: stg-playground-sa
   email: stg-playground-sa@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/artifactregistry.reader
   - role: roles/bigquery.dataViewer
@@ -767,12 +908,14 @@
   - role: roles/stackdriver.resourceMetadata.writer
 - username: stg-playground-sa-cf
   email: stg-playground-sa-cf@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/cloudfunctions.invoker
   - role: roles/datastore.user
   - role: roles/storage.objectViewer
 - username: stg-tourofbeam-cb-cd
   email: stg-tourofbeam-cb-cd@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: organizations/433637338589/roles/GcsBucketLister
   - role: roles/datastore.user
@@ -782,12 +925,14 @@
   - role: roles/storage.objectAdmin
 - username: stg-tourofbeam-cb-ci
   email: stg-tourofbeam-cb-ci@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/secretmanager.secretAccessor
   - role: roles/storage.insightsCollectorService
   - role: roles/storage.objectAdmin
 - username: stg-tourofbeam-cb-deploy
   email: stg-tourofbeam-cb-deploy@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/cloudfunctions.admin
   - role: roles/container.clusterViewer
@@ -801,10 +946,12 @@
   - role: roles/storage.admin
 - username: svetaksundhar
   email: svetaksundhar@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: svetaksundhar-233
   email: svetaksundhar-233@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/bigquery.admin
   - role: roles/bigquery.dataEditor
@@ -812,10 +959,12 @@
   - role: roles/bigquery.jobUser
 - username: talatu
   email: talatu@google.com
+  member_type: user
   permissions:
   - role: roles/owner
 - username: tannapareddy
   email: tannapareddy@google.com
+  member_type: user
   permissions:
   - role: organizations/433637338589/roles/GcsBucketOwner
   - role: roles/alloydb.admin
@@ -829,10 +978,12 @@
   - role: roles/storage.admin
 - username: tanusharmaa
   email: tanusharmaa@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: tarun-926
   email: tarun-926@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/alloydb.admin
   - role: roles/artifactregistry.admin
@@ -849,6 +1000,7 @@
   - role: roles/tpu.admin
 - username: tarunannapareddy1997
   email: tarunannapareddy1997@gmail.com
+  member_type: user
   permissions:
   - role: roles/bigquery.admin
   - role: roles/iam.serviceAccountAdmin
@@ -856,50 +1008,60 @@
   - role: roles/tpu.admin
 - username: tf-test-dataflow-egyosq0h66-0
   email: tf-test-dataflow-egyosq0h66-0@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/dataflow.worker
   - role: roles/storage.admin
 - username: tf-test-dataflow-egyosq0h66-1
   email: tf-test-dataflow-egyosq0h66-1@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/dataflow.worker
   - role: roles/storage.admin
 - username: tf-test-dataflow-ntgfw3y4q6-0
   email: tf-test-dataflow-ntgfw3y4q6-0@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/dataflow.worker
   - role: roles/storage.admin
 - username: tf-test-dataflow-ntgfw3y4q6-1
   email: tf-test-dataflow-ntgfw3y4q6-1@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/dataflow.worker
   - role: roles/storage.admin
 - username: tf-test-dataflow-odmv2iiu6v-0
   email: tf-test-dataflow-odmv2iiu6v-0@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/dataflow.worker
   - role: roles/storage.admin
 - username: tf-test-dataflow-odmv2iiu6v-1
   email: tf-test-dataflow-odmv2iiu6v-1@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/dataflow.worker
   - role: roles/storage.admin
 - username: tf-test-dataflow-uzgihx18zf-0
   email: tf-test-dataflow-uzgihx18zf-0@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/dataflow.worker
   - role: roles/storage.admin
 - username: tf-test-dataflow-uzgihx18zf-1
   email: tf-test-dataflow-uzgihx18zf-1@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/dataflow.worker
   - role: roles/storage.admin
 - username: timur.sultanov.akvelon
   email: timur.sultanov.akvelon@gmail.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: tourofbeam-cb-cd-prod
   email: tourofbeam-cb-cd-prod@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/datastore.user
   - role: roles/secretmanager.secretAccessor
@@ -907,12 +1069,14 @@
   - role: roles/storage.objectAdmin
 - username: tourofbeam-cb-ci-prod
   email: tourofbeam-cb-ci-prod@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/secretmanager.secretAccessor
   - role: roles/storage.insightsCollectorService
   - role: roles/storage.objectAdmin
 - username: tourofbeam-cb-deploy-prod
   email: tourofbeam-cb-deploy-prod@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/cloudfunctions.admin
   - role: roles/container.clusterViewer
@@ -926,6 +1090,7 @@
   - role: roles/storage.admin
 - username: tourofbeam-cf-sa-prod
   email: tourofbeam-cf-sa-prod@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/cloudfunctions.admin
   - role: roles/datastore.user
@@ -934,6 +1099,7 @@
   - role: roles/storage.objectViewer
 - username: tourofbeam-cf-sa-stg
   email: tourofbeam-cf-sa-stg@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/cloudfunctions.admin
   - role: roles/datastore.user
@@ -942,6 +1108,7 @@
   - role: roles/storage.objectViewer
 - username: tourofbeam-stg3-cloudfunc-sa
   email: tourofbeam-stg3-cloudfunc-sa@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/cloudfunctions.admin
   - role: roles/datastore.user
@@ -950,15 +1117,18 @@
   - role: roles/storage.objectViewer
 - username: valentyn
   email: valentyn@google.com
+  member_type: user
   permissions:
   - role: roles/owner
 - username: valentyn-dataflow-deployer
   email: valentyn-dataflow-deployer@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/dataflow.admin
   - role: roles/iam.serviceAccountUser
 - username: valentyn-test
   email: valentyn-test@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/compute.admin
   - role: roles/dataflow.admin
@@ -966,6 +1136,7 @@
   - role: roles/storage.admin
 - username: vdjerek-test
   email: vdjerek-test@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: organizations/433637338589/roles/GceStorageAdmin
   - role: roles/automlrecommendations.editor
@@ -987,6 +1158,7 @@
   - role: roles/pubsub.editor
 - username: vitaly-terentyev
   email: vitaly-terentyev@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/container.clusterViewer
   - role: roles/container.viewer
@@ -996,6 +1168,7 @@
   - role: roles/storage.objectCreator
 - username: vitaly.terentyev.akv
   email: vitaly.terentyev.akv@gmail.com
+  member_type: user
   permissions:
   - role: roles/container.admin
   - role: roles/editor
@@ -1004,10 +1177,12 @@
   - role: roles/secretmanager.secretAccessor
 - username: vladislav.chunikhin
   email: vladislav.chunikhin@akvelon.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: vlado.djerek
   email: vlado.djerek@akvelon.com
+  member_type: user
   permissions:
   - role: organizations/433637338589/roles/GceStorageAdmin
   - role: roles/cloudfunctions.admin
@@ -1017,6 +1192,7 @@
   - role: roles/secretmanager.secretAccessor
 - username: wasmx-jbdthx
   email: wasmx-jbdthx@apache-beam-testing.iam.gserviceaccount.com
+  member_type: serviceAccount
   permissions:
   - role: roles/autoscaling.metricsWriter
   - role: roles/logging.logWriter
@@ -1025,10 +1201,12 @@
   - role: roles/stackdriver.resourceMetadata.writer
 - username: wdg-team
   email: wdg-team@google.com
+  member_type: group
   permissions:
   - role: roles/looker.instanceUser
 - username: xqhu
   email: xqhu@google.com
+  member_type: user
   permissions:
   - role: roles/editor
   - role: roles/iam.serviceAccountTokenCreator
@@ -1036,29 +1214,23 @@
   - role: roles/storage.admin
 - username: yathu
   email: yathu@google.com
+  member_type: user
   permissions:
   - role: roles/editor
   - role: roles/iam.serviceAccountTokenCreator
   - role: roles/owner
 - username: ylabur
   email: ylabur@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: yyingwang
   email: yyingwang@google.com
+  member_type: user
   permissions:
   - role: roles/editor
 - username: zhoufek
   email: zhoufek@google.com
+  member_type: user
   permissions:
   - role: roles/editor
-- username: abdelrahman.ibrahim
-  email: abdelrahman.ibrahim@akvelon.us
-  permissions:
-  - role: roles/bigquery.admin
-  - role: roles/container.admin
-  - role: roles/editor
-  - role: roles/iam.serviceAccountUser
-  - role: roles/secretmanager.admin
-  - role: roles/storage.objectAdmin
-  - role: roles/storage.objectCreator


### PR DESCRIPTION
This pull request introduces support for specifying the member type (`user`, `serviceAccount`, or `group`) for IAM users across the infrastructure codebase. The changes ensure that member type is consistently captured, exported, and used for IAM policy management and compliance checks. This now makes it posible to work with the groups.

Also updated users.yml to the actual state.