### PR TITLE
Move the logic to LP TestStream encoded bytes to transform preparer

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/coders.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/coders.go
@@ -199,11 +199,11 @@ func lpUnknownCoders(cID string, bundle, base map[string]*pipepb.Coder) (string,
 }
 
 // forceLpCoder always add a new LP-coder for a given coder into the "base" map
-func forceLpCoder(cID string, base map[string]*pipepb.Coder) (string, error) {
+func forceLpCoder(cID string, bundle, base map[string]*pipepb.Coder) (string, error) {
 	// First check if we've already added the LP version of this coder to coders already.
 	lpcID := cID + "_flp"
 	// Check if we've done this one before.
-	if _, ok := base[lpcID]; ok {
+	if _, ok := bundle[lpcID]; ok {
 		return lpcID, nil
 	}
 	// Look up the canonical location.
@@ -219,7 +219,7 @@ func forceLpCoder(cID string, base map[string]*pipepb.Coder) (string, error) {
 		},
 		ComponentCoderIds: []string{cID},
 	}
-	base[lpcID] = lpc
+	bundle[lpcID] = lpc
 	return lpcID, nil
 }
 

--- a/sdks/go/pkg/beam/runners/prism/internal/execute.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/execute.go
@@ -16,7 +16,6 @@
 package internal
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -27,7 +26,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/coder"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/mtime"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime/exec"
 	pipepb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/pipeline_v1"
@@ -270,58 +268,11 @@ func executePipeline(ctx context.Context, wks map[string]*worker.W, j *jobservic
 			case urns.TransformTestStream:
 				// Add a synthetic stage that should largely be unused.
 				em.AddStage(stage.ID, nil, maps.Values(t.GetOutputs()), nil)
+
 				// Decode the test stream, and convert it to the various events for the ElementManager.
 				var pyld pipepb.TestStreamPayload
 				if err := proto.Unmarshal(t.GetSpec().GetPayload(), &pyld); err != nil {
 					return fmt.Errorf("prism error building stage %v - decoding TestStreamPayload: \n%w", stage.ID, err)
-				}
-
-				// Ensure awareness of the coder used for the teststream.
-				cID, err := lpUnknownCoders(pyld.GetCoderId(), coders, comps.GetCoders())
-				if err != nil {
-					panic(err)
-				}
-				mayLP := func(v []byte) []byte {
-					//slog.Warn("teststream bytes", "value", string(v), "bytes", v)
-					return v
-				}
-				// If the TestStream coder needs to be LP'ed or if it is a coder that has different
-				// behaviors between nested context and outer context (in Java SDK), then we must
-				// LP this coder and the TestStream data elements.
-				forceLP := cID != pyld.GetCoderId() ||
-					coders[cID].GetSpec().GetUrn() == urns.CoderStringUTF8 ||
-					coders[cID].GetSpec().GetUrn() == urns.CoderBytes ||
-					coders[cID].GetSpec().GetUrn() == urns.CoderKV
-				if forceLP {
-					// slog.Warn("recoding TestStreamValue", "cID", cID, "newUrn", coders[cID].GetSpec().GetUrn(), "payloadCoder", pyld.GetCoderId(), "oldUrn", coders[pyld.GetCoderId()].GetSpec().GetUrn())
-					// The coder needed length prefixing. For simplicity, add a length prefix to each
-					// encoded element, since we will be sending a length prefixed coder to consume
-					// this anyway. This is simpler than trying to find all the re-written coders after the fact.
-					// This also adds a LP-coder for the original coder in comps.
-					cID, err := forceLpCoder(pyld.GetCoderId(), comps.GetCoders())
-					if err != nil {
-						panic(err)
-					}
-					slog.Debug("teststream: add coder", "coderId", cID)
-
-					mayLP = func(v []byte) []byte {
-						var buf bytes.Buffer
-						if err := coder.EncodeVarInt((int64)(len(v)), &buf); err != nil {
-							panic(err)
-						}
-						if _, err := buf.Write(v); err != nil {
-							panic(err)
-						}
-						//slog.Warn("teststream bytes - after LP", "value", string(v), "bytes", buf.Bytes())
-						return buf.Bytes()
-					}
-
-					// we need to change Coder and Pcollection in comps directly before they are used to build descriptors
-					for _, col := range t.GetOutputs() {
-						oCID := comps.Pcollections[col].CoderId
-						comps.Pcollections[col].CoderId = cID
-						slog.Debug("teststream: rewrite coder for output pcoll", "colId", col, "oldId", oCID, "newId", cID)
-					}
 				}
 
 				tsb := em.AddTestStream(stage.ID, t.Outputs)
@@ -330,7 +281,8 @@ func executePipeline(ctx context.Context, wks map[string]*worker.W, j *jobservic
 					case *pipepb.TestStreamPayload_Event_ElementEvent:
 						var elms []engine.TestStreamElement
 						for _, e := range ev.ElementEvent.GetElements() {
-							elms = append(elms, engine.TestStreamElement{Encoded: mayLP(e.GetEncodedElement()), EventTime: mtime.FromMilliseconds(e.GetTimestamp())})
+							// Encoded bytes are already handled in handleTestStream if needed.
+							elms = append(elms, engine.TestStreamElement{Encoded: e.GetEncodedElement(), EventTime: mtime.FromMilliseconds(e.GetTimestamp())})
 						}
 						tsb.AddElementEvent(ev.ElementEvent.GetTag(), elms)
 					case *pipepb.TestStreamPayload_Event_WatermarkEvent:


### PR DESCRIPTION
A follow-up PR to #36424.

Add a new transform preparer for TestStream and move the logic of LP'ing its encoded bytes there. In this case, we can modify the comps earlier during the preprocessing step and ensure they are in good shape during stage building later.

fixes #36440