### PR TITLE
Revert "Per element schema parsing in ConvertToBeamRows"

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -2764,9 +2764,6 @@ class StorageWriteToBigQuery(PTransform):
 
   class ConvertToBeamRows(PTransform):
     def __init__(self, schema, dynamic_destinations):
-      if not isinstance(schema,
-                        (bigquery.TableSchema, bigquery.TableFieldSchema)):
-        schema = bigquery_tools.get_bq_tableschema(schema)
       self.schema = schema
       self.dynamic_destinations = dynamic_destinations
 


### PR DESCRIPTION
Reverts apache/beam#36393

Fix #35285 ; fix #34990

Clean up tests for release cut. Since the original PR is for optimization not bug fix, forward fix can be done in parallel.

Tested locally with `export EXPANSION_JARS=...; pytest -v --capture=no apache_beam/io/external/xlang_bigqueryio_it_test.py::BigQueryXlangStorageWriteIT::test_write_with_dicts_cdc --test-pipeline-options='--runner=TestDirectRunner --project=apache-beam-testing'`