### PR TITLE
Add a flag to control whether to allow splitting on sdf.

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
@@ -186,6 +186,11 @@ type Config struct {
 	EnableRTC bool
 	// Whether to process the data in a streaming mode
 	StreamingMode bool
+	// Whether to enable splitting on splittable dofn.
+	// This flag is currently used when calling KafkaIO in streaming mode. It prevents an
+	// error ("KafkaConsumer is not safe for multi-threaded access") that can occur
+	// if the SDK allows splitting a single topic.
+	EnableSDFSplit bool
 }
 
 // ElementManager handles elements, watermarks, and related errata to determine

--- a/sdks/go/pkg/beam/runners/prism/internal/stage.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/stage.go
@@ -88,7 +88,8 @@ type stage struct {
 	OutputsToCoders   map[string]engine.PColInfo
 
 	// Stage specific progress and splitting interval.
-	baseProgTick atomic.Value // time.Duration
+	baseProgTick  atomic.Value // time.Duration
+	sdfSplittable bool
 }
 
 // The minimum and maximum durations between each ProgressBundleRequest and split evaluation.
@@ -234,7 +235,7 @@ progress:
 
 			// Check if there has been any measurable progress by the input, or all output pcollections since last report.
 			slow := previousIndex == index["index"] && previousTotalCount == index["totalCount"]
-			if slow && unsplit && b.EstimatedInputElements > 0 {
+			if slow && unsplit && b.EstimatedInputElements > 0 && s.sdfSplittable {
 				slog.Debug("splitting report", "bundle", rb, "index", index)
 				sr, err := b.Split(ctx, wk, 0.5 /* fraction of remainder */, nil /* allowed splits */)
 				if err != nil {


### PR DESCRIPTION
I ran into a problem when trying to run a simple pipeline to read from Kafka on prism. The kafka instance I used has only one topic. 

When prism was processing the kafka input bundle, it requested a split while waiting for more data. The KafkaIO SDF returned a split. Then prism started a new bundle on the same topic, which leads to an exception below.

```
bundle inst003 stage-002 failed:org.apache.beam.sdk.util.UserCodeException: java.util.ConcurrentModificationException: KafkaConsumer is not safe for multi-threaded access. currentThread(name: pool-2-thread-6, id: 33) otherThread(id: 32)
INFO:PrismJobServer:    at org.apache.beam.sdk.util.UserCodeException.wrap(UserCodeException.java:39)
INFO:PrismJobServer:    at org.apache.beam.sdk.io.kafka.ReadFromKafkaDoFn$Unbounded$DoFnInvoker.invokeProcessElement(Unknown Source)
INFO:PrismJobServer:    at org.apache.beam.fn.harness.FnApiDoFnRunner.processElementForWindowObservingSizedElementAndRestriction(FnApiDoFnRunner.java:695)
INFO:PrismJobServer:    at org.apache.beam.fn.harness.FnApiDoFnRunner.access$1000(FnApiDoFnRunner.java:139)
INFO:PrismJobServer:    at org.apache.beam.fn.harness.FnApiDoFnRunner$2.accept(FnApiDoFnRunner.java:494)
INFO:PrismJobServer:    at org.apache.beam.fn.harness.FnApiDoFnRunner$2.accept(FnApiDoFnRunner.java:489)
INFO:PrismJobServer:    at org.apache.beam.fn.harness.data.PCollectionConsumerRegistry$MetricTrackingFnDataReceiver.accept(PCollectionConsumerRegistry.java:349)
INFO:PrismJobServer:    at org.apache.beam.fn.harness.data.PCollectionConsumerRegistry$MetricTrackingFnDataReceiver.accept(PCollectionConsumerRegistry.java:276)
INFO:PrismJobServer:    at org.apache.beam.fn.harness.BeamFnDataReadRunner.forwardElementToConsumer(BeamFnDataReadRunner.java:228)
INFO:PrismJobServer:    at org.apache.beam.sdk.fn.data.BeamFnDataInboundObserver.multiplexElements(BeamFnDataInboundObserver.java:232)
INFO:PrismJobServer:    at org.apache.beam.sdk.fn.data.BeamFnDataInboundObserver.awaitCompletion(BeamFnDataInboundObserver.java:186)
INFO:PrismJobServer:    at org.apache.beam.fn.harness.control.ProcessBundleHandler.processBundle(ProcessBundleHandler.java:542)
INFO:PrismJobServer:    at org.apache.beam.fn.harness.control.BeamFnControlClient.delegateOnInstructionRequestType(BeamFnControlClient.java:150)
INFO:PrismJobServer:    at org.apache.beam.fn.harness.control.BeamFnControlClient$InboundObserver.lambda$onNext$0(BeamFnControlClient.java:115)
INFO:PrismJobServer:    at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
INFO:PrismJobServer:    at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
INFO:PrismJobServer:    at org.apache.beam.sdk.util.UnboundedScheduledExecutorService$ScheduledFutureTask.run(UnboundedScheduledExecutorService.java:163)
INFO:PrismJobServer:    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
INFO:PrismJobServer:    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
INFO:PrismJobServer:    at java.base/java.lang.Thread.run(Thread.java:833)
INFO:PrismJobServer:Caused by: java.util.ConcurrentModificationException: KafkaConsumer is not safe for multi-threaded access. currentThread(name: pool-2-thread-6, id: 33) otherThread(id: 32)
INFO:PrismJobServer:    at org.apache.kafka.clients.consumer.internals.ClassicKafkaConsumer.acquire(ClassicKafkaConsumer.java:1232)
INFO:PrismJobServer:    at org.apache.kafka.clients.consumer.internals.ClassicKafkaConsumer.acquireAndEnsureOpen(ClassicKafkaConsumer.java:1213)
INFO:PrismJobServer:    at org.apache.kafka.clients.consumer.internals.ClassicKafkaConsumer.resume(ClassicKafkaConsumer.java:965)
INFO:PrismJobServer:    at org.apache.kafka.clients.consumer.KafkaConsumer.resume(KafkaConsumer.java:1524)
INFO:PrismJobServer:    at org.apache.beam.sdk.io.kafka.ReadFromKafkaDoFn.processElement(ReadFromKafkaDoFn.java:623)
``` 

In theory, we shouldn't have a split in this scenario, because Kafka doesn't allow multiple threads accessing the same consumer.

To mitigate the problem, we add a flag in prism to temporarily disable SDF splitting on the pipeline level. The long-term solution, however, should be on the SDF side to not accept such a split in this case.

Note that, we haven't seen this in dataflow, which may suggest that the code path is never triggered there.