### PR TITLE
[Python]: accepts --serviceAccount as alias of --service_account_email

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -1023,7 +1023,7 @@ class GoogleCloudOptions(PipelineOptions):
         help='The Google Compute Engine region for creating '
         'Dataflow job.')
     parser.add_argument(
-        '--service_account_email',
+        '--service_account_email', '--serviceAccount',
         default=None,
         help='Identity to run virtual machines as.')
     parser.add_argument(

--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -973,7 +973,17 @@ class PipelineOptionsTest(unittest.TestCase):
         'option1=value1', 'option2=value2', 'option3=value3', 'option4=value4'
     ],
                      options.get_all_options()['dataflow_service_options'])
+  
+  
+  def test_service_account_alias_camelCase(self):
+    options = PipelineOptions(['--serviceAccount', 'svc@example.com'])
+    gco = options.view_as(GoogleCloudOptions)
+    self.assertEqual(gco.service_account_email, 'svc@example.com')
 
+  def test_service_account_snake_case_still_works(self):
+    options = PipelineOptions(['--service_account_email', 'svc2@example.com'])
+    gco = options.view_as(GoogleCloudOptions)
+    self.assertEqual(gco.service_account_email, 'svc2@example.com')
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)


### PR DESCRIPTION
# Python: accept --serviceAccount as alias of --service_account_email

- **Fixes:** #19278
- **Relates to:** #36173 (Beam 3.0.0 – Milestone 1 consistency work)

## Summary
- Adds the Java-style flag `--serviceAccount` as an alias for the existing Python flag `--service_account_email` in [GoogleCloudOptions](cci:2://file:///home/shreypatel/OpSrc/beam/sdks/python/apache_beam/options/pipeline_options.py:970:0-1263:15).
- Both flags map to the same destination `service_account_email` and behave identically.

## Motivation
- **Consistency across SDKs:** Java commonly uses `--serviceAccount`. Aligning Python reduces friction for users moving between SDKs or reusing scripts.
- **Improved UX:** Prevents “unknown option” errors when users copy examples from Java or shared docs.
- **Non-breaking change:** Existing `--service_account_email` remains fully supported.

## Changes
- **Flag alias added**
  - File: [sdks/python/apache_beam/options/pipeline_options.py](cci:7://file:///home/shreypatel/OpSrc/beam/sdks/python/apache_beam/options/pipeline_options.py:0:0-0:0)
  - Class: [GoogleCloudOptions](cci:2://file:///home/shreypatel/OpSrc/beam/sdks/python/apache_beam/options/pipeline_options.py:970:0-1263:15)
  - Method: [GoogleCloudOptions._add_argparse_args()](cci:1://file:///home/shreypatel/OpSrc/beam/sdks/python/apache_beam/options/pipeline_options.py:987:2-1163:80)
  - Change: accept both flags while mapping to the same destination
    ```python
    parser.add_argument(
        '--service_account_email', '--serviceAccount',
        dest='service_account_email',
        default=None,
        help='Identity to run virtual machines as.')
    ```

- **Unit tests added**
  - File: [sdks/python/apache_beam/options/pipeline_options_test.py](cci:7://file:///home/shreypatel/OpSrc/beam/sdks/python/apache_beam/options/pipeline_options_test.py:0:0-0:0)
  - Tests:
    - [PipelineOptionsTest.test_service_account_alias_camelCase](cci:1://file:///home/shreypatel/OpSrc/beam/sdks/python/apache_beam/options/pipeline_options_test.py:977:2-980:66)
    - [PipelineOptionsTest.test_service_account_snake_case_still_works](cci:1://file:///home/shreypatel/OpSrc/beam/sdks/python/apache_beam/options/pipeline_options_test.py:982:2-985:67)
  - Purpose: Verify that both `--serviceAccount` and `--service_account_email` set `GoogleCloudOptions.service_account_email`.

my first apache contribution

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
