### PR TITLE
Add "return []" to PGBK to silence warning

### DIFF
--- a/sdks/python/apache_beam/runners/direct/direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner.py
@@ -27,7 +27,6 @@ import itertools
 import logging
 import typing
 
-import more_itertools
 from google.protobuf import wrappers_pb2
 
 import apache_beam as beam
@@ -57,8 +56,6 @@ from apache_beam.utils.interactive_utils import is_in_ipython
 __all__ = ['BundleBasedDirectRunner', 'DirectRunner', 'SwitchingDirectRunner']
 
 _LOGGER = logging.getLogger(__name__)
-K = typing.TypeVar('K')
-V = typing.TypeVar('V')
 
 
 class SwitchingDirectRunner(PipelineRunner):
@@ -264,36 +261,6 @@ class _GroupByKeyOnly(PTransform):
   def expand(self, pcoll):
     self._check_pcollection(pcoll)
     return PCollection.from_(pcoll)
-
-
-@typehints.with_input_types(typing.Tuple[K, V])
-@typehints.with_output_types(typing.Tuple[K, typing.Iterable[V]])
-class _GroupIntoBatches(PTransform):
-  """
-  PTransform that batches the input into desired batch size after
-  grouping by key.
-
-  Identical behavior to Beam's GroupIntoBatches but doesn't use
-  Beam timer's (which are unsupported by the SeamRunner).
-  """
-  def __init__(self, batch_size: int):
-    if batch_size <= 0:
-      raise ValueError("batch_size must be a positive integer.")
-    self.batch_size = batch_size
-
-  def expand(self, pcoll):
-    return (
-        pcoll | beam.GroupByKey() | "BatchGroupedValues" >> beam.FlatMap(
-            self._batch_elements, batch_size=self.batch_size)
-        | beam.Reshuffle())
-
-  @staticmethod
-  def _batch_elements(key_values: tuple, batch_size: int):
-    """
-    Batch the structures by multisim key up to a specified batch size.
-    """
-    k, values = key_values
-    return ((k, batch) for batch in more_itertools.batched(values, batch_size))
 
 
 @typehints.with_input_types(typing.Tuple[K, typing.Iterable[V]])
@@ -505,20 +472,6 @@ def _get_transform_overrides(pipeline_options):
         self, applied_ptransform):
       return _GroupByKey()
 
-  class GroupIntoBatchesOverride(PTransformOverride):
-    """A ``PTransformOverride`` for ``GroupIntoBatches``.
-
-    This replaces the Beam implementation as a primitive.
-    """
-    def matches(self, applied_ptransform):
-      # Imported here to avoid circular dependencies.
-      # pylint: disable=wrong-import-order, wrong-import-position
-      from apache_beam.transforms.util import GroupIntoBatches
-      return isinstance(applied_ptransform.transform, GroupIntoBatches)
-
-    def get_replacement_transform(self, ptransform):
-      return _GroupIntoBatches(ptransform.params.batch_size)
-
   overrides = [
       # This needs to be the first and the last override. Other overrides depend
       # on the GroupByKey implementation to be composed of _GroupByKeyOnly and
@@ -528,7 +481,6 @@ def _get_transform_overrides(pipeline_options):
       ProcessKeyedElementsViaKeyedWorkItemsOverride(),
       CombinePerKeyOverride(),
       TestStreamOverride(),
-      GroupIntoBatchesOverride(),
   ]
 
   # Add streaming overrides, if necessary.

--- a/sdks/python/apache_beam/runners/direct/direct_runner_test.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner_test.py
@@ -35,7 +35,6 @@ from apache_beam.pipeline import Pipeline
 from apache_beam.runners import DirectRunner
 from apache_beam.runners import TestDirectRunner
 from apache_beam.runners import create_runner
-from apache_beam.runners.direct.direct_runner import BundleBasedDirectRunner
 from apache_beam.runners.direct.evaluation_context import _ExecutionContext
 from apache_beam.runners.direct.transform_evaluator import _GroupByKeyOnlyEvaluator
 from apache_beam.runners.direct.transform_evaluator import _TransformEvaluator
@@ -166,14 +165,6 @@ class BundleBasedRunnerTest(unittest.TestCase):
   def test_impulse(self):
     with test_pipeline.TestPipeline(runner='BundleBasedDirectRunner') as p:
       assert_that(p | beam.Impulse(), equal_to([b'']))
-
-  def test_groupintobatches(self):
-    with beam.Pipeline(runner=BundleBasedDirectRunner()) as p:
-      groups = (
-          p
-          | "Create input" >> beam.Create([(0, 0)])
-          | "Batch in groups" >> beam.GroupIntoBatches(5))
-      assert_that(groups, equal_to([(0, (0, ))]))
 
 
 class DirectRunnerRetryTests(unittest.TestCase):


### PR DESCRIPTION
A user reported that the PartialGroupByKeyCombiningValues transform reported the "no iterator returned" warning and was concerned it was actually an issue.

Just add `return []` to silence the error

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
