### PR TITLE
Fix PostCommit Python ValidatesContainer Dataflow With RC flakiness

### DIFF
--- a/sdks/python/container/run_validatescontainer.sh
+++ b/sdks/python/container/run_validatescontainer.sh
@@ -99,15 +99,25 @@ fi
 function cleanup_container {
   # Delete the container locally and remotely
   docker rmi $CONTAINER:$TAG || echo "Built container image was not removed. Possibly, it was not not saved locally."
-  for image in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep $PREBUILD_SDK_CONTAINER_REGISTRY_PATH)
+
+  for image in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep $PREBUILD_SDK_CONTAINER_REGISTRY_PATH | grep -E "(beam_python_prebuilt_sdk|$TAG)")
   do
     echo "Deleting Docker image: $image"
     docker rmi $image || echo "Failed to remove prebuilt sdk container image"
     image_tag="${image##*:}"
+
     digest=$(gcloud container images list-tags $PREBUILD_SDK_CONTAINER_REGISTRY_PATH/beam_python_prebuilt_sdk --filter="tags=$image_tag" --format="get(digest)")
-    echo "Deleting from GCloud an image with digest: $digest"
-    gcloud container images delete $PREBUILD_SDK_CONTAINER_REGISTRY_PATH/beam_python_prebuilt_sdk@$digest --force-delete-tags --quiet || echo "Failed to remove prebuilt sdk container image"
+
+    echo "Looking for digest for tag '$image_tag', found: '$digest'"
+
+    if [[ -n "$digest" && "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+      echo "Deleting from GCloud an image with digest: $digest"
+      gcloud container images delete $PREBUILD_SDK_CONTAINER_REGISTRY_PATH/beam_python_prebuilt_sdk@$digest --force-delete-tags --quiet || echo "Failed to remove prebuilt sdk container image"
+    else
+      echo "Skipping deletion of image with invalid or empty digest: '$digest'"
+    fi
   done
+
   # Note: we don't delete the multi-arch containers here because this command only deletes the manifest list with the tag,
   # the associated container images can't be deleted because they are not tagged. However, multi-arch containers that are
   # older than 6 weeks old are deleted by stale_dataflow_prebuilt_image_cleaner.sh that runs daily.


### PR DESCRIPTION
Fixes: #30525

Successful Run : https://github.com/aIbrahiim/beam/actions/runs/18563249221

## Solution
- **Safer image filtering** - Only delete images that belong to current run using `grep -E "(beam_python_prebuilt_sdk|$TAG)"`
- **Digest validation** - Check digest format before deletion: `if [[ -n "$digest" && "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]`
- **Better error handling** - Skip deletion when digest is invalid/empty
- **Debug logging** - Added logging to help diagnose future issues

## Changes
- Modified `sdks/python/container/run_validatescontainer.sh` cleanup logic
- Added digest validation and safer image filtering
- Added debugging logs for troubleshooting

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
