### PR TITLE
Revert "Add gRPC experiments to Python dockerfile"

### DIFF
--- a/sdks/python/container/Dockerfile
+++ b/sdks/python/container/Dockerfile
@@ -29,11 +29,6 @@ COPY target/launcher/${TARGETOS}_${TARGETARCH}/boot target/LICENSE target/NOTICE
 ENV CLOUDSDK_CORE_DISABLE_PROMPTS yes
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
-# Enable GRPC experiments to mitigate timeout issues in later versions
-# of the grpc package. 
-ENV GRPC_EXPERIMENTS="event_engine_fork,event_engine_poller_for_python"
-ENV GRPC_ENABLE_FORK_SUPPORT=1
-
 # Use one RUN command to reduce the number of layers.
 ARG py_version
 RUN  \


### PR DESCRIPTION
Reverts apache/beam#36525. 

#36525 might affect GRPC functionality in scenarios when a process launches subprocesses. We made this change an attempt to mitigate flakiness observed in Python 3.13 test suite.

Out of caution, let's revert, since #36525 would apply to all Python containers, not just 3.13.

Let's report test flakiness we observed in Python 3.13 to GRPC team in a separate issue. If we need to set any experiment like this, we may need to be mindful of minimal `grpcio` version on which such experiments are stable, let's first confirm them first with the GRPC team.