### PR TITLE
Call now() once so start and end have exactly the same base timestamp.

### DIFF
--- a/sdks/python/apache_beam/transforms/periodicsequence.py
+++ b/sdks/python/apache_beam/transforms/periodicsequence.py
@@ -337,8 +337,7 @@ class PeriodicImpulse(PTransform):
     if self.rebase == RebaseMode.REBASE_ALL:
       duration = Timestamp.of(self.stop_ts) - Timestamp.of(self.start_ts)
       impulse_element = pbegin | beam.Impulse() | beam.Map(
-          lambda _:
-          [Timestamp.now(), Timestamp.now() + duration, self.interval])
+          lambda _: [now := Timestamp.now(), now + duration, self.interval])
     elif self.rebase == RebaseMode.REBASE_START:
       impulse_element = pbegin | beam.Impulse() | beam.Map(
           lambda _: [Timestamp.now(), self.stop_ts, self.interval])


### PR DESCRIPTION
When we have two calls to `Timestamp.now()`, we can get two different now values in some cases, which leads to one more data point generated.

The fix proposed here ensures the start and end use the same "now" as their base.