### PR TITLE
Create a BatchOnly category to exclude some batch tests from Dataflow Validates Runner Streaming

### DIFF
--- a/.github/trigger_files/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming.json
+++ b/.github/trigger_files/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming.json
@@ -1,8 +1,3 @@
 {
-  "https://github.com/apache/beam/pull/34902": "Introducing OutputBuilder",
-  "comment": "Modify this file in a trivial way to cause this test suite to run",
-  "https://github.com/apache/beam/pull/31156": "noting that PR #31156 should run this test",
-  "https://github.com/apache/beam/pull/31268": "noting that PR #31268 should run this test",
-  "https://github.com/apache/beam/pull/31490": "noting that PR #31490 should run this test",
-  "https://github.com/apache/beam/pull/35159": "moving WindowedValue and making an interface"
+  "comment": "Modify this file in a trivial way to cause this test suite to run"
 }

--- a/.github/trigger_files/beam_PostCommit_Java_ValidatesRunner_Dataflow_V2_Streaming.json
+++ b/.github/trigger_files/beam_PostCommit_Java_ValidatesRunner_Dataflow_V2_Streaming.json
@@ -1,7 +1,3 @@
 {
-  "https://github.com/apache/beam/pull/34902": "Introducing OutputBuilder",
-  "comment": "Modify this file in a trivial way to cause this test suite to run",
-  "https://github.com/apache/beam/pull/31156": "noting that PR #31156 should run this test",
-  "https://github.com/apache/beam/pull/31268": "noting that PR #31268 should run this test",
-  "https://github.com/apache/beam/pull/31490": "noting that PR #31490 should run this test"
+  "comment": "Modify this file in a trivial way to cause this test suite to run"
 }

--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -440,6 +440,7 @@ task validatesRunnerStreaming {
     name: 'validatesRunnerLegacyWorkerTestStreaming',
     pipelineOptions: legacyPipelineOptions + ['--streaming'],
     excludedCategories: [
+      'org.apache.beam.sdk.testing.BatchOnly',
       'org.apache.beam.sdk.testing.UsesCommittedMetrics',
       'org.apache.beam.sdk.testing.UsesMapState',
       'org.apache.beam.sdk.testing.UsesRequiresTimeSortedInput',
@@ -550,6 +551,7 @@ task validatesRunnerV2Streaming {
     name: 'validatesRunnerV2TestStreaming',
     pipelineOptions: runnerV2PipelineOptions + ['--streaming', '--experiments=enable_streaming_engine'],
     excludedCategories: [
+      'org.apache.beam.sdk.testing.BatchOnly',
       'org.apache.beam.sdk.testing.LargeKeys$Above10KB',
       'org.apache.beam.sdk.testing.UsesBoundedSplittableParDo',
       'org.apache.beam.sdk.testing.UsesCommittedMetrics',

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/BatchOnly.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/BatchOnly.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testing;
+
+import org.apache.beam.sdk.annotations.Internal;
+
+/**
+ * Category tag for validation tests run on batch mode only.
+ *
+ * <p>Used to dedup tests from streaming test suites as long as its batch counterpart running the
+ * same test is considered sufficient.
+ */
+@Internal
+public interface BatchOnly {}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java
@@ -53,6 +53,7 @@ import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.coders.VoidCoder;
+import org.apache.beam.sdk.testing.BatchOnly;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
@@ -665,13 +666,13 @@ public class CombineTest implements Serializable {
     }
 
     @Test
-    @Category({ValidatesRunner.class, UsesSideInputs.class})
+    @Category({ValidatesRunner.class, UsesSideInputs.class, BatchOnly.class})
     public void testSimpleCombineEmpty() {
       runTestSimpleCombine(EMPTY_TABLE, 0, Collections.emptyList());
     }
 
     @Test
-    @Category({ValidatesRunner.class, UsesSideInputs.class})
+    @Category({ValidatesRunner.class, UsesSideInputs.class, BatchOnly.class})
     public void testBasicCombine() {
       runTestBasicCombine(
           Arrays.asList(KV.of("a", 1), KV.of("a", 1), KV.of("a", 4), KV.of("b", 1), KV.of("b", 13)),
@@ -682,7 +683,7 @@ public class CombineTest implements Serializable {
     }
 
     @Test
-    @Category({ValidatesRunner.class, UsesSideInputs.class})
+    @Category({ValidatesRunner.class, UsesSideInputs.class, BatchOnly.class})
     public void testBasicCombineEmpty() {
       runTestBasicCombine(EMPTY_TABLE, ImmutableSet.of(), Collections.emptyList());
     }
@@ -702,7 +703,7 @@ public class CombineTest implements Serializable {
     }
 
     @Test
-    @Category({ValidatesRunner.class})
+    @Category({ValidatesRunner.class, BatchOnly.class})
     public void testHotKeyCombining() {
       PCollection<KV<String, Integer>> input =
           copy(
@@ -839,7 +840,7 @@ public class CombineTest implements Serializable {
     }
 
     @Test
-    @Category(ValidatesRunner.class)
+    @Category({ValidatesRunner.class, BatchOnly.class})
     public void testCombinePerKeyPrimitiveDisplayData() {
       DisplayDataEvaluator evaluator = DisplayDataEvaluator.create();
 
@@ -909,7 +910,7 @@ public class CombineTest implements Serializable {
 
     /** Tests creation of a per-key binary {@link Combine} via a Java 8 lambda. */
     @Test
-    @Category(ValidatesRunner.class)
+    @Category({ValidatesRunner.class, BatchOnly.class})
     public void testBinaryCombinePerKeyLambda() {
 
       PCollection<KV<String, Integer>> output =
@@ -923,7 +924,7 @@ public class CombineTest implements Serializable {
 
     /** Tests creation of a per-key {@link Combine} via a Java 8 method reference. */
     @Test
-    @Category(ValidatesRunner.class)
+    @Category({ValidatesRunner.class, BatchOnly.class})
     public void testCombinePerKeyInstanceMethodReference() {
 
       PCollection<KV<String, Integer>> output =
@@ -937,7 +938,7 @@ public class CombineTest implements Serializable {
 
     /** Tests creation of a per-key binary {@link Combine} via a Java 8 method reference. */
     @Test
-    @Category(ValidatesRunner.class)
+    @Category({ValidatesRunner.class, BatchOnly.class})
     public void testBinaryCombinePerKeyInstanceMethodReference() {
 
       PCollection<KV<String, Integer>> output =
@@ -1001,7 +1002,7 @@ public class CombineTest implements Serializable {
     }
 
     @Test
-    @Category({ValidatesRunner.class, UsesSideInputs.class})
+    @Category({ValidatesRunner.class, UsesSideInputs.class, BatchOnly.class})
     public void testSimpleCombineWithContextEmpty() {
       runTestSimpleCombineWithContext(EMPTY_TABLE, 0, Collections.emptyList(), new String[] {});
     }
@@ -1031,7 +1032,7 @@ public class CombineTest implements Serializable {
     }
 
     @Test
-    @Category({ValidatesRunner.class, UsesSideInputs.class})
+    @Category({ValidatesRunner.class, UsesSideInputs.class, BatchOnly.class})
     public void testHotKeyCombineWithSideInputs() {
       PCollection<KV<String, Integer>> input =
           createInput(

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CreateTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CreateTest.java
@@ -52,6 +52,7 @@ import org.apache.beam.sdk.options.ValueProvider.NestedValueProvider;
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.SchemaCoder;
+import org.apache.beam.sdk.testing.BatchOnly;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.SourceTestUtils;
@@ -101,7 +102,7 @@ public class CreateTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category({ValidatesRunner.class, BatchOnly.class})
   public void testCreateEmpty() {
     PCollection<String> output = p.apply(Create.empty(StringUtf8Coder.of()));
 
@@ -125,7 +126,7 @@ public class CreateTest {
   }
 
   @Test
-  @Category(NeedsRunner.class)
+  @Category({NeedsRunner.class, BatchOnly.class})
   public void testCreateEmptyIterableWithCoder() {
     PCollection<Void> output =
         p.apply(Create.of(Collections.<Void>emptyList()).withCoder(VoidCoder.of()));
@@ -161,7 +162,7 @@ public class CreateTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category({ValidatesRunner.class, BatchOnly.class})
   public void testCreateWithNullsAndValues() throws Exception {
     PCollection<String> output =
         p.apply(

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -98,6 +98,7 @@ import org.apache.beam.sdk.state.TimerMap;
 import org.apache.beam.sdk.state.TimerSpec;
 import org.apache.beam.sdk.state.TimerSpecs;
 import org.apache.beam.sdk.state.ValueState;
+import org.apache.beam.sdk.testing.BatchOnly;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
@@ -405,7 +406,7 @@ public class ParDoTest implements Serializable {
     }
 
     @Test
-    @Category(ValidatesRunner.class)
+    @Category({ValidatesRunner.class, BatchOnly.class})
     public void testParDoEmpty() {
 
       List<Integer> inputs = Arrays.asList();
@@ -421,7 +422,7 @@ public class ParDoTest implements Serializable {
     }
 
     @Test
-    @Category(ValidatesRunner.class)
+    @Category({ValidatesRunner.class, BatchOnly.class})
     public void testParDoEmptyOutputs() {
 
       List<Integer> inputs = Arrays.asList();
@@ -442,7 +443,7 @@ public class ParDoTest implements Serializable {
     }
 
     @Test
-    @Category(ValidatesRunner.class)
+    @Category({ValidatesRunner.class, BatchOnly.class})
     public void testParDoInCustomTransform() {
 
       List<Integer> inputs = Arrays.asList(3, -42, 666);
@@ -629,7 +630,7 @@ public class ParDoTest implements Serializable {
     }
 
     @Test
-    @Category(ValidatesRunner.class)
+    @Category({ValidatesRunner.class, BatchOnly.class})
     public void testPipelineOptionsParameter() {
       PCollection<String> results =
           pipeline
@@ -728,7 +729,7 @@ public class ParDoTest implements Serializable {
     }
 
     @Test
-    @Category(ValidatesRunner.class)
+    @Category({ValidatesRunner.class, BatchOnly.class})
     public void testParDoEmptyWithTaggedOutput() {
       TupleTag<String> mainOutputTag = new TupleTag<String>("main") {};
       TupleTag<String> additionalOutputTag1 = new TupleTag<String>("additional1") {};
@@ -770,7 +771,7 @@ public class ParDoTest implements Serializable {
     }
 
     @Test
-    @Category(ValidatesRunner.class)
+    @Category({ValidatesRunner.class, BatchOnly.class})
     public void testParDoWithEmptyTaggedOutput() {
       TupleTag<String> mainOutputTag = new TupleTag<String>("main") {};
       TupleTag<String> additionalOutputTag1 = new TupleTag<String>("additional1") {};
@@ -794,7 +795,7 @@ public class ParDoTest implements Serializable {
     }
 
     @Test
-    @Category(ValidatesRunner.class)
+    @Category({ValidatesRunner.class, BatchOnly.class})
     public void testParDoWithOnlyTaggedOutput() {
 
       List<Integer> inputs = Arrays.asList(3, -42, 666);
@@ -823,7 +824,7 @@ public class ParDoTest implements Serializable {
     }
 
     @Test
-    @Category(NeedsRunner.class)
+    @Category({NeedsRunner.class, BatchOnly.class})
     public void testParDoWritingToUndeclaredTag() {
       List<Integer> inputs = Arrays.asList(3, -42, 666);
 
@@ -906,7 +907,7 @@ public class ParDoTest implements Serializable {
     }
 
     @Test
-    @Category({NeedsRunner.class, UsesSideInputs.class})
+    @Category({NeedsRunner.class, UsesSideInputs.class, BatchOnly.class})
     public void testSideInputAnnotationFailedValidationMissing() {
       // SideInput tag id
       final String sideInputTag1 = "tag1";
@@ -923,7 +924,7 @@ public class ParDoTest implements Serializable {
     }
 
     @Test
-    @Category({NeedsRunner.class, UsesSideInputs.class})
+    @Category({NeedsRunner.class, UsesSideInputs.class, BatchOnly.class})
     public void testSideInputAnnotationFailedValidationSingletonType() {
 
       final PCollectionView<Integer> sideInput1 =
@@ -948,7 +949,7 @@ public class ParDoTest implements Serializable {
     }
 
     @Test
-    @Category({NeedsRunner.class, UsesSideInputs.class})
+    @Category({NeedsRunner.class, UsesSideInputs.class, BatchOnly.class})
     public void testSideInputAnnotationFailedValidationListType() {
 
       final PCollectionView<List<Integer>> sideInput1 =
@@ -973,7 +974,7 @@ public class ParDoTest implements Serializable {
     }
 
     @Test
-    @Category({NeedsRunner.class, UsesSideInputs.class})
+    @Category({NeedsRunner.class, UsesSideInputs.class, BatchOnly.class})
     public void testSideInputAnnotationFailedValidationIterableType() {
 
       final PCollectionView<Iterable<Integer>> sideInput1 =
@@ -998,7 +999,7 @@ public class ParDoTest implements Serializable {
     }
 
     @Test
-    @Category({NeedsRunner.class, UsesSideInputs.class})
+    @Category({NeedsRunner.class, UsesSideInputs.class, BatchOnly.class})
     public void testSideInputAnnotationFailedValidationMapType() {
 
       final PCollectionView<Map<Integer, Integer>> sideInput1 =
@@ -1048,7 +1049,7 @@ public class ParDoTest implements Serializable {
     }
 
     @Test
-    @Category({ValidatesRunner.class, UsesSideInputs.class})
+    @Category({ValidatesRunner.class, UsesSideInputs.class, BatchOnly.class})
     public void testSideInputAnnotation() {
 
       final PCollectionView<List<Integer>> sideInput1 =
@@ -1184,7 +1185,7 @@ public class ParDoTest implements Serializable {
     }
 
     @Test
-    @Category({ValidatesRunner.class, UsesSideInputs.class})
+    @Category({ValidatesRunner.class, UsesSideInputs.class, BatchOnly.class})
     public void testParDoWithSideInputsIsCumulative() {
 
       List<Integer> inputs = Arrays.asList(3, -42, 666);
@@ -1294,7 +1295,7 @@ public class ParDoTest implements Serializable {
     }
 
     @Test
-    @Category(NeedsRunner.class)
+    @Category({NeedsRunner.class, BatchOnly.class})
     public void testParDoReadingFromUnknownSideInput() {
 
       List<Integer> inputs = Arrays.asList(3, -42, 666);
@@ -1506,7 +1507,7 @@ public class ParDoTest implements Serializable {
     }
 
     @Test
-    @Category(NeedsRunner.class)
+    @Category({NeedsRunner.class, BatchOnly.class})
     public void testMainOutputUnregisteredExplicitCoder() {
 
       PCollection<Integer> input = pipeline.apply(Create.of(Arrays.asList(1, 2, 3)));
@@ -1524,7 +1525,7 @@ public class ParDoTest implements Serializable {
     }
 
     @Test
-    @Category(NeedsRunner.class)
+    @Category({NeedsRunner.class, BatchOnly.class})
     public void testMainOutputApplyTaggedOutputNoCoder() {
       // Regression test: applying a transform to the main output
       // should not cause a crash based on lack of a coder for the


### PR DESCRIPTION
Dataflow Streaming Validates Runner Streaming tests setup by gathering all `@ValidatesRunnerTest` and add `--streaming` pipeline options. There is a Dataflow Streaming Validates Runner test suites also exercising this test.

Over the time the number of test grows so does execution time. We already increased timeout several times in the past. Here I try to dedup some test cases that

- already run in batch test suites, and
- is error handling, or test some streaming mode irrelevant feature, or have a base test case not excluded

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
