### PR TITLE
Enabled path normalization when enable_best_effort_determinism set to…

### DIFF
--- a/sdks/python/apache_beam/internal/cloudpickle_pickler.py
+++ b/sdks/python/apache_beam/internal/cloudpickle_pickler.py
@@ -157,7 +157,7 @@ def _dumps(
     config: cloudpickle.CloudPickleConfig = DEFAULT_CONFIG) -> bytes:
 
   if enable_stable_code_identifier_pickling:
-      config = STABLE_CODE_IDENTIFIER_CONFIG
+    config = STABLE_CODE_IDENTIFIER_CONFIG
   config_kwargs = config.__dict__.copy()
 
   if enable_best_effort_determinism:
@@ -166,7 +166,8 @@ def _dumps(
     config_kwargs['filepath_interceptor'] = cloudpickle.get_relative_path
     _LOGGER.info(
         'Option not fully supported:'
-        'enable_best_effort_determinism is True: Applying file path normalization for pickling.'
+        'enable_best_effort_determinism is True: Applying file path '
+        'normalization for pickling.'
         'This has been fully implemented for dill.')
 
   final_config = cloudpickle.CloudPickleConfig(**config_kwargs)

--- a/sdks/python/apache_beam/internal/cloudpickle_pickler_test.py
+++ b/sdks/python/apache_beam/internal/cloudpickle_pickler_test.py
@@ -216,7 +216,7 @@ self.assertEqual(DataClass(datum='abc'), loads(dumps(DataClass(datum='abc'))))
 
   def test_best_effort_determinism_is_partially_supported(self):
     with self.assertLogs('apache_beam.internal.cloudpickle_pickler',
-                        "INFO") as l:
+                         "INFO") as l:
       dumps(123, enable_best_effort_determinism=True)
       self.assertIn(
           'Option not fully supported:'
@@ -224,7 +224,7 @@ self.assertEqual(DataClass(datum='abc'), loads(dumps(DataClass(datum='abc'))))
           'normalization for pickling.'
           'This has been fully implemented for dill.',
           '\n'.join(l.output))
-      
+
   def test_code_object_path_is_normalized(self):
     """Tests that cloudpickle normalizes a function's co_filename."""
     func = module_for_path_test.func_for_path_test
@@ -233,9 +233,11 @@ self.assertEqual(DataClass(datum='abc'), loads(dumps(DataClass(datum='abc'))))
     unpickled_func = loads(dumps(func, enable_best_effort_determinism=True))
 
     unpickled_filename = unpickled_func.__code__.co_filename
-    expected_normalized_filename = 'apache_beam/internal/test_data/module_for_path_test.py'
+    expected_normalized_filename = 'apache_beam/internal/test_data/' \
+    'module_for_path_test.py'
 
     self.assertEqual(unpickled_filename, expected_normalized_filename)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/sdks/python/apache_beam/internal/test_data/module_for_path_test.py
+++ b/sdks/python/apache_beam/internal/test_data/module_for_path_test.py
@@ -16,6 +16,7 @@
 
 """A test module for source file path normalization."""
 
+
 def func_for_path_test():
   """A simple function for path normalization testing."""
   return "hello"


### PR DESCRIPTION
… True for cloudpickle

This change fixes a source of non-deterministic serialization in the Beam Python SDK by ensuring that file paths associated with code objects (`co_filename`) are normalized before being pickled by `cloudpickle`.

This PR implements path normalization by tying it to the existing `enable_best_effort_determinism` flag in `cloudpickle_pickler.py`. When this flag is enabled, a `filepath_interceptor` is used to replace the absolute path with a deterministic, relative path.

Tested:
- Added `test_code_object_path_is_normalized`, a new unit test that specifically verifies that a function's `co_filename` is correctly normalized when the `enable_best_effort_determinism` flag is used.
- Updated `test_best_effort_determinism_not_implemented` (renamed to `test_best_effort_determinism_is_partially_supported`) to check for the new, more informative log message that is emitted when the flag is enabled.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
