### PR TITLE
Add batch version of OrderedWindowElements in examples

### DIFF
--- a/sdks/python/apache_beam/examples/cookbook/ordered_window_elements/batch.py
+++ b/sdks/python/apache_beam/examples/cookbook/ordered_window_elements/batch.py
@@ -22,7 +22,6 @@ from typing import Callable
 from typing import Optional
 
 import apache_beam as beam
-
 from apache_beam.coders import BooleanCoder
 from apache_beam.coders import PickleCoder
 from apache_beam.pvalue import AsDict

--- a/sdks/python/apache_beam/examples/cookbook/ordered_window_elements/batch_test.py
+++ b/sdks/python/apache_beam/examples/cookbook/ordered_window_elements/batch_test.py
@@ -25,8 +25,8 @@ from parameterized import param
 from parameterized import parameterized
 
 import apache_beam as beam
-from apache_beam.examples.cookbook.ordered_window_elements.batch import OrderedWindowElements  # pylint: disable=line-too-long
-from apache_beam.examples.cookbook.ordered_window_elements.batch import WindowGapStrategy  # pylint: disable=line-too-long
+from apache_beam.examples.cookbook.ordered_window_elements.batch import OrderedWindowElements
+from apache_beam.examples.cookbook.ordered_window_elements.batch import WindowGapStrategy
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that


### PR DESCRIPTION
A sister PR of #36575, but for batch data.

Notice that there is some difference on the arguments between the batch and the streaming versions, which I plan to address in a follow-up PR. The tests will also be consolidated into one. 