### PR TITLE
fix(website): Use standard method for CSP frame-src exceptions

### DIFF
--- a/website/www/site/static/.htaccess
+++ b/website/www/site/static/.htaccess
@@ -27,4 +27,6 @@ RedirectMatch "/contribute/release-guide" "https://github.com/apache/beam/blob/m
 
 RedirectMatch "/contribute/committer-guide" "https://github.com/apache/beam/blob/master/contributor-docs/committer-guide.md"
 
-Header set Content-Security-Policy "frame-src 'self' https://play.beam.apache.org/ https://www.youtube.com/ https://drive.google.com/ ;"
+# Allow embedding content from play.beam.apache.org, youtube.com and drive.google.com
+# This is the standard way to add local exceptions to the CSP, see https://infra.apache.org/tools/csp.html
+SetEnv CSP_PROJECT_DOMAINS "https://play.beam.apache.org/ https://www.youtube.com/ https://drive.google.com/"


### PR DESCRIPTION
The method for allowing specific domains in iframes has been updated to align with Apache Infra's recommended practices.

Instead of directly setting the Content-Security-Policy header, this change uses the `SetEnv CSP_PROJECT_DOMAINS` directive. This is the standard way to add local exceptions, ensuring they are correctly merged with the global CSP managed by Apache Infra.

This change maintains the existing permissions for embedding content from Beam Playground, YouTube, and Google Drive.

Fixes https://github.com/apache/beam/issues/36622

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
