### PR TITLE
Revert "fix(website): Use standard method for CSP frame-src exceptions"

### DIFF
--- a/website/www/site/static/.htaccess
+++ b/website/www/site/static/.htaccess
@@ -27,6 +27,4 @@ RedirectMatch "/contribute/release-guide" "https://github.com/apache/beam/blob/m
 
 RedirectMatch "/contribute/committer-guide" "https://github.com/apache/beam/blob/master/contributor-docs/committer-guide.md"
 
-# Allow embedding content from play.beam.apache.org, youtube.com and drive.google.com
-# This is the standard way to add local exceptions to the CSP, see https://infra.apache.org/tools/csp.html
-SetEnv CSP_PROJECT_DOMAINS "https://play.beam.apache.org/ https://www.youtube.com/ https://drive.google.com/"
+Header set Content-Security-Policy "frame-src 'self' https://play.beam.apache.org/ https://www.youtube.com/ https://drive.google.com/ ;"


### PR DESCRIPTION
Reverts apache/beam#36653. This was causing website rendering issues like:

<img width="3444" height="1730" alt="image" src="https://github.com/user-attachments/assets/1459afb5-4d2a-42d3-90e3-59566921d320" />
