### PR TITLE
Add documentation and examples for SQL calcite_connection…

### DIFF
--- a/sdks/python/apache_beam/yaml/examples/transforms/sql/calcite_connection_properties.yaml
+++ b/sdks/python/apache_beam/yaml/examples/transforms/sql/calcite_connection_properties.yaml
@@ -1,0 +1,41 @@
+# SQL transform — how to provide calcite_connection_properties
+#
+# This example shows how to provide Calcite connection properties (for
+# example to enable PostgreSQL-specific functions) to a YAML pipeline.
+#
+# The connection properties can be provided under the top-level `options:`
+# key. Most of the time you can provide them as normal YAML mappings.
+# Some environments may expect a JSON-formatted string instead; both forms
+# are shown below.
+
+pipeline:
+  transforms:
+    - name: Source
+      type: Create
+      config:
+        elements:
+        - {a: "x", b: 1}
+        - {a: "x", b: 2}
+        - {a: "x", b: 3}
+        - {a: "y", b: 10}
+    - name: Transform
+      type: Sql
+      config:
+        query: "SELECT STRING_TO_ARRAY('abc def g', ' ') as col_name"
+      input: Source
+    - name: Sink
+      type: LogForTesting
+      input: Transform
+      config:
+        level: INFO
+
+# Preferred: pass connection properties as YAML mapping
+options:
+  calcite_connection_properties:
+    fun: postgresql
+
+# Alternative: pass as a JSON string (useful if your runner or expansion
+# service expects a stringified JSON). Note the quoting.
+#
+# options:
+#   calcite_connection_properties: '{"fun": "postgresql"}'


### PR DESCRIPTION
### Issue Components closes #36614

- [x] Component: Beam YAML

### Changes Made

1. **Added example YAML pipeline** in \`sdks/python/apache_beam/yaml/examples/transforms/sql/calcite_connection_properties.yaml\`
   - Shows how to provide \`calcite_connection_properties\` under the top-level \`options:\` key
   - Demonstrates both YAML mapping format (preferred) and JSON string format (for compatibility)
   - Includes a working SQL transform example using PostgreSQL functions

2. **Updated YAML docs generator** in \`sdks/python/apache_beam/yaml/generate_yaml_docs.py\`
   - Added special handling for the SQL transform to include a callout about calcite connection properties
   - The generated transform catalog page will now include clear documentation and examples
   - Shows both approaches for providing connection properties

### Example Usage

**Preferred YAML mapping approach:**
\`\`\`yaml
options:
  calcite_connection_properties:
    fun: postgresql
\`\`\`

**Alternative JSON string approach:**
\`\`\`yaml
options:
  calcite_connection_properties: '{\"fun\": \"postgresql\"}'
\`\`\`

### Testing

- Syntax validation passed for the modified Python generator
- Example YAML follows existing patterns in the examples directory
- Changes are backwards compatible and don't affect existing functionality