### PR TITLE
Update beam-master images for python sdks

### DIFF
--- a/sdks/python/apache_beam/runners/dataflow/internal/names.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/names.py
@@ -34,6 +34,6 @@ SERIALIZED_SOURCE_KEY = 'serialized_source'
 # Unreleased sdks use container image tag specified below.
 # Update this tag whenever there is a change that
 # requires changes to SDK harness container or SDK harness launcher.
-BEAM_DEV_SDK_CONTAINER_TAG = 'beam-master-20251020'
+BEAM_DEV_SDK_CONTAINER_TAG = 'beam-master-20251031'
 
 DATAFLOW_CONTAINER_IMAGE_REPOSITORY = 'gcr.io/cloud-dataflow/v1beta3'


### PR DESCRIPTION
The new beam master images are ready:

https://pantheon.corp.google.com/artifacts/docker/cloud-dataflow/us/gcr.io/v1beta3%2Fbeam_python3.11_sdk/sha256:c10966b890092ba9ba5f375641ec05c4955c27b9f3ca0ba22a2236420390a18a