### PR TITLE
Fix warning message

### DIFF
--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -1520,9 +1520,8 @@ def _check_fn_use_yield_and_return(fn):
         if lstripped_line.rstrip() == "return None" or lstripped_line.rstrip(
         ) == "return(None)":
           has_return_none = True
-        else:
-          has_return = True
-      if has_yield and (has_return or has_return_none):
+        has_return = True
+      if has_yield and has_return:
         return True
 
     if has_return_none:

--- a/sdks/python/apache_beam/transforms/core_test.py
+++ b/sdks/python/apache_beam/transforms/core_test.py
@@ -115,6 +115,12 @@ class TestDoFn10(beam.DoFn):
 
 
 class TestDoFn11(beam.DoFn):
+  """test process returning None (no return and no yield)"""
+  def process(self, element):
+    pass
+
+
+class TestDoFn12(beam.DoFn):
   """test process returning None in a filter pattern"""
   def process(self, element):
     if element == 0:
@@ -187,9 +193,14 @@ class CreateTest(unittest.TestCase):
       assert RETURN_NONE_PARTIAL_WARNING in self._caplog.text
       assert str(TestDoFn10) in self._caplog.text
 
-  def test_dofn_with_implicit_return_none_and_value(self):
+  def test_dofn_with_implicit_return_none_missing_return_and_yield(self):
     with self._caplog.at_level(logging.WARNING):
       beam.ParDo(TestDoFn11())
+      assert RETURN_NONE_PARTIAL_WARNING not in self._caplog.text
+
+  def test_dofn_with_implicit_return_none_and_value(self):
+    with self._caplog.at_level(logging.WARNING):
+      beam.ParDo(TestDoFn12())
       assert RETURN_NONE_PARTIAL_WARNING not in self._caplog.text
 
 


### PR DESCRIPTION
The following kind of DoFn no longer issue warning:

```
class DoFn:
  do_some_work # may intended for side effect for incoming elements and not intended to emit anything
```

```
class DoFn:
  if not a
    return # A valid filter pattern
  do_some_thing
  return some_output
```

#28061 was meant to warn this scenario:

```
class DoFn:
  do_some_work
  return None # user may assume it will emit a "None" downstream, which is not the case
```

in addition, the formatting of current warning message is wrong. log.warning(("%s", 's',)) will output `("%s", 's',)`, not formatted string

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
