### PR TITLE
[Website] Clickable cards for cases without links

### DIFF
--- a/website/www/site/assets/scss/_case_study.scss
+++ b/website/www/site/assets/scss/_case_study.scss
@@ -68,9 +68,12 @@
     opacity: 0;
     width: 0;
     overflow-y: scroll;
+    color: #10141b;
   }
 
   &:hover {
+    text-decoration: none;
+
     .case-study-used-by-card-description {
       font-size: 14px;
       line-height: 1.63;

--- a/website/www/site/assets/scss/_global.sass
+++ b/website/www/site/assets/scss/_global.sass
@@ -92,7 +92,6 @@ body
 .container-main-content
   @media (max-width: $ak-breakpoint-lg)
     padding: 0 24px
-  min-height: 100vh
   padding: 0 22px
   position: relative
   background-color: #fff

--- a/website/www/site/layouts/case-studies/list.html
+++ b/website/www/site/layouts/case-studies/list.html
@@ -80,14 +80,14 @@ limitations under the License. See accompanying LICENSE file.
                 </div>
             </a>
             {{ else }}
-            <div class="case-study-used-by-card case-study-used-by-card--responsive">
+            <a class="case-study-used-by-card case-study-used-by-card--responsive" href="{{ .RelPermalink }}">
                 <div class="case-study-used-by-card-img">
                     <img src="{{.Params.icon}}" loading="lazy"></i>
                 </div>
                 <div class="case-study-used-by-card-description">
                     {{ .Params.cardDescription | safeHTML }}
                 </div>
-            </div>
+            </a>
             {{ end }}
         {{ end }}
     </div>


### PR DESCRIPTION
This update enhances the user experience by making all case study cards fully clickable, regardless of whether they have an external link.

- Made all case study cards clickable, triggering a navigation to a dedicated internal case page.
- Previously, only cards with an external link were interactive.