### PR TITLE
Check that billing project is not null in BigQuerySourceBase

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySourceBase.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySourceBase.java
@@ -134,9 +134,13 @@ abstract class BigQuerySourceBase<T> extends BoundedSource<T> {
           BigQueryHelpers.getDatasetLocation(
               datasetService, tableToExtract.getProjectId(), tableToExtract.getDatasetId());
       String bqProjectId =
-          bqOptions.getBigQueryProject() != null
-              ? bqOptions.getBigQueryProject()
-              : bqOptions.getProject();
+          checkArgumentNotNull(
+              bqOptions.getBigQueryProject() != null
+                  ? bqOptions.getBigQueryProject()
+                  : bqOptions.getProject(),
+              "Cannot export data from table "
+                  + tableToExtract
+                  + " without a valid billing project. Check that either --bigQueryProject or --project has been set.");
       List<ResourceId> tempFiles =
           executeExtract(
               extractJobId,


### PR DESCRIPTION
When neither `project` nor `bigQueryProject` or set, a BigQueryIO read will fail on source split with the error:

```
Caused by: java.lang.NullPointerException: Required parameter projectId must be specified.
	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:924)
	at com.google.api.client.util.Preconditions.checkNotNull(Preconditions.java:138)
	at com.google.api.services.bigquery.Bigquery$Jobs$Insert.<init>(Bigquery.java:2654)
	at com.google.api.services.bigquery.Bigquery$Jobs.insert(Bigquery.java:2593)
	at org.apache.beam.sdk.io.gcp.bigquery.BigQueryServicesImpl$JobServiceImpl.startJob(BigQueryServicesImpl.java:378)
	at org.apache.beam.sdk.io.gcp.bigquery.BigQueryServicesImpl$JobServiceImpl.startJob(BigQueryServicesImpl.java:363)
	at org.apache.beam.sdk.io.gcp.bigquery.BigQueryServicesImpl$JobServiceImpl.startExtractJob(BigQueryServicesImpl.java:318)
	at org.apache.beam.sdk.io.gcp.bigquery.BigQuerySourceBase.executeExtract(BigQuerySourceBase.java:218)
	at org.apache.beam.sdk.io.gcp.bigquery.BigQuerySourceBase.extractFiles(BigQuerySourceBase.java:137)
	at org.apache.beam.sdk.io.gcp.bigquery.BigQuerySourceBase.split(BigQuerySourceBase.java:157)
	at 
```

(strange that the job doesn't fail earlier, but 😅 )

This is a confusing error message for the user because it implies that a param like `--projectId` is required, when really it's just derived in `BigQuerySourceBase` from either the `--project`/`--bigQueryProject` param.

This PR just adds a null check earlier along in the stack trace that's more actionable for the Beam user.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
