### PR TITLE
Fix DinD Action failure

### DIFF
--- a/.github/actions/dind-up-action/action.yml
+++ b/.github/actions/dind-up-action/action.yml
@@ -43,7 +43,7 @@ inputs:
   storage-driver:
     default: overlay2
   additional-dockerd-args:
-    default: ""
+    default: "--tls=false"
   use-host-network:
     description: "Run DinD with --network host instead of publishing a TCP port."
     default: "false"
@@ -206,20 +206,20 @@ runs:
       run: |
         set -euo pipefail
         NAME="${{ inputs.container-name || 'dind-daemon' }}"
-        
+
         # Use host daemon to inspect the DinD container
         nm=$(docker inspect -f '{{.HostConfig.NetworkMode}}' "$NAME")
         echo "DinD NetworkMode=${nm}"
 
         # Try to find the bridge network IP
         ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$NAME" || true)
-        
+
         # If still empty, likely host networking -> use loopback
         if [[ -z "${ip}" || "${nm}" == "host" ]]; then
           echo "No bridge IP found or using host network. Falling back to 127.0.0.1."
           ip="127.0.0.1"
         fi
-        
+
         echo "Discovered DinD IP: ${ip}"
         echo "dind-ip=${ip}" >> "$GITHUB_OUTPUT"
 
@@ -237,7 +237,7 @@ runs:
         hostport=$(docker port redis-smoke 6379/tcp | sed 's/.*://')
         echo "Redis container started, mapped to host port ${hostport}"
         echo "Probing connection to ${DIND_IP}:${hostport} ..."
-        
+
         timeout 5 bash -c 'exec 3<>/dev/tcp/$DIND_IP/'"$hostport"
         if [[ $? -eq 0 ]]; then
           echo "TCP connection successful. Port mapping is working."


### PR DESCRIPTION
Fix failing Docker in Docker action

https://github.com/apache/beam/actions/runs/19269301203/job/55093052729

time="2025-11-11T14:49:11.463163352Z" level=warning msg="[DEPRECATION NOTICE] In future versions this will be a hard failure preventing the daemon from starting! Learn more at: https://docs.docker.com/go/api-security/" host="tcp://0.0.0.0:2375"
time="2025-11-11T14:49:12.463269590Z" level=warning msg="Binding to an IP address without --tlsverify is deprecated. Startup is intentionally being slowed down to show this message" host="tcp://0.0.0.0:2375"

From logs looks like the DinD is intentionally delayed due to accessing docker demon with out encryption. It added suggestion to disable if needed. 

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
