### PR TITLE
Increase the GZip DeflaterOutputStream buffer size to increase performance

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Compression.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Compression.java
@@ -101,7 +101,7 @@ public enum Compression {
     public WritableByteChannel writeCompressed(WritableByteChannel channel) throws IOException {
       // Increase the default deflate output stream buffer size from 512 to 4096 for performance.
       return Channels.newChannel(
-        new GZIPOutputStream(Channels.newOutputStream(channel), 4096, true));
+          new GZIPOutputStream(Channels.newOutputStream(channel), 4096, true));
     }
   },
 


### PR DESCRIPTION
The default buffer size is 512 bytes and this PR increases it to 4096.
Based upon benchmarks https://bugs.openjdk.org/secure/attachment/87709/InflaterOutputStreamWrite.java
from https://bugs.openjdk.org/browse/JDK-8242864
it is expected that this will decrease cpu of write by 2x. This cpu usage is 50% of cpu profiles of a streaming dataflow pipeline writing gzip files.

The buffers used for other codecs appear to be in megabytes, and the data written to files is generally much larger so I'm not particularly concerned about the memory increase.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
