### PR TITLE
Provide more contextual error message for PyCoder

### DIFF
--- a/sdks/python/apache_beam/coders/coder_impl.py
+++ b/sdks/python/apache_beam/coders/coder_impl.py
@@ -1018,9 +1018,10 @@ class VarIntCoderImpl(StreamCoderImpl):
       out.write_var_int64(value)
     except OverflowError as e:
       raise OverflowError(
-          f"Integer value '{value}' is out of the encodable range for VarIntCoder. "
-          f"This coder is limited to values that fit within a 64-bit signed integer "
-          f"(-(2**63) to 2**63 - 1). Original error: {e}") from e
+          f"Integer value '{value}' is out of the encodable range for "
+          f"VarIntCoder. This coder is limited to values that fit "
+          f"within a 64-bit signed integer (-(2**63) to 2**63 - 1). "
+          f"Original error: {e}") from e
 
   def decode_from_stream(self, in_stream, nested):
     # type: (create_InputStream, bool) -> int


### PR DESCRIPTION
Fixes #36824

**Description:**
Improve error messages by providing more contextual debugging information. Modify the `VarIntCoderImpl` class to catch the `OverflowError` and provide a more informative message.

**Fix/Changes::**

1.  **Modified `encode_to_stream(self, value, out, nested)` in `coder_impl.py`:**
    *   Wrapped the call to out.write_var_int64(value) in a try...except OverflowError block.
    *   If an OverflowError occurs, a new OverflowError is raised with a message explicitly stating:
        *   The value causing the error.
        *   That the VarIntCoder is limited to the 64-bit signed integer range.

2. **`estimate_size(self, value, nested=False)` in `coder_impl.py`:**
    *   Wrapped the call to `get_varint_size(value)` in a try...except `OverflowError` block.
    *   If an `OverflowError` occurs, it means the value is too large to even calculate the varint size, so a more specific `OverflowError` is raised.

**Impact of these Changes:**
1.   When a Python integer larger than what can be represented by a signed 64-bit integer is passed to a Beam pipeline and a `VarIntCoder` is used, the user will now get a much clearer error message.
2.   The message will immediately point to the size limitation of the coder, making it much easier to debug issues.
3.   This improves the user experience by making the error message more actionable and less cryptic.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
