### PR TITLE
BEAM-13231: Add glob wildcard escaping utilities to FileSystems

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystems.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystems.java
@@ -78,6 +78,8 @@ public class FileSystems {
   private static final Pattern FILE_SCHEME_PATTERN =
       Pattern.compile("(?<scheme>[a-zA-Z][-a-zA-Z0-9+.]*):/.*");
   private static final Pattern GLOB_PATTERN = Pattern.compile("[*?{}]");
+  private static final Pattern ESCAPED_GLOB_PATTERN = Pattern.compile("\\\\[*?{}]");
+  private static final String GLOB_ESCAPE_PREFIX = "\\";
 
   private static final AtomicReference<KV<Long, Integer>> FILESYSTEM_REVISION =
       new AtomicReference<>();
@@ -90,6 +92,40 @@ public class FileSystems {
   /** Checks whether the given spec contains a glob wildcard character. */
   public static boolean hasGlobWildcard(String spec) {
     return GLOB_PATTERN.matcher(spec).find();
+  }
+
+  /**
+   * Escapes glob wildcard characters in the given spec so they are treated as literals.
+   *
+   * <p>This method escapes the characters '*', '?', '{', and '}' by prefixing them with a
+   * backslash, allowing them to be treated as literal characters in a file path rather than as
+   * glob wildcards.
+   *
+   * <p>Example: {@code escapeGlobWildcards("file*.txt")} returns {@code "file\\*.txt"}
+   *
+   * @param spec the file path specification to escape
+   * @return the escaped specification
+   */
+  public static String escapeGlobWildcards(String spec) {
+    checkNotNull(spec, "spec cannot be null");
+    return spec.replaceAll("([*?{}])", "\\\\$1");
+  }
+
+  /**
+   * Unescapes glob wildcard characters in the given spec that were previously escaped with {@link
+   * #escapeGlobWildcards(String)}.
+   *
+   * <p>This method removes the backslash prefix from escaped glob characters ('*', '?', '{', '}'),
+   * restoring them to their unescaped form.
+   *
+   * <p>Example: {@code unescapeGlobWildcards("file\\*.txt")} returns {@code "file*.txt"}
+   *
+   * @param spec the file path specification to unescape
+   * @return the unescaped specification
+   */
+  public static String unescapeGlobWildcards(String spec) {
+    checkNotNull(spec, "spec cannot be null");
+    return spec.replaceAll("\\\\([*?{}])", "$1");
   }
 
   /**

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileSystemsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileSystemsTest.java
@@ -354,6 +354,56 @@ public class FileSystemsTest {
     }
   }
 
+  @Test
+  public void testEscapeGlobWildcards() {
+    // Test escaping asterisk
+    assertEquals("file\\*.txt", FileSystems.escapeGlobWildcards("file*.txt"));
+
+    // Test escaping question mark
+    assertEquals("file\\?.txt", FileSystems.escapeGlobWildcards("file?.txt"));
+
+    // Test escaping braces
+    assertEquals("file\\{1,2\\}.txt", FileSystems.escapeGlobWildcards("file{1,2}.txt"));
+
+    // Test escaping multiple characters
+    assertEquals("\\*\\?\\{\\}.txt", FileSystems.escapeGlobWildcards("*?{}.txt"));
+
+    // Test string with no glob characters
+    assertEquals("file.txt", FileSystems.escapeGlobWildcards("file.txt"));
+
+    // Test empty string
+    assertEquals("", FileSystems.escapeGlobWildcards(""));
+  }
+
+  @Test
+  public void testUnescapeGlobWildcards() {
+    // Test unescaping asterisk
+    assertEquals("file*.txt", FileSystems.unescapeGlobWildcards("file\\*.txt"));
+
+    // Test unescaping question mark
+    assertEquals("file?.txt", FileSystems.unescapeGlobWildcards("file\\?.txt"));
+
+    // Test unescaping braces
+    assertEquals("file{1,2}.txt", FileSystems.unescapeGlobWildcards("file\\{1,2\\}.txt"));
+
+    // Test unescaping multiple characters
+    assertEquals("*?{}.txt", FileSystems.unescapeGlobWildcards("\\*\\?\\{\\}.txt"));
+
+    // Test string with no escaped characters
+    assertEquals("file.txt", FileSystems.unescapeGlobWildcards("file.txt"));
+
+    // Test empty string
+    assertEquals("", FileSystems.unescapeGlobWildcards(""));
+  }
+
+  @Test
+  public void testEscapeUnescapeRoundTrip() {
+    String original = "file*test?.txt";
+    String escaped = FileSystems.escapeGlobWildcards(original);
+    String unescaped = FileSystems.unescapeGlobWildcards(escaped);
+    assertEquals(original, unescaped);
+  }
+
   private LocalResourceId toLocalResourceId(String str) throws Exception {
     boolean isDirectory;
     if (SystemUtils.IS_OS_WINDOWS) {


### PR DESCRIPTION
This commit adds support for escaping and unescaping glob wildcard characters in file path specifications, addressing the issue where files with literal glob metacharacters (*, ?, {, }) in their names cannot be matched.

Changes:
- Added escapeGlobWildcards(String spec) method to escape glob metacharacters by prefixing them with backslash
- Added unescapeGlobWildcards(String spec) method to remove backslash prefixes from escaped glob characters
- Added comprehensive test cases for both methods including round-trip testing

These utilities provide the foundation for allowing users to treat glob metacharacters as literals when they appear in actual filenames.

Fixes BEAM-13231

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
