### PR TITLE
Fix linkage check script to handle detached HEAD state

### DIFF
--- a/sdks/java/build-tools/beam-linkage-check.sh
+++ b/sdks/java/build-tools/beam-linkage-check.sh
@@ -69,9 +69,12 @@ if [ ! -z "$(git diff)" ]; then
   exit 1
 fi
 
-STARTING_REF=$(git rev-parse --abbrev-ref HEAD)
+# Use the full commit SHA instead of branch name to handle detached HEAD state.
+# This commonly happens when verifying someone else's PR, which involves
+# merging two non-branch references. See https://github.com/apache/beam/issues/20558
+STARTING_REF=$(git rev-parse HEAD)
 function cleanup() {
-  git checkout $STARTING_REF
+  git -c advice.detachedHead=false checkout $STARTING_REF
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
The `beam-linkage-check.sh` script fails to restore the original git position when starting from a detached HEAD state. This commonly happens when verifying someone else's PR, which involves merging two non-branch references.

**Root Cause:**
The script used `git rev-parse --abbrev-ref HEAD` which returns the string "HEAD" in detached state instead of a valid reference. The cleanup function then fails to restore the original position.

**Fix:**
- Use `git rev-parse HEAD` to get the full commit SHA instead of branch name
- Add `-c advice.detachedHead=false` to suppress warnings during cleanup checkout

Fixes #20558

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).