### PR TITLE
Improve linkage check script documentation for git references

### DIFF
--- a/sdks/java/build-tools/beam-linkage-check.sh
+++ b/sdks/java/build-tools/beam-linkage-check.sh
@@ -20,7 +20,13 @@
 # one branch and another.
 
 # Usage:
-#  /bin/bash sdks/java/build-tools/beam-linkage-check.sh origin/master <your branch>
+#  /bin/bash sdks/java/build-tools/beam-linkage-check.sh <baseline ref> <proposed ref>
+#
+#  The <baseline ref> and <proposed ref> can be any valid git reference such as:
+#  - A remote branch: origin/master, upstream/main
+#  - A local branch: master, my-feature-branch
+#  - A commit SHA: abc123def
+#  - A tag: v2.50.0
 #
 #  By default, this checks the Maven artifacts listed in ARTIFACTS variable below.
 #


### PR DESCRIPTION
The usage documentation in `beam-linkage-check.sh` showed `origin/master` as an example, which incorrectly suggested that users must have a remote called "origin". The script actually accepts any valid git reference.

**Changes:**
- Use generic `<baseline ref>` placeholder instead of `origin/master`
- Add examples of valid git references:
  - Remote branches: `origin/master`, `upstream/main`
  - Local branches: `master`, `my-feature-branch`
  - Commit SHAs: `abc123def`
  - Tags: `v2.50.0`

Fixes #20650

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).