### PR TITLE
Enforce version upper bound for scikit-learn.

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -448,7 +448,7 @@ if __name__ == '__main__':
               'pytest>=7.1.2,<9.0',
               'pytest-xdist>=2.5.0,<4',
               'pytest-timeout>=2.1.0,<3',
-              'scikit-learn>=0.20.0',
+              'scikit-learn>=0.20.0,<1.8.0',
               'sqlalchemy>=1.3,<3.0',
               'psycopg2-binary>=2.8.5,<3.0',
               'testcontainers[mysql,kafka,milvus]>=4.0.0,<5.0.0',


### PR DESCRIPTION
There is a breaking change coming to scikit-learn v1.8.0 (e.g. rc1) which leads to some ML test failures.

Here we set the upper bound of it to fix the test and unblock the release.


See #36936, #31285