### PR TITLE
test: update libraries-bom

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -612,8 +612,8 @@ class BeamModulePlugin implements Plugin<Project> {
     def google_ads_version = "33.0.0"
     def google_clients_version = "2.0.0"
     def google_cloud_bigdataoss_version = "2.2.26"
-    // [bomupgrader] TODO(#35868): currently pinned, should be determined by: com.google.cloud:google-cloud-spanner, consistent with: google_cloud_platform_libraries_bom
-    def google_cloud_spanner_version = "6.95.1"
+    // [bomupgrader] determined by: com.google.cloud:google-cloud-spanner, consistent with: google_cloud_platform_libraries_bom
+    def google_cloud_spanner_version = "6.103.0"
     def google_code_gson_version = "2.10.1"
     def google_oauth_clients_version = "1.34.1"
     // [bomupgrader] determined by: io.grpc:grpc-netty, consistent with: google_cloud_platform_libraries_bom


### PR DESCRIPTION
Beam is already on 4.33(https://github.com/apache/beam/blob/3ce2abdc505d09569b668d8071f89306ea9aeb81/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy#L641).

Running `python3 scripts/tools/bomupgrader.py 26.72.0` to update libraries-bom

```
INFO:root:-----Update BeamModulePlugin-----
INFO:root:Unchanged: com.google.api:gax:2.72.1
INFO:root:Changed com.google.cloud:google-cloud-spanner: 6.95.1 -> 6.103.0
INFO:root:Unchanged: io.grpc:grpc-netty:1.76.0
INFO:root:Unchanged: io.netty:netty-transport:4.1.124.Final
INFO:root:Unchanged: io.opentelemetry:opentelemetry-sdk:1.52.0
INFO:root:Unchanged: com.google.protobuf:protobuf-java:4.33.0
INFO:root:Unchanged: org.apache.arrow:arrow-memory-core:17.0.0
INFO:root:Unchanged: com.google.apis:google-api-services-bigquery:v2-rev20251012-2.0.0
INFO:root:Unchanged: com.google.apis:google-api-services-cloudresourcemanager:v1-rev20250606-2.0.0
INFO:root:Unchanged: com.google.apis:google-api-services-storage:v1-rev20250925-2.0.0
INFO:root:Unchanged: com.google.cloud.datastore:datastore-v1-proto-client:2.33.0
INFO:root:-----Update dep_urls_java.yaml-----

```
