### PR TITLE
Fix too-many-pings on FnAPI runner under grpc mode

### DIFF
--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/worker_handlers.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/worker_handlers.py
@@ -465,14 +465,15 @@ class GrpcServer(object):
     # received or sent over the data plane. The actual buffer size
     # is controlled in a layer above. Also, options to keep the server alive
     # when too many pings are received.
-    options = [("grpc.max_receive_message_length", -1),
-               ("grpc.max_send_message_length", -1),
-               ("grpc.http2.max_pings_without_data", 0),
-               ("grpc.http2.max_ping_strikes", 0),
-               # match `grpc.keepalive_time_ms` defined in the client
-               # (channel_factory.py)
-               ("grpc.http2.min_ping_interval_without_data_ms", 20_000),
-               ]
+    options = [
+        ("grpc.max_receive_message_length", -1),
+        ("grpc.max_send_message_length", -1),
+        ("grpc.http2.max_pings_without_data", 0),
+        ("grpc.http2.max_ping_strikes", 0),
+        # match `grpc.keepalive_time_ms` defined in the client
+        # (channel_factory.py)
+        ("grpc.http2.min_ping_interval_without_data_ms", 20_000),
+    ]
 
     self.state = state
     self.provision_info = provision_info


### PR DESCRIPTION
GRPC error as in https://github.com/apache/beam/actions/runs/19958369481/job/57232567333. Notice Python Precommit ML is running on FnAPI runner not prism, as Go environment is not set up in the workflow: https://github.com/apache/beam/blob/6aab0afeefff1d693777170e7707eebeec0cd80d/.github/workflows/beam_PreCommit_Python_ML.yml#L109-L113

The error message:
```
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1764927812.016144   20174 chttp2_transport.cc:1341] ipv4:127.0.0.1:54619: Got goaway [11] err=UNAVAILABLE:GOAWAY received; Error code: 11; Debug Text: too_many_pings {grpc_status:14, http2_error:11}
E0000 00:00:1764927812.016312   20174 chttp2_transport.cc:1370] ipv4:127.0.0.1:54619: Received a GOAWAY with error code ENHANCE_YOUR_CALM and debug data equal to "too_many_pings". Current keepalive time (before throttling): 20000ms
ERROR:apache_beam.runners.worker.data_plane:Failed to read inputs in the data plane.
Traceback (most recent call last):
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py313/build/srcs/sdks/python/target/.tox-py313-ml/py313-ml/lib/python3.13/site-packages/apache_beam/runners/worker/data_plane.py", line 707, in _read_inputs
    for elements in elements_iterator:
                    ^^^^^^^^^^^^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py313/build/srcs/sdks/python/target/.tox-py313-ml/py313-ml/lib/python3.13/site-packages/grpc/_channel.py", line 538, in __next__
    return self._next()
           ~~~~~~~~~~^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py313/build/srcs/sdks/python/target/.tox-py313-ml/py313-ml/lib/python3.13/site-packages/grpc/_channel.py", line 962, in _next
    raise self
grpc._channel._MultiThreadedRendezvous: <_MultiThreadedRendezvous of RPC that terminated with:
	status = StatusCode.UNAVAILABLE
	details = "Socket closed"
	debug_error_string = "UNKNOWN:Error received from peer ipv4:127.0.0.1:54619 {grpc_message:"Socket closed", grpc_status:14}"
>
I0000 00:00:1764927973.139396    3231 chttp2_transport.cc:1341] ipv4:127.0.0.1:54619: Got goaway [11] err=UNAVAILABLE:GOAWAY received; Error code: 11; Debug Text: too_many_pings {http2_error:11, grpc_status:14}
E0000 00:00:1764927973.139482    3231 chttp2_transport.cc:1370] ipv4:127.0.0.1:54619: Received a GOAWAY with error code ENHANCE_YOUR_CALM and debug data equal to "too_many_pings". Current keepalive time (before throttling): 40000ms
```

I also notice that the change on `sdks/python/apache_beam/utils/subprocess_server.py` in #36528 may not be effective. Even though the file and class name has "server", it is actually a grpc client which connects to the grpc server endpoint (https://github.com/liferoad/beam/blob/782a0e7cc26e582c31534253fa5a00018bce4c38/sdks/python/apache_beam/utils/subprocess_server.py#L202).


If this fix works (getting rid of too-many-pings errors in precommits), we may also tune the setting on PrismRunner.


### Some references:

- https://github.com/apache/beam/pull/36528
- https://github.com/apache/beam/pull/15314
- https://stackoverflow.com/questions/66271810/grpc-error-on-long-connections-too-many-pings