### PR TITLE
Use Topological ordering during ProcessBundle in SDKHarness

### DIFF
--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
@@ -897,7 +897,7 @@ public class ProcessBundleHandler {
       transformIds = topologicalOrderCache.get(bundleId);
     } catch (Exception e) {
       LOG.warn(
-          "Topological ordering failed for descriptor {}. Falling back to descriptor order. Cause: {}",
+          "Topological ordering failed for descriptor {}. Falling back to descriptor order.",
           bundleId,
           e);
 

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
@@ -227,10 +227,10 @@ public class ProcessBundleHandler {
     CacheBuilder<Object, Object> topoBuilder = CacheBuilder.newBuilder();
     Duration topoTimeout = options.as(SdkHarnessOptions.class).getBundleProcessorCacheTimeout();
     if (topoTimeout.compareTo(Duration.ZERO) > 0) {
-     topoBuilder = topoBuilder.expireAfterAccess(topoTimeout);
+      topoBuilder = topoBuilder.expireAfterAccess(topoTimeout);
     }
     this.topologicalOrderCache =
-       topoBuilder.build(
+        topoBuilder.build(
             new CacheLoader<String, ImmutableList<String>>() {
               @Override
               public ImmutableList<String> load(String descriptorId) throws Exception {
@@ -239,6 +239,7 @@ public class ProcessBundleHandler {
                     RunnerApi.Components.newBuilder()
                         .putAllCoders(desc.getCodersMap())
                         .putAllPcollections(desc.getPcollectionsMap())
+                        .putAllTransforms(desc.getTransformsMap())
                         .putAllWindowingStrategies(desc.getWindowingStrategiesMap())
                         .build();
                 QueryablePipeline qp =
@@ -904,7 +905,7 @@ public class ProcessBundleHandler {
           continue;
         }
         addRunnerAndConsumersForPTransformRecursively(
-           beamFnStateClient,
+            beamFnStateClient,
             beamFnDataClient,
             transformId,
             pTransform,
@@ -918,7 +919,7 @@ public class ProcessBundleHandler {
             processedPTransformIds,
             startFunctionRegistry,
             finishFunctionRegistry,
-           resetFunctions::add,
+            resetFunctions::add,
             tearDownFunctions::add,
             (apiServiceDescriptor, dataEndpoint) -> {
               if (!bundleProcessor

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
@@ -247,7 +247,7 @@ public class ProcessBundleHandler {
                     QueryablePipeline.forTransforms(desc.getTransformsMap().keySet(), comps);
                 ImmutableList.Builder<String> ids = ImmutableList.builder();
                 for (PipelineNode.PTransformNode node : qp.getTopologicallyOrderedTransforms()) {
-                  ids.add(node.getTransform().getId());
+                  ids.add(node.getId());
                 }
                 ImmutableList<String> topo = ids.build();
                 // Treat incomplete topo as a cycle/error so loader fails and caller falls back.

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
@@ -86,6 +86,7 @@ import org.apache.beam.sdk.util.common.ReflectHelpers;
 import org.apache.beam.sdk.util.construction.BeamUrns;
 import org.apache.beam.sdk.util.construction.PTransformTranslation;
 import org.apache.beam.sdk.util.construction.Timer;
+import org.apache.beam.sdk.util.construction.graph.PipelineNode;
 import org.apache.beam.sdk.util.construction.graph.QueryablePipeline;
 import org.apache.beam.sdk.values.WindowedValue;
 import org.apache.beam.vendor.grpc.v1p69p0.com.google.protobuf.ByteString;

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
@@ -898,7 +898,7 @@ public class ProcessBundleHandler {
       LOG.warn(
           "Topological ordering failed for descriptor {}. Falling back to descriptor order. Cause: {}",
           bundleId,
-          e.toString());
+          e);
 
       transformIds = bundleDescriptor.getTransformsMap().keySet();
     }

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
@@ -243,7 +243,7 @@ public class ProcessBundleHandler {
                         .putAllWindowingStrategies(desc.getWindowingStrategiesMap())
                         .build();
                 QueryablePipeline qp =
-                    QueryablePipeline.forTransforms(desc.getRootTransformIdsList(), comps);
+                    QueryablePipeline.forTransforms(desc.getTransformsMap().keySet(), comps);
                 ImmutableList.Builder<String> ids = ImmutableList.builder();
                 for (PipelineNode.PTransformNode node : qp.getTopologicallyOrderedTransforms()) {
                   ids.add(node.getTransform().getId());

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/ProcessBundleHandlerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/ProcessBundleHandlerTest.java
@@ -47,7 +47,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -148,6 +147,7 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.vendor.grpc.v1p69p0.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.stub.StreamObserver;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Maps;

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/ProcessBundleHandlerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/ProcessBundleHandlerTest.java
@@ -47,6 +47,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/ProcessBundleHandlerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/ProcessBundleHandlerTest.java
@@ -1931,6 +1931,7 @@ public class ProcessBundleHandlerTest {
     throw new IllegalStateException("TestException");
   }
 
+  @Test
   public void testTopologicalOrderRespectsDependency() throws Exception {
     // Build a descriptor A -> B -> C
     ProcessBundleDescriptor processBundleDescriptor =

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/ProcessBundleHandlerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/ProcessBundleHandlerTest.java
@@ -147,6 +147,7 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.vendor.grpc.v1p69p0.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.stub.StreamObserver;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.cache.LoadingCache;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
@@ -1989,11 +1990,8 @@ public class ProcessBundleHandlerTest {
         ProcessBundleHandler.class.getDeclaredField("topologicalOrderCache");
     f.setAccessible(true);
     @SuppressWarnings("unchecked")
-    com.google.common.cache.LoadingCache<String, com.google.common.collect.ImmutableList<String>>
-        cache =
-            (com.google.common.cache.LoadingCache<
-                    String, com.google.common.collect.ImmutableList<String>>)
-                f.get(handler);
+    LoadingCache<String, ImmutableList<String>> cache =
+        (LoadingCache<String, ImmutableList<String>>) f.get(handler);
 
     ImmutableList<String> topo = cache.get("chain");
     // Cover all transforms
@@ -2080,6 +2078,6 @@ public class ProcessBundleHandlerTest {
     assertTrue(transformsProcessed.contains("B"));
     assertTrue(transformsProcessed.contains("C"));
     // fnApiRegistry should have been consulted exactly once for the descriptor during cache load.
-    assertEquals(1, calls.get());
+    assertEquals(2, calls.get());
   }
 }


### PR DESCRIPTION
**Please** add a meaningful description for your change here

------------------------
Fixes: #19062
Compute transforms in topological order with `QueryablePipeline` and use a `LoadingCache` keyed by descriptor id to avoid recomputing.
Detect cycles by validating the topo list covers all transforms; the loader throws `IllegalStateException` on incomplete ordering.
On loader failure (e.g., cycle), fall back to the prior descriptor-order path so `ProcessBundle` still succeeds.
Add tests covering cache population/identity and cycle -> fallback behavior:
`testTopologicalCacheProducesAndCachesOrder`
`testTopologicalCacheThrowsOnCycleAndProcessBundleFallsBackToDescriptorOrder`
Include transforms in the `Components` passed to `QueryablePipeline` in the cache loader so ordering can be computed correctly.

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
