### PR TITLE
Attempt to bump httplib2 version upper bound

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -379,7 +379,7 @@ if __name__ == '__main__':
           # TODO(https://github.com/grpc/grpc/issues/37710): Unpin grpc
           'grpcio>=1.33.1,<2,!=1.48.0,!=1.59.*,!=1.60.*,!=1.61.*,!=1.62.0,!=1.62.1,<1.66.0; python_version <= "3.12"',  # pylint: disable=line-too-long
           'grpcio>=1.67.0; python_version >= "3.13"',
-          'httplib2>=0.8,<0.23.0',
+          'httplib2>=0.8,<1.0.0',
           'jsonpickle>=3.0.0,<4.0.0',
           # numpy can have breaking changes in minor versions.
           # Use a strict upper bound.


### PR DESCRIPTION
Bump httplib2 version to get rid of deprecating warnings

```
  /runner/_work/beam/beam/sdks/python/test-suites/tox/py310/build/srcs/sdks/python/target/.tox-py310-cloud/py310-cloud/lib/python3.10/site-packages/httplib2/auth.py:20: DeprecationWarning: 'setName' deprecated - use 'set_name'
    token = pp.Word(tchar).setName("token")
DeprecationWarning: 'setName' deprecated - use 'set_name'
    token = pp.Word(tchar).setName("token")
...
  /runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/httplib2/auth.py:21: DeprecationWarning: 'leaveWhitespace' deprecated - use 'leave_whitespace'
    token68 = pp.Combine(pp.Word("-._~+/" + pp.nums + pp.alphas) + pp.Optional(pp.Word("=").leaveWhitespace())).setName(
```