### PR TITLE
Add primitive read translators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,7 +84,7 @@
 
 ## Bugfixes
 
-* Fixed Flink classic runner failing with "No translator known for PrimitiveUnboundedRead" when using unbounded source connectors like KinesisIO after SDF-to-primitive-read conversion (Java) ([#XXXXX](https://github.com/apache/beam/issues/XXXXX)).
+* Fixed Flink classic runner failing with "No translator known for PrimitiveUnboundedRead" when using unbounded source connectors like KinesisIO after SDF-to-primitive-read conversion (Java) ([#37035](https://github.com/apache/beam/issues/37035)).
 * Fixed FirestoreV1 Beam connectors allow configuring inconsistent project/database IDs between RPC requests and routing headers #36895 (Java) ([#36895](https://github.com/apache/beam/issues/36895)).
  Logical type and coder registry are saved for pipelines in the case of default pickler. This fixes a side effect of switching to cloudpickle as default pickler in Beam 2.65.0 (Python) ([#35738](https://github.com/apache/beam/issues/35738)).
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,6 +84,7 @@
 
 ## Bugfixes
 
+* Fixed Flink classic runner failing with "No translator known for PrimitiveUnboundedRead" when using unbounded source connectors like KinesisIO after SDF-to-primitive-read conversion (Java) ([#XXXXX](https://github.com/apache/beam/issues/XXXXX)).
 * Fixed FirestoreV1 Beam connectors allow configuring inconsistent project/database IDs between RPC requests and routing headers #36895 (Java) ([#36895](https://github.com/apache/beam/issues/36895)).
  Logical type and coder registry are saved for pipelines in the case of default pickler. This fixes a side effect of switching to cloudpickle as default pickler in Beam 2.65.0 (Python) ([#35738](https://github.com/apache/beam/issues/35738)).
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
@@ -192,6 +192,12 @@ class FlinkStreamingTransformTranslators {
     return context.getCurrentTransform().getFullName();
   }
 
+  /** Returns the parallelism to use for source operators. */
+  private static int getSourceParallelism(FlinkStreamingTranslationContext context) {
+    int maxParallelism = context.getExecutionEnvironment().getMaxParallelism();
+    return maxParallelism > 0 ? maxParallelism : context.getExecutionEnvironment().getParallelism();
+  }
+
   // --------------------------------------------------------------------------------------------
   //  Transformation Implementations
   // --------------------------------------------------------------------------------------------
@@ -222,10 +228,7 @@ class FlinkStreamingTransformTranslators {
 
     String fullName = getCurrentTransformName(context);
     try {
-      int parallelism =
-          context.getExecutionEnvironment().getMaxParallelism() > 0
-              ? context.getExecutionEnvironment().getMaxParallelism()
-              : context.getExecutionEnvironment().getParallelism();
+      int parallelism = getSourceParallelism(context);
 
       FlinkUnboundedSource<T> unboundedSource =
           FlinkSource.unbounded(
@@ -274,10 +277,7 @@ class FlinkStreamingTransformTranslators {
     TypeInformation<WindowedValue<T>> outputTypeInfo = context.getTypeInfo(output);
 
     String fullName = getCurrentTransformName(context);
-    int parallelism =
-        context.getExecutionEnvironment().getMaxParallelism() > 0
-            ? context.getExecutionEnvironment().getMaxParallelism()
-            : context.getExecutionEnvironment().getParallelism();
+    int parallelism = getSourceParallelism(context);
 
     FlinkBoundedSource<T> flinkBoundedSource =
         FlinkSource.bounded(

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslatorsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslatorsTest.java
@@ -196,7 +196,8 @@ public class FlinkStreamingTransformTranslatorsTest {
 
     FlinkSource<?, ?> source =
         (FlinkSource<?, ?>)
-            ((SourceTransformation<?, ?, ?>) Iterables.getOnlyElement(oneInputTransform.getInputs()))
+            ((SourceTransformation<?, ?, ?>)
+                    Iterables.getOnlyElement(oneInputTransform.getInputs()))
                 .getSource();
 
     assertEquals(maxParallelism, source.getNumSplits());
@@ -208,7 +209,8 @@ public class FlinkStreamingTransformTranslatorsTest {
     final int parallelism = 2;
 
     SplittableParDo.PrimitiveBoundedRead<String> transform =
-        new SplittableParDo.PrimitiveBoundedRead<>(Read.from(new TestBoundedSource(maxParallelism)));
+        new SplittableParDo.PrimitiveBoundedRead<>(
+            Read.from(new TestBoundedSource(maxParallelism)));
     StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
     env.setParallelism(parallelism);
     env.setMaxParallelism(maxParallelism);
@@ -288,8 +290,7 @@ public class FlinkStreamingTransformTranslatorsTest {
             Pipeline.create());
 
     ctx.setCurrentTransform(appliedTransform);
-    ((FlinkStreamingPipelineTranslator.StreamTransformTranslator<PTransform<?, ?>>)
-            translator)
+    ((FlinkStreamingPipelineTranslator.StreamTransformTranslator<PTransform<?, ?>>) translator)
         .translateNode(transform, ctx);
 
     return ctx.getInputDataStream(pc).getTransformation();


### PR DESCRIPTION
# Pull Request: Add PrimitiveUnboundedRead/PrimitiveBoundedRead Translators to Flink Runner

## Title

`[Flink Runner] Add translators for PrimitiveUnboundedRead and PrimitiveBoundedRead`

## Description

### What is this PR doing?

This PR adds explicit translators for `SplittableParDo.PrimitiveUnboundedRead` and `SplittableParDo.PrimitiveBoundedRead` to the Flink streaming transform translators. These translators handle the case where `Read.Unbounded` and `Read.Bounded` are converted to primitive reads by `SplittableParDo.convertReadBasedSplittableDoFnsToPrimitiveReadsIfNecessary()`.

### Why is this needed?

The Flink classic runner (non-portable) calls `convertReadBasedSplittableDoFnsToPrimitiveReadsIfNecessary()` when NOT using the `beam_fn_api` experiment. This converts SDF-wrapped reads to `PrimitiveUnboundedRead` and `PrimitiveBoundedRead` transforms. However, there were no registered translators for these transforms, causing pipelines using unbounded sources (like `KinesisIO.read()`) to fail with:

```
java.lang.IllegalStateException: No translator known for org.apache.beam.sdk.util.construction.SplittableParDo$PrimitiveUnboundedRead
```

### How does it work?

The new translators:

1. **`PrimitiveUnboundedReadTranslator`**: Extracts the `UnboundedSource` from `PrimitiveUnboundedRead.getSource()` and creates a `FlinkUnboundedSource`, following the same pattern as the existing `UnboundedReadSourceTranslator`.

2. **`PrimitiveBoundedReadTranslator`**: Extracts the `BoundedSource` from `PrimitiveBoundedRead.getSource()` and creates a `FlinkBoundedSource`, following the same pattern as the existing `BoundedReadSourceTranslator`.

The key difference from the existing translators is that they retrieve the source directly from the transform (`transform.getSource()`) rather than using `ReadTranslation.unboundedSourceFromTransform()`, since `PrimitiveUnboundedRead` and `PrimitiveBoundedRead` are not standard Read transforms with URNs.

### Changes

- **`FlinkStreamingTransformTranslators.java`**:
  - Added `PrimitiveUnboundedReadTranslator<T>` class
  - Added `PrimitiveBoundedReadTranslator<T>` class  
  - Modified `getTranslator()` to check for `PrimitiveUnboundedRead` and `PrimitiveBoundedRead` instances before URN lookup

- **`FlinkStreamingTransformTranslatorsTest.java`**:
  - Added `getTranslatorReturnsPrimitiveUnboundedReadTranslator()` test
  - Added `getTranslatorReturnsPrimitiveBoundedReadTranslator()` test
  - Added `primitiveUnboundedReadTranslatorProducesCorrectSource()` test
  - Added `primitiveBoundedReadTranslatorProducesCorrectSource()` test

- **`CHANGES.md`**:
  - Added bugfix entry for 2.71.0

## Issue

Fixes [#37035](https://github.com/apache/beam/issues/37035)

Created issue: #37035
Related to #20530 (Use SDF read as default)

## Checklist

- [x] Code formatted with `./gradlew :runners:flink:1.18:spotlessApply`
- [x] Unit tests added in `FlinkStreamingTransformTranslatorsTest.java`
- [x] All Flink runner tests pass (`./gradlew :runners:flink:1.18:test`)
- [x] `CHANGES.md` updated and formatted with `./gradlew formatChanges`
- [x] No breaking changes to public API

## Testing

### Unit Tests

```bash
./gradlew :runners:flink:1.18:test
# BUILD SUCCESSFUL - all tests pass
```

### Integration Testing

Tested on AWS Managed Apache Flink with a real pipeline using `KinesisIO.read()`:

1. **Before fix**: Pipeline fails during translation with "No translator known for PrimitiveUnboundedRead"
2. **After fix**: Pipeline successfully translates and runs, reading records from Kinesis

Test environment:
- AWS Managed Apache Flink (FLINK-1_18 runtime)
- Apache Beam 2.71.0-SNAPSHOT (with this fix)
- KinesisIO.read() connector

## Backwards Compatibility

This change is **fully backwards compatible**:

1. **No public API changes**: Only internal translator classes are added
2. **No behavior changes for existing code**: The new translators only activate when `PrimitiveUnboundedRead` or `PrimitiveBoundedRead` transforms are present (which previously caused failures)
3. **Existing URN-based translation unchanged**: Standard `Read.Bounded` and `Read.Unbounded` with URNs continue to use the existing `ReadSourceTranslator`

## Performance

No performance impact expected. The new translators use the same `FlinkUnboundedSource` and `FlinkBoundedSource` implementations as the existing translators.

