### PR TITLE
Pass options in DaskOptions inheritance hierarchy only for Dask runner

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -204,11 +204,6 @@ class PipelineOptionsTest(unittest.TestCase):
       parser.add_argument(
           '--fake_multi_option', action='append', help='fake multi option')
 
-  class FakeSubclassOptions(FakeOptions):
-    @classmethod
-    def _add_argparse_args(cls, parser):
-      parser.add_argument('--fake_sub_option', help='fake option')
-
   @parameterized.expand(TEST_CASES)
   def test_display_data(self, flags, _, display_data):
     options = PipelineOptions(flags=flags)
@@ -244,25 +239,16 @@ class PipelineOptionsTest(unittest.TestCase):
         expected['mock_multi_option'])
 
   def test_get_superclass_options(self):
-    flags = [
-        "--mock_option",
-        "mock",
-        "--fake_option",
-        "fake",
-        "--fake_sub_option",
-        "fake_sub"
-    ]
+    flags = ["--mock_option", "mock", "--fake_option", "fake"]
     options = PipelineOptions(flags=flags).view_as(
-        PipelineOptionsTest.FakeSubclassOptions)
-    items = options.get_all_options(hierarchy_only=True).items()
+        PipelineOptionsTest.FakeOptions)
+    items = options.get_all_options(current_only=True).items()
     print(items)
     self.assertTrue(('fake_option', 'fake') in items)
-    self.assertTrue(('fake_sub_option', 'fake_sub') in items)
     self.assertFalse(('mock_option', 'mock') in items)
     items = options.view_as(PipelineOptionsTest.MockOptions).get_all_options(
-        hierarchy_only=True).items()
+        current_only=True).items()
     self.assertFalse(('fake_option', 'fake') in items)
-    self.assertFalse(('fake_sub_option', 'fake_sub') in items)
     self.assertTrue(('mock_option', 'mock') in items)
 
   @parameterized.expand(TEST_CASES)

--- a/sdks/python/apache_beam/runners/dask/dask_runner.py
+++ b/sdks/python/apache_beam/runners/dask/dask_runner.py
@@ -236,7 +236,7 @@ class DaskRunner(BundleBasedDirectRunner):
           'DaskRunner is not available. Please install apache_beam[dask].')
 
     dask_options = options.view_as(DaskOptions).get_all_options(
-        drop_default=True, hierarchy_only=True)
+        drop_default=True, current_only=True)
     bag_kwargs = DaskOptions._extract_bag_kwargs(dask_options)
     client = ddist.Client(**dask_options)
 


### PR DESCRIPTION
Fix  #30528

There is a pre-exisitng bug such that Dask runner passing all (non-default) pipeline options to dask client. Whenever there is a pipeline option added that is not part of DaskOptions, pipeline run will crash.

#36271 made `save_main_session` gets resolved before pipeline submission time and introduced a "non-default" option. It has to be resolved early (unlike other worker options can leave to None and get resolved on worker side) because it is needed as early as staging a pipeline.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
