### PR TITLE
Exclude a few options in doc for jdbc managed IOs

### DIFF
--- a/sdks/java/managed/src/main/resources/available_configs.yaml
+++ b/sdks/java/managed/src/main/resources/available_configs.yaml
@@ -38,3 +38,38 @@
         - "keep"
         - "drop"
         - "only"
+"beam:schematransform:org.apache.beam:postgres_read:v1":
+    ignored:
+        - "connection_init_sql"
+        - "disable_auto_commit"
+        - "driver_class_name"
+        - "driver_jars"
+        - "jdbc_type"
+"beam:schematransform:org.apache.beam:postgres_write:v1":
+    ignored:
+        - "connection_init_sql"
+        - "driver_class_name"
+        - "driver_jars"
+        - "jdbc_type"
+"beam:schematransform:org.apache.beam:mysql_read:v1":
+    ignored:
+        - "driver_class_name"
+        - "driver_jars"
+        - "jdbc_type"
+"beam:schematransform:org.apache.beam:mysql_write:v1":
+    ignored:
+        - "driver_class_name"
+        - "driver_jars"
+        - "jdbc_type"
+"beam:schematransform:org.apache.beam:sql_server_read:v1":
+    ignored:
+        - "connection_init_sql"
+        - "driver_class_name"
+        - "driver_jars"
+        - "jdbc_type"
+"beam:schematransform:org.apache.beam:sql_server_write:v1":
+    ignored:
+        - "connection_init_sql"
+        - "driver_class_name"
+        - "driver_jars"
+        - "jdbc_type"


### PR DESCRIPTION
These options are not configurable in the Managed version and thus should be excluded in the documentation.

- [Doc link](https://beam.apache.org/documentation/io/managed-io/#available-configurations)

- [Internal design doc](http://go/beam-managed-jdbcio?tab=t.0#heading=h.xrdk1dciu14o)