### PR TITLE
Make TypeScript test reporter optional

### DIFF
--- a/sdks/typescript/reporterConfig.js
+++ b/sdks/typescript/reporterConfig.js
@@ -10,8 +10,19 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-const develocityReporter = require.resolve('@gradle-tech/develocity-agent/mocha-reporter');
+let develocityReporter = null;
+try {
+  // Optional: used in ASF CI for build scans. Local contributors may not have it.
+  develocityReporter = require.resolve(
+    "@gradle-tech/develocity-agent/mocha-reporter",
+  );
+} catch (e) {
+  // Fall back to the default reporter when the Develocity reporter is not installed.
+  develocityReporter = null;
+}
 
 module.exports = {
-  reporterEnabled: ['spec', develocityReporter].join(', '),
-}
+  reporterEnabled: develocityReporter
+    ? ["spec", develocityReporter].join(", ")
+    : "spec",
+};


### PR DESCRIPTION
## Summary

Fixes #37181

Makes the Develocity mocha reporter optional in the TypeScript SDK test configuration, allowing `npm test` to run out-of-the-box after `npm install` without requiring the `@gradle-tech/develocity-agent` package.

## Problem

The TypeScript SDK test configuration (`sdks/typescript/reporterConfig.js`) hard-requires `@gradle-tech/develocity-agent/mocha-reporter` via `require.resolve()`, but this package is not listed in `package.json` devDependencies. This causes `npm test` to fail for new contributors on a fresh clone with: Error: Cannot find module '@gradle-tech/develocity-agent/mocha-reporter'

## Solution

- Wrap `require.resolve()` in a try-catch block to gracefully handle when the module is not available
- Fall back to the default `spec` reporter when the Develocity reporter cannot be resolved
- The reporter is still used in CI environments where it's installed (for build scans), but local development no longer requires it

## Changes

- Modified `sdks/typescript/reporterConfig.js` to make the Develocity reporter optional

## Testing

- ✅ `npm test` passes locally without the Develocity reporter installed
- ✅ Tests run successfully with the fallback `spec` reporter
- ✅ No breaking changes (backward compatible - CI environments with the reporter installed will continue to use it)

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
