### PR TITLE
fix dual license pull issue

### DIFF
--- a/sdks/java/container/license_scripts/pull_licenses_java.py
+++ b/sdks/java/container/license_scripts/pull_licenses_java.py
@@ -137,7 +137,7 @@ def pull_from_url(file_name, url, dep, no_list, use_cache=False):
     if use_cache:
         CACHED_LICENSES.add(os.path.basename(pulled_file_name))
         logging.info(f"Copying {pulled_file_name} -> {file_name}")
-        shutil.copy(pull_file_name, file_name)
+        shutil.copy(pulled_file_name, file_name)
 
 def pull_source_code(base_url, dir_name, dep):
     # base_url example: https://repo1.maven.org/maven2/org/mortbay/jetty/jsp-2.1/6.1.14/
@@ -189,7 +189,7 @@ def execute(dep):
         "moduleLicenseUrl": "http://www.antlr.org/license.html"
     }
     '''
-
+    logging.debug("Dep: %s", dep)
     name = dep['moduleName'].split(':')[1]
     version = dep['moduleVersion']
     name_version = name + '-' + version
@@ -218,8 +218,14 @@ def execute(dep):
                 with thread_lock:
                     no_licenses.append(name_version)
                 license_url = 'skip'
-        pull_from_url(dir_name + '/LICENSE', license_url, name_version,
-                      no_licenses, use_cache=use_license_cache)
+
+        # Split the url string by commas in case of multiple/dual licenses
+        # NOTE: If license doesn't have a ',', this is a no-op.
+        # TODO: Do we only download our preferred one?
+        license_urls = [u.strip() for u in license_url.split(',')]
+        for license_url in license_urls:
+            pull_from_url(dir_name + '/LICENSE', license_url, name_version,
+                        no_licenses, use_cache=use_license_cache)
         # pull notice
         try:
             notice_url = dep_config[name][version]['notice']


### PR DESCRIPTION
When a dependency is dual licensed, the current script fails because it treats the url string as one license.

Fix #37271

For debugging: 
pip install wheel --index-url https://pypi.org/simple
beam/sdks/java/container$ ./license_scripts/license_script.sh python3.11

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
