### PR TITLE
update RateLimiter execution function name

### DIFF
--- a/sdks/python/apache_beam/examples/rate_limiter_simple.py
+++ b/sdks/python/apache_beam/examples/rate_limiter_simple.py
@@ -53,7 +53,7 @@ class SampleApiDoFn(beam.DoFn):
     self.rate_limiter = self._shared.acquire(init_limiter)
 
   def process(self, element):
-    self.rate_limiter.throttle()
+    self.rate_limiter.allow()
 
     # Process the element mock API call
     logging.info("Processing element: %s", element)

--- a/sdks/python/apache_beam/io/components/rate_limiter.py
+++ b/sdks/python/apache_beam/io/components/rate_limiter.py
@@ -61,7 +61,7 @@ class RateLimiter(abc.ABC):
     self.rpc_latency = Metrics.distribution(namespace, 'RatelimitRpcLatencyMs')
 
   @abc.abstractmethod
-  def throttle(self, **kwargs) -> bool:
+  def allow(self, **kwargs) -> bool:
     """Applies rate limiting to the request.
 
     This method checks if the request is permitted by the rate limiting policy.
@@ -148,7 +148,7 @@ class EnvoyRateLimiter(RateLimiter):
           channel = grpc.insecure_channel(self.service_address)
           self._stub = EnvoyRateLimiter.RateLimitServiceStub(channel)
 
-  def throttle(self, hits_added: int = 1) -> bool:
+  def allow(self, hits_added: int = 1) -> bool:
     """Calls the Envoy RLS to apply rate limits.
 
     Sends a rate limit request to the configured Envoy Rate Limit Service.

--- a/sdks/python/apache_beam/ml/inference/base.py
+++ b/sdks/python/apache_beam/ml/inference/base.py
@@ -450,7 +450,7 @@ class RemoteModelHandler(ABC, ModelHandler[ExampleT, PredictionT, ModelT]):
 
         self._shared_rate_limiter = self._shared_handle.acquire(init_limiter)
 
-      if not self._shared_rate_limiter.throttle(hits_added=len(batch)):
+      if not self._shared_rate_limiter.allow(hits_added=len(batch)):
         raise RateLimitExceeded(
             "Rate Limit Exceeded, "
             "Could not process this batch.")

--- a/sdks/python/apache_beam/ml/inference/base_test.py
+++ b/sdks/python/apache_beam/ml/inference/base_test.py
@@ -2076,7 +2076,7 @@ class RunInferenceRemoteTest(unittest.TestCase):
       def __init__(self):
         super().__init__(namespace='test_namespace')
 
-      def throttle(self, hits_added=1):
+      def allow(self, hits_added=1):
         self.requests_counter.inc()
         return True
 
@@ -2114,7 +2114,7 @@ class RunInferenceRemoteTest(unittest.TestCase):
       def __init__(self):
         super().__init__(namespace='test_namespace')
 
-      def throttle(self, hits_added=1):
+      def allow(self, hits_added=1):
         return False
 
     class ConcreteRemoteModelHandler(base.RemoteModelHandler):


### PR DESCRIPTION
Update Ratelimiter execution function name from throttle -> allow, as throttle seems more apt for  throttler. In ratelimiter we either allow request(by fetching tokens with retry) or do not allow(if retries exceeded)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
