### PR TITLE
Add Kerberos authentication support to HadoopFileSystem #20719

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,6 +70,7 @@
 ## New Features / Improvements
 
 * X feature added (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
+* HadoopFileSystem now supports Kerberos authentication via `--hdfs_client=KERBEROS` flag (Python) ([#20719](https://github.com/apache/beam/issues/20719)).
 
 ## Breaking Changes
 
@@ -2349,4 +2350,4 @@ Schema Options, it will be removed in version `2.23.0`. ([BEAM-9704](https://iss
 
 ## Highlights
 
-- For versions 2.19.0 and older release notes are available on [Apache Beam Blog](https://beam.apache.org/blog/).
+- - For versions 2.19.0 and older release notes are available on [Apache Beam Blog](https://beam.apache.org/blog/).

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -1328,6 +1328,14 @@ class HadoopFileSystemOptions(PipelineOptions):
             'If set, URLs will be parsed as "hdfs://server/path/...", instead '
             'of "hdfs://path/...". The "server" part will be unused (use '
             '--hdfs_host and --hdfs_port).'))
+    parser.add_argument(
+        '--hdfs_client',
+        default='INSECURE',
+        choices=['INSECURE', 'KERBEROS'],
+        help=(
+            'HDFS client type for authentication. INSECURE uses simple '
+            'username-based authentication (default). KERBEROS uses Kerberos '
+            'authentication (requires kinit or keytab configuration).'))
 
   def validate(self, validator):
     errors = []


### PR DESCRIPTION
Closes #20719                                                                                                                                        
                                                                                                                                                       
  Adds Kerberos authentication support to Python HadoopFileSystem via new `--hdfs_client` flag.                                                        
                                                                                                                                                       
  **Changes:**                                                                                                                                         
  - Added `--hdfs_client` option (default: `INSECURE`, new: `KERBEROS`)                                                                                
  - Uses `hdfs.ext.kerberos.KerberosClient` for Kerberos mode                                                                                          
  - Added `requests-kerberos` dependency to hadoop extra                                                                                               
  - 6 new unit tests covering both authentication modes                                                                                                
                                                                                                                                                       
  **Usage:**                                                                                                                                           
  ```python                                                                                                                                            
  options = PipelineOptions([                                                                                                                          
      '--hdfs_client=KERBEROS',                                                                                                                        
      '--hdfs_host=namenode.com',                                                                                                                      
      '--hdfs_port=9871',                                                                                                                              
      '--hdfs_user=user',                                                                                                                              
  ])