### PR TITLE
Fix RequestResponseIO parseAndThrow to preserve retryable exception types

### DIFF
--- a/sdks/java/io/rrio/src/main/java/org/apache/beam/io/requestresponse/Call.java
+++ b/sdks/java/io/rrio/src/main/java/org/apache/beam/io/requestresponse/Call.java
@@ -46,7 +46,6 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
-import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Throwables;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.joda.time.Duration;
 
@@ -614,33 +613,10 @@ class Call<RequestT, ResponseT> extends PTransform<PCollection<RequestT>, Result
   private static <T> void parseAndThrow(Future<T> future, ExecutionException e)
       throws UserCodeExecutionException {
     future.cancel(true);
-
-    try {
-      UserCodeExecutionException genericException = null;
-      for (Throwable throwable : Throwables.getCausalChain(e)) {
-        if (throwable instanceof UserCodeQuotaException) {
-          throw (UserCodeQuotaException) throwable;
-        } else if (throwable instanceof UserCodeTimeoutException) {
-          throw (UserCodeTimeoutException) throwable;
-        } else if (throwable instanceof UserCodeRemoteSystemException) {
-          throw (UserCodeRemoteSystemException) throwable;
-        } else if (genericException == null && throwable instanceof UserCodeExecutionException) {
-          genericException = (UserCodeExecutionException) throwable;
-        }
-      }
-      if (genericException != null) {
-        throw genericException;
-      }
-    } catch (IllegalArgumentException iae) {
-      // Circular reference detected in causal chain
-      throw new UserCodeExecutionException(
-          "circular reference detected in exception causal chain", e);
-    }
-
     Throwable cause = e.getCause();
-    if (cause == null) {
-      throw new UserCodeExecutionException(e);
+    if (cause instanceof UserCodeExecutionException) {
+      throw (UserCodeExecutionException) cause;
     }
-    throw new UserCodeExecutionException(cause);
+    throw new UserCodeExecutionException(cause == null ? e : cause);
   }
 }

--- a/sdks/java/io/rrio/src/test/java/org/apache/beam/io/requestresponse/CallTest.java
+++ b/sdks/java/io/rrio/src/test/java/org/apache/beam/io/requestresponse/CallTest.java
@@ -105,6 +105,34 @@ public class CallTest {
   }
 
   @Test
+  public void givenCallerThrowsNonUserCodeException_emitsWrappedUserCodeExecutionException() {
+    Result<Response> result =
+        pipeline
+            .apply(Create.of(new Request("a")))
+            .apply(Call.of(new CallerThrowsRuntimeException(), NON_DETERMINISTIC_RESPONSE_CODER));
+
+    PCollection<ApiIOError> failures = result.getFailures();
+    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeExecutionException.class))
+        .isEqualTo(1L);
+
+    pipeline.run();
+  }
+
+  @Test
+  public void givenCallerThrowsCircularCausalChain_emitsUserCodeExecutionException() {
+    Result<Response> result =
+        pipeline
+            .apply(Create.of(new Request("a")))
+            .apply(Call.of(new CallerThrowsCircularCause(), NON_DETERMINISTIC_RESPONSE_CODER));
+
+    PCollection<ApiIOError> failures = result.getFailures();
+    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeExecutionException.class))
+        .isEqualTo(1L);
+
+    pipeline.run();
+  }
+
+  @Test
   public void givenCallerThrowsQuotaException_emitsIntoFailurePCollection() {
     Result<Response> result =
         pipeline
@@ -142,7 +170,7 @@ public class CallTest {
   }
 
   @Test
-  public void givenCallerThrowsTimeoutException_emitsFailurePCollection() {
+  public void givenCallerThrowsTimeoutException_thenPreservesExceptionType() {
     Result<Response> result =
         pipeline
             .apply(Create.of(new Request("a")))
@@ -150,10 +178,157 @@ public class CallTest {
 
     PCollection<ApiIOError> failures = result.getFailures();
     PAssert.thatSingleton(countStackTracesOf(failures, UserCodeExecutionException.class))
-        .isEqualTo(1L);
+        .isEqualTo(0L);
     PAssert.thatSingleton(countStackTracesOf(failures, UserCodeQuotaException.class)).isEqualTo(0L);
     PAssert.thatSingleton(countStackTracesOf(failures, UserCodeTimeoutException.class))
         .isEqualTo(1L);
+
+    pipeline.run();
+  }
+
+  @Test
+  public void givenCallerThrowsRemoteSystemException_thenPreservesExceptionType() {
+    Result<Response> result =
+        pipeline
+            .apply(Create.of(new Request("a")))
+            .apply(
+                Call.of(new CallerThrowsRemoteSystemException(), NON_DETERMINISTIC_RESPONSE_CODER));
+
+    PCollection<ApiIOError> failures = result.getFailures();
+    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeRemoteSystemException.class))
+        .isEqualTo(1L);
+    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeExecutionException.class))
+        .isEqualTo(0L);
+
+    pipeline.run();
+  }
+
+  @Test
+  public void givenNestedExecutionException_thenPreservesExceptionType() {
+    Result<Response> result =
+        pipeline
+            .apply(Create.of(new Request("a")))
+            .apply(
+                Call.of(
+                    new CallerThrowsNestedExecutionException(), NON_DETERMINISTIC_RESPONSE_CODER));
+
+    PCollection<ApiIOError> failures = result.getFailures();
+    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeExecutionException.class))
+        .isEqualTo(1L);
+    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeTimeoutException.class))
+        .isEqualTo(0L);
+    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeRemoteSystemException.class))
+        .isEqualTo(0L);
+
+    pipeline.run();
+  }
+
+  @Test
+  public void givenCallerThrowsGenericWrappingTimeout_thenPreservesExceptionType() {
+    Result<Response> result =
+        pipeline
+            .apply(Create.of(new Request("a")))
+            .apply(
+                Call.of(
+                    new CallerThrowsGenericWrappingTimeout(), NON_DETERMINISTIC_RESPONSE_CODER));
+
+    PCollection<ApiIOError> failures = result.getFailures();
+    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeTimeoutException.class))
+        .isEqualTo(1L);
+    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeExecutionException.class))
+        .isEqualTo(0L);
+
+    pipeline.run();
+  }
+
+  @Test
+  public void givenCallerThrowsGenericWrappingQuota_thenPreservesExceptionType() {
+    Result<Response> result =
+        pipeline
+            .apply(Create.of(new Request("a")))
+            .apply(
+                Call.of(new CallerThrowsGenericWrappingQuota(), NON_DETERMINISTIC_RESPONSE_CODER));
+
+    PCollection<ApiIOError> failures = result.getFailures();
+    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeQuotaException.class)).isEqualTo(1L);
+    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeExecutionException.class))
+        .isEqualTo(0L);
+
+    pipeline.run();
+  }
+
+  @Test
+  public void givenCallerThrowsGenericWrappingRemoteSystem_thenPreservesExceptionType() {
+    Result<Response> result =
+        pipeline
+            .apply(Create.of(new Request("a")))
+            .apply(
+                Call.of(
+                    new CallerThrowsGenericWrappingRemoteSystem(),
+                    NON_DETERMINISTIC_RESPONSE_CODER));
+
+    PCollection<ApiIOError> failures = result.getFailures();
+    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeRemoteSystemException.class))
+        .isEqualTo(1L);
+    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeExecutionException.class))
+        .isEqualTo(0L);
+
+    pipeline.run();
+  }
+
+  @Test
+  public void
+      givenCallerThrowsUncheckedExecutionExceptionWrappingTimeout_thenPreservesExceptionType() {
+    Result<Response> result =
+        pipeline
+            .apply(Create.of(new Request("a")))
+            .apply(
+                Call.of(
+                    new CallerThrowsUncheckedExecutionExceptionWrappingTimeout(),
+                    NON_DETERMINISTIC_RESPONSE_CODER));
+
+    PCollection<ApiIOError> failures = result.getFailures();
+    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeTimeoutException.class))
+        .isEqualTo(1L);
+    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeExecutionException.class))
+        .isEqualTo(0L);
+
+    pipeline.run();
+  }
+
+  @Test
+  public void
+      givenCallerThrowsUncheckedExecutionExceptionWrappingRemoteSystem_thenPreservesExceptionType() {
+    Result<Response> result =
+        pipeline
+            .apply(Create.of(new Request("a")))
+            .apply(
+                Call.of(
+                    new CallerThrowsUncheckedExecutionExceptionWrappingRemoteSystem(),
+                    NON_DETERMINISTIC_RESPONSE_CODER));
+
+    PCollection<ApiIOError> failures = result.getFailures();
+    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeRemoteSystemException.class))
+        .isEqualTo(1L);
+    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeExecutionException.class))
+        .isEqualTo(0L);
+
+    pipeline.run();
+  }
+
+  @Test
+  public void givenCallerThrowsTripleNestedTimeout_thenPreservesExceptionType() {
+    Result<Response> result =
+        pipeline
+            .apply(Create.of(new Request("a")))
+            .apply(
+                Call.of(new CallerThrowsTripleNestedTimeout(), NON_DETERMINISTIC_RESPONSE_CODER));
+
+    PCollection<ApiIOError> failures = result.getFailures();
+    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeTimeoutException.class))
+        .isEqualTo(1L);
+    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeExecutionException.class))
+        .isEqualTo(0L);
 
     pipeline.run();
   }
@@ -376,11 +551,98 @@ public class CallTest {
     }
   }
 
+  private static class CallerThrowsRuntimeException implements Caller<Request, Response> {
+
+    @Override
+    public Response call(Request request) {
+      throw new RuntimeException("unexpected error");
+    }
+  }
+
+  private static class CallerThrowsCircularCause implements Caller<Request, Response> {
+
+    @Override
+    public Response call(Request request) {
+      Exception a = new Exception("a");
+      Exception b = new Exception("b", a);
+      a.initCause(b); // a -> b -> a (circular reference)
+      throw new RuntimeException("boom", a);
+    }
+  }
+
   private static class CallerThrowsTimeout implements Caller<Request, Response> {
 
     @Override
     public Response call(Request request) throws UserCodeExecutionException {
       throw new UserCodeTimeoutException("");
+    }
+  }
+
+  private static class CallerThrowsRemoteSystemException implements Caller<Request, Response> {
+
+    @Override
+    public Response call(Request request) throws UserCodeExecutionException {
+      throw new UserCodeRemoteSystemException("");
+    }
+  }
+
+  private static class CallerThrowsNestedExecutionException implements Caller<Request, Response> {
+
+    @Override
+    public Response call(Request request) throws UserCodeExecutionException {
+      throw new UncheckedExecutionException(new UserCodeExecutionException("nested"));
+    }
+  }
+
+  private static class CallerThrowsGenericWrappingTimeout implements Caller<Request, Response> {
+
+    @Override
+    public Response call(Request request) throws UserCodeExecutionException {
+      throw new UserCodeExecutionException("generic", new UserCodeTimeoutException("timeout"));
+    }
+  }
+
+  private static class CallerThrowsGenericWrappingQuota implements Caller<Request, Response> {
+
+    @Override
+    public Response call(Request request) throws UserCodeExecutionException {
+      throw new UserCodeExecutionException("generic", new UserCodeQuotaException("quota"));
+    }
+  }
+
+  private static class CallerThrowsGenericWrappingRemoteSystem
+      implements Caller<Request, Response> {
+
+    @Override
+    public Response call(Request request) throws UserCodeExecutionException {
+      throw new UserCodeExecutionException("generic", new UserCodeRemoteSystemException("remote"));
+    }
+  }
+
+  private static class CallerThrowsUncheckedExecutionExceptionWrappingTimeout
+      implements Caller<Request, Response> {
+
+    @Override
+    public Response call(Request request) throws UserCodeExecutionException {
+      throw new UncheckedExecutionException(new UserCodeTimeoutException("timeout"));
+    }
+  }
+
+  private static class CallerThrowsUncheckedExecutionExceptionWrappingRemoteSystem
+      implements Caller<Request, Response> {
+
+    @Override
+    public Response call(Request request) throws UserCodeExecutionException {
+      throw new UncheckedExecutionException(new UserCodeRemoteSystemException("remote"));
+    }
+  }
+
+  private static class CallerThrowsTripleNestedTimeout implements Caller<Request, Response> {
+
+    @Override
+    public Response call(Request request) throws UserCodeExecutionException {
+      throw new UncheckedExecutionException(
+          new RuntimeException(new UserCodeTimeoutException("deep timeout")));
     }
   }
 

--- a/sdks/java/io/rrio/src/test/java/org/apache/beam/io/requestresponse/CallTest.java
+++ b/sdks/java/io/rrio/src/test/java/org/apache/beam/io/requestresponse/CallTest.java
@@ -119,20 +119,6 @@ public class CallTest {
   }
 
   @Test
-  public void givenCallerThrowsCircularCausalChain_emitsUserCodeExecutionException() {
-    Result<Response> result =
-        pipeline
-            .apply(Create.of(new Request("a")))
-            .apply(Call.of(new CallerThrowsCircularCause(), NON_DETERMINISTIC_RESPONSE_CODER));
-
-    PCollection<ApiIOError> failures = result.getFailures();
-    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeExecutionException.class))
-        .isEqualTo(1L);
-
-    pipeline.run();
-  }
-
-  @Test
   public void givenCallerThrowsQuotaException_emitsIntoFailurePCollection() {
     Result<Response> result =
         pipeline
@@ -196,136 +182,6 @@ public class CallTest {
 
     PCollection<ApiIOError> failures = result.getFailures();
     PAssert.thatSingleton(countStackTracesOf(failures, UserCodeRemoteSystemException.class))
-        .isEqualTo(1L);
-    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeExecutionException.class))
-        .isEqualTo(0L);
-
-    pipeline.run();
-  }
-
-  @Test
-  public void givenNestedExecutionException_thenPreservesExceptionType() {
-    Result<Response> result =
-        pipeline
-            .apply(Create.of(new Request("a")))
-            .apply(
-                Call.of(
-                    new CallerThrowsNestedExecutionException(), NON_DETERMINISTIC_RESPONSE_CODER));
-
-    PCollection<ApiIOError> failures = result.getFailures();
-    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeExecutionException.class))
-        .isEqualTo(1L);
-    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeTimeoutException.class))
-        .isEqualTo(0L);
-    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeRemoteSystemException.class))
-        .isEqualTo(0L);
-
-    pipeline.run();
-  }
-
-  @Test
-  public void givenCallerThrowsGenericWrappingTimeout_thenPreservesExceptionType() {
-    Result<Response> result =
-        pipeline
-            .apply(Create.of(new Request("a")))
-            .apply(
-                Call.of(
-                    new CallerThrowsGenericWrappingTimeout(), NON_DETERMINISTIC_RESPONSE_CODER));
-
-    PCollection<ApiIOError> failures = result.getFailures();
-    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeTimeoutException.class))
-        .isEqualTo(1L);
-    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeExecutionException.class))
-        .isEqualTo(0L);
-
-    pipeline.run();
-  }
-
-  @Test
-  public void givenCallerThrowsGenericWrappingQuota_thenPreservesExceptionType() {
-    Result<Response> result =
-        pipeline
-            .apply(Create.of(new Request("a")))
-            .apply(
-                Call.of(new CallerThrowsGenericWrappingQuota(), NON_DETERMINISTIC_RESPONSE_CODER));
-
-    PCollection<ApiIOError> failures = result.getFailures();
-    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeQuotaException.class)).isEqualTo(1L);
-    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeExecutionException.class))
-        .isEqualTo(0L);
-
-    pipeline.run();
-  }
-
-  @Test
-  public void givenCallerThrowsGenericWrappingRemoteSystem_thenPreservesExceptionType() {
-    Result<Response> result =
-        pipeline
-            .apply(Create.of(new Request("a")))
-            .apply(
-                Call.of(
-                    new CallerThrowsGenericWrappingRemoteSystem(),
-                    NON_DETERMINISTIC_RESPONSE_CODER));
-
-    PCollection<ApiIOError> failures = result.getFailures();
-    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeRemoteSystemException.class))
-        .isEqualTo(1L);
-    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeExecutionException.class))
-        .isEqualTo(0L);
-
-    pipeline.run();
-  }
-
-  @Test
-  public void
-      givenCallerThrowsUncheckedExecutionExceptionWrappingTimeout_thenPreservesExceptionType() {
-    Result<Response> result =
-        pipeline
-            .apply(Create.of(new Request("a")))
-            .apply(
-                Call.of(
-                    new CallerThrowsUncheckedExecutionExceptionWrappingTimeout(),
-                    NON_DETERMINISTIC_RESPONSE_CODER));
-
-    PCollection<ApiIOError> failures = result.getFailures();
-    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeTimeoutException.class))
-        .isEqualTo(1L);
-    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeExecutionException.class))
-        .isEqualTo(0L);
-
-    pipeline.run();
-  }
-
-  @Test
-  public void
-      givenCallerThrowsUncheckedExecutionExceptionWrappingRemoteSystem_thenPreservesExceptionType() {
-    Result<Response> result =
-        pipeline
-            .apply(Create.of(new Request("a")))
-            .apply(
-                Call.of(
-                    new CallerThrowsUncheckedExecutionExceptionWrappingRemoteSystem(),
-                    NON_DETERMINISTIC_RESPONSE_CODER));
-
-    PCollection<ApiIOError> failures = result.getFailures();
-    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeRemoteSystemException.class))
-        .isEqualTo(1L);
-    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeExecutionException.class))
-        .isEqualTo(0L);
-
-    pipeline.run();
-  }
-
-  @Test
-  public void givenCallerThrowsTripleNestedTimeout_thenPreservesExceptionType() {
-    Result<Response> result =
-        pipeline
-            .apply(Create.of(new Request("a")))
-            .apply(
-                Call.of(new CallerThrowsTripleNestedTimeout(), NON_DETERMINISTIC_RESPONSE_CODER));
-
-    PCollection<ApiIOError> failures = result.getFailures();
-    PAssert.thatSingleton(countStackTracesOf(failures, UserCodeTimeoutException.class))
         .isEqualTo(1L);
     PAssert.thatSingleton(countStackTracesOf(failures, UserCodeExecutionException.class))
         .isEqualTo(0L);
@@ -559,17 +415,6 @@ public class CallTest {
     }
   }
 
-  private static class CallerThrowsCircularCause implements Caller<Request, Response> {
-
-    @Override
-    public Response call(Request request) {
-      Exception a = new Exception("a");
-      Exception b = new Exception("b", a);
-      a.initCause(b); // a -> b -> a (circular reference)
-      throw new RuntimeException("boom", a);
-    }
-  }
-
   private static class CallerThrowsTimeout implements Caller<Request, Response> {
 
     @Override
@@ -583,66 +428,6 @@ public class CallTest {
     @Override
     public Response call(Request request) throws UserCodeExecutionException {
       throw new UserCodeRemoteSystemException("");
-    }
-  }
-
-  private static class CallerThrowsNestedExecutionException implements Caller<Request, Response> {
-
-    @Override
-    public Response call(Request request) throws UserCodeExecutionException {
-      throw new UncheckedExecutionException(new UserCodeExecutionException("nested"));
-    }
-  }
-
-  private static class CallerThrowsGenericWrappingTimeout implements Caller<Request, Response> {
-
-    @Override
-    public Response call(Request request) throws UserCodeExecutionException {
-      throw new UserCodeExecutionException("generic", new UserCodeTimeoutException("timeout"));
-    }
-  }
-
-  private static class CallerThrowsGenericWrappingQuota implements Caller<Request, Response> {
-
-    @Override
-    public Response call(Request request) throws UserCodeExecutionException {
-      throw new UserCodeExecutionException("generic", new UserCodeQuotaException("quota"));
-    }
-  }
-
-  private static class CallerThrowsGenericWrappingRemoteSystem
-      implements Caller<Request, Response> {
-
-    @Override
-    public Response call(Request request) throws UserCodeExecutionException {
-      throw new UserCodeExecutionException("generic", new UserCodeRemoteSystemException("remote"));
-    }
-  }
-
-  private static class CallerThrowsUncheckedExecutionExceptionWrappingTimeout
-      implements Caller<Request, Response> {
-
-    @Override
-    public Response call(Request request) throws UserCodeExecutionException {
-      throw new UncheckedExecutionException(new UserCodeTimeoutException("timeout"));
-    }
-  }
-
-  private static class CallerThrowsUncheckedExecutionExceptionWrappingRemoteSystem
-      implements Caller<Request, Response> {
-
-    @Override
-    public Response call(Request request) throws UserCodeExecutionException {
-      throw new UncheckedExecutionException(new UserCodeRemoteSystemException("remote"));
-    }
-  }
-
-  private static class CallerThrowsTripleNestedTimeout implements Caller<Request, Response> {
-
-    @Override
-    public Response call(Request request) throws UserCodeExecutionException {
-      throw new UncheckedExecutionException(
-          new RuntimeException(new UserCodeTimeoutException("deep timeout")));
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #37176 — `RequestResponseIO` loses retryable exception types in `parseAndThrow`.

`Call.parseAndThrow` unwrapped the `ExecutionException` from `Future.get()` but only special-cased
`UserCodeQuotaException`. Every other `UserCodeExecutionException` subclass — notably
`UserCodeTimeoutException` and `UserCodeRemoteSystemException` — was re-wrapped in a plain
`UserCodeExecutionException`, so `Call`'s repeater saw `shouldRepeat() == false` and gave up on failures
that were meant to be retried.

### Fix

`Future.get()` wraps a user exception in exactly one `ExecutionException`, so a single-level
`e.getCause()` check is sufficient:

```java
Throwable cause = e.getCause();
if (cause instanceof UserCodeExecutionException) {
  throw (UserCodeExecutionException) cause;
}
throw new UserCodeExecutionException(cause == null ? e : cause);
```

Rethrowing the cause as-is preserves the concrete subclass rather than enumerating known ones, so it also
covers any `UserCodeExecutionException` subclass added later. The null-cause path still produces a
`UserCodeExecutionException` wrapping the original `ExecutionException`, as before.

An earlier revision of this PR walked the whole causal chain with Guava's `Throwables.getCausalChain()`.
That was dropped — the deep-nesting cases it handled cannot occur on this code path — and the tests that
only exercised the traversal were removed with it.

### Changes

- `sdks/java/io/rrio/.../Call.java` — `parseAndThrow` rethrows the cause when it already is a
  `UserCodeExecutionException`.
- `sdks/java/io/rrio/.../CallTest.java` — two new tests plus one retargeted:
  - `givenCallerThrowsRemoteSystemException_thenPreservesExceptionType` — asserts the failure carries
    `UserCodeRemoteSystemException` and *not* a bare `UserCodeExecutionException`.
  - `givenCallerThrowsNonUserCodeException_emitsWrappedUserCodeExecutionException` — a plain
    `RuntimeException` is still wrapped, so the fallback path is covered.
  - `givenCallerThrowsTimeoutException_emitsFailurePCollection` → renamed to
    `..._thenPreservesExceptionType` and tightened: the bare-`UserCodeExecutionException` count now has to
    be `0`, which is what actually fails without the fix.

Both `*_thenPreservesExceptionType` tests are regression tests: they assert the bare
`UserCodeExecutionException` count is `0`, which only holds with the `Call.java` change.
