### PR TITLE
Add filter() method to PCollection in TypeScript SDK

### DIFF
--- a/sdks/typescript/test/primitives_test.ts
+++ b/sdks/typescript/test/primitives_test.ts
@@ -96,6 +96,51 @@ export function suite(runner: beam.Runner = directRunner()) {
       });
     });
 
+    it("runs a filter", async function () {
+      await runner.run((root) => {
+        root
+          .apply(beam.create([1, 2, 3, 4, 5, 6]))
+          .filter((x) => x % 2 === 0)
+          .apply(testing.assertDeepEqual([2, 4, 6]));
+      });
+    });
+
+    it("runs a filter with predicate returning false for all", async function () {
+      await runner.run((root) => {
+        root
+          .apply(beam.create([1, 3, 5, 7]))
+          .filter((x) => x % 2 === 0)
+          .apply(testing.assertDeepEqual([]));
+      });
+    });
+
+    it("runs a filter with predicate returning true for all", async function () {
+      await runner.run((root) => {
+        root
+          .apply(beam.create([2, 4, 6, 8]))
+          .filter((x) => x % 2 === 0)
+          .apply(testing.assertDeepEqual([2, 4, 6, 8]));
+      });
+    });
+
+    it("runs a filter with context", async function () {
+      await runner.run((root) => {
+        root
+          .apply(beam.create([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+          .filter((x: number, threshold: number) => x > threshold, 5)
+          .apply(testing.assertDeepEqual([6, 7, 8, 9, 10]));
+      });
+    });
+
+    it("runs a filter on strings", async function () {
+      await runner.run((root) => {
+        root
+          .apply(beam.create(["apple", "banana", "apricot", "cherry"]))
+          .filter((s) => s.startsWith("a"))
+          .apply(testing.assertDeepEqual(["apple", "apricot"]));
+      });
+    });
+
     it("runs a Splitter", async function () {
       await runner.run((root) => {
         const pcolls = root


### PR DESCRIPTION

### Description:
Adds a `filter()` method to the `PCollection` class in the TypeScript SDK, addressing a TODO from README-dev.md.

Fixes #37407 

## Changes

- Added `filter()` method to `PCollection` class in `pvalue.ts`
- Added 5 test cases for the filter functionality in `primitives_test.ts`

## Usage Examples

// Basic filtering
const evens = pcoll.filter(x => x % 2 === 0);

// Filter with context
const filtered = pcoll.filter((x, threshold) => x > threshold, 5);

// Filter strings
const aWords = words.filter(s => s.startsWith('a'));


## Implementation Details

- Follows the same pattern as existing `map()` and `flatMap()` methods
- Uses `parDo` internally with a process function that returns `[element]` or `[]`
- Supports optional context parameter for side inputs, counters, etc.
- Added proper TypeScript constraint (`ContextT extends Object | undefined`) to match `parDo` signature

## Tests Added

| Test Case | Description |
|-----------|-------------|
| `runs a filter` | Basic even number filtering |
| `runs a filter with predicate returning false for all` | Empty result case |
| `runs a filter with predicate returning true for all` | All elements pass |
| `runs a filter with context` | Context parameter support |
| `runs a filter on strings` | Non-numeric type support |

## Checklist

- [x] Tests added and passing (297 tests total)
- [x] Follows existing code patterns (`map`, `flatMap`)
- [x] Documentation added (JSDoc comments with examples)
- [X] Mention the appropriate issue in your description

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
