### PR TITLE
[#19711] Fix missing step_id in Python SDK worker logs during DoFn setup

### DIFF
--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -1091,6 +1091,7 @@ class BundleProcessor(object):
       state_handler: sdk_worker.CachingStateHandler,
       data_channel_factory: data_plane.DataChannelFactory,
       data_sampler: Optional[data_sampler.DataSampler] = None,
+      instruction_id: Optional[str] = None,
   ) -> None:
     """Initialize a bundle processor.
 
@@ -1159,8 +1160,13 @@ class BundleProcessor(object):
         from apache_beam.runners.worker.sdk_worker_main import terminate_sdk_harness
         terminate_sdk_harness()
 
-    for op in reversed(self.ops.values()):
-      op.setup(self.data_sampler)
+      if instruction_id:
+        with statesampler.instruction_id(instruction_id):
+          for op in reversed(self.ops.values()):
+            op.setup(self.data_sampler)
+      else:
+        for op in reversed(self.ops.values()):
+          op.setup(self.data_sampler)
     self.splitting_lock = threading.Lock()
 
   def create_execution_tree(

--- a/sdks/python/apache_beam/runners/worker/log_handler.py
+++ b/sdks/python/apache_beam/runners/worker/log_handler.py
@@ -134,9 +134,12 @@ class FnApiLogRecordHandler(logging.Handler):
     log_entry.timestamp.nanos = int(nanoseconds)
     if record.exc_info:
       log_entry.trace = ''.join(traceback.format_exception(*record.exc_info))
-    instruction_id = statesampler.get_current_instruction_id()
-    if instruction_id:
-      log_entry.instruction_id = instruction_id
+    if hasattr(record, 'instruction_id'):
+      log_entry.instruction_id = record.instruction_id
+    if not log_entry.instruction_id:
+      instruction_id = statesampler.get_current_instruction_id()
+      if instruction_id:
+        log_entry.instruction_id = instruction_id
     tracker = statesampler.get_current_tracker()
     if tracker:
       current_state = tracker.current_state()

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -520,7 +520,8 @@ class BundleProcessorCache(object):
         self.state_handler_factory.create_state_handler(
             pbd.state_api_service_descriptor),
         self.data_channel_factory,
-        self.data_sampler)
+        self.data_sampler,
+        instruction_id=instruction_id)
     with self._lock:
       self.active_bundle_processors[
         instruction_id] = bundle_descriptor_id, processor


### PR DESCRIPTION
Fixes #19711

This PR addresses the issue where `step_id` (instruction ID) was consistently missing or empty in worker logs generated during the `DoFn.setup()` lifecycle method.

### Rationale
The `FnApiLogRecordHandler` relies on `statesampler` thread-local storage to populate the `instruction_id` in log entries. Previously, the `BundleProcessor` executed the `setup()` method for operations *before* the thread-local context was fully initialized for that instruction, causing logs emitted during setup to become orphaned (missing metadata).

### Changes
1. **`sdks/python/apache_beam/runners/worker/sdk_worker.py`**: Updated `create_bundle_processor` to pass the active `instruction_id` into the `BundleProcessor` constructor.
2. **`sdks/python/apache_beam/runners/worker/bundle_processor.py`**:
    * Updated `__init__` to accept `instruction_id`.
    * Added logic to manually inject the `instruction_id` into the `statesampler` context specifically while iterating through operations to call `op.setup()`.
3. **`sdks/python/apache_beam/runners/worker/log_handler.py`**: Updated `emit()` to check `record.instruction_id` before falling back to thread-local storage, ensuring explicitly injected IDs are respected.

### Verification
I verified this fix locally using a reproduction script which forces a log during `setup()`.
* **Before fix:** Logs during `setup()` had `instruction_id: None`.
* **After fix:** Logs during `setup()` correctly display the `instruction_id` (e.g., `bundle_...`).

------------------------

- [x] Mention the appropriate issue in your description (e.g. `fixes #19711`).
- [ ] Update `CHANGES.md` with noteworthy changes.
- [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
