### PR TITLE
Fix KeyError for huggingface notebook

### DIFF
--- a/examples/notebooks/beam-ml/run_inference_huggingface.ipynb
+++ b/examples/notebooks/beam-ml/run_inference_huggingface.ipynb
@@ -237,7 +237,7 @@
         "  \"\"\"\n",
         "  def process(self, element):\n",
         "    example = element.example\n",
-        "    translated_text = element.inference[0]['translation_text']\n",
+        "    translated_text = element.inference['translation_text']\n",
         "    print(f'Example: {example}')\n",
         "    print(f'Translated text: {translated_text}')\n",
         "    print('-' * 80)\n"


### PR DESCRIPTION
The notebook example returns one inference element, not a list. The current code gives this error:

```
ERROR:apache_beam.runners.common:KeyError: 0 [while running '[20]: Print']
Traceback (most recent call last):
  File "apache_beam/runners/common.py", line 1498, in apache_beam.runners.common.DoFnRunner.process
  File "apache_beam/runners/common.py", line 685, in apache_beam.runners.common.SimpleInvoker.invoke_process
  File "/tmp/ipython-input-3766419850.py", line 7, in process
    translated_text = element.inference[0]['translation_text']
                      ~~~~~~~~~~~~~~~~~^^^
KeyError: 0
```

Fixed by accessing the inference result directly