### PR TITLE
[Python] Add take(n) convenience for PCollection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,7 @@
 ## New Features / Improvements
 
 * (Python) Added exception chaining to preserve error context in CloudSQLEnrichmentHandler, processes utilities, and core transforms ([#37422](https://github.com/apache/beam/issues/37422)).
+* (Python) Added `take(n)` convenience for PCollection: `beam.take(n)` and `pcoll.take(n)` to get the first N elements deterministically without Top.Of + FlatMap ([#X](https://github.com/apache/beam/issues/37429)).
 * X feature added (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
 
 ## Breaking Changes

--- a/sdks/python/apache_beam/pvalue.py
+++ b/sdks/python/apache_beam/pvalue.py
@@ -176,6 +176,25 @@ class PCollection(PValue, Generic[T]):
       is_bounded = pcoll.is_bounded
     return PCollection(pcoll.pipeline, is_bounded=is_bounded)
 
+  def take(self, n: int) -> 'PCollection[T]':
+    """Takes the first N elements from this PCollection.
+
+    This is a convenience method that returns a new PCollection containing
+    at most N elements from this PCollection. The elements are taken
+    deterministically (not randomly sampled).
+
+    Args:
+      n: Number of elements to take. Must be a positive integer.
+
+    Returns:
+      A new PCollection containing at most N elements.
+
+    Example::
+      first_10 = pcoll.take(10)
+    """
+    from apache_beam.transforms import util
+    return self | util.take(n)
+
   def to_runner_api(
       self, context: 'PipelineContext') -> beam_runner_api_pb2.PCollection:
     return beam_runner_api_pb2.PCollection(

--- a/sdks/python/apache_beam/transforms/util_test.py
+++ b/sdks/python/apache_beam/transforms/util_test.py
@@ -1934,6 +1934,45 @@ class ToStringTest(unittest.TestCase):
       assert_that(result, equal_to(["one1", "two2"]))
 
 
+class TakeTest(unittest.TestCase):
+  def test_take_function_syntax(self):
+    with TestPipeline() as p:
+      result = p | beam.Create([1, 2, 3, 4, 5]) | util.take(3)
+      assert_that(result, equal_to([1, 2, 3]))
+
+  def test_take_method_syntax(self):
+    with TestPipeline() as p:
+      pcoll = p | beam.Create([10, 20, 30, 40, 50])
+      result = pcoll.take(2)
+      assert_that(result, equal_to([10, 20]))
+
+  def test_take_more_than_available(self):
+    with TestPipeline() as p:
+      result = p | beam.Create([1, 2, 3]) | util.take(10)
+      assert_that(result, equal_to([1, 2, 3]))
+
+  def test_take_single_element(self):
+    with TestPipeline() as p:
+      result = p | beam.Create([100, 200, 300]) | util.take(1)
+      assert_that(result, equal_to([100]))
+
+  def test_take_all_elements(self):
+    with TestPipeline() as p:
+      data = [1, 2, 3, 4, 5]
+      result = p | beam.Create(data) | util.take(len(data))
+      assert_that(result, equal_to(data))
+
+  def test_take_invalid_n_zero(self):
+    with self.assertRaises(ValueError) as ctx:
+      util.Take(0)
+    self.assertIn('n must be positive', str(ctx.exception))
+
+  def test_take_invalid_n_negative(self):
+    with self.assertRaises(ValueError) as ctx:
+      util.Take(-1)
+    self.assertIn('n must be positive', str(ctx.exception))
+
+
 class LogElementsTest(unittest.TestCase):
   @pytest.fixture(scope="function")
   def _capture_stdout_log(request, capsys):


### PR DESCRIPTION
Adds `take(n)` convenience for PCollection: get the first N elements deterministically without using `Top.Of` + `FlatMap` manually.

## Changes

- **transforms/util.py:** Add `Take` transform and `take(n)` function (uses Top.Of + FlatMap internally).
- **pvalue.py:** Add `PCollection.take(n)` method.
- **util_test.py:** Add `TakeTest` (function/method syntax, edge cases, invalid n).
- **CHANGES.md:** New Features entry for take(n).

## Usage

# Function syntax
first_10 = pcoll | beam.take(10)

# Method syntax
first_10 = pcoll.take(10)

Fixes #37429

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
