### PR TITLE
fix(dataflow): 'update' infinite loop and nil pointer dereference

### DIFF
--- a/sdks/go/pkg/beam/runners/dataflow/dataflowlib/job.go
+++ b/sdks/go/pkg/beam/runners/dataflow/dataflowlib/job.go
@@ -322,21 +322,20 @@ func GetRunningJobByName(client *df.Service, project, region string, name string
 	jobsListCall := client.Projects.Locations.Jobs.List(project, region)
 	jobsListCall.Filter("ACTIVE")
 	jobsResponse, err := jobsListCall.Do()
-	if err != nil {
-		return nil, err
-	}
-	for len(jobsResponse.Jobs) > 0 {
+	for {
+		if err != nil {
+			return nil, err
+		}
 		for _, job := range jobsResponse.Jobs {
 			if job.Name == name {
 				return job, nil
 			}
 		}
-
+		if jobsResponse.NextPageToken == "" {
+			break
+		}
 		jobsListCall.PageToken(jobsResponse.NextPageToken)
 		jobsResponse, err = jobsListCall.Do()
-		if err != nil {
-			return nil, err
-		}
 	}
 	return nil, errors.New(fmt.Sprintf("Unable to find running job with name %s", name))
 }


### PR DESCRIPTION
There is currently a nil pointer dereference in a specific edge case that hides the real error and makes it impossible to debug. 

If the Dataflow API is not enabled in the service account project, then `jobsResponse.Jobs` is nil, and the for loop panics. Checking for errors before the for loop allows us to catch the error and return it to the end user.

**EDIT**: After the initial fix, I also found in the non-happy path an infinite loop if the job name is not found with the `-update` flag set. I can fix it in another PR, but since it is the same code, it is probably not worth opening another one.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
