### PR TITLE
Make GCS filesystem lookup lazy to match S3 behavior 

### DIFF
--- a/sdks/python/apache_beam/io/gcp/gcsfilesystem.py
+++ b/sdks/python/apache_beam/io/gcp/gcsfilesystem.py
@@ -50,19 +50,18 @@ class GCSFileSystem(FileSystem):
           'GCSFileSystem requires apache-beam[gcp]. '
           'Install it with: pip install apache-beam[gcp]')
 
-  _CHUNK_SIZE = None
-
-  @property
-  def CHUNK_SIZE(self):
-    if self._CHUNK_SIZE is None:
-      self._CHUNK_SIZE = self._get_gcsio().MAX_BATCH_OPERATION_SIZE
-    return self._CHUNK_SIZE  # Chuck size in batch operations
-
   GCS_PREFIX = 'gs://'
 
   def __init__(self, pipeline_options):
     super().__init__(pipeline_options)
     self._pipeline_options = pipeline_options
+    self._chunk_size = None
+
+  @property
+  def CHUNK_SIZE(self):
+    if self._chunk_size is None:
+      self._chunk_size = self._get_gcsio().MAX_BATCH_OPERATION_SIZE
+    return self._chunk_size
 
   @classmethod
   def scheme(cls):
@@ -387,7 +386,7 @@ class GCSFileSystem(FileSystem):
     try:
       gcsio = self._get_gcsio()
       components = gcsio.parse_gcs_path(path, object_optional=True)
-    except ValueError:
+    except (ImportError, ValueError):
       # report lineage is fail-safe
       traceback.print_exc()
       return

--- a/sdks/python/apache_beam/io/gcp/gcsfilesystem.py
+++ b/sdks/python/apache_beam/io/gcp/gcsfilesystem.py
@@ -35,23 +35,20 @@ from apache_beam.io.filesystem import CompressionTypes
 from apache_beam.io.filesystem import FileMetadata
 from apache_beam.io.filesystem import FileSystem
 
-
 __all__ = ['GCSFileSystem']
 
 
 class GCSFileSystem(FileSystem):
   """A GCS ``FileSystem`` implementation for accessing files on GCS.
   """
- 
   def _get_gcsio(self):
     try:
       from apache_beam.io.gcp import gcsio
       return gcsio
     except ImportError:
       raise ImportError(
-         'GCSFileSystem requires apache-beam[gcp]. '
-         'Install it with: pip install apache-beam[gcp]'
-      )
+          'GCSFileSystem requires apache-beam[gcp]. '
+          'Install it with: pip install apache-beam[gcp]')
 
   _CHUNK_SIZE = None
 
@@ -60,6 +57,7 @@ class GCSFileSystem(FileSystem):
     if self._CHUNK_SIZE is None:
       self._CHUNK_SIZE = self._get_gcsio().MAX_BATCH_OPERATION_SIZE
     return self._CHUNK_SIZE  # Chuck size in batch operations
+
   GCS_PREFIX = 'gs://'
 
   def __init__(self, pipeline_options):

--- a/sdks/python/apache_beam/io/gcp/gcsfilesystem_test.py
+++ b/sdks/python/apache_beam/io/gcp/gcsfilesystem_test.py
@@ -40,7 +40,6 @@ except ImportError:
 
 
 class GCSFileSystemLazyLoadTest(unittest.TestCase):
-
   def test_get_filesystem_does_not_require_gcp_extra(self):
     fs = FileSystems.get_filesystem('gs://test-bucket/path')
     self.assertEqual(fs.scheme(), 'gs')

--- a/sdks/python/apache_beam/io/gcp/gcsfilesystem_test.py
+++ b/sdks/python/apache_beam/io/gcp/gcsfilesystem_test.py
@@ -27,8 +27,8 @@ import mock
 
 from apache_beam.io.filesystem import BeamIOError
 from apache_beam.io.filesystem import FileMetadata
-from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.io.filesystems import FileSystems
+from apache_beam.options.pipeline_options import PipelineOptions
 
 # Protect against environments where apitools library is not available.
 # pylint: disable=wrong-import-order, wrong-import-position
@@ -36,6 +36,11 @@ try:
   from apache_beam.io.gcp import gcsfilesystem
 except ImportError:
   gcsfilesystem = None  # type: ignore
+
+try:
+  from apache_beam.io.gcp import gcsio
+except ImportError:
+  gcsio = None  # type: ignore
 # pylint: enable=wrong-import-order, wrong-import-position
 
 
@@ -45,13 +50,17 @@ class GCSFileSystemLazyLoadTest(unittest.TestCase):
     self.assertEqual(fs.scheme(), 'gs')
 
 
-@unittest.skipIf(gcsfilesystem is None, 'GCP dependencies are not installed')
+@unittest.skipIf(
+    gcsfilesystem is None or gcsio is None,
+    'GCP dependencies are not installed')
 class GCSFileSystemTest(unittest.TestCase):
   def setUp(self):
+    assert gcsfilesystem is not None
     pipeline_options = PipelineOptions()
     self.fs = gcsfilesystem.GCSFileSystem(pipeline_options=pipeline_options)
 
   def test_scheme(self):
+    assert gcsfilesystem is not None
     self.assertEqual(self.fs.scheme(), 'gs')
     self.assertEqual(gcsfilesystem.GCSFileSystem.scheme(), 'gs')
 


### PR DESCRIPTION
Resolves #37445

### What changes were proposed in this pull request?

`FileSystems.get_filesystem()` previously raised a `ValueError` for `gs://`
paths when GCP dependencies were not installed, while `s3://` paths returned
a filesystem object and deferred dependency validation until usage time.

This pull request aligns GCS behavior with S3 by making GCS filesystem lookup
lazy. `get_filesystem()` now returns a `GCSFileSystem` instance without
requiring `apache-beam[gcp]`, deferring dependency validation until the
filesystem is actually used (for example, on `open`, `match`, etc.).

A regression test has been added to ensure that GCS filesystem lookup does not
require GCP extras and that dependency errors are raised only at usage time.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Addresses #37445
 - [ ] Update `CHANGES.md` with noteworthy changes (not required; no user-facing API change)
 - [x] This change is small and does not require an Apache ICLA

### How was this tested?

- Added a unit test verifying that `FileSystems.get_filesystem("gs://...")`
  succeeds without `apache-beam[gcp]` installed.
- Manually verified that GCP dependency errors are raised only when invoking
  filesystem operations (e.g., `open`) and not during lookup.
