### PR TITLE
[Iceberg] Support nested column paths in keep/drop configuration

### DIFF
--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergScanConfig.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergScanConfig.java
@@ -24,6 +24,7 @@ import static org.apache.hadoop.util.Sets.newHashSet;
 import com.google.auto.value.AutoValue;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.apache.beam.sdk.io.iceberg.IcebergIO.ReadRows.StartingStrategy;
@@ -36,6 +37,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.expressions.Evaluator;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.types.TypeUtil;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.qual.Pure;
@@ -91,30 +93,16 @@ public abstract class IcebergScanConfig implements Serializable {
     if (keep != null && !keep.isEmpty()) {
       selectedFieldsBuilder.addAll(keep);
     } else if (drop != null && !drop.isEmpty()) {
-      // Get all field paths including nested ones
-      java.util.List<String> allPaths =
-          new java.util.ArrayList<>(
-              org.apache.iceberg.types.TypeUtil.indexByName(schema.asStruct()).keySet());
-      java.util.Collections.sort(allPaths);
-
-      // Identify leaf fields only (fields that are not parents of other fields)
-      // This prevents selecting a parent struct from implicitly including dropped children
-      java.util.Set<String> leaves = new java.util.HashSet<>();
-      for (int i = 0; i < allPaths.size(); i++) {
-        String path = allPaths.get(i);
-        // If the next path starts with "path.", then "path" is a parent - skip it
-        if (i + 1 < allPaths.size() && allPaths.get(i + 1).startsWith(path + ".")) {
-          continue;
+      List<String> paths = new ArrayList<>(TypeUtil.indexNameById(schema.asStruct()).values());
+      Collections.sort(paths);
+      for (int i = 0; i < paths.size(); i++) {
+        String path = paths.get(i);
+        boolean isParent = i + 1 < paths.size() && paths.get(i + 1).startsWith(path + ".");
+        boolean isDrop = drop.stream().anyMatch(d -> path.equals(d) || path.startsWith(d + "."));
+        if (!isParent && !isDrop) {
+          selectedFieldsBuilder.add(path);
         }
-        leaves.add(path);
       }
-
-      // Remove fields that are dropped or are children of dropped fields
-      for (String d : drop) {
-        leaves.removeIf(f -> f.equals(d) || f.startsWith(d + "."));
-      }
-
-      selectedFieldsBuilder.addAll(leaves);
     } else {
       // default: include all columns
       return schema;
@@ -345,8 +333,6 @@ public abstract class IcebergScanConfig implements Serializable {
         param = "drop";
         fieldsSpecified = newHashSet(checkNotNull(drop));
       }
-      // Use findField() to support nested column paths (e.g., "colA.colB")
-      // Iceberg's Schema.findField() resolves dot-notation paths for nested fields
       fieldsSpecified.removeIf(name -> table.schema().findField(name) != null);
 
       checkArgument(

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/IcebergIOReadTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/IcebergIOReadTest.java
@@ -274,9 +274,8 @@ public class IcebergIOReadTest {
   }
 
   @Test
-  public void testNestedColumnPruningValidation() {
-    // Test that nested column paths (dot notation) are accepted in keep/drop configuration
-    org.apache.iceberg.Schema schemaWithNested =
+  public void testProjectedSchemaWithNestedFields() {
+    org.apache.iceberg.Schema schema =
         new org.apache.iceberg.Schema(
             required(1, "id", StringType.get()),
             required(
@@ -286,38 +285,22 @@ public class IcebergIOReadTest {
                     required(3, "name", StringType.get()), required(4, "value", StringType.get()))),
             required(5, "metadata", StringType.get()));
 
-    // Test that nested column path "data.name" is valid and can be selected
-    org.apache.iceberg.Schema projectNestedKeep =
-        resolveSchema(schemaWithNested, asList("id", "data.name"), null);
-
-    // Verify the projected schema contains the nested field
-    assertTrue(projectNestedKeep.findField("id") != null);
-    assertTrue(projectNestedKeep.findField("data.name") != null);
-  }
-
-  @Test
-  public void testNestedColumnDropValidation() {
-    // Test that nested column paths work correctly with drop configuration
-    org.apache.iceberg.Schema schemaWithNested =
+    // test nested keep
+    org.apache.iceberg.Schema projectKeep = resolveSchema(schema, asList("id", "data.name"), null);
+    org.apache.iceberg.Schema expectedKeep =
         new org.apache.iceberg.Schema(
             required(1, "id", StringType.get()),
-            required(
-                2,
-                "data",
-                StructType.of(
-                    required(3, "name", StringType.get()), required(4, "value", StringType.get()))),
+            required(2, "data", StructType.of(required(3, "name", StringType.get()))));
+    assertTrue(projectKeep.sameSchema(expectedKeep));
+
+    // test nested drop
+    org.apache.iceberg.Schema projectDrop = resolveSchema(schema, null, asList("data.name"));
+    org.apache.iceberg.Schema expectedDrop =
+        new org.apache.iceberg.Schema(
+            required(1, "id", StringType.get()),
+            required(2, "data", StructType.of(required(4, "value", StringType.get()))),
             required(5, "metadata", StringType.get()));
-
-    // Test dropping a nested field "data.name" - should keep id, data.value, metadata
-    org.apache.iceberg.Schema projectNestedDrop =
-        resolveSchema(schemaWithNested, null, asList("data.name"));
-
-    // Verify "data.name" is NOT in the projected schema
-    assertTrue(projectNestedDrop.findField("id") != null);
-    assertTrue(projectNestedDrop.findField("data.value") != null);
-    assertTrue(projectNestedDrop.findField("metadata") != null);
-    // data.name should be dropped
-    assertTrue(projectNestedDrop.findField("data.name") == null);
+    assertTrue(projectDrop.sameSchema(expectedDrop));
   }
 
   @Test


### PR DESCRIPTION
## Summary

This PR enables support for nested column paths (dot notation) in both `keep` and `drop` configuration for Iceberg IO column pruning.

**Problem:**
Users cannot specify nested column paths like `keep: ["data.name"]` or `drop: ["data.name"]` - the validation fails with:
```
Invalid source configuration: 'keep' specifies unknown field(s): [data.name]
```

**Solution:**
1. **Validation fix:** Replace top-level-only column validation with `Schema.findField()` which natively resolves dot-notation paths
2. **Drop fix:** Use `TypeUtil.indexByName()` to enumerate all field paths (including nested), then select only leaf fields to prevent parent structs from implicitly including dropped children

**Changes:**
- `IcebergScanConfig.java`: 
  - Updated `validate()` method to use `findField()` for nested path support
  - Rewrote `resolveSchema()` drop logic to handle nested paths correctly
- `IcebergIOReadTest.java`: Added test cases for nested column keep and drop

Fixes #37486

## Test plan

- [x] Added `testNestedColumnPruningValidation` - verifies nested paths in `keep` are accepted
- [x] Added `testNestedColumnDropValidation` - verifies nested paths in `drop` work correctly
- [ ] Existing tests should continue to pass

---