### PR TITLE
[Java SDK] Warn when ValueState contains collection types

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
@@ -2371,11 +2371,10 @@ public class DoFnSignatures {
     }
 
     if (recommendation != null) {
-      LOG.info(
+      LOG.warn(
           "DoFn {} declares ValueState '{}' with collection type {}. "
               + "ValueState reads/writes the entire collection on each access. "
-              + "This is appropriate for small collections or atomic replacement. "
-              + "For large collections or frequent appends, consider using {} instead "
+              + "For large or frequently-updated collections, consider using {} instead "
               + "(if supported by your runner).",
           fnClazz.getSimpleName(),
           stateId,

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
@@ -104,6 +104,8 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Immuta
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Maps;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Utilities for working with {@link DoFnSignature}. See {@link #getSignature}. */
 @Internal
@@ -112,6 +114,8 @@ import org.joda.time.Instant;
   "rawtypes"
 })
 public class DoFnSignatures {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DoFnSignatures.class);
 
   private DoFnSignatures() {}
 
@@ -2327,10 +2331,75 @@ public class DoFnSignatures {
           (TypeDescriptor<? extends State>)
               TypeDescriptor.of(fnClazz).resolveType(unresolvedStateType);
 
+      // Warn if ValueState contains a collection type that could benefit from specialized state
+      warnIfValueStateContainsCollection(fnClazz, id, stateType);
+
       declarations.put(id, DoFnSignature.StateDeclaration.create(id, field, stateType));
     }
 
     return ImmutableMap.copyOf(declarations);
+  }
+
+  /**
+   * Warns if a ValueState is declared with a collection type (Map, List, Set) that could benefit
+   * from using specialized state types (MapState, BagState, SetState) for better performance.
+   */
+  private static void warnIfValueStateContainsCollection(
+      Class<?> fnClazz, String stateId, TypeDescriptor<? extends State> stateType) {
+    if (!stateType.isSubtypeOf(TypeDescriptor.of(ValueState.class))) {
+      return;
+    }
+
+    try {
+      // Get the type directly and extract ValueState's type parameter
+      Type type = stateType.getType();
+      if (!(type instanceof ParameterizedType)) {
+        return;
+      }
+
+      // Find ValueState in the type hierarchy and get its type argument
+      Type valueType = null;
+      ParameterizedType pType = (ParameterizedType) type;
+      if (pType.getRawType() == ValueState.class) {
+        valueType = pType.getActualTypeArguments()[0];
+      } else {
+        // For subtypes of ValueState, we need to resolve the type parameter
+        return;
+      }
+
+      if (valueType == null
+          || valueType instanceof java.lang.reflect.TypeVariable
+          || valueType instanceof java.lang.reflect.WildcardType) {
+        // Cannot determine actual type, skip warning
+        return;
+      }
+
+      TypeDescriptor<?> valueTypeDescriptor = TypeDescriptor.of(valueType);
+      Class<?> rawType = valueTypeDescriptor.getRawType();
+
+      String recommendation = null;
+      if (Map.class.isAssignableFrom(rawType)) {
+        recommendation = "MapState";
+      } else if (List.class.isAssignableFrom(rawType)) {
+        recommendation = "BagState or OrderedListState";
+      } else if (java.util.Set.class.isAssignableFrom(rawType)) {
+        recommendation = "SetState";
+      }
+
+      if (recommendation != null) {
+        LOG.warn(
+            "DoFn {} declares ValueState '{}' with type {}. "
+                + "Storing collections in ValueState requires reading and writing the entire "
+                + "collection on each access, which can cause performance issues. "
+                + "Consider using {} instead for better performance with large collections.",
+            fnClazz.getSimpleName(),
+            stateId,
+            rawType.getSimpleName(),
+            recommendation);
+      }
+    } catch (Exception e) {
+      // If we can't determine the type, don't warn - it's just an optimization hint
+    }
   }
 
   private static @Nullable Method findAnnotatedMethod(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
@@ -2387,11 +2387,12 @@ public class DoFnSignatures {
       }
 
       if (recommendation != null) {
-        LOG.warn(
-            "DoFn {} declares ValueState '{}' with type {}. "
-                + "Storing collections in ValueState requires reading and writing the entire "
-                + "collection on each access, which can cause performance issues. "
-                + "Consider using {} instead for better performance with large collections.",
+        LOG.info(
+            "DoFn {} declares ValueState '{}' with collection type {}. "
+                + "ValueState reads/writes the entire collection on each access. "
+                + "This is appropriate for small collections or atomic replacement. "
+                + "For large collections or frequent appends, consider using {} instead "
+                + "(if supported by your runner).",
             fnClazz.getSimpleName(),
             stateId,
             rawType.getSimpleName(),

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
@@ -2355,12 +2355,11 @@ public class DoFnSignatures {
     TypeDescriptor<?> valueTypeDescriptor =
         stateType.resolveType(ValueState.class.getTypeParameters()[0]);
 
-    // Skip if the type has unresolved parameters (e.g., TypeVariable, WildcardType)
-    if (valueTypeDescriptor.hasUnresolvedParameters()) {
-      return;
-    }
-
-    // Use TypeDescriptor.isSubtypeOf() for type checking - stays in TypeDescriptor API
+    // Match on the collection's raw type. We intentionally do not skip types with unresolved
+    // parameters: for a parameterized collection such as ValueState<Set<T>> the collection's own
+    // raw type (Set) is known even though the element type T is a type variable, so we can still
+    // recommend SetState. A payload that is itself a bare type variable (e.g. ValueState<T>) simply
+    // matches none of the branches below and produces no recommendation.
     String recommendation = null;
     if (valueTypeDescriptor.isSubtypeOf(TypeDescriptor.of(Map.class))) {
       recommendation = "MapState";

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesTest.java
@@ -1700,4 +1700,65 @@ public class DoFnSignaturesTest {
     @Override
     public void processWithTimer(ProcessContext context, Timer timer) {}
   }
+
+  // Test DoFns for ValueState collection warning tests
+  private static class DoFnWithMapValueState extends DoFn<String, String> {
+    @StateId("mapState")
+    private final StateSpec<ValueState<java.util.Map<String, String>>> mapState =
+        StateSpecs.value();
+
+    @ProcessElement
+    public void process() {}
+  }
+
+  private static class DoFnWithListValueState extends DoFn<String, String> {
+    @StateId("listState")
+    private final StateSpec<ValueState<java.util.List<String>>> listState = StateSpecs.value();
+
+    @ProcessElement
+    public void process() {}
+  }
+
+  private static class DoFnWithSetValueState extends DoFn<String, String> {
+    @StateId("setState")
+    private final StateSpec<ValueState<java.util.Set<String>>> setState = StateSpecs.value();
+
+    @ProcessElement
+    public void process() {}
+  }
+
+  private static class DoFnWithSimpleValueState extends DoFn<String, String> {
+    @StateId("simpleState")
+    private final StateSpec<ValueState<String>> simpleState = StateSpecs.value();
+
+    @ProcessElement
+    public void process() {}
+  }
+
+  @Test
+  public void testValueStateWithMapLogsWarning() {
+    // This test verifies that the signature can be parsed for DoFns with collection ValueState.
+    // The warning is logged but doesn't prevent the signature from being created.
+    DoFnSignature signature = DoFnSignatures.getSignature(DoFnWithMapValueState.class);
+    assertThat(signature.stateDeclarations().get("mapState"), notNullValue());
+  }
+
+  @Test
+  public void testValueStateWithListLogsWarning() {
+    DoFnSignature signature = DoFnSignatures.getSignature(DoFnWithListValueState.class);
+    assertThat(signature.stateDeclarations().get("listState"), notNullValue());
+  }
+
+  @Test
+  public void testValueStateWithSetLogsWarning() {
+    DoFnSignature signature = DoFnSignatures.getSignature(DoFnWithSetValueState.class);
+    assertThat(signature.stateDeclarations().get("setState"), notNullValue());
+  }
+
+  @Test
+  public void testValueStateWithSimpleTypeNoWarning() {
+    // Simple types should not trigger any warning
+    DoFnSignature signature = DoFnSignatures.getSignature(DoFnWithSimpleValueState.class);
+    assertThat(signature.stateDeclarations().get("simpleState"), notNullValue());
+  }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesTest.java
@@ -51,6 +51,7 @@ import org.apache.beam.sdk.state.TimerSpec;
 import org.apache.beam.sdk.state.TimerSpecs;
 import org.apache.beam.sdk.state.ValueState;
 import org.apache.beam.sdk.state.WatermarkHoldState;
+import org.apache.beam.sdk.testing.ExpectedLogs;
 import org.apache.beam.sdk.testing.SerializableMatchers;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.Sum;
@@ -100,6 +101,8 @@ import org.junit.runners.JUnit4;
 public class DoFnSignaturesTest {
 
   @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Rule public ExpectedLogs expectedLogs = ExpectedLogs.none(DoFnSignatures.class);
 
   @Test
   public void testBasicDoFnProcessContext() throws Exception {
@@ -1735,6 +1738,32 @@ public class DoFnSignaturesTest {
     public void process() {}
   }
 
+  private static class DoFnWithParameterizedSetValueState<T> extends DoFn<String, String> {
+    @StateId("parameterizedSetState")
+    private final StateSpec<ValueState<java.util.Set<T>>> parameterizedSetState =
+        StateSpecs.value();
+
+    @ProcessElement
+    public void process() {}
+  }
+
+  private static class DoFnWithParameterizedListValueState<T> extends DoFn<String, String> {
+    @StateId("parameterizedListState")
+    private final StateSpec<ValueState<java.util.List<T>>> parameterizedListState =
+        StateSpecs.value();
+
+    @ProcessElement
+    public void process() {}
+  }
+
+  private static class DoFnWithTypeVariableValueState<T> extends DoFn<String, String> {
+    @StateId("typeVariableState")
+    private final StateSpec<ValueState<T>> typeVariableState = StateSpecs.value();
+
+    @ProcessElement
+    public void process() {}
+  }
+
   @Test
   public void testValueStateWithMapLogsWarning() {
     // This test verifies that the signature can be parsed for DoFns with collection ValueState.
@@ -1760,5 +1789,32 @@ public class DoFnSignaturesTest {
     // Simple types should not trigger any warning
     DoFnSignature signature = DoFnSignatures.getSignature(DoFnWithSimpleValueState.class);
     assertThat(signature.stateDeclarations().get("simpleState"), notNullValue());
+    expectedLogs.verifyNotLogged("with collection type");
+  }
+
+  @Test
+  public void testValueStateWithParameterizedSetLogsWarning() {
+    // A parameterized collection such as ValueState<Set<T>> still has a known raw collection type
+    // (Set) even though the element type is a type variable, so it should still recommend SetState.
+    DoFnSignature signature = DoFnSignatures.getSignature(DoFnWithParameterizedSetValueState.class);
+    assertThat(signature.stateDeclarations().get("parameterizedSetState"), notNullValue());
+    expectedLogs.verifyWarn("SetState");
+  }
+
+  @Test
+  public void testValueStateWithParameterizedListLogsWarning() {
+    DoFnSignature signature =
+        DoFnSignatures.getSignature(DoFnWithParameterizedListValueState.class);
+    assertThat(signature.stateDeclarations().get("parameterizedListState"), notNullValue());
+    expectedLogs.verifyWarn("BagState or OrderedListState");
+  }
+
+  @Test
+  public void testValueStateWithBareTypeVariableNoWarning() {
+    // A bare type variable payload (ValueState<T>) has no raw collection type to inspect and must
+    // not produce a collection recommendation.
+    DoFnSignature signature = DoFnSignatures.getSignature(DoFnWithTypeVariableValueState.class);
+    assertThat(signature.stateDeclarations().get("typeVariableState"), notNullValue());
+    expectedLogs.verifyNotLogged("with collection type");
   }
 }


### PR DESCRIPTION
## Summary

This PR adds a warning when users declare `ValueState` with collection types (`Map`, `List`, `Set`) that could benefit from using specialized state types for better performance.

**Problem:**
When users store collections in `ValueState`, the entire collection must be read and written on each access. This can cause significant performance issues for large collections.

**Solution:**
Log a warning during pipeline construction suggesting:
- `ValueState<Map>` → Use `MapState` instead
- `ValueState<List>` → Use `BagState` or `OrderedListState` instead  
- `ValueState<Set>` → Use `SetState` instead

**Changes:**
- `DoFnSignatures.java`: Added `warnIfValueStateContainsCollection()` method that inspects state declarations and logs warnings for collection types
- `DoFnSignaturesTest.java`: Added test cases to verify the warning logic works correctly

Fixes #36746

## Test plan

- [x] Added tests for `ValueState<Map>`, `ValueState<List>`, `ValueState<Set>`
- [x] Added test for simple `ValueState<String>` (no warning expected)
- [ ] Existing tests should continue to pass

---