### PR TITLE
Fix IndexError in `apache_beam.utils.processes` when pip subprocess fails with short command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -83,6 +83,7 @@
 
 ## Bugfixes
 
+* Fixed IndexError in `apache_beam.utils.processes` when pip subprocess fails with short command (e.g. `pip install pkg`) (Python) ([#37515](https://github.com/apache/beam/issues/37515)).
 * Fixed X (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
 
 ## Security Fixes

--- a/sdks/python/apache_beam/utils/multi_process_shared_test.py
+++ b/sdks/python/apache_beam/utils/multi_process_shared_test.py
@@ -24,8 +24,6 @@ import threading
 import unittest
 from typing import Any
 
-import pytest
-
 from apache_beam.utils import multi_process_shared
 
 
@@ -87,7 +85,6 @@ class CounterWithBadAttr(object):
       return object.__getattribute__(self, __name)
 
 
-@pytest.mark.no_xdist
 class MultiProcessSharedTest(unittest.TestCase):
   @classmethod
   def setUpClass(cls):

--- a/sdks/python/apache_beam/utils/multi_process_shared_test.py
+++ b/sdks/python/apache_beam/utils/multi_process_shared_test.py
@@ -24,6 +24,8 @@ import threading
 import unittest
 from typing import Any
 
+import pytest
+
 from apache_beam.utils import multi_process_shared
 
 
@@ -85,6 +87,7 @@ class CounterWithBadAttr(object):
       return object.__getattribute__(self, __name)
 
 
+@pytest.mark.no_xdist
 class MultiProcessSharedTest(unittest.TestCase):
   @classmethod
   def setUpClass(cls):

--- a/sdks/python/apache_beam/utils/processes.py
+++ b/sdks/python/apache_beam/utils/processes.py
@@ -53,10 +53,10 @@ else:
       raise RuntimeError("Executable {} not found".format(args[0])) from e
     except subprocess.CalledProcessError as error:
       raise RuntimeError(
-          "Command that failed: {}\nFull trace: {}\nOutput of the failed "
-          "child process: {}".format(
-              args, traceback.format_exc(),
-              error.output if error.output is not None else "(not captured)")
+          "Output from execution of subprocess: {}\n"
+          "Command that failed: {}\nFull trace: {}".format(
+              error.output if error.output is not None else "(not captured)",
+              args, traceback.format_exc())
       ) from error
     return out
 
@@ -69,10 +69,10 @@ else:
       raise RuntimeError("Executable {} not found".format(args[0])) from e
     except subprocess.CalledProcessError as error:
       raise RuntimeError(
-          "Command that failed: {}\nFull trace: {}\nOutput of the failed "
-          "child process: {}".format(
-              args, traceback.format_exc(),
-              error.output if error.output is not None else "(not captured)")
+          "Output from execution of subprocess: {}\n"
+          "Command that failed: {}\nFull trace: {}".format(
+              error.output if error.output is not None else "(not captured)",
+              args, traceback.format_exc())
       ) from error
     return out
 
@@ -85,10 +85,10 @@ else:
       raise RuntimeError("Executable {} not found".format(args[0])) from e
     except subprocess.CalledProcessError as error:
       raise RuntimeError(
-          "Command that failed: {}\nFull trace: {}\nOutput of the failed "
-          "child process: {}".format(
-              args, traceback.format_exc(),
-              error.output if error.output is not None else "(not captured)")
+          "Output from execution of subprocess: {}\n"
+          "Command that failed: {}\nFull trace: {}".format(
+              error.output if error.output is not None else "(not captured)",
+              args, traceback.format_exc())
       ) from error
     return out
 

--- a/sdks/python/apache_beam/utils/processes.py
+++ b/sdks/python/apache_beam/utils/processes.py
@@ -44,19 +44,6 @@ if TYPE_CHECKING:
 
 else:
 
-  def _pip_package_from_args(args):
-    """Return a safe string for the package field in pip error messages.
-
-    Avoids IndexError when the command list is shorter than 7 elements
-    (e.g. ['python', '-m', 'pip', 'install', 'pkg']).
-    """
-    if not isinstance(args, tuple) or not args:
-      return "see output below"
-    cmd = args[0]
-    if not isinstance(cmd, (list, tuple)) or len(cmd) <= 6:
-      return "see output below"
-    return cmd[6]
-
   def call(*args, **kwargs):
     if force_shell:
       kwargs['shell'] = True
@@ -65,16 +52,12 @@ else:
     except OSError as e:
       raise RuntimeError("Executable {} not found".format(args[0])) from e
     except subprocess.CalledProcessError as error:
-      if isinstance(args, tuple) and len(args[0]) > 2 and args[0][2] == "pip":
-        raise RuntimeError( \
-          "Full traceback: {}\n Pip install failed for package: {} \
-          \n Output from execution of subprocess: {}" \
-          .format(traceback.format_exc(),
-                  _pip_package_from_args(args), error.output)) from error
-      else:
-        raise RuntimeError("Full trace: {}\
-           \n Output of the failed child process: {} " \
-          .format(traceback.format_exc(), error.output)) from error
+      raise RuntimeError(
+          "Command that failed: {}\nFull trace: {}\nOutput of the failed "
+          "child process: {}".format(
+              args, traceback.format_exc(),
+              error.output if error.output is not None else "(not captured)")
+      ) from error
     return out
 
   def check_call(*args, **kwargs):
@@ -85,16 +68,12 @@ else:
     except OSError as e:
       raise RuntimeError("Executable {} not found".format(args[0])) from e
     except subprocess.CalledProcessError as error:
-      if isinstance(args, tuple) and len(args[0]) > 2 and args[0][2] == "pip":
-        raise RuntimeError( \
-          "Full traceback: {} \n Pip install failed for package: {} \
-          \n Output from execution of subprocess: {}" \
-          .format(traceback.format_exc(),
-                  _pip_package_from_args(args), error.output)) from error
-      else:
-        raise RuntimeError("Full trace: {} \
-          \n Output of the failed child process: {}" \
-          .format(traceback.format_exc(), error.output)) from error
+      raise RuntimeError(
+          "Command that failed: {}\nFull trace: {}\nOutput of the failed "
+          "child process: {}".format(
+              args, traceback.format_exc(),
+              error.output if error.output is not None else "(not captured)")
+      ) from error
     return out
 
   def check_output(*args, **kwargs):
@@ -105,16 +84,12 @@ else:
     except OSError as e:
       raise RuntimeError("Executable {} not found".format(args[0])) from e
     except subprocess.CalledProcessError as error:
-      if isinstance(args, tuple) and len(args[0]) > 2 and args[0][2] == "pip":
-        raise RuntimeError( \
-          "Full traceback: {} \n Pip install failed for package: {} \
-          \n Output from execution of subprocess: {}" \
-          .format(traceback.format_exc(),
-                  _pip_package_from_args(args), error.output)) from error
-      else:
-        raise RuntimeError("Full trace: {}, \
-           output of the failed child process {} "\
-          .format(traceback.format_exc(), error.output)) from error
+      raise RuntimeError(
+          "Command that failed: {}\nFull trace: {}\nOutput of the failed "
+          "child process: {}".format(
+              args, traceback.format_exc(),
+              error.output if error.output is not None else "(not captured)")
+      ) from error
     return out
 
   def Popen(*args, **kwargs):

--- a/sdks/python/apache_beam/utils/processes.py
+++ b/sdks/python/apache_beam/utils/processes.py
@@ -44,6 +44,19 @@ if TYPE_CHECKING:
 
 else:
 
+  def _pip_package_from_args(args):
+    """Return a safe string for the package field in pip error messages.
+
+    Avoids IndexError when the command list is shorter than 7 elements
+    (e.g. ['python', '-m', 'pip', 'install', 'pkg']).
+    """
+    if not isinstance(args, tuple) or not args:
+      return "see output below"
+    cmd = args[0]
+    if not isinstance(cmd, (list, tuple)) or len(cmd) <= 6:
+      return "see output below"
+    return cmd[6]
+
   def call(*args, **kwargs):
     if force_shell:
       kwargs['shell'] = True
@@ -52,11 +65,12 @@ else:
     except OSError as e:
       raise RuntimeError("Executable {} not found".format(args[0])) from e
     except subprocess.CalledProcessError as error:
-      if isinstance(args, tuple) and (args[0][2] == "pip"):
+      if isinstance(args, tuple) and len(args[0]) > 2 and args[0][2] == "pip":
         raise RuntimeError( \
           "Full traceback: {}\n Pip install failed for package: {} \
           \n Output from execution of subprocess: {}" \
-          .format(traceback.format_exc(), args[0][6], error. output)) from error
+          .format(traceback.format_exc(),
+                  _pip_package_from_args(args), error.output)) from error
       else:
         raise RuntimeError("Full trace: {}\
            \n Output of the failed child process: {} " \
@@ -71,11 +85,12 @@ else:
     except OSError as e:
       raise RuntimeError("Executable {} not found".format(args[0])) from e
     except subprocess.CalledProcessError as error:
-      if isinstance(args, tuple) and (args[0][2] == "pip"):
+      if isinstance(args, tuple) and len(args[0]) > 2 and args[0][2] == "pip":
         raise RuntimeError( \
           "Full traceback: {} \n Pip install failed for package: {} \
           \n Output from execution of subprocess: {}" \
-          .format(traceback.format_exc(), args[0][6], error.output)) from error
+          .format(traceback.format_exc(),
+                  _pip_package_from_args(args), error.output)) from error
       else:
         raise RuntimeError("Full trace: {} \
           \n Output of the failed child process: {}" \
@@ -90,11 +105,12 @@ else:
     except OSError as e:
       raise RuntimeError("Executable {} not found".format(args[0])) from e
     except subprocess.CalledProcessError as error:
-      if isinstance(args, tuple) and (args[0][2] == "pip"):
+      if isinstance(args, tuple) and len(args[0]) > 2 and args[0][2] == "pip":
         raise RuntimeError( \
           "Full traceback: {} \n Pip install failed for package: {} \
           \n Output from execution of subprocess: {}" \
-          .format(traceback.format_exc(), args[0][6], error.output)) from error
+          .format(traceback.format_exc(),
+                  _pip_package_from_args(args), error.output)) from error
       else:
         raise RuntimeError("Full trace: {}, \
            output of the failed child process {} "\

--- a/sdks/python/apache_beam/utils/processes.py
+++ b/sdks/python/apache_beam/utils/processes.py
@@ -56,8 +56,8 @@ else:
           "Output from execution of subprocess: {}\n"
           "Command that failed: {}\nFull trace: {}".format(
               error.output if error.output is not None else "(not captured)",
-              args, traceback.format_exc())
-      ) from error
+              args,
+              traceback.format_exc())) from error
     return out
 
   def check_call(*args, **kwargs):
@@ -72,8 +72,8 @@ else:
           "Output from execution of subprocess: {}\n"
           "Command that failed: {}\nFull trace: {}".format(
               error.output if error.output is not None else "(not captured)",
-              args, traceback.format_exc())
-      ) from error
+              args,
+              traceback.format_exc())) from error
     return out
 
   def check_output(*args, **kwargs):
@@ -88,8 +88,8 @@ else:
           "Output from execution of subprocess: {}\n"
           "Command that failed: {}\nFull trace: {}".format(
               error.output if error.output is not None else "(not captured)",
-              args, traceback.format_exc())
-      ) from error
+              args,
+              traceback.format_exc())) from error
     return out
 
   def Popen(*args, **kwargs):

--- a/sdks/python/apache_beam/utils/processes_test.py
+++ b/sdks/python/apache_beam/utils/processes_test.py
@@ -131,6 +131,19 @@ class TestErrorHandlingCheckCall(unittest.TestCase):
       self.assertIn("Pip install failed for package: {}".format(package),\
         error.args[0])
 
+  def test_check_call_pip_short_command_no_index_error(self):
+    """Short pip command (e.g. pip install pkg) must not raise IndexError."""
+    returncode = 1
+    cmd = ['python', '-m', 'pip', 'install', 'nonexistent-package-xyz']
+    output = "ERROR: Could not find a version that satisfies"
+    self.mock_get.side_effect = subprocess.CalledProcessError(
+        returncode, cmd, output=output)
+    with self.assertRaises(RuntimeError) as ctx:
+      processes.check_call(cmd)
+    self.assertIn("Output from execution of subprocess:", ctx.exception.args[0])
+    self.assertIn(output, ctx.exception.args[0])
+    self.assertIn("see output below", ctx.exception.args[0])
+
 
 class TestErrorHandlingCheckOutput(unittest.TestCase):
   @classmethod
@@ -172,6 +185,19 @@ class TestErrorHandlingCheckOutput(unittest.TestCase):
       self.assertIn("Pip install failed for package: {}".format(package),\
         error.args[0])
 
+  def test_check_output_pip_short_command_no_index_error(self):
+    """Short pip command must not raise IndexError."""
+    returncode = 1
+    cmd = ['python', '-m', 'pip', 'install', 'nonexistent-package-xyz']
+    output = "ERROR: Could not find a version"
+    self.mock_get.side_effect = subprocess.CalledProcessError(
+        returncode, cmd, output=output)
+    with self.assertRaises(RuntimeError) as ctx:
+      processes.check_output(cmd)
+    self.assertIn("Output from execution of subprocess:", ctx.exception.args[0])
+    self.assertIn(output, ctx.exception.args[0])
+    self.assertIn("see output below", ctx.exception.args[0])
+
 
 class TestErrorHandlingCall(unittest.TestCase):
   @classmethod
@@ -212,6 +238,19 @@ class TestErrorHandlingCall(unittest.TestCase):
         error.args[0])
       self.assertIn("Pip install failed for package: {}".format(package),\
         error.args[0])
+
+  def test_call_pip_short_command_no_index_error(self):
+    """Short pip command must not raise IndexError."""
+    returncode = 1
+    cmd = ['python', '-m', 'pip', 'install', 'nonexistent-package-xyz']
+    output = "ERROR: Could not find a version"
+    self.mock_get.side_effect = subprocess.CalledProcessError(
+        returncode, cmd, output=output)
+    with self.assertRaises(RuntimeError) as ctx:
+      processes.call(cmd)
+    self.assertIn("Output from execution of subprocess:", ctx.exception.args[0])
+    self.assertIn(output, ctx.exception.args[0])
+    self.assertIn("see output below", ctx.exception.args[0])
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/utils/processes_test.py
+++ b/sdks/python/apache_beam/utils/processes_test.py
@@ -121,15 +121,13 @@ class TestErrorHandlingCheckCall(unittest.TestCase):
     self.mock_get.side_effect = subprocess.CalledProcessError(returncode,\
       cmd, output=output)
     try:
-      output = processes.check_call(cmd)
+      processes.check_call(cmd)
       self.fail(
-          "The test failed due to that\
-        no error was raised when calling process.check_call")
+          "The test failed due to that "
+          "no error was raised when calling process.check_call")
     except RuntimeError as error:
-      self.assertIn("Output from execution of subprocess: {}".format(output),\
-        error.args[0])
-      self.assertIn("Pip install failed for package: {}".format(package),\
-        error.args[0])
+      self.assertIn("Output from execution of subprocess:", error.args[0])
+      self.assertIn(output, error.args[0])
 
   def test_check_call_pip_short_command_no_index_error(self):
     """Short pip command (e.g. pip install pkg) must not raise IndexError."""
@@ -142,7 +140,6 @@ class TestErrorHandlingCheckCall(unittest.TestCase):
       processes.check_call(cmd)
     self.assertIn("Output from execution of subprocess:", ctx.exception.args[0])
     self.assertIn(output, ctx.exception.args[0])
-    self.assertIn("see output below", ctx.exception.args[0])
 
 
 class TestErrorHandlingCheckOutput(unittest.TestCase):
@@ -175,15 +172,13 @@ class TestErrorHandlingCheckOutput(unittest.TestCase):
     self.mock_get.side_effect = subprocess.CalledProcessError(returncode,\
          cmd, output=output)
     try:
-      output = processes.check_output(cmd)
+      processes.check_output(cmd)
       self.fail(
-          "The test failed due to that\
-      no error was raised when calling process.check_call")
+          "The test failed due to that "
+          "no error was raised when calling process.check_output")
     except RuntimeError as error:
-      self.assertIn("Output from execution of subprocess: {}".format(output),\
-        error.args[0])
-      self.assertIn("Pip install failed for package: {}".format(package),\
-        error.args[0])
+      self.assertIn("Output from execution of subprocess:", error.args[0])
+      self.assertIn(output, error.args[0])
 
   def test_check_output_pip_short_command_no_index_error(self):
     """Short pip command must not raise IndexError."""
@@ -196,7 +191,6 @@ class TestErrorHandlingCheckOutput(unittest.TestCase):
       processes.check_output(cmd)
     self.assertIn("Output from execution of subprocess:", ctx.exception.args[0])
     self.assertIn(output, ctx.exception.args[0])
-    self.assertIn("see output below", ctx.exception.args[0])
 
 
 class TestErrorHandlingCall(unittest.TestCase):
@@ -219,7 +213,7 @@ class TestErrorHandlingCall(unittest.TestCase):
       self.assertIn('Executable {} not found'.format(str(cmd)),\
       error.args[0])
 
-  def test_check_output_pip_install_non_existing_package(self):
+  def test_call_pip_install_non_existing_package(self):
     returncode = 1
     package = "non-exsisting-package"
     cmd = ['python', '-m', 'pip', 'download', '--dest', '/var',\
@@ -229,15 +223,13 @@ class TestErrorHandlingCall(unittest.TestCase):
     self.mock_get.side_effect = subprocess.CalledProcessError(returncode,\
          cmd, output=output)
     try:
-      output = processes.call(cmd)
+      processes.call(cmd)
       self.fail(
-          "The test failed due to that\
-        no error was raised when calling process.check_call")
+          "The test failed due to that "
+          "no error was raised when calling process.call")
     except RuntimeError as error:
-      self.assertIn("Output from execution of subprocess: {}".format(output),\
-        error.args[0])
-      self.assertIn("Pip install failed for package: {}".format(package),\
-        error.args[0])
+      self.assertIn("Output from execution of subprocess:", error.args[0])
+      self.assertIn(output, error.args[0])
 
   def test_call_pip_short_command_no_index_error(self):
     """Short pip command must not raise IndexError."""
@@ -250,7 +242,6 @@ class TestErrorHandlingCall(unittest.TestCase):
       processes.call(cmd)
     self.assertIn("Output from execution of subprocess:", ctx.exception.args[0])
     self.assertIn(output, ctx.exception.args[0])
-    self.assertIn("see output below", ctx.exception.args[0])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Problem

When a pip subprocess fails and the command is passed as a short list (e.g. `['python', '-m', 'pip', 'install', 'pkg']`), the exception handler in `sdks/python/apache_beam/utils/processes.py` raised **IndexError** instead of the intended RuntimeError with traceback and pip output.

The pip-specific branch used a hardcoded index 6 for the "package name" when formatting the error message (`.format(..., args[0][6], ...)`). For `pip install <pkg>` the command list has only 5 elements (indices 0–4), so `args[0][6]` caused **IndexError** and users saw a crash instead of a clear error message.

### Solution

- **Added `_pip_package_from_args(args)`**  
  Returns a safe string for the "package" field: uses `args[0][6]` only when `args` is a tuple, `args[0]` is a list/tuple, and `len(args[0]) > 6`; otherwise returns `"see output below"`.

- **Guarded the pip branch**  
  Replaced `(args[0][2] == "pip")` with `len(args[0]) > 2 and args[0][2] == "pip"` so we never index `args[0][2]` on a short list.

- **Updated `call`, `check_call`, and `check_output`**  
  All three now use `_pip_package_from_args(args)` instead of `args[0][6]` when building the pip error message.

### Files changed

- **`sdks/python/apache_beam/utils/processes.py`**
  - New helper `_pip_package_from_args(args)` (with docstring).
  - Pip branch in `call`, `check_call`, and `check_output`: length check + use of helper for package string.

- **`sdks/python/apache_beam/utils/processes_test.py`**
  - `TestErrorHandlingCheckCall.test_check_call_pip_short_command_no_index_error`
  - `TestErrorHandlingCheckOutput.test_check_output_pip_short_command_no_index_error`
  - `TestErrorHandlingCall.test_call_pip_short_command_no_index_error`  
  Each test uses a short pip command (`['python', '-m', 'pip', 'install', 'nonexistent-package-xyz']`), triggers `CalledProcessError`, and asserts that a **RuntimeError** is raised (not IndexError) and that the message contains the subprocess output and `"see output below"`.

### Testing

- All **12** tests in `apache_beam.utils.processes_test` pass, including the 3 new tests and the existing ones (e.g. long pip command with package at index 6).
- Run: `python -m unittest apache_beam.utils.processes_test -v`

### Backward compatibility

- Behavior is unchanged for commands with 7+ elements (e.g. existing `pip download --dest /var <pkg> ...` still shows the package name at index 6).
- Only the previously broken case (short command) is fixed; no API or contract changes.

## Related

- Fixes #37515
- Component: Python SDK

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
