### PR TITLE
fix(python): Register all output pcollections of a transform rather than only ones that happened to be accessed in DoOutputsTuple

### DIFF
--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -843,9 +843,10 @@ class Pipeline(HasDisplayData):
 
         assert isinstance(result.producer.inputs, tuple)
         if isinstance(result, pvalue.DoOutputsTuple):
-          for tag, pc in list(result._pcolls.items()):
+          all_tags = [result._main_tag] + list(result._tags)
+          for tag in all_tags:
             if tag not in current.outputs:
-              current.add_output(pc, tag)
+              current.add_output(result[tag], tag)
           continue
 
         # If there is already a tag with the same name, increase a counter for

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -1646,9 +1646,47 @@ class RunnerApiTest(unittest.TestCase):
       all_applied_transforms[xform.full_label] = xform
       current_transforms.extend(xform.parts)
     xform = all_applied_transforms['Split Sales']
-    # Confirm that Split Sales correctly has two outputs as specified by
-    #  ParDo.with_outputs in ParentSalesSplitter.
-    assert len(xform.outputs) == 2
+    # Confirm that Split Sales correctly has three outputs: the main
+    # (untagged) output plus the two tagged outputs specified by
+    # ParDo.with_outputs in ParentSalesSplitter.
+    assert len(xform.outputs) == 3
+
+  def test_do_outputs_tuple_subclass_registers_all_outputs(self):
+    """Test that a composite returning a DoOutputsTuple subclass registers
+    all declared outputs, not just those lazily accessed via _pcolls."""
+    class PipeToMain(beam.pvalue.DoOutputsTuple):
+      """Wrapper enabling: composite | Next (pipes to main output)."""
+      def __init__(self, wrapped):
+        self.__dict__.update(wrapped.__dict__)
+
+      def __or__(self, other):
+        return self[self._main_tag].__or__(other)
+
+    class MyComposite(beam.PTransform):
+      def expand(self, pcoll):
+        return PipeToMain(
+            pcoll | beam.ParDo(beam.DoFn()).with_outputs('dropped'))
+
+    p = beam.Pipeline()
+    result = p | beam.Create([1]) | 'Composite' >> MyComposite()
+    _ = result | 'UseMain' >> beam.Map(lambda x: x)
+
+    proto = p.to_runner_api()
+    composite_outputs = None
+    consumed_pcoll = None
+    for t in proto.components.transforms.values():
+      if t.unique_name == 'Composite':
+        composite_outputs = dict(t.outputs)
+      if t.unique_name == 'UseMain':
+        consumed_pcoll = list(t.inputs.values())[0]
+
+    self.assertIsNotNone(composite_outputs)
+    self.assertIsNotNone(consumed_pcoll)
+    self.assertIn(
+        consumed_pcoll,
+        composite_outputs.values(),
+        "PCollection consumed by downstream transform must be in "
+        "composite's registered outputs")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Fix composite transform output registration to iterate over all declared tags instead of the lazily-populated `_pcolls` dict
- Ensures pipeline proto graph is complete and correct for composites returning `DoOutputsTuple`

## Description

PR #36220 changed composite output registration to iterate over `result._pcolls.items()`. However, `_pcolls` is lazily populated — entries are only added when accessed via `__getitem__`. Any output that hasn't been accessed at registration time is silently missing from the composite's outputs in the pipeline proto, producing an incorrect graph with disconnected edges.

**Fix:** Iterate over all declared tags (`_main_tag` + `_tags`) and access each via `result[tag]`, ensuring all outputs are materialized and registered regardless of prior access patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)