### PR TITLE
[Stateful] Implement length-aware keying to minimize padding in BatchElements (Part 2/3)

### DIFF
--- a/sdks/python/apache_beam/ml/inference/base.py
+++ b/sdks/python/apache_beam/ml/inference/base.py
@@ -178,6 +178,8 @@ class ModelHandler(Generic[ExampleT, PredictionT, ModelT]):
       max_batch_duration_secs: Optional[int] = None,
       max_batch_weight: Optional[int] = None,
       element_size_fn: Optional[Callable[[Any], int]] = None,
+      length_fn: Optional[Callable[[Any], int]] = None,
+      bucket_boundaries: Optional[list[int]] = None,
       large_model: bool = False,
       model_copies: Optional[int] = None,
       **kwargs):
@@ -190,6 +192,11 @@ class ModelHandler(Generic[ExampleT, PredictionT, ModelT]):
         before emitting; used in streaming contexts.
       max_batch_weight: the maximum weight of a batch. Requires element_size_fn.
       element_size_fn: a function that returns the size (weight) of an element.
+      length_fn: a callable mapping an element to its length. When set with
+        max_batch_duration_secs, enables length-aware bucketed keying so
+        elements of similar length are batched together.
+      bucket_boundaries: sorted list of positive boundary values for length
+        bucketing. Requires length_fn.
       large_model: set to true if your model is large enough to run into
         memory pressure if you load multiple copies.
       model_copies: The exact number of models that you would like loaded
@@ -209,6 +216,10 @@ class ModelHandler(Generic[ExampleT, PredictionT, ModelT]):
       self._batching_kwargs['max_batch_weight'] = max_batch_weight
     if element_size_fn is not None:
       self._batching_kwargs['element_size_fn'] = element_size_fn
+    if length_fn is not None:
+      self._batching_kwargs['length_fn'] = length_fn
+    if bucket_boundaries is not None:
+      self._batching_kwargs['bucket_boundaries'] = bucket_boundaries
     self._large_model = large_model
     self._model_copies = model_copies
     self._share_across_processes = large_model or (model_copies is not None)

--- a/sdks/python/apache_beam/ml/inference/base.py
+++ b/sdks/python/apache_beam/ml/inference/base.py
@@ -178,8 +178,8 @@ class ModelHandler(Generic[ExampleT, PredictionT, ModelT]):
       max_batch_duration_secs: Optional[int] = None,
       max_batch_weight: Optional[int] = None,
       element_size_fn: Optional[Callable[[Any], int]] = None,
-      length_fn: Optional[Callable[[Any], int]] = None,
-      bucket_boundaries: Optional[list[int]] = None,
+      batch_length_fn: Optional[Callable[[Any], int]] = None,
+      batch_bucket_boundaries: Optional[list[int]] = None,
       large_model: bool = False,
       model_copies: Optional[int] = None,
       **kwargs):
@@ -192,11 +192,17 @@ class ModelHandler(Generic[ExampleT, PredictionT, ModelT]):
         before emitting; used in streaming contexts.
       max_batch_weight: the maximum weight of a batch. Requires element_size_fn.
       element_size_fn: a function that returns the size (weight) of an element.
-      length_fn: a callable mapping an element to its length. When set with
-        max_batch_duration_secs, enables length-aware bucketed keying so
-        elements of similar length are batched together.
-      bucket_boundaries: sorted list of positive boundary values for length
-        bucketing. Requires length_fn.
+      batch_length_fn: a callable mapping an element to its length (int). When
+        set together with max_batch_duration_secs, enables length-aware bucketed
+        keying so that elements of similar length are batched together, reducing
+        padding waste for variable-length inputs. Bucket assignment uses
+        bisect_right so boundaries are lower-inclusive: e.g., for boundaries
+        [10, 50], buckets are (-inf, 10), [10, 50), [50, inf).
+      batch_bucket_boundaries: a sorted list of positive boundary values for
+        length bucketing. Boundaries are lower-inclusive (bisect_right
+        semantics): bucket i covers lengths in [boundaries[i-1], boundaries[i]).
+        Requires batch_length_fn. Defaults to [16, 32, 64, 128, 256, 512] when
+        batch_length_fn is set.
       large_model: set to true if your model is large enough to run into
         memory pressure if you load multiple copies.
       model_copies: The exact number of models that you would like loaded
@@ -216,10 +222,10 @@ class ModelHandler(Generic[ExampleT, PredictionT, ModelT]):
       self._batching_kwargs['max_batch_weight'] = max_batch_weight
     if element_size_fn is not None:
       self._batching_kwargs['element_size_fn'] = element_size_fn
-    if length_fn is not None:
-      self._batching_kwargs['length_fn'] = length_fn
-    if bucket_boundaries is not None:
-      self._batching_kwargs['bucket_boundaries'] = bucket_boundaries
+    if batch_length_fn is not None:
+      self._batching_kwargs['length_fn'] = batch_length_fn
+    if batch_bucket_boundaries is not None:
+      self._batching_kwargs['bucket_boundaries'] = batch_bucket_boundaries
     self._large_model = large_model
     self._model_copies = model_copies
     self._share_across_processes = large_model or (model_copies is not None)

--- a/sdks/python/apache_beam/ml/inference/base_test.py
+++ b/sdks/python/apache_beam/ml/inference/base_test.py
@@ -2279,38 +2279,40 @@ class ModelHandlerBatchingArgsTest(unittest.TestCase):
 
     self.assertEqual(kwargs, {'max_batch_duration_secs': 60})
 
-  def test_length_fn_and_bucket_boundaries(self):
-    """length_fn and bucket_boundaries are passed through to kwargs."""
+  def test_batch_length_fn_and_batch_bucket_boundaries(self):
+    """batch_length_fn and batch_bucket_boundaries passed through to kwargs."""
     handler = FakeModelHandlerForBatching(
-        length_fn=len, bucket_boundaries=[16, 32, 64])
+        batch_length_fn=len, batch_bucket_boundaries=[16, 32, 64])
     kwargs = handler.batch_elements_kwargs()
 
     self.assertIs(kwargs['length_fn'], len)
     self.assertEqual(kwargs['bucket_boundaries'], [16, 32, 64])
 
-  def test_length_fn_only(self):
-    """length_fn alone is passed through without bucket_boundaries."""
-    handler = FakeModelHandlerForBatching(length_fn=len)
+  def test_batch_length_fn_only(self):
+    """batch_length_fn alone is passed through without bucket_boundaries."""
+    handler = FakeModelHandlerForBatching(batch_length_fn=len)
     kwargs = handler.batch_elements_kwargs()
 
     self.assertIs(kwargs['length_fn'], len)
     self.assertNotIn('bucket_boundaries', kwargs)
 
-  def test_bucket_boundaries_without_length_fn(self):
-    """Passing bucket_boundaries without length_fn should fail in BatchElements.
+  def test_batch_bucket_boundaries_without_batch_length_fn(self):
+    """Passing batch_bucket_boundaries without batch_length_fn should fail in
+    BatchElements.
 
     Note: ModelHandler.__init__ doesn't validate this; the error is raised
     by BatchElements when batch_elements_kwargs are used."""
-    handler = FakeModelHandlerForBatching(bucket_boundaries=[10, 20])
+    handler = FakeModelHandlerForBatching(batch_bucket_boundaries=[10, 20])
     kwargs = handler.batch_elements_kwargs()
     # The kwargs are stored, but BatchElements will reject them
     self.assertEqual(kwargs['bucket_boundaries'], [10, 20])
     self.assertNotIn('length_fn', kwargs)
 
   def test_batching_kwargs_none_values_omitted(self):
-    """None values for length_fn and bucket_boundaries are not in kwargs."""
+    """None values for batch_length_fn and batch_bucket_boundaries are not in
+    kwargs."""
     handler = FakeModelHandlerForBatching(
-        min_batch_size=5, length_fn=None, bucket_boundaries=None)
+        min_batch_size=5, batch_length_fn=None, batch_bucket_boundaries=None)
     kwargs = handler.batch_elements_kwargs()
     self.assertNotIn('length_fn', kwargs)
     self.assertNotIn('bucket_boundaries', kwargs)

--- a/sdks/python/apache_beam/ml/inference/base_test.py
+++ b/sdks/python/apache_beam/ml/inference/base_test.py
@@ -2279,6 +2279,43 @@ class ModelHandlerBatchingArgsTest(unittest.TestCase):
 
     self.assertEqual(kwargs, {'max_batch_duration_secs': 60})
 
+  def test_length_fn_and_bucket_boundaries(self):
+    """length_fn and bucket_boundaries are passed through to kwargs."""
+    handler = FakeModelHandlerForBatching(
+        length_fn=len, bucket_boundaries=[16, 32, 64])
+    kwargs = handler.batch_elements_kwargs()
+
+    self.assertIs(kwargs['length_fn'], len)
+    self.assertEqual(kwargs['bucket_boundaries'], [16, 32, 64])
+
+  def test_length_fn_only(self):
+    """length_fn alone is passed through without bucket_boundaries."""
+    handler = FakeModelHandlerForBatching(length_fn=len)
+    kwargs = handler.batch_elements_kwargs()
+
+    self.assertIs(kwargs['length_fn'], len)
+    self.assertNotIn('bucket_boundaries', kwargs)
+
+  def test_bucket_boundaries_without_length_fn(self):
+    """Passing bucket_boundaries without length_fn should fail in BatchElements.
+
+    Note: ModelHandler.__init__ doesn't validate this; the error is raised
+    by BatchElements when batch_elements_kwargs are used."""
+    handler = FakeModelHandlerForBatching(bucket_boundaries=[10, 20])
+    kwargs = handler.batch_elements_kwargs()
+    # The kwargs are stored, but BatchElements will reject them
+    self.assertEqual(kwargs['bucket_boundaries'], [10, 20])
+    self.assertNotIn('length_fn', kwargs)
+
+  def test_batching_kwargs_none_values_omitted(self):
+    """None values for length_fn and bucket_boundaries are not in kwargs."""
+    handler = FakeModelHandlerForBatching(
+        min_batch_size=5, length_fn=None, bucket_boundaries=None)
+    kwargs = handler.batch_elements_kwargs()
+    self.assertNotIn('length_fn', kwargs)
+    self.assertNotIn('bucket_boundaries', kwargs)
+    self.assertEqual(kwargs['min_batch_size'], 5)
+
 
 class SimpleFakeModelHandler(base.ModelHandler[int, int, FakeModel]):
   def load_model(self):

--- a/sdks/python/apache_beam/transforms/util.py
+++ b/sdks/python/apache_beam/transforms/util.py
@@ -20,6 +20,7 @@
 
 # pytype: skip-file
 
+import bisect
 import collections
 import contextlib
 import hashlib
@@ -1208,6 +1209,28 @@ class WithSharedKey(DoFn):
     yield (self.key, element)
 
 
+class WithLengthBucketKey(DoFn):
+  """Keys elements with (worker_uuid, length_bucket) for length-aware
+  stateful batching. Elements of similar length are routed to the same
+  state partition, reducing padding waste."""
+  def __init__(self, length_fn, bucket_boundaries):
+    self.shared_handle = shared.Shared()
+    self._length_fn = length_fn
+    self._bucket_boundaries = bucket_boundaries
+
+  def setup(self):
+    self.key = self.shared_handle.acquire(
+        load_shared_key, "WithLengthBucketKey").key
+
+  def _get_bucket(self, length):
+    return bisect.bisect_left(self._bucket_boundaries, length)
+
+  def process(self, element):
+    length = self._length_fn(element)
+    bucket = self._get_bucket(length)
+    yield ((self.key, bucket), element)
+
+
 @typehints.with_input_types(T)
 @typehints.with_output_types(list[T])
 class BatchElements(PTransform):
@@ -1267,7 +1290,18 @@ class BatchElements(PTransform):
         donwstream operations (mostly for testing)
     record_metrics: (optional) whether or not to record beam metrics on
         distributions of the batch size. Defaults to True.
+    length_fn: (optional) a callable mapping an element to its length (int).
+        When set together with max_batch_duration_secs, enables length-aware
+        bucketed keying on the stateful path so that elements of similar length
+        are routed to the same batch, reducing padding waste.
+    bucket_boundaries: (optional) a sorted list of positive boundary values
+        for length bucketing. Elements with length < boundaries[i] go to
+        bucket i; overflow goes to bucket len(boundaries). Defaults to
+        [16, 32, 64, 128, 256, 512] when length_fn is set. Requires
+        length_fn.
   """
+  _DEFAULT_BUCKET_BOUNDARIES = [16, 32, 64, 128, 256, 512]
+
   def __init__(
       self,
       min_batch_size=1,
@@ -1280,7 +1314,17 @@ class BatchElements(PTransform):
       element_size_fn=lambda x: 1,
       variance=0.25,
       clock=time.time,
-      record_metrics=True):
+      record_metrics=True,
+      length_fn=None,
+      bucket_boundaries=None):
+    if bucket_boundaries is not None and length_fn is None:
+      raise ValueError('bucket_boundaries requires length_fn to be set.')
+    if bucket_boundaries is not None:
+      if (not bucket_boundaries or any(b <= 0 for b in bucket_boundaries) or
+          bucket_boundaries != sorted(bucket_boundaries)):
+        raise ValueError(
+            'bucket_boundaries must be a non-empty sorted list of '
+            'positive values.')
     self._batch_size_estimator = _BatchSizeEstimator(
         min_batch_size=min_batch_size,
         max_batch_size=max_batch_size,
@@ -1294,13 +1338,23 @@ class BatchElements(PTransform):
     self._element_size_fn = element_size_fn
     self._max_batch_dur = max_batch_duration_secs
     self._clock = clock
+    self._length_fn = length_fn
+    if length_fn is not None and bucket_boundaries is None:
+      self._bucket_boundaries = self._DEFAULT_BUCKET_BOUNDARIES
+    else:
+      self._bucket_boundaries = bucket_boundaries
 
   def expand(self, pcoll):
     if getattr(pcoll.pipeline.runner, 'is_streaming', False):
       raise NotImplementedError("Requires stateful processing (BEAM-2687)")
     elif self._max_batch_dur is not None:
       coder = coders.registry.get_coder(pcoll)
-      return pcoll | ParDo(WithSharedKey()) | ParDo(
+      if self._length_fn is not None:
+        keying_dofn = WithLengthBucketKey(
+            self._length_fn, self._bucket_boundaries)
+      else:
+        keying_dofn = WithSharedKey()
+      return pcoll | ParDo(keying_dofn) | ParDo(
           _pardo_stateful_batch_elements(
               coder,
               self._batch_size_estimator,

--- a/sdks/python/apache_beam/transforms/util_test.py
+++ b/sdks/python/apache_beam/transforms/util_test.py
@@ -1030,13 +1030,15 @@ class BatchElementsTest(unittest.TestCase):
     """WithLengthBucketKey assigns correct bucket indices."""
     boundaries = [10, 50, 100]
     dofn = util.WithLengthBucketKey(length_fn=len, bucket_boundaries=boundaries)
-    # bisect_left: length < 10 -> bucket 0, 10 <= length < 50 -> bucket 1, etc.
+    # bisect_right: boundaries are lower-inclusive.
+    # e.g., for boundaries [10, 50, 100], buckets are:
+    #   (-inf, 10), [10, 50), [50, 100), [100, inf)
     self.assertEqual(dofn._get_bucket(5), 0)
-    self.assertEqual(dofn._get_bucket(10), 0)
+    self.assertEqual(dofn._get_bucket(10), 1)
     self.assertEqual(dofn._get_bucket(11), 1)
-    self.assertEqual(dofn._get_bucket(50), 1)
+    self.assertEqual(dofn._get_bucket(50), 2)
     self.assertEqual(dofn._get_bucket(51), 2)
-    self.assertEqual(dofn._get_bucket(100), 2)
+    self.assertEqual(dofn._get_bucket(100), 3)
     self.assertEqual(dofn._get_bucket(101), 3)
     self.assertEqual(dofn._get_bucket(999), 3)
 


### PR DESCRIPTION
[Stateful] Implement length-aware keying to minimize padding in BatchElements (Part 2/3)

Rationale

Issue: #37531 (Stateful Core - Part 2)
Part 1: https://github.com/apache/beam/pull/37532

This PR adds length-aware keying to BatchElements to improve batching efficiency for variable-length inputs (for example, NLP inference workloads).

Today, stateful BatchElements uses one shared key (WithSharedKey). That causes short and long sequences to be mixed in the same batch, so padding is dictated by the longest item and compute is wasted. This PR addresses that by routing elements into length buckets before stateful batching.

What changed

1. New DoFn: WithLengthBucketKey

* Implemented in apache_beam/transforms/util.py
* Uses bisect-based bucket lookup
* Routes elements into length buckets (for example, 0-16, 16-32, etc.) so similarly sized elements are batched together
* Uses a composite key: (worker_uuid, bucket_index)

2. API updates

* BatchElements now accepts length_fn and bucket_boundaries
* ModelHandler.**init** now accepts length_fn and bucket_boundaries
* Default boundaries: [16, 32, 64, 128, 256, 512]

3. Stateful-path integration

* Length-aware routing is enabled automatically on the stateful path when max_batch_duration_secs is set and length_fn is provided

Testing and results

Added test_padding_efficiency_bimodal in util_test.py to represent a bimodal workload:

* 500 short elements (length 5-30)
* 500 long elements (length 200-512)

Observed result:

* Unbucketed baseline padding efficiency: about 68%
* Bucketed padding efficiency (this PR): about 77%
* Improvement: about +9 percentage points

Interpretation:

* Unbucketed path mixes short and long elements, increasing padding waste
* Bucketed path separates short/long cohorts, reducing wasted compute and memory
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 
