### PR TITLE
[Iceberg] Add dependencies for AWS and Azure

### DIFF
--- a/sdks/java/io/iceberg/build.gradle
+++ b/sdks/java/io/iceberg/build.gradle
@@ -63,6 +63,10 @@ dependencies {
     permitUnusedDeclared "org.immutables:value:2.8.8"
     implementation library.java.vendored_calcite_1_40_0
     runtimeOnly "org.apache.iceberg:iceberg-gcp:$iceberg_version"
+    runtimeOnly "org.apache.iceberg:iceberg-aws:$iceberg_version"
+    runtimeOnly "org.apache.iceberg:iceberg-aws-bundle:$iceberg_version"
+    runtimeOnly "org.apache.iceberg:iceberg-azure:$iceberg_version"
+    runtimeOnly "org.apache.iceberg:iceberg-azure-bundle:$iceberg_version"
     runtimeOnly library.java.bigdataoss_gcs_connector
     runtimeOnly library.java.hadoop_client
 


### PR DESCRIPTION
Enables AWS S3FileIO + Glue Catalog, and equivalent for Azure