### PR TITLE
Fix spelling mistakes in Go comments

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/harness/datamgr.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/datamgr.go
@@ -433,7 +433,7 @@ func (c *DataChannel) read(ctx context.Context) {
 			// for all transforms in an instruction before the instruction even begun. However, we can't
 			// know this until we received the Control instruction which knows how many transforms for which
 			// we need to receive data. So we check the cache directly every so often and evict closed
-			// readers. We will never recieve data for these instructions again.
+			// readers. We will never receive data for these instructions again.
 			for instID, r := range cache {
 				if r.Closed() {
 					delete(cache, instID)

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/teststream.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/teststream.go
@@ -299,7 +299,7 @@ func (tsi *testStreamImpl) initHandler(id string) {
 	}
 }
 
-// TagsToPCollections recieves the map of local output tags to global pcollection ids.
+// TagsToPCollections receives the map of local output tags to global pcollection ids.
 func (tsi *testStreamImpl) TagsToPCollections(tagToPcol map[string]string) {
 	tsi.em.testStreamHandler.TagsToPCollections(tagToPcol)
 }


### PR DESCRIPTION
This PR fixes minor spelling mistakes in Go comments.

Changes:
- recieve → receive
- recieves → receives

No functional or behavioral changes.
This is my first contribution to Apache Beam.
Thank you for reviewing!