### PR TITLE
Fix type checking failure with Python 3.10+ union pipe syntax (int | None)

### DIFF
--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -1462,15 +1462,10 @@ def normalize(x, none_as_type=False):
   # Convert bare builtin types to correct type hints directly
   elif x in _KNOWN_PRIMITIVE_TYPES:
     return _KNOWN_PRIMITIVE_TYPES[x]
-  elif isinstance(x, types.UnionType):
-    beam_type = native_type_compatibility.convert_to_beam_type(x)
-    if beam_type != x:
-      return beam_type
-    else:
-      return Any
-  elif getattr(x, '__module__',
-               None) in ('typing', 'collections', 'collections.abc') or getattr(
-                   x, '__origin__', None) in _KNOWN_PRIMITIVE_TYPES:
+  elif isinstance(x, types.UnionType) or getattr(
+      x, '__module__',
+      None) in ('typing', 'collections', 'collections.abc') or getattr(
+          x, '__origin__', None) in _KNOWN_PRIMITIVE_TYPES:
     beam_type = native_type_compatibility.convert_to_beam_type(x)
     if beam_type != x:
       # We were able to do the conversion.

--- a/sdks/python/apache_beam/typehints/typehints_test.py
+++ b/sdks/python/apache_beam/typehints/typehints_test.py
@@ -1597,9 +1597,6 @@ class DecoratorHelpers(TypeHintTestCase):
     self.assertFalse(is_consistent_with(str, NonBuiltInGeneric[str]))
 
   def test_hint_helper_pipe_union(self):
-    # GH issue: https://github.com/apache/beam/issues/36592
-    # Python 3.10+ pipe operator union types (types.UnionType) should work
-    # in is_consistent_with just like typing.Union.
     pipe_union = int | None  # pylint: disable=unsupported-binary-operation
     typing_union = Union[int, None]
     self.assertTrue(is_consistent_with(int, pipe_union))
@@ -1954,8 +1951,6 @@ class TestPTransformAnnotations(unittest.TestCase):
         native_type_compatibility.convert_to_beam_type(type_b))
 
   def test_normalize_pipe_union(self):
-    # GH issue: https://github.com/apache/beam/issues/36592
-    # normalize() should convert types.UnionType to Beam's UnionConstraint.
     pipe_union = int | None  # pylint: disable=unsupported-binary-operation
     normalized = typehints.normalize(pipe_union)
     self.assertIsInstance(normalized, typehints.UnionConstraint)


### PR DESCRIPTION
## Summary

Fixes #36592

Using Python 3.10+ pipe operator union types (e.g. `int | None`) in function type hints causes `TypeError: issubclass() arg 1 must be a class` when Beam performs type checking.

```
# This was crashing:
def func(x: int, y: int | None = None):
    return x

with beam.Pipeline() as p:
    (p | beam.Create([1]) | beam.Map(func))
# TypeError: issubclass() arg 1 must be a class

```
## Root Cause
The normalize() function in typehints.py did not handle types.UnionType (Python 3.10+ pipe union syntax). On Python 3.10–3.13, int | None creates a types.UnionType whose __module__ is not 'typing' and has no __origin__, so it passed through normalize() unchanged. This caused is_consistent_with() to fall through to issubclass() with a non-class argument.
## Fix
Added a types.UnionType check in normalize() that routes pipe union types through convert_to_beam_type(), which already handles the conversion to Beam's UnionConstraint.
## Tests Added
  `test_hint_helper_pipe_union `— verifies `is_consistent_with()` works with pipe union types
`test_normalize_pipe_union` — verifies `normalize()` converts `types.UnionType` to `UnionConstraint`

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
