### PR TITLE
Adds triggerring configuration to KafkaIO eos.

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaExactlyOnceSink.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaExactlyOnceSink.java
@@ -162,8 +162,8 @@ class KafkaExactlyOnceSink<K, V>
   @Override
   public PCollection<Void> expand(PCollection<ProducerRecord<K, V>> input) {
     String topic = Preconditions.checkStateNotNull(spec.getTopic());
-    int numElements = spec.getNumElements();
-    Duration timeout = spec.getTimeout();
+    int numElements = spec.getEosTriggerNumElements();
+    Duration timeout = spec.getEosTriggerTimeout();
     int numShards = spec.getNumShards();
     if (numShards <= 0) {
       try (Consumer<?, ?> consumer = openConsumer(spec)) {

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -648,8 +648,8 @@ public class KafkaIO {
     return new AutoValue_KafkaIO_WriteRecords.Builder<K, V>()
         .setProducerConfig(WriteRecords.DEFAULT_PRODUCER_PROPERTIES)
         .setEOS(false)
-        .setNumElements(100)
-        .setTimeout(Duration.standardSeconds(1))
+        .setEosTriggerNumElements(100)
+        .setEosTriggerTimeout(Duration.standardSeconds(1))
         .setNumShards(0)
         .setConsumerFactoryFn(KafkaIOUtils.KAFKA_CONSUMER_FACTORY_FN)
         .setBadRecordRouter(BadRecordRouter.THROWING_ROUTER)
@@ -3187,9 +3187,9 @@ public class KafkaIO {
     @Pure
     public abstract boolean isEOS();
 
-    public abstract int getNumElements();
+    public abstract int getEosTriggerNumElements();
 
-    public abstract Duration getTimeout();
+    public abstract Duration getEosTriggerTimeout();
 
     @Pure
     public abstract @Nullable String getSinkGroupId();
@@ -3227,9 +3227,9 @@ public class KafkaIO {
 
       abstract Builder<K, V> setEOS(boolean eosEnabled);
 
-      abstract Builder<K, V> setNumElements(int numElements);
+      abstract Builder<K, V> setEosTriggerNumElements(int numElements);
 
-      abstract Builder<K, V> setTimeout(Duration timeout);
+      abstract Builder<K, V> setEosTriggerTimeout(Duration timeout);
 
       abstract Builder<K, V> setSinkGroupId(String sinkGroupId);
 
@@ -3381,7 +3381,7 @@ public class KafkaIO {
     public WriteRecords<K, V> withEOSTriggerConfig(int numElements, Duration timeout) {
       checkArgument(numElements >= 1, "numElements should be >= 1");
       checkArgument(timeout != null, "timeout is required for exactly-once sink");
-      return toBuilder().setNumElements(numElements).setTimeout(timeout).build();
+      return toBuilder().setEosTriggerNumElements(numElements).setEosTriggerTimeout(timeout).build();
     }
 
     /**

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -3381,7 +3381,10 @@ public class KafkaIO {
     public WriteRecords<K, V> withEOSTriggerConfig(int numElements, Duration timeout) {
       checkArgument(numElements >= 1, "numElements should be >= 1");
       checkArgument(timeout != null, "timeout is required for exactly-once sink");
-      return toBuilder().setEosTriggerNumElements(numElements).setEosTriggerTimeout(timeout).build();
+      return toBuilder()
+          .setEosTriggerNumElements(numElements)
+          .setEosTriggerTimeout(timeout)
+          .build();
     }
 
     /**

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -648,6 +648,8 @@ public class KafkaIO {
     return new AutoValue_KafkaIO_WriteRecords.Builder<K, V>()
         .setProducerConfig(WriteRecords.DEFAULT_PRODUCER_PROPERTIES)
         .setEOS(false)
+        .setNumElements(100)
+        .setTimeout(Duration.standardSeconds(1))
         .setNumShards(0)
         .setConsumerFactoryFn(KafkaIOUtils.KAFKA_CONSUMER_FACTORY_FN)
         .setBadRecordRouter(BadRecordRouter.THROWING_ROUTER)
@@ -3185,6 +3187,10 @@ public class KafkaIO {
     @Pure
     public abstract boolean isEOS();
 
+    public abstract int getNumElements();
+
+    public abstract Duration getTimeout();
+
     @Pure
     public abstract @Nullable String getSinkGroupId();
 
@@ -3220,6 +3226,10 @@ public class KafkaIO {
           KafkaPublishTimestampFunction<ProducerRecord<K, V>> timestampFunction);
 
       abstract Builder<K, V> setEOS(boolean eosEnabled);
+
+      abstract Builder<K, V> setNumElements(int numElements);
+
+      abstract Builder<K, V> setTimeout(Duration timeout);
 
       abstract Builder<K, V> setSinkGroupId(String sinkGroupId);
 
@@ -3366,6 +3376,12 @@ public class KafkaIO {
       checkArgument(numShards >= 1, "numShards should be >= 1");
       checkArgument(sinkGroupId != null, "sinkGroupId is required for exactly-once sink");
       return toBuilder().setEOS(true).setNumShards(numShards).setSinkGroupId(sinkGroupId).build();
+    }
+
+    public WriteRecords<K, V> withEOSTriggerConfig(int numElements, Duration timeout) {
+      checkArgument(numElements >= 1, "numElements should be >= 1");
+      checkArgument(timeout != null, "timeout is required for exactly-once sink");
+      return toBuilder().setNumElements(numElements).setTimeout(timeout).build();
     }
 
     /**
@@ -3651,6 +3667,19 @@ public class KafkaIO {
      */
     public Write<K, V> withEOS(int numShards, String sinkGroupId) {
       return withWriteRecordsTransform(getWriteRecordsTransform().withEOS(numShards, sinkGroupId));
+    }
+
+    /**
+     * Set the frequency and numElements threshold at which messages are triggered.
+     *
+     * <p>This is only applicable when the write method is set to EOS.
+     *
+     * <p>Every timeout duration, or numElements (repeated, after first condition is met) collection
+     * of elements written.
+     */
+    public Write<K, V> withEOSTriggerConfig(int numElements, Duration timeout) {
+      return withWriteRecordsTransform(
+          getWriteRecordsTransform().withEOSTriggerConfig(numElements, timeout));
     }
 
     /**

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -648,8 +648,8 @@ public class KafkaIO {
     return new AutoValue_KafkaIO_WriteRecords.Builder<K, V>()
         .setProducerConfig(WriteRecords.DEFAULT_PRODUCER_PROPERTIES)
         .setEOS(false)
-        .setEosTriggerNumElements(100)
-        .setEosTriggerTimeout(Duration.standardSeconds(1))
+        .setEosTriggerNumElements(1) // keep default numElements
+        .setEosTriggerTimeout(null) // keep default trigger (timeout)
         .setNumShards(0)
         .setConsumerFactoryFn(KafkaIOUtils.KAFKA_CONSUMER_FACTORY_FN)
         .setBadRecordRouter(BadRecordRouter.THROWING_ROUTER)
@@ -3189,7 +3189,7 @@ public class KafkaIO {
 
     public abstract int getEosTriggerNumElements();
 
-    public abstract Duration getEosTriggerTimeout();
+    public abstract @Nullable Duration getEosTriggerTimeout();
 
     @Pure
     public abstract @Nullable String getSinkGroupId();
@@ -3229,7 +3229,7 @@ public class KafkaIO {
 
       abstract Builder<K, V> setEosTriggerNumElements(int numElements);
 
-      abstract Builder<K, V> setEosTriggerTimeout(Duration timeout);
+      abstract Builder<K, V> setEosTriggerTimeout(@Nullable Duration timeout);
 
       abstract Builder<K, V> setSinkGroupId(String sinkGroupId);
 

--- a/sdks/java/io/kafka/upgrade/src/main/java/org/apache/beam/sdk/io/kafka/upgrade/KafkaIOTranslation.java
+++ b/sdks/java/io/kafka/upgrade/src/main/java/org/apache/beam/sdk/io/kafka/upgrade/KafkaIOTranslation.java
@@ -480,7 +480,7 @@ public class KafkaIOTranslation {
             .addNullableByteArrayField("publish_timestamp_fn")
             .addBooleanField("eos")
             .addInt32Field("eos_trigger_num_elements")
-            .addInt64Field("eos_trigger_timeout_ms")
+            .addNullableInt64Field("eos_trigger_timeout_ms")
             .addInt32Field("num_shards")
             .addNullableStringField("sink_group_id")
             .addNullableByteArrayField("consumer_factory_fn")
@@ -549,8 +549,10 @@ public class KafkaIOTranslation {
       }
 
       fieldValues.put("eos", writeRecordsTransform.isEOS());
-      fieldValues.put(
-          "eos_trigger_timeout_ms", writeRecordsTransform.getEosTriggerTimeout().getMillis());
+      org.joda.time.Duration eosTriggerTimeout = writeRecordsTransform.getEosTriggerTimeout();
+      if (eosTriggerTimeout != null) {
+        fieldValues.put("eos_trigger_timeout_ms", eosTriggerTimeout.getMillis());
+      }
       fieldValues.put("eos_trigger_num_elements", writeRecordsTransform.getEosTriggerNumElements());
       fieldValues.put("num_shards", writeRecordsTransform.getNumShards());
 

--- a/sdks/java/io/kafka/upgrade/src/main/java/org/apache/beam/sdk/io/kafka/upgrade/KafkaIOTranslation.java
+++ b/sdks/java/io/kafka/upgrade/src/main/java/org/apache/beam/sdk/io/kafka/upgrade/KafkaIOTranslation.java
@@ -479,6 +479,8 @@ public class KafkaIOTranslation {
             .addNullableByteArrayField("producer_factory_fn")
             .addNullableByteArrayField("publish_timestamp_fn")
             .addBooleanField("eos")
+            .addInt32Field("eos_trigger_num_elements")
+            .addInt64Field("eos_trigger_timeout_ms")
             .addInt32Field("num_shards")
             .addNullableStringField("sink_group_id")
             .addNullableByteArrayField("consumer_factory_fn")
@@ -547,6 +549,9 @@ public class KafkaIOTranslation {
       }
 
       fieldValues.put("eos", writeRecordsTransform.isEOS());
+      fieldValues.put(
+          "eos_trigger_timeout_ms", writeRecordsTransform.getEosTriggerTimeout().getMillis());
+      fieldValues.put("eos_trigger_num_elements", writeRecordsTransform.getEosTriggerNumElements());
       fieldValues.put("num_shards", writeRecordsTransform.getNumShards());
 
       if (writeRecordsTransform.getSinkGroupId() != null) {

--- a/sdks/java/io/kafka/upgrade/src/test/java/org/apache/beam/sdk/io/kafka/upgrade/KafkaIOTranslationTest.java
+++ b/sdks/java/io/kafka/upgrade/src/test/java/org/apache/beam/sdk/io/kafka/upgrade/KafkaIOTranslationTest.java
@@ -94,6 +94,8 @@ public class KafkaIOTranslationTest {
     WRITE_TRANSFORM_SCHEMA_MAPPING.put("getValueSerializer", "value_serializer");
     WRITE_TRANSFORM_SCHEMA_MAPPING.put("getPublishTimestampFunction", "publish_timestamp_fn");
     WRITE_TRANSFORM_SCHEMA_MAPPING.put("isEOS", "eos");
+    WRITE_TRANSFORM_SCHEMA_MAPPING.put("getEosTriggerTimeout", "eos_trigger_timeout_ms");
+    WRITE_TRANSFORM_SCHEMA_MAPPING.put("getEosTriggerNumElements", "eos_trigger_num_elements");
     WRITE_TRANSFORM_SCHEMA_MAPPING.put("getSinkGroupId", "sink_group_id");
     WRITE_TRANSFORM_SCHEMA_MAPPING.put("getNumShards", "num_shards");
     WRITE_TRANSFORM_SCHEMA_MAPPING.put("getConsumerFactoryFn", "consumer_factory_fn");


### PR DESCRIPTION
Adds triggerring configuration to KafkaIO eos sink. EOS sink is slow when sending transactions with single element, to speed up, it's needed to trigger together multiple messages.

Scope of the change:
- adds configuration (numElements, timeout)
- adds window definition

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
