### PR TITLE
[Go SDK] Rewrite dot runner to generate DOT from portable pipeline proto

### DIFF
--- a/sdks/go/pkg/beam/core/util/dot/dot.go
+++ b/sdks/go/pkg/beam/core/util/dot/dot.go
@@ -14,6 +14,9 @@
 // limitations under the License.
 
 // Package dot produces DOT graphs from Beam graph representations.
+//
+// Deprecated:This package is no longer used by the Beam Go SDK.
+// It is slated for removal in a future Beam release.
 package dot
 
 import (

--- a/sdks/go/pkg/beam/runners/dot/dot.go
+++ b/sdks/go/pkg/beam/runners/dot/dot.go
@@ -108,11 +108,6 @@ func Execute(ctx context.Context, p *beam.Pipeline) (beam.PipelineResult, error)
 					continue // Defensively skip if the consumer transform is missing
 				}
 
-				// Skip composite consumers
-				if len(consumer.GetSubtransforms()) != 0 {
-					continue
-				}
-
 				to := consumer.GetUniqueName()
 				fmt.Fprintf(&buf, "\"%s\" -> \"%s\";\n", from, to)
 			}

--- a/sdks/go/pkg/beam/runners/dot/dot_test.go
+++ b/sdks/go/pkg/beam/runners/dot/dot_test.go
@@ -1,0 +1,53 @@
+package dot
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/apache/beam/sdks/v2/go/pkg/beam"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/testing/passert"
+)
+
+func TestDotRunner_GeneratesDeterministicOutput(t *testing.T) {
+	ctx := context.Background()
+
+	// Create temporary DOT file
+	tmpFile, err := os.CreateTemp("", "dot_test_*.dot")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	// Set flag manually
+	*dotFile = tmpFile.Name()
+
+	// Build simple pipeline
+	p, s := beam.NewPipelineWithRoot()
+
+	col := beam.Create(s, "a", "b", "c")
+	passert.Count(s, col, "", 3)
+
+	// Run with dot runner
+	_, err = Execute(ctx, p)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	// Read generated file
+	data, err := os.ReadFile(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("failed to read dot file: %v", err)
+	}
+
+	content := string(data)
+
+	if !strings.HasPrefix(content, "digraph G {") {
+		t.Fatalf("dot output missing header")
+	}
+
+	if !strings.Contains(content, "->") {
+		t.Fatalf("dot output contains no edges")
+	}
+}

--- a/sdks/go/pkg/beam/runners/dot/dot_test.go
+++ b/sdks/go/pkg/beam/runners/dot/dot_test.go
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package dot
 
 import (


### PR DESCRIPTION
Fixes #27508

This change rewrites the Go SDK dot runner to generate the DOT graph from the portable pipeline proto representation instead of relying on Go SDK internal graph structures.

By basing DOT generation on the portable pipeline model:

• Cross-language pipelines can now be rendered correctly.
• The implementation aligns with the portable runner architecture.
• It enables future reuse in Prism Runner and other portable tooling.

The current implementation focuses on rendering leaf transforms (composites are skipped explicitly), keeping the traversal simple while leaving room for future refinement of composite expansion strategies.