### PR TITLE
[python][io] Add native GenerateSequence bounded PTransform (#18088)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,7 @@
 
 ## New Features / Improvements
 
+* Added native Python GenerateSequence transform for generating bounded sequences of integers (Python) ([#18088](https://github.com/apache/beam/issues/18088)).
 * Added support for large pipeline options via a file (Python) ([#37370](https://github.com/apache/beam/issues/37370)).
 
 ## Breaking Changes

--- a/sdks/python/apache_beam/io/generate_sequence.py
+++ b/sdks/python/apache_beam/io/generate_sequence.py
@@ -1,0 +1,198 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""A native Python implementation of GenerateSequence transform.
+
+This module provides a PTransform that generates a bounded sequence of
+integers, equivalent to Java SDK's GenerateSequence/CountingSource.
+
+For the external (Flink-only) version that uses Java expansion service,
+see apache_beam.io.external.generate_sequence.
+
+Example usage::
+
+    import apache_beam as beam
+    from apache_beam.io.generate_sequence import GenerateSequence
+
+    with beam.Pipeline() as p:
+        numbers = p | GenerateSequence(start=0, stop=100)
+
+"""
+
+import apache_beam as beam
+from apache_beam import coders
+from apache_beam.io import iobase
+from apache_beam.io.range_trackers import OffsetRangeTracker
+from apache_beam.transforms.display import DisplayDataItem
+
+__all__ = ['GenerateSequence']
+
+
+class GenerateSequence(beam.PTransform):
+  """A PTransform that generates a bounded sequence of integers.
+
+  This transform produces integers from ``start`` (inclusive) to ``stop``
+  (exclusive). It is the native Python equivalent of Java SDK's
+  GenerateSequence transform.
+
+  Example usage::
+
+      # Generate integers [0, 100)
+      p | GenerateSequence(start=0, stop=100)
+
+      # Generate integers [10, 20)
+      p | GenerateSequence(start=10, stop=20)
+  """
+
+  def __init__(self, start, stop=None):
+    """Initializes GenerateSequence.
+
+    Args:
+      start: The first integer to generate (inclusive). Must be >= 0.
+      stop: The upper bound (exclusive). If None, unbounded mode will be
+          used (not yet implemented).
+
+    Raises:
+      ValueError: If start < 0 or stop < start.
+    """
+    super().__init__()
+    if start < 0:
+      raise ValueError('start must be >= 0, got %s' % start)
+    if stop is not None and stop < start:
+      raise ValueError(
+          'stop (%s) must be >= start (%s)' % (stop, start))
+    self._start = start
+    self._stop = stop
+
+  def expand(self, pbegin):
+    if self._stop is not None:
+      return pbegin | iobase.Read(_BoundedCountingSource(self._start,
+                                                         self._stop))
+    else:
+      raise NotImplementedError(
+          'Unbounded GenerateSequence is not yet implemented. '
+          'Please specify a stop value for bounded mode.')
+
+  def display_data(self):
+    return {
+        'start': DisplayDataItem(self._start, label='Start'),
+        'stop': DisplayDataItem(self._stop, label='Stop'),
+    }
+
+
+class _BoundedCountingSource(iobase.BoundedSource):
+  """A BoundedSource that produces integers in the range [start, stop).
+
+  This is an internal class that implements the BoundedSource interface
+  for generating a sequence of integers. Users should use the
+  GenerateSequence PTransform instead of using this class directly.
+  """
+
+  def __init__(self, start, stop):
+    """Initializes _BoundedCountingSource.
+
+    Args:
+      start: The first integer to generate (inclusive).
+      stop: The upper bound (exclusive).
+    """
+    self._start = start
+    self._stop = stop
+
+  def estimate_size(self):
+    """Estimates the size of this source in bytes.
+
+    Each integer is assumed to be 8 bytes, matching Java's
+    CountingSource.getBytesPerOffset().
+
+    Returns:
+      The estimated size in bytes.
+    """
+    return (self._stop - self._start) * 8
+
+  def split(self, desired_bundle_size, start_position=None, stop_position=None):
+    """Splits the source into bundles of approximately the desired size.
+
+    Args:
+      desired_bundle_size: The desired size of each bundle in bytes.
+      start_position: Optional starting position for splitting.
+      stop_position: Optional stopping position for splitting.
+
+    Yields:
+      SourceBundle objects representing the splits.
+    """
+    start = start_position if start_position is not None else self._start
+    stop = stop_position if stop_position is not None else self._stop
+
+    # Convert desired bytes to desired number of elements
+    # (8 bytes per integer, same as Java's getBytesPerOffset())
+    bundle_size_in_elements = max(1, desired_bundle_size // 8)
+
+    bundle_start = start
+    while bundle_start < stop:
+      bundle_stop = min(bundle_start + bundle_size_in_elements, stop)
+      yield iobase.SourceBundle(
+          weight=(bundle_stop - bundle_start) * 8,
+          source=_BoundedCountingSource(bundle_start, bundle_stop),
+          start_position=bundle_start,
+          stop_position=bundle_stop,
+      )
+      bundle_start = bundle_stop
+
+  def get_range_tracker(self, start_position, stop_position):
+    """Returns an OffsetRangeTracker for the given position range.
+
+    Args:
+      start_position: The starting position (inclusive). If None, uses
+          this source's start.
+      stop_position: The stopping position (exclusive). If None, uses
+          this source's stop.
+
+    Returns:
+      An OffsetRangeTracker for the specified range.
+    """
+    start = start_position if start_position is not None else self._start
+    stop = stop_position if stop_position is not None else self._stop
+    return OffsetRangeTracker(start, stop)
+
+  def read(self, range_tracker):
+    """Reads integers from this source.
+
+    This generator yields integers from the range tracker's start position
+    up to (but not including) the stop position. It respects dynamic work
+    rebalancing by calling try_claim() for each position.
+
+    Args:
+      range_tracker: The RangeTracker for the range to read.
+
+    Yields:
+      Integers in the specified range.
+    """
+    for i in range(range_tracker.start_position(),
+                   range_tracker.stop_position()):
+      if not range_tracker.try_claim(i):
+        return
+      yield i
+
+  def default_output_coder(self):
+    """Returns the default coder for the integers produced by this source."""
+    return coders.VarIntCoder()
+
+  def display_data(self):
+    return {
+        'start': DisplayDataItem(self._start, label='Start'),
+        'stop': DisplayDataItem(self._stop, label='Stop'),
+    }

--- a/sdks/python/apache_beam/io/generate_sequence.py
+++ b/sdks/python/apache_beam/io/generate_sequence.py
@@ -57,7 +57,6 @@ class GenerateSequence(beam.PTransform):
       # Generate integers [10, 20)
       p | GenerateSequence(start=10, stop=20)
   """
-
   def __init__(self, start, stop=None):
     """Initializes GenerateSequence.
 
@@ -73,15 +72,14 @@ class GenerateSequence(beam.PTransform):
     if start < 0:
       raise ValueError('start must be >= 0, got %s' % start)
     if stop is not None and stop < start:
-      raise ValueError(
-          'stop (%s) must be >= start (%s)' % (stop, start))
+      raise ValueError('stop (%s) must be >= start (%s)' % (stop, start))
     self._start = start
     self._stop = stop
 
   def expand(self, pbegin):
     if self._stop is not None:
-      return pbegin | iobase.Read(_BoundedCountingSource(self._start,
-                                                         self._stop))
+      return pbegin | iobase.Read(
+          _BoundedCountingSource(self._start, self._stop))
     else:
       raise NotImplementedError(
           'Unbounded GenerateSequence is not yet implemented. '
@@ -101,7 +99,6 @@ class _BoundedCountingSource(iobase.BoundedSource):
   for generating a sequence of integers. Users should use the
   GenerateSequence PTransform instead of using this class directly.
   """
-
   def __init__(self, start, stop):
     """Initializes _BoundedCountingSource.
 

--- a/sdks/python/apache_beam/io/generate_sequence_test.py
+++ b/sdks/python/apache_beam/io/generate_sequence_test.py
@@ -1,0 +1,168 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for GenerateSequence transform."""
+
+import unittest
+
+import apache_beam as beam
+from apache_beam.io.generate_sequence import GenerateSequence
+from apache_beam.io.generate_sequence import _BoundedCountingSource
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.testing.util import assert_that
+from apache_beam.testing.util import equal_to
+
+
+class GenerateSequenceTest(unittest.TestCase):
+
+  def test_basic_bounded(self):
+    with TestPipeline() as p:
+      result = p | GenerateSequence(start=0, stop=5)
+      assert_that(result, equal_to([0, 1, 2, 3, 4]))
+
+  def test_start_not_zero(self):
+    with TestPipeline() as p:
+      result = p | GenerateSequence(start=3, stop=7)
+      assert_that(result, equal_to([3, 4, 5, 6]))
+
+  def test_empty_range(self):
+    with TestPipeline() as p:
+      result = p | GenerateSequence(start=5, stop=5)
+      assert_that(result, equal_to([]))
+
+  def test_single_element(self):
+    with TestPipeline() as p:
+      result = p | GenerateSequence(start=42, stop=43)
+      assert_that(result, equal_to([42]))
+
+  def test_invalid_negative_start(self):
+    with self.assertRaises(ValueError):
+      GenerateSequence(start=-1, stop=10)
+
+  def test_invalid_stop_less_than_start(self):
+    with self.assertRaises(ValueError):
+      GenerateSequence(start=10, stop=5)
+
+  def test_large_sequence(self):
+    with TestPipeline() as p:
+      result = p | GenerateSequence(start=0, stop=1000)
+      assert_that(result, equal_to(list(range(1000))))
+
+  def test_unbounded_not_implemented(self):
+    with self.assertRaises(NotImplementedError):
+      with TestPipeline() as p:
+        _ = p | GenerateSequence(start=0)
+
+
+class BoundedCountingSourceTest(unittest.TestCase):
+
+  def test_estimate_size(self):
+    source = _BoundedCountingSource(0, 100)
+    # 100 elements * 8 bytes per element = 800 bytes
+    self.assertEqual(source.estimate_size(), 800)
+
+  def test_estimate_size_empty(self):
+    source = _BoundedCountingSource(5, 5)
+    self.assertEqual(source.estimate_size(), 0)
+
+  def test_split_creates_multiple_bundles(self):
+    source = _BoundedCountingSource(0, 100)
+    # 80 bytes = 10 elements per bundle
+    bundles = list(source.split(desired_bundle_size=80))
+    self.assertEqual(len(bundles), 10)
+
+    # Verify no elements are missed or duplicated
+    all_starts = [b.start_position for b in bundles]
+    all_stops = [b.stop_position for b in bundles]
+    self.assertEqual(all_starts[0], 0)
+    self.assertEqual(all_stops[-1], 100)
+    for i in range(len(bundles) - 1):
+      self.assertEqual(all_stops[i], all_starts[i + 1])
+
+  def test_split_single_bundle(self):
+    source = _BoundedCountingSource(0, 10)
+    # Large bundle size means single bundle
+    bundles = list(source.split(desired_bundle_size=8000))
+    self.assertEqual(len(bundles), 1)
+    self.assertEqual(bundles[0].start_position, 0)
+    self.assertEqual(bundles[0].stop_position, 10)
+
+  def test_split_with_custom_range(self):
+    source = _BoundedCountingSource(0, 100)
+    bundles = list(source.split(
+        desired_bundle_size=80, start_position=20, stop_position=50))
+    # Should only cover range [20, 50)
+    self.assertEqual(bundles[0].start_position, 20)
+    self.assertEqual(bundles[-1].stop_position, 50)
+    # Total elements should be 30
+    total_elements = sum(b.stop_position - b.start_position for b in bundles)
+    self.assertEqual(total_elements, 30)
+
+  def test_get_range_tracker(self):
+    source = _BoundedCountingSource(0, 100)
+    tracker = source.get_range_tracker(10, 50)
+    self.assertEqual(tracker.start_position(), 10)
+    self.assertEqual(tracker.stop_position(), 50)
+
+  def test_get_range_tracker_default_positions(self):
+    source = _BoundedCountingSource(5, 15)
+    tracker = source.get_range_tracker(None, None)
+    self.assertEqual(tracker.start_position(), 5)
+    self.assertEqual(tracker.stop_position(), 15)
+
+  def test_read_with_range_tracker(self):
+    source = _BoundedCountingSource(0, 10)
+    tracker = source.get_range_tracker(0, 10)
+    result = list(source.read(tracker))
+    self.assertEqual(result, list(range(10)))
+
+  def test_read_subset_range(self):
+    source = _BoundedCountingSource(0, 100)
+    tracker = source.get_range_tracker(25, 30)
+    result = list(source.read(tracker))
+    self.assertEqual(result, [25, 26, 27, 28, 29])
+
+  def test_default_output_coder(self):
+    source = _BoundedCountingSource(0, 10)
+    coder = source.default_output_coder()
+    # Should be able to encode/decode integers
+    encoded = coder.encode(42)
+    decoded = coder.decode(encoded)
+    self.assertEqual(decoded, 42)
+
+  def test_display_data(self):
+    source = _BoundedCountingSource(10, 100)
+    display_data = source.display_data()
+    self.assertIn('start', display_data)
+    self.assertIn('stop', display_data)
+    self.assertEqual(display_data['start'].value, 10)
+    self.assertEqual(display_data['stop'].value, 100)
+
+
+class GenerateSequenceDisplayDataTest(unittest.TestCase):
+
+  def test_display_data(self):
+    transform = GenerateSequence(start=5, stop=50)
+    display_data = transform.display_data()
+    self.assertIn('start', display_data)
+    self.assertIn('stop', display_data)
+    self.assertEqual(display_data['start'].value, 5)
+    self.assertEqual(display_data['stop'].value, 50)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/sdks/python/apache_beam/io/generate_sequence_test.py
+++ b/sdks/python/apache_beam/io/generate_sequence_test.py
@@ -19,7 +19,6 @@
 
 import unittest
 
-import apache_beam as beam
 from apache_beam.io.generate_sequence import GenerateSequence
 from apache_beam.io.generate_sequence import _BoundedCountingSource
 from apache_beam.testing.test_pipeline import TestPipeline


### PR DESCRIPTION
## Description

This PR adds a native Python `GenerateSequence` bounded PTransform to the
Python SDK, equivalent to the Java SDK's `GenerateSequence` (formerly known
as `CountingInput`).

Addresses #18088

### Motivation

The Python SDK previously had no native equivalent of Java's `GenerateSequence`
/ `CountingInput` transform. The only existing Python implementation
(`apache_beam/io/external/generate_sequence.py`) requires a Java expansion
service and only works with the Flink runner, making it inaccessible to most
Python users.

This PR introduces a pure Python implementation that works on **all runners**
(DirectRunner, Dataflow, etc.) without any Java dependency.

### Changes

- Added `sdks/python/apache_beam/io/generate_sequence.py`:
  - `GenerateSequence` — a `PTransform` that produces a bounded sequence
    of integers from `start` (inclusive) to `stop` (exclusive)
  - `_BoundedCountingSource` — a `BoundedSource` backed by
    `OffsetRangeTracker`, supporting efficient splitting and dynamic
    work rebalancing across workers
- Added `sdks/python/apache_beam/io/generate_sequence_test.py` with unit
  tests covering basic usage, edge cases, splitting behaviour, and
  size estimation

### Notes

- This is **Phase 1 (bounded only)**. Unbounded streaming support with
  rate limiting will follow in a separate PR.
- The existing external Flink-only version at
  `apache_beam/io/external/generate_sequence.py` is **untouched**.
- Implementation is modelled after the Java `CountingSource.java` and
  follows the same `BoundedSource` + `OffsetRangeTracker` pattern used
  by other Python SDK IO sources.

### Testing

```bash
cd sdks/python
python -m pytest apache_beam/io/generate_sequence_test.py -v