### PR TITLE
[Dataflow Streaming] Remove dead code around redundant experiments

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -1301,14 +1301,6 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
 
       if (useUnifiedWorker(options)) {
         options.setEnableStreamingEngine(true);
-        List<String> experiments =
-            new ArrayList<>(options.getExperiments()); // non-null if useUnifiedWorker is true
-        if (!experiments.contains("enable_streaming_engine")) {
-          experiments.add("enable_streaming_engine");
-        }
-        if (!experiments.contains("enable_windmill_service")) {
-          experiments.add("enable_windmill_service");
-        }
       }
     }
 


### PR DESCRIPTION
The experiments are not needed, they are also not set on the outgoing requests.
