### PR TITLE
[ErrorProne]  Fix EqualsGetClass warnings and enable Error Prone check

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -1538,7 +1538,6 @@ class BeamModulePlugin implements Plugin<Project> {
             "ComparableType",
             "DoNotMockAutoValue",
             "EmptyBlockTag",
-            "EqualsGetClass",
             "EqualsUnsafeCast",
             "EscapedEntity",
             "ExtendsAutoValue",

--- a/examples/java/iceberg/src/main/java/org/apache/beam/examples/iceberg/IcebergRestCatalogStreamingWriteExample.java
+++ b/examples/java/iceberg/src/main/java/org/apache/beam/examples/iceberg/IcebergRestCatalogStreamingWriteExample.java
@@ -211,7 +211,7 @@ public class IcebergRestCatalogStreamingWriteExample {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof Accum)) {
         return false;
       }
       Accum accum = (Accum) o;

--- a/examples/java/src/main/java/org/apache/beam/examples/complete/TrafficRoutes.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/complete/TrafficRoutes.java
@@ -140,7 +140,7 @@ public class TrafficRoutes {
       if (object == null) {
         return false;
       }
-      if (object.getClass() != getClass()) {
+      if (!(object instanceof StationSpeed)) {
         return false;
       }
       StationSpeed otherStationSpeed = (StationSpeed) object;

--- a/examples/java/src/main/java/org/apache/beam/examples/complete/game/UserScore.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/complete/game/UserScore.java
@@ -121,7 +121,7 @@ public class UserScore {
       if (this == o) {
         return true;
       }
-      if (o == null || o.getClass() != this.getClass()) {
+      if (!(o instanceof GameActionInfo)) {
         return false;
       }
 

--- a/examples/java/twitter/src/main/java/org/apache/beam/examples/twitterstreamgenerator/ReadFromTwitterDoFn.java
+++ b/examples/java/twitter/src/main/java/org/apache/beam/examples/twitterstreamgenerator/ReadFromTwitterDoFn.java
@@ -64,7 +64,7 @@ final class ReadFromTwitterDoFn extends DoFn<TwitterConfig, String> {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof OffsetHolder)) {
         return false;
       }
       OffsetHolder that = (OffsetHolder) o;

--- a/examples/java/twitter/src/main/java/org/apache/beam/examples/twitterstreamgenerator/TwitterConfig.java
+++ b/examples/java/twitter/src/main/java/org/apache/beam/examples/twitterstreamgenerator/TwitterConfig.java
@@ -53,7 +53,7 @@ public class TwitterConfig implements Serializable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof TwitterConfig)) {
       return false;
     }
     TwitterConfig that = (TwitterConfig) o;

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/construction/SerializablePipelineOptions.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/construction/SerializablePipelineOptions.java
@@ -89,7 +89,7 @@ public class SerializablePipelineOptions implements Serializable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof SerializablePipelineOptions)) {
       return false;
     }
     SerializablePipelineOptions that = (SerializablePipelineOptions) o;

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/BoundedTrieData.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/BoundedTrieData.java
@@ -286,7 +286,7 @@ public class BoundedTrieData implements Serializable {
     if (this == other) {
       return true;
     }
-    if (other == null || this.getClass() != other.getClass()) {
+    if (!(other instanceof BoundedTrieData)) {
       return false;
     }
     BoundedTrieData that = (BoundedTrieData) other;
@@ -590,7 +590,7 @@ public class BoundedTrieData implements Serializable {
       if (this == other) {
         return true;
       }
-      if (other == null || getClass() != other.getClass()) {
+      if (!(other instanceof BoundedTrieNode)) {
         return false;
       }
       BoundedTrieNode that = (BoundedTrieNode) other;

--- a/runners/flink/2.0/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
+++ b/runners/flink/2.0/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
@@ -309,7 +309,7 @@ public class FlinkExecutionEnvironments {
 
     @Override
     public boolean equals(Object obj) {
-      if (obj == null || this.getClass() != obj.getClass()) {
+      if (!(obj instanceof GlobalJobParametersImpl)) {
         return false;
       }
 

--- a/runners/flink/2.0/src/main/java/org/apache/beam/runners/flink/translation/types/CoderTypeInformation.java
+++ b/runners/flink/2.0/src/main/java/org/apache/beam/runners/flink/translation/types/CoderTypeInformation.java
@@ -110,7 +110,7 @@ public class CoderTypeInformation<T> extends TypeInformation<T> implements Atomi
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof CoderTypeInformation)) {
       return false;
     }
 

--- a/runners/flink/2.0/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkBroadcastStateInternals.java
+++ b/runners/flink/2.0/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkBroadcastStateInternals.java
@@ -339,7 +339,7 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FlinkBroadcastStateInternals.FlinkBroadcastValueState)) {
         return false;
       }
 
@@ -430,7 +430,7 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FlinkBroadcastStateInternals.FlinkBroadcastBagState)) {
         return false;
       }
 
@@ -545,7 +545,7 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FlinkBroadcastStateInternals.FlinkCombiningState)) {
         return false;
       }
 
@@ -677,7 +677,7 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FlinkBroadcastStateInternals.FlinkCombiningStateWithContext)) {
         return false;
       }
 

--- a/runners/flink/2.0/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
+++ b/runners/flink/2.0/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
@@ -134,7 +134,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof StateAndNamespaceDescriptor<?>)) {
         return false;
       }
       StateAndNamespaceDescriptor<?> other = (StateAndNamespaceDescriptor<?>) o;
@@ -580,7 +580,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FlinkValueState<?>)) {
         return false;
       }
 
@@ -840,7 +840,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FlinkBagState<?>)) {
         return false;
       }
 
@@ -1002,7 +1002,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FlinkCombiningState<?, ?, ?, ?>)) {
         return false;
       }
 
@@ -1167,7 +1167,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FlinkCombiningStateWithContext<?, ?, ?, ?>)) {
         return false;
       }
 
@@ -1289,7 +1289,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FlinkStateInternals.FlinkWatermarkHoldState)) {
         return false;
       }
 
@@ -1511,7 +1511,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FlinkMapState<?, ?>)) {
         return false;
       }
 
@@ -1660,7 +1660,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FlinkSetState<?>)) {
         return false;
       }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
@@ -336,7 +336,7 @@ public class FlinkExecutionEnvironments {
 
     @Override
     public boolean equals(Object obj) {
-      if (obj == null || this.getClass() != obj.getClass()) {
+      if (!(obj instanceof GlobalJobParametersImpl)) {
         return false;
       }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/types/CoderTypeInformation.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/types/CoderTypeInformation.java
@@ -109,7 +109,7 @@ public class CoderTypeInformation<T> extends TypeInformation<T> implements Atomi
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof CoderTypeInformation)) {
       return false;
     }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializer.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializer.java
@@ -137,7 +137,7 @@ public class CoderTypeSerializer<T> extends TypeSerializer<T> {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof CoderTypeSerializer)) {
       return false;
     }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkBroadcastStateInternals.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkBroadcastStateInternals.java
@@ -339,7 +339,7 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FlinkBroadcastStateInternals.FlinkBroadcastValueState)) {
         return false;
       }
 
@@ -430,7 +430,7 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FlinkBroadcastStateInternals.FlinkBroadcastBagState)) {
         return false;
       }
 
@@ -545,7 +545,7 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FlinkBroadcastStateInternals.FlinkCombiningState)) {
         return false;
       }
 
@@ -677,7 +677,7 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FlinkBroadcastStateInternals.FlinkCombiningStateWithContext)) {
         return false;
       }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
@@ -134,7 +134,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof StateAndNamespaceDescriptor<?>)) {
         return false;
       }
       StateAndNamespaceDescriptor<?> other = (StateAndNamespaceDescriptor<?>) o;
@@ -580,7 +580,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FlinkValueState<?>)) {
         return false;
       }
 
@@ -840,7 +840,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FlinkBagState<?>)) {
         return false;
       }
 
@@ -1002,7 +1002,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FlinkCombiningState<?, ?, ?, ?>)) {
         return false;
       }
 
@@ -1167,7 +1167,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FlinkCombiningStateWithContext<?, ?, ?, ?>)) {
         return false;
       }
 
@@ -1289,7 +1289,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FlinkStateInternals.FlinkWatermarkHoldState)) {
         return false;
       }
 
@@ -1511,7 +1511,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FlinkMapState<?, ?>)) {
         return false;
       }
 
@@ -1660,7 +1660,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FlinkSetState<?>)) {
         return false;
       }
 

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/PrimitiveParDoSingleFactoryTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/PrimitiveParDoSingleFactoryTest.java
@@ -156,7 +156,7 @@ public class PrimitiveParDoSingleFactoryTest implements Serializable {
 
     @Override
     public boolean equals(@Nullable Object other) {
-      return other != null && other.getClass().equals(getClass());
+      return other instanceof ToLongFn;
     }
 
     @Override

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/util/CloudObjectsTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/util/CloudObjectsTest.java
@@ -276,7 +276,7 @@ public class CloudObjectsTest {
 
     @Override
     public boolean equals(@Nullable Object other) {
-      return other != null && getClass().equals(other.getClass());
+      return other instanceof ObjectCoder;
     }
 
     @Override
@@ -321,7 +321,7 @@ public class CloudObjectsTest {
       if (this == o) {
         return true;
       }
-      return o != null && getClass() == o.getClass();
+      return o instanceof RowIdentity;
     }
   }
 }

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ReferenceCountingExecutableStageContextFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ReferenceCountingExecutableStageContextFactory.java
@@ -224,7 +224,7 @@ public class ReferenceCountingExecutableStageContextFactory
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof WrappedContext)) {
         return false;
       }
       WrappedContext that = (WrappedContext) o;

--- a/runners/jet/src/main/java/org/apache/beam/runners/jet/Utils.java
+++ b/runners/jet/src/main/java/org/apache/beam/runners/jet/Utils.java
@@ -280,7 +280,7 @@ public class Utils {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof ByteArrayKey)) {
         return false;
       }
       ByteArrayKey that = (ByteArrayKey) o;

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/KeyedTimerData.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/KeyedTimerData.java
@@ -121,7 +121,7 @@ public class KeyedTimerData<K> implements Comparable<KeyedTimerData<K>> {
       return true;
     }
 
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof KeyedTimerData)) {
       return false;
     }
 

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/OpMessage.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/OpMessage.java
@@ -112,7 +112,7 @@ public class OpMessage<T> {
       return true;
     }
 
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof OpMessage<?>)) {
       return false;
     }
 

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaStoreStateInternals.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaStoreStateInternals.java
@@ -392,7 +392,7 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SamzaStoreStateInternals.AbstractSamzaState)) {
         return false;
       }
 
@@ -1016,7 +1016,7 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
 
     @Override
     public boolean equals(@Nullable Object o) {
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof ByteArray)) {
         return false;
       }
       ByteArray byteArray = (ByteArray) o;

--- a/runners/spark/3/src/test/java/org/apache/beam/runners/spark/structuredstreaming/translation/helpers/EncoderHelpersTest.java
+++ b/runners/spark/3/src/test/java/org/apache/beam/runners/spark/structuredstreaming/translation/helpers/EncoderHelpersTest.java
@@ -276,7 +276,7 @@ public class EncoderHelpersTest {
 
     @Override
     public boolean equals(Object o) {
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof PrivateString)) {
         return false;
       }
       PrivateString that = (PrivateString) o;

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/stateful/SparkStateInternals.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/stateful/SparkStateInternals.java
@@ -212,7 +212,7 @@ public class SparkStateInternals<K> implements StateInternals {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof AbstractState)) {
         return false;
       }
       @SuppressWarnings("unchecked")

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/util/ByteArray.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/util/ByteArray.java
@@ -37,7 +37,7 @@ public class ByteArray implements Serializable, Comparable<ByteArray> {
 
   @Override
   public boolean equals(@Nullable Object o) {
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof ByteArray)) {
       return false;
     }
     ByteArray byteArray = (ByteArray) o;

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/util/SideInputStorage.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/util/SideInputStorage.java
@@ -63,7 +63,7 @@ class SideInputStorage {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof Key)) {
         return false;
       }
       Key<?> key = (Key<?>) o;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AtomicCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AtomicCoder.java
@@ -69,6 +69,7 @@ public abstract class AtomicCoder<T> extends StructuredCoder<T> {
    * @return true if the other object has the same class as this {@link AtomicCoder}.
    */
   @Override
+  @SuppressWarnings("EqualsGetClass")
   public final boolean equals(@Nullable Object other) {
     return other != null && this.getClass().equals(other.getClass());
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/DelegateCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/DelegateCoder.java
@@ -122,6 +122,7 @@ public final class DelegateCoder<T, IntermediateT> extends CustomCoder<T> {
   }
 
   @Override
+  @SuppressWarnings("EqualsGetClass")
   public boolean equals(@Nullable Object o) {
     if (o == null || this.getClass() != o.getClass()) {
       return false;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoder.java
@@ -53,6 +53,7 @@ public class RowCoder extends SchemaCoder<Row> {
   }
 
   @Override
+  @SuppressWarnings("EqualsGetClass")
   public boolean equals(@Nullable Object o) {
     if (this == o) {
       return true;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/SerializableCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/SerializableCoder.java
@@ -215,6 +215,7 @@ public class SerializableCoder<T extends Serializable> extends CustomCoder<T> {
   }
 
   @Override
+  @SuppressWarnings("EqualsGetClass")
   public boolean equals(@Nullable Object other) {
     return !(other == null || getClass() != other.getClass())
         && type == ((SerializableCoder<?>) other).type;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/StringDelegateCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/StringDelegateCoder.java
@@ -70,6 +70,7 @@ public final class StringDelegateCoder<T> extends CustomCoder<T> {
   }
 
   @Override
+  @SuppressWarnings("EqualsGetClass")
   public boolean equals(@Nullable Object o) {
     if (o == null || this.getClass() != o.getClass()) {
       return false;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/StructuredCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/StructuredCoder.java
@@ -56,6 +56,7 @@ public abstract class StructuredCoder<T> extends Coder<T> {
    *     components.
    */
   @Override
+  @SuppressWarnings("EqualsGetClass")
   public boolean equals(@Nullable Object o) {
     if (o == null || this.getClass() != o.getClass()) {
       return false;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/ZstdCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/ZstdCoder.java
@@ -154,7 +154,7 @@ public class ZstdCoder<T> extends Coder<T> {
     if (o == this) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof ZstdCoder)) {
       return false;
     }
     ZstdCoder<?> that = (ZstdCoder<?>) o;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileIO.java
@@ -475,7 +475,7 @@ public class FileIO {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof ReadableFile)) {
         return false;
       }
       ReadableFile that = (ReadableFile) o;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/range/OffsetRange.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/range/OffsetRange.java
@@ -69,7 +69,7 @@ public class OffsetRange
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof OffsetRange)) {
       return false;
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
@@ -329,6 +329,7 @@ class ProxyInvocationHandler implements InvocationHandler, Serializable {
    *     same ProxyInvocationHandler as this.
    */
   @Override
+  @SuppressWarnings("EqualsGetClass")
   public boolean equals(@Nullable Object obj) {
     return obj != null
         && ((obj instanceof ProxyInvocationHandler && this == obj)

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/CachingFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/CachingFactory.java
@@ -76,7 +76,7 @@ public class CachingFactory<CreatedT extends @NonNull Object> implements Factory
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof CachingFactory)) {
       return false;
     }
     CachingFactory<?> that = (CachingFactory<?>) o;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FromRowUsingCreator.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FromRowUsingCreator.java
@@ -275,7 +275,7 @@ class FromRowUsingCreator<T> implements SerializableFunction<Row, T>, Function<R
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof FromRowUsingCreator)) {
       return false;
     }
     FromRowUsingCreator<?> that = (FromRowUsingCreator<?>) o;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/GetterBasedSchemaProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/GetterBasedSchemaProvider.java
@@ -186,8 +186,9 @@ public abstract class GetterBasedSchemaProvider implements SchemaProvider {
   }
 
   @Override
+  @SuppressWarnings("EqualsGetClass")
   public boolean equals(@Nullable Object obj) {
-    return obj instanceof GetterBasedSchemaProvider;
+    return obj != null && this.getClass() == obj.getClass();
   }
 
   private static class RowValueGettersFactory<T extends @NonNull Object>

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/GetterBasedSchemaProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/GetterBasedSchemaProvider.java
@@ -146,7 +146,7 @@ public abstract class GetterBasedSchemaProvider implements SchemaProvider {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof ToRowWithValueGetters)) {
         return false;
       }
       ToRowWithValueGetters<?> that = (ToRowWithValueGetters<?>) o;
@@ -187,7 +187,7 @@ public abstract class GetterBasedSchemaProvider implements SchemaProvider {
 
   @Override
   public boolean equals(@Nullable Object obj) {
-    return obj != null && this.getClass() == obj.getClass();
+    return obj instanceof GetterBasedSchemaProvider;
   }
 
   private static class RowValueGettersFactory<T extends @NonNull Object>

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaBeanSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaBeanSchema.java
@@ -95,7 +95,7 @@ public class JavaBeanSchema extends GetterBasedSchemaProviderV2 {
 
     @Override
     public boolean equals(@Nullable Object obj) {
-      return obj != null && this.getClass() == obj.getClass();
+      return obj instanceof GetterTypeSupplier;
     }
   }
 
@@ -148,7 +148,7 @@ public class JavaBeanSchema extends GetterBasedSchemaProviderV2 {
 
     @Override
     public boolean equals(@Nullable Object obj) {
-      return obj != null && this.getClass() == obj.getClass();
+      return obj instanceof SetterTypeSupplier;
     }
   }
 
@@ -236,6 +236,6 @@ public class JavaBeanSchema extends GetterBasedSchemaProviderV2 {
 
   @Override
   public boolean equals(@Nullable Object obj) {
-    return obj != null && this.getClass() == obj.getClass();
+    return obj instanceof JavaBeanSchema;
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -407,7 +407,7 @@ public class Schema implements Serializable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof Schema)) {
       return false;
     }
     Schema other = (Schema) o;
@@ -1246,7 +1246,7 @@ public class Schema implements Serializable {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof Options)) {
         return false;
       }
       Options options1 = (Options) o;
@@ -1296,7 +1296,7 @@ public class Schema implements Serializable {
         if (this == o) {
           return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof Option)) {
           return false;
         }
         Option option = (Option) o;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaCoder.java
@@ -204,7 +204,7 @@ public class SchemaCoder<T> extends CustomCoder<T> {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof SchemaCoder)) {
       return false;
     }
     SchemaCoder<?> that = (SchemaCoder<?>) o;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/EnumerationType.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/EnumerationType.java
@@ -163,7 +163,7 @@ public class EnumerationType implements LogicalType<Value, Integer> {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof Value)) {
         return false;
       }
       Value enumValue = (Value) o;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/OneOfType.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/OneOfType.java
@@ -206,7 +206,7 @@ public class OneOfType implements LogicalType<OneOfType.Value, Row> {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof Value)) {
         return false;
       }
       Value value1 = (Value) o;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ByteBuddyUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ByteBuddyUtils.java
@@ -634,7 +634,7 @@ public class ByteBuddyUtils {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof TransformingMap)) {
         return false;
       }
       TransformingMap<?, ?, ?, ?> that = (TransformingMap<?, ?, ?, ?>) o;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
@@ -204,7 +204,7 @@ public class PAssert {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof PAssertionSite)) {
         return false;
       }
       PAssertionSite that = (PAssertionSite) o;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ApproximateUnique.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ApproximateUnique.java
@@ -352,7 +352,7 @@ public class ApproximateUnique {
         if (this == o) {
           return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof LargestUnique)) {
           return false;
         }
         LargestUnique that = (LargestUnique) o;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/CombineFns.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/CombineFns.java
@@ -213,7 +213,7 @@ public class CombineFns {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof CoCombineResult)) {
         return false;
       }
       CoCombineResult that = (CoCombineResult) o;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Count.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Count.java
@@ -195,7 +195,7 @@ public class Count {
 
     @Override
     public boolean equals(@Nullable Object other) {
-      return other != null && getClass().equals(other.getClass());
+      return other instanceof CountFn;
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/PeriodicSequence.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/PeriodicSequence.java
@@ -85,7 +85,7 @@ public class PeriodicSequence
         return true;
       }
 
-      if (obj == null || obj.getClass() != this.getClass()) {
+      if (!(obj instanceof SequenceDefinition)) {
         return false;
       }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Sum.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Sum.java
@@ -142,7 +142,7 @@ public class Sum {
 
     @Override
     public boolean equals(@Nullable Object other) {
-      return other != null && other.getClass().equals(this.getClass());
+      return other instanceof SumIntegerFn;
     }
 
     @Override
@@ -165,7 +165,7 @@ public class Sum {
 
     @Override
     public boolean equals(@Nullable Object other) {
-      return other != null && other.getClass().equals(this.getClass());
+      return other instanceof SumLongFn;
     }
 
     @Override
@@ -188,7 +188,7 @@ public class Sum {
 
     @Override
     public boolean equals(@Nullable Object other) {
-      return other != null && other.getClass().equals(this.getClass());
+      return other instanceof SumDoubleFn;
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/join/RawUnionValue.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/join/RawUnionValue.java
@@ -54,7 +54,7 @@ public class RawUnionValue {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof RawUnionValue)) {
       return false;
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/PTransformMatchers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/PTransformMatchers.java
@@ -84,7 +84,7 @@ public class PTransformMatchers {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof EqualUrnPTransformMatcher)) {
         return false;
       }
       EqualUrnPTransformMatcher that = (EqualUrnPTransformMatcher) o;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/SerializableCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/SerializableCoderTest.java
@@ -77,7 +77,7 @@ public class SerializableCoderTest implements Serializable {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof MyRecord)) {
         return false;
       }
 
@@ -326,7 +326,7 @@ public class SerializableCoderTest implements Serializable {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof ProperEquals)) {
         return false;
       }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/TimestampPrefixingWindowCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/TimestampPrefixingWindowCoderTest.java
@@ -51,7 +51,7 @@ public class TimestampPrefixingWindowCoderTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof CustomWindow)) {
         return false;
       }
       CustomWindow that = (CustomWindow) o;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsFactoryTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsFactoryTest.java
@@ -2174,7 +2174,7 @@ public class PipelineOptionsFactoryTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof ComplexType2)) {
         return false;
       }
       ComplexType2 that = (ComplexType2) o;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ProxyInvocationHandlerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ProxyInvocationHandlerTest.java
@@ -683,9 +683,7 @@ public class ProxyInvocationHandlerTest {
 
     @Override
     public boolean equals(@Nullable Object obj) {
-      return obj != null
-          && getClass().equals(obj.getClass())
-          && doubleField == ((InnerType) obj).doubleField;
+      return obj instanceof InnerType && doubleField == ((InnerType) obj).doubleField;
     }
   }
 
@@ -703,8 +701,7 @@ public class ProxyInvocationHandlerTest {
 
     @Override
     public boolean equals(@Nullable Object obj) {
-      return obj != null
-          && getClass().equals(obj.getClass())
+      return obj instanceof ComplexType
           && Objects.equals(stringField, ((ComplexType) obj).stringField)
           && Objects.equals(intField, ((ComplexType) obj).intField)
           && Objects.equals(genericType, ((ComplexType) obj).genericType)

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaCoderTest.java
@@ -144,7 +144,7 @@ public class SchemaCoderTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SimpleBean)) {
         return false;
       }
       SimpleBean that = (SimpleBean) o;
@@ -179,7 +179,7 @@ public class SchemaCoderTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SimplePojo)) {
         return false;
       }
       SimplePojo that = (SimplePojo) o;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CoGroupTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CoGroupTest.java
@@ -85,7 +85,7 @@ public class CoGroupTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof CgPojo)) {
         return false;
       }
       CgPojo cgPojo = (CgPojo) o;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/ConvertTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/ConvertTest.java
@@ -65,7 +65,7 @@ public class ConvertTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof POJO1)) {
         return false;
       }
       POJO1 pojo1 = (POJO1) o;
@@ -95,7 +95,7 @@ public class ConvertTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof POJO1Nested)) {
         return false;
       }
       POJO1Nested that = (POJO1Nested) o;
@@ -149,7 +149,7 @@ public class ConvertTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof POJO2)) {
         return false;
       }
       POJO2 pojo2 = (POJO2) o;
@@ -179,7 +179,7 @@ public class ConvertTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof POJO2Nested)) {
         return false;
       }
       POJO2Nested that = (POJO2Nested) o;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/JsonUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/JsonUtilsTest.java
@@ -173,7 +173,7 @@ public class JsonUtilsTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof Cat)) {
         return false;
       }
       Cat cat = (Cat) o;
@@ -227,7 +227,7 @@ public class JsonUtilsTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof NestedCat)) {
         return false;
       }
       NestedCat nestedCat = (NestedCat) o;
@@ -277,7 +277,7 @@ public class JsonUtilsTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof ArrayOfCats)) {
         return false;
       }
       ArrayOfCats that = (ArrayOfCats) o;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestJavaBeans.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestJavaBeans.java
@@ -69,7 +69,7 @@ public class TestJavaBeans {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof NullableBean)) {
         return false;
       }
       NullableBean that = (NullableBean) o;
@@ -102,7 +102,7 @@ public class TestJavaBeans {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof MismatchingNullableBean)) {
         return false;
       }
       MismatchingNullableBean that = (MismatchingNullableBean) o;
@@ -260,7 +260,7 @@ public class TestJavaBeans {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SimpleBean)) {
         return false;
       }
       SimpleBean that = (SimpleBean) o;
@@ -447,7 +447,7 @@ public class TestJavaBeans {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SimpleBean)) {
         return false;
       }
       SimpleBean that = (SimpleBean) o;
@@ -617,7 +617,7 @@ public class TestJavaBeans {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SimpleBeanWithAnnotations)) {
         return false;
       }
       SimpleBeanWithAnnotations that = (SimpleBeanWithAnnotations) o;
@@ -696,7 +696,7 @@ public class TestJavaBeans {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof NestedBean)) {
         return false;
       }
       NestedBean that = (NestedBean) o;
@@ -758,7 +758,7 @@ public class TestJavaBeans {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof PrimitiveArrayBean)) {
         return false;
       }
       PrimitiveArrayBean that = (PrimitiveArrayBean) o;
@@ -808,7 +808,7 @@ public class TestJavaBeans {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof NestedArrayBean)) {
         return false;
       }
       NestedArrayBean that = (NestedArrayBean) o;
@@ -849,7 +849,7 @@ public class TestJavaBeans {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof NestedArraysBean)) {
         return false;
       }
       NestedArraysBean that = (NestedArraysBean) o;
@@ -900,7 +900,7 @@ public class TestJavaBeans {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof NestedCollectionBean)) {
         return false;
       }
       NestedCollectionBean that = (NestedCollectionBean) o;
@@ -945,7 +945,7 @@ public class TestJavaBeans {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof PrimitiveMapBean)) {
         return false;
       }
       PrimitiveMapBean that = (PrimitiveMapBean) o;
@@ -986,7 +986,7 @@ public class TestJavaBeans {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof NestedMapBean)) {
         return false;
       }
       NestedMapBean that = (NestedMapBean) o;
@@ -1070,7 +1070,7 @@ public class TestJavaBeans {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof BeanWithBoxedFields)) {
         return false;
       }
       BeanWithBoxedFields that = (BeanWithBoxedFields) o;
@@ -1131,7 +1131,7 @@ public class TestJavaBeans {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof BeanWithByteArray)) {
         return false;
       }
       BeanWithByteArray that = (BeanWithByteArray) o;
@@ -1174,7 +1174,7 @@ public class TestJavaBeans {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof IterableBean)) {
         return false;
       }
       IterableBean that = (IterableBean) o;
@@ -1215,7 +1215,7 @@ public class TestJavaBeans {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof ArrayOfByteArray)) {
         return false;
       }
       ArrayOfByteArray that = (ArrayOfByteArray) o;
@@ -1264,7 +1264,7 @@ public class TestJavaBeans {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof BeanWithCaseFormat)) {
         return false;
       }
       BeanWithCaseFormat that = (BeanWithCaseFormat) o;
@@ -1337,7 +1337,7 @@ public class TestJavaBeans {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof BeanWithCaseFormat)) {
         return false;
       }
       BeanWithCaseFormat that = (BeanWithCaseFormat) o;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestPOJOs.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestPOJOs.java
@@ -92,7 +92,7 @@ public class TestPOJOs {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof POJOWithNestedNullable)) {
         return false;
       }
       POJOWithNestedNullable that = (POJOWithNestedNullable) o;
@@ -302,7 +302,7 @@ public class TestPOJOs {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof AnnotatedSimplePojo)) {
         return false;
       }
       AnnotatedSimplePojo that = (AnnotatedSimplePojo) o;
@@ -440,7 +440,7 @@ public class TestPOJOs {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SimplePOJO)) {
         return false;
       }
       SimplePOJO that = (SimplePOJO) o;
@@ -511,7 +511,7 @@ public class TestPOJOs {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof NestedPOJO)) {
         return false;
       }
       NestedPOJO that = (NestedPOJO) o;
@@ -549,7 +549,7 @@ public class TestPOJOs {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof PrimitiveArrayPOJO)) {
         return false;
       }
       PrimitiveArrayPOJO that = (PrimitiveArrayPOJO) o;
@@ -591,7 +591,7 @@ public class TestPOJOs {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof NestedArrayPOJO)) {
         return false;
       }
       NestedArrayPOJO that = (NestedArrayPOJO) o;
@@ -624,7 +624,7 @@ public class TestPOJOs {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof NestedArraysPOJO)) {
         return false;
       }
       NestedArraysPOJO that = (NestedArraysPOJO) o;
@@ -659,7 +659,7 @@ public class TestPOJOs {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof NestedCollectionPOJO)) {
         return false;
       }
       NestedCollectionPOJO that = (NestedCollectionPOJO) o;
@@ -696,7 +696,7 @@ public class TestPOJOs {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof PrimitiveMapPOJO)) {
         return false;
       }
       PrimitiveMapPOJO that = (PrimitiveMapPOJO) o;
@@ -730,7 +730,7 @@ public class TestPOJOs {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof NestedMapPOJO)) {
         return false;
       }
       NestedMapPOJO that = (NestedMapPOJO) o;
@@ -774,7 +774,7 @@ public class TestPOJOs {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof POJOWithBoxedFields)) {
         return false;
       }
       POJOWithBoxedFields that = (POJOWithBoxedFields) o;
@@ -819,7 +819,7 @@ public class TestPOJOs {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof POJOWithByteArray)) {
         return false;
       }
       POJOWithByteArray that = (POJOWithByteArray) o;
@@ -927,7 +927,7 @@ public class TestPOJOs {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof PojoWithEnum)) {
         return false;
       }
       PojoWithEnum that = (PojoWithEnum) o;
@@ -999,7 +999,7 @@ public class TestPOJOs {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof NullablePOJO)) {
         return false;
       }
       NullablePOJO that = (NullablePOJO) o;
@@ -1075,7 +1075,7 @@ public class TestPOJOs {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof PojoWithCaseFormat)) {
         return false;
       }
       PojoWithCaseFormat that = (PojoWithCaseFormat) o;
@@ -1124,7 +1124,7 @@ public class TestPOJOs {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SelfNestedPOJO)) {
         return false;
       }
       SelfNestedPOJO that = (SelfNestedPOJO) o;
@@ -1155,7 +1155,7 @@ public class TestPOJOs {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FirstCircularNestedPOJO)) {
         return false;
       }
       FirstCircularNestedPOJO that = (FirstCircularNestedPOJO) o;
@@ -1186,7 +1186,7 @@ public class TestPOJOs {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SecondCircularNestedPOJO)) {
         return false;
       }
       SecondCircularNestedPOJO that = (SecondCircularNestedPOJO) o;
@@ -1217,7 +1217,7 @@ public class TestPOJOs {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof NestedPOJOWithSimplePOJO)) {
         return false;
       }
       NestedPOJOWithSimplePOJO that = (NestedPOJOWithSimplePOJO) o;
@@ -1254,7 +1254,7 @@ public class TestPOJOs {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SimplePOJOWithDescription)) {
         return false;
       }
       SimplePOJOWithDescription that = (SimplePOJOWithDescription) o;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineFnsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineFnsTest.java
@@ -329,7 +329,7 @@ public class CombineFnsTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof UserString)) {
         return false;
       }
       UserString that = (UserString) o;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/WindowTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/WindowTest.java
@@ -709,7 +709,7 @@ public class WindowTest implements Serializable {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof CustomWindow)) {
         return false;
       }
       CustomWindow that = (CustomWindow) o;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/construction/CombineTranslationTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/construction/CombineTranslationTest.java
@@ -224,7 +224,7 @@ public class CombineTranslationTest {
 
     @Override
     public boolean equals(@Nullable Object other) {
-      return other != null && other.getClass().equals(TestCombineFn.class);
+      return other instanceof TestCombineFn;
     }
 
     @Override

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/construction/ReadTranslationTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/construction/ReadTranslationTest.java
@@ -114,7 +114,7 @@ public class ReadTranslationTest {
 
     @Override
     public boolean equals(@Nullable Object other) {
-      return other != null && other.getClass().equals(TestBoundedSource.class);
+      return other instanceof TestBoundedSource;
     }
 
     @Override
@@ -148,7 +148,7 @@ public class ReadTranslationTest {
 
     @Override
     public boolean equals(@Nullable Object other) {
-      return other != null && other.getClass().equals(TestUnboundedSource.class);
+      return other instanceof TestUnboundedSource;
     }
 
     @Override

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/construction/WindowIntoTranslationTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/construction/WindowIntoTranslationTest.java
@@ -114,7 +114,7 @@ public class WindowIntoTranslationTest {
 
     @Override
     public boolean equals(@Nullable Object other) {
-      return other != null && other.getClass().equals(this.getClass());
+      return other instanceof CustomWindows;
     }
 
     @Override

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/construction/WindowingStrategyTranslationTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/construction/WindowingStrategyTranslationTest.java
@@ -210,7 +210,7 @@ public class WindowingStrategyTranslationTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof CustomWindow)) {
         return false;
       }
       CustomWindow that = (CustomWindow) o;
@@ -315,7 +315,7 @@ public class WindowingStrategyTranslationTest {
 
     @Override
     public boolean equals(@Nullable Object o) {
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof CustomWindowFn)) {
         return false;
       }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/construction/graph/ProjectionPushdownOptimizerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/construction/graph/ProjectionPushdownOptimizerTest.java
@@ -217,7 +217,7 @@ public class ProjectionPushdownOptimizerTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SchemaSourceTransform)) {
         return false;
       }
       SchemaSourceTransform<?> that = (SchemaSourceTransform<?>) o;
@@ -345,7 +345,7 @@ public class ProjectionPushdownOptimizerTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof MultipleOutputSourceWithPushdown)) {
         return false;
       }
       MultipleOutputSourceWithPushdown that = (MultipleOutputSourceWithPushdown) o;

--- a/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/coders/AvroCoder.java
+++ b/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/coders/AvroCoder.java
@@ -865,7 +865,7 @@ public class AvroCoder<T> extends CustomCoder<T> {
     if (this == other) {
       return true;
     }
-    if (other == null || this.getClass() != other.getClass()) {
+    if (!(other instanceof AvroCoder)) {
       return false;
     }
     AvroCoder<?> that = (AvroCoder<?>) other;
@@ -940,7 +940,7 @@ public class AvroCoder<T> extends CustomCoder<T> {
 
     @Override
     public boolean equals(@Nullable Object o) {
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof AvroCoderCacheKey)) {
         return false;
       }
       AvroCoderCacheKey that = (AvroCoderCacheKey) o;

--- a/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/io/AvroDatumFactory.java
+++ b/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/io/AvroDatumFactory.java
@@ -96,7 +96,7 @@ public abstract class AvroDatumFactory<T>
     if (this == other) {
       return true;
     }
-    if (other == null || getClass() != other.getClass()) {
+    if (!(other instanceof AvroDatumFactory)) {
       return false;
     }
     AvroDatumFactory<?> that = (AvroDatumFactory<?>) other;

--- a/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/schemas/utils/AvroUtils.java
+++ b/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/schemas/utils/AvroUtils.java
@@ -767,7 +767,7 @@ public class AvroUtils {
       if (this == other) {
         return true;
       }
-      if (other == null || getClass() != other.getClass()) {
+      if (!(other instanceof GenericRecordToRowFn)) {
         return false;
       }
       GenericRecordToRowFn that = (GenericRecordToRowFn) other;
@@ -806,7 +806,7 @@ public class AvroUtils {
       if (this == other) {
         return true;
       }
-      if (other == null || getClass() != other.getClass()) {
+      if (!(other instanceof RowToGenericRecordFn)) {
         return false;
       }
       RowToGenericRecordFn that = (RowToGenericRecordFn) other;

--- a/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/coders/AvroCoderTest.java
+++ b/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/coders/AvroCoderTest.java
@@ -156,7 +156,7 @@ public class AvroCoderTest {
       if (this == other) {
         return true;
       }
-      if (other == null || getClass() != other.getClass()) {
+      if (!(other instanceof Pojo)) {
         return false;
       }
       Pojo that = (Pojo) other;

--- a/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/schemas/SchemaCoderTest.java
+++ b/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/schemas/SchemaCoderTest.java
@@ -80,7 +80,7 @@ public class SchemaCoderTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SimpleAvro)) {
         return false;
       }
       SimpleAvro that = (SimpleAvro) o;

--- a/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/schemas/transforms/ConvertTest.java
+++ b/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/schemas/transforms/ConvertTest.java
@@ -66,7 +66,7 @@ public class ConvertTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof POJO1)) {
         return false;
       }
       POJO1 pojo1 = (POJO1) o;
@@ -96,7 +96,7 @@ public class ConvertTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof POJO1Nested)) {
         return false;
       }
       POJO1Nested that = (POJO1Nested) o;

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/gcsfs/GcsPath.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/gcsfs/GcsPath.java
@@ -552,7 +552,7 @@ public class GcsPath implements Path, Serializable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof GcsPath)) {
       return false;
     }
 

--- a/sdks/java/extensions/jackson/src/test/java/org/apache/beam/sdk/extensions/jackson/JacksonTransformsTest.java
+++ b/sdks/java/extensions/jackson/src/test/java/org/apache/beam/sdk/extensions/jackson/JacksonTransformsTest.java
@@ -406,7 +406,7 @@ public class JacksonTransformsTest implements Serializable {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof MyEmptyBean)) {
         return false;
       }
 

--- a/sdks/java/extensions/kryo/src/main/java/org/apache/beam/sdk/extensions/kryo/KryoCoder.java
+++ b/sdks/java/extensions/kryo/src/main/java/org/apache/beam/sdk/extensions/kryo/KryoCoder.java
@@ -283,7 +283,7 @@ public class KryoCoder<T> extends CustomCoder<T> {
 
   @Override
   public boolean equals(@Nullable Object other) {
-    if (other != null && getClass().equals(other.getClass())) {
+    if (other instanceof KryoCoder) {
       return instanceId.equals(((KryoCoder<?>) other).instanceId);
     }
     return false;

--- a/sdks/java/extensions/kryo/src/test/java/org/apache/beam/sdk/extensions/kryo/KryoCoderTest.java
+++ b/sdks/java/extensions/kryo/src/test/java/org/apache/beam/sdk/extensions/kryo/KryoCoderTest.java
@@ -238,7 +238,7 @@ public class KryoCoderTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof ClassToBeEncoded)) {
         return false;
       }
       ClassToBeEncoded that = (ClassToBeEncoded) o;
@@ -267,7 +267,7 @@ public class KryoCoderTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof TestClass)) {
         return false;
       }
       TestClass testClass = (TestClass) o;

--- a/sdks/java/extensions/ordered/src/main/java/org/apache/beam/sdk/extensions/ordered/OrderedProcessingStatus.java
+++ b/sdks/java/extensions/ordered/src/main/java/org/apache/beam/sdk/extensions/ordered/OrderedProcessingStatus.java
@@ -103,7 +103,7 @@ public abstract class OrderedProcessingStatus {
     if (obj == null) {
       return false;
     }
-    if (!OrderedProcessingStatus.class.isAssignableFrom(obj.getClass())) {
+    if (!(obj instanceof OrderedProcessingStatus)) {
       return false;
     }
     OrderedProcessingStatus that = (OrderedProcessingStatus) obj;

--- a/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/DynamicProtoCoder.java
+++ b/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/DynamicProtoCoder.java
@@ -103,6 +103,7 @@ public class DynamicProtoCoder extends ProtoCoder<DynamicMessage> {
             .build());
   }
 
+  @SuppressWarnings("EqualsGetClass")
   @Override
   public boolean equals(@Nullable Object other) {
     if (this == other) {

--- a/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoCoder.java
+++ b/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoCoder.java
@@ -208,6 +208,7 @@ public class ProtoCoder<T extends Message> extends CustomCoder<T> {
     }
   }
 
+  @SuppressWarnings("EqualsGetClass")
   @Override
   public boolean equals(@Nullable Object other) {
     if (this == other) {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/example/model/Customer.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/example/model/Customer.java
@@ -70,7 +70,7 @@ public class Customer implements Serializable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof Customer)) {
       return false;
     }
     Customer customer = (Customer) o;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/example/model/Order.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/example/model/Order.java
@@ -57,7 +57,7 @@ public class Order implements Serializable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof Order)) {
       return false;
     }
     Order order = (Order) o;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BeamSqlUnparseContext.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BeamSqlUnparseContext.java
@@ -157,7 +157,7 @@ public class BeamSqlUnparseContext extends SqlImplementor.SimpleContext {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SqlDateTimeLiteral)) {
         return false;
       }
       if (!super.equals(o)) {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/InferredJavaBeanSqlTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/InferredJavaBeanSqlTest.java
@@ -73,7 +73,7 @@ public class InferredJavaBeanSqlTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof PersonBean)) {
         return false;
       }
       PersonBean that = (PersonBean) o;
@@ -120,7 +120,7 @@ public class InferredJavaBeanSqlTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof OrderBean)) {
         return false;
       }
       OrderBean orderBean = (OrderBean) o;

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/FnApiStateAccessor.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/FnApiStateAccessor.java
@@ -1231,7 +1231,7 @@ public class FnApiStateAccessor<K> implements SideInputReader, StateBinder {
       }
       UserStateCacheKeyBase other = (UserStateCacheKeyBase) o;
       return hash == other.hash
-          && this.getClass().equals(o.getClass())
+          && this.getClass().equals(other.getClass())
           && ptransformId.equals(other.ptransformId)
           && stateId.equals(other.stateId)
           && window.equals(other.window)

--- a/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/common/ObjectPool.java
+++ b/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/common/ObjectPool.java
@@ -134,7 +134,7 @@ public class ObjectPool<KeyT extends @NonNull Object, ObjectT extends @NonNull O
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof ObjectPool.RefCounted)) {
         return false;
       }
       // only identity of ref counted shared object matters

--- a/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/kinesis/ShardCheckpoint.java
+++ b/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/kinesis/ShardCheckpoint.java
@@ -239,7 +239,7 @@ class ShardCheckpoint implements Serializable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof ShardCheckpoint)) {
       return false;
     }
     ShardCheckpoint that = (ShardCheckpoint) o;

--- a/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/kinesis/StartingPoint.java
+++ b/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/kinesis/StartingPoint.java
@@ -65,7 +65,7 @@ class StartingPoint implements Serializable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof StartingPoint)) {
       return false;
     }
     StartingPoint that = (StartingPoint) o;

--- a/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/schemas/AwsSchemaProvider.java
+++ b/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/schemas/AwsSchemaProvider.java
@@ -134,7 +134,7 @@ public class AwsSchemaProvider extends GetterBasedSchemaProviderV2 {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof FromRowWithBuilder)) {
         return false;
       }
       FromRowWithBuilder<?> that = (FromRowWithBuilder<?>) o;

--- a/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/sqs/SqsCheckpointMark.java
+++ b/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/sqs/SqsCheckpointMark.java
@@ -99,7 +99,7 @@ class SqsCheckpointMark implements UnboundedSource.CheckpointMark, Serializable 
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof SqsCheckpointMark)) {
       return false;
     }
     SqsCheckpointMark that = (SqsCheckpointMark) o;

--- a/sdks/java/io/amazon-web-services2/src/test/java/org/apache/beam/sdk/io/aws2/dynamodb/DynamoDBIOWriteTest.java
+++ b/sdks/java/io/amazon-web-services2/src/test/java/org/apache/beam/sdk/io/aws2/dynamodb/DynamoDBIOWriteTest.java
@@ -257,7 +257,7 @@ public class DynamoDBIOWriteTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof Item)) {
         return false;
       }
       return Objects.equals(entries, ((Item) o).entries);

--- a/sdks/java/io/amazon-web-services2/src/test/java/org/apache/beam/sdk/io/aws2/kinesis/EFOShardSubscribersPoolTest.java
+++ b/sdks/java/io/amazon-web-services2/src/test/java/org/apache/beam/sdk/io/aws2/kinesis/EFOShardSubscribersPoolTest.java
@@ -941,7 +941,7 @@ public class EFOShardSubscribersPoolTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof KinesisRecordView)) {
         return false;
       }
       KinesisRecordView that = (KinesisRecordView) o;

--- a/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOTest.java
+++ b/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOTest.java
@@ -808,7 +808,7 @@ public class CassandraIOTest implements Serializable {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof Scientist)) {
         return false;
       }
       Scientist scientist = (Scientist) o;
@@ -1125,7 +1125,7 @@ public class CassandraIOTest implements Serializable {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof ReservedKeywordEntity)) {
         return false;
       }
       ReservedKeywordEntity that = (ReservedKeywordEntity) o;
@@ -1166,7 +1166,7 @@ public class CassandraIOTest implements Serializable {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof CustomQueryEntity)) {
         return false;
       }
       CustomQueryEntity that = (CustomQueryEntity) o;
@@ -1203,7 +1203,7 @@ public class CassandraIOTest implements Serializable {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof MultiPartitionEntity)) {
         return false;
       }
       MultiPartitionEntity that = (MultiPartitionEntity) o;

--- a/sdks/java/io/common/src/main/java/org/apache/beam/sdk/io/common/HashingFn.java
+++ b/sdks/java/io/common/src/main/java/org/apache/beam/sdk/io/common/HashingFn.java
@@ -57,7 +57,7 @@ public class HashingFn extends CombineFn<String, HashingFn.Accum, String> {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof Accum)) {
         return false;
       }
 

--- a/sdks/java/io/file-schema-transform/src/main/java/org/apache/beam/sdk/io/fileschematransform/XmlRowAdapter.java
+++ b/sdks/java/io/file-schema-transform/src/main/java/org/apache/beam/sdk/io/fileschematransform/XmlRowAdapter.java
@@ -75,7 +75,7 @@ class XmlRowAdapter implements Serializable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof XmlRowAdapter)) {
       return false;
     }
     XmlRowAdapter that = (XmlRowAdapter) o;

--- a/sdks/java/io/file-schema-transform/src/main/java/org/apache/beam/sdk/io/fileschematransform/XmlRowValue.java
+++ b/sdks/java/io/file-schema-transform/src/main/java/org/apache/beam/sdk/io/fileschematransform/XmlRowValue.java
@@ -211,7 +211,7 @@ class XmlRowValue implements Serializable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof XmlRowValue)) {
       return false;
     }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryInsertError.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryInsertError.java
@@ -68,7 +68,7 @@ public class BigQueryInsertError {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof BigQueryInsertError)) {
       return false;
     }
     BigQueryInsertError that = (BigQueryInsertError) o;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
@@ -85,7 +85,7 @@ class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
     if (this == obj) {
       return true;
     }
-    if (obj == null || getClass() != obj.getClass()) {
+    if (!(obj instanceof BigQueryStorageStreamSource)) {
       return false;
     }
     BigQueryStorageStreamSource<?> other = (BigQueryStorageStreamSource<?>) obj;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/PassThroughThenCleanup.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/PassThroughThenCleanup.java
@@ -94,8 +94,9 @@ class PassThroughThenCleanup<T> extends PTransform<PCollection<T>, PCollection<T
     }
 
     @Override
+    @SuppressWarnings("EqualsGetClass")
     public boolean equals(@Nullable Object obj) {
-      return obj != null && obj.getClass() == this.getClass();
+      return obj instanceof CleanupOperation && obj.getClass() == this.getClass();
     }
   }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiFlushAndFinalizeDoFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiFlushAndFinalizeDoFn.java
@@ -134,7 +134,7 @@ public class StorageApiFlushAndFinalizeDoFn extends DoFn<KV<String, Operation>, 
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof Operation)) {
         return false;
       }
       Operation operation = (Operation) o;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/healthcare/FhirSearchParameter.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/healthcare/FhirSearchParameter.java
@@ -97,7 +97,7 @@ public class FhirSearchParameter<T> {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof FhirSearchParameter)) {
       return false;
     }
     FhirSearchParameter<?> that = (FhirSearchParameter<?>) o;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubClient.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubClient.java
@@ -156,7 +156,7 @@ public abstract class PubsubClient implements Closeable {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof ProjectPath)) {
         return false;
       }
 
@@ -270,7 +270,7 @@ public abstract class PubsubClient implements Closeable {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SubscriptionPath)) {
         return false;
       }
       SubscriptionPath that = (SubscriptionPath) o;
@@ -350,7 +350,7 @@ public abstract class PubsubClient implements Closeable {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof TopicPath)) {
         return false;
       }
       TopicPath topicPath = (TopicPath) o;

--- a/sdks/java/io/google-cloud-platform/src/test/java/com/google/cloud/spanner/FakeBatchTransactionId.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/com/google/cloud/spanner/FakeBatchTransactionId.java
@@ -42,7 +42,7 @@ public class FakeBatchTransactionId extends BatchTransactionId {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof FakeBatchTransactionId)) {
       return false;
     }
     FakeBatchTransactionId that = (FakeBatchTransactionId) o;

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOReadTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOReadTest.java
@@ -178,7 +178,7 @@ public class BigQueryIOReadTest implements Serializable {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof MyData)) {
         return false;
       }
       MyData myData = (MyData) o;

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamOrderedByTimestampAndTransactionIdIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamOrderedByTimestampAndTransactionIdIT.java
@@ -557,7 +557,7 @@ public class SpannerChangeStreamOrderedByTimestampAndTransactionIdIT {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SpannerChangeStreamOrderedByTimestampAndTransactionIdIT.SortKey)) {
         return false;
       }
       SpannerChangeStreamOrderedByTimestampAndTransactionIdIT.SortKey sortKey =

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamOrderedWithinKeyGloballyIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamOrderedWithinKeyGloballyIT.java
@@ -466,7 +466,7 @@ public class SpannerChangeStreamOrderedWithinKeyGloballyIT {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SortKey)) {
         return false;
       }
       SortKey sortKey = (SortKey) o;

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamOrderedWithinKeyIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamOrderedWithinKeyIT.java
@@ -284,7 +284,7 @@ public class SpannerChangeStreamOrderedWithinKeyIT {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SortKey)) {
         return false;
       }
       SortKey sortKey = (SortKey) o;

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamTransactionBoundariesIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamTransactionBoundariesIT.java
@@ -291,7 +291,7 @@ public class SpannerChangeStreamTransactionBoundariesIT {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SpannerChangeStreamTransactionBoundariesIT.SortKey)) {
         return false;
       }
       SpannerChangeStreamTransactionBoundariesIT.SortKey sortKey =

--- a/sdks/java/io/hadoop-format/src/test/java/org/apache/beam/sdk/io/hadoop/format/Employee.java
+++ b/sdks/java/io/hadoop-format/src/test/java/org/apache/beam/sdk/io/hadoop/format/Employee.java
@@ -60,7 +60,7 @@ public class Employee {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof Employee)) {
       return false;
     }
 

--- a/sdks/java/io/hbase/src/main/java/org/apache/beam/sdk/io/hbase/HBaseIO.java
+++ b/sdks/java/io/hbase/src/main/java/org/apache/beam/sdk/io/hbase/HBaseIO.java
@@ -299,7 +299,7 @@ public class HBaseIO {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof Read)) {
         return false;
       }
       Read read = (Read) o;
@@ -676,7 +676,7 @@ public class HBaseIO {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof Write)) {
         return false;
       }
       Write write = (Write) o;
@@ -842,7 +842,7 @@ public class HBaseIO {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof WriteRowMutations)) {
         return false;
       }
       WriteRowMutations writeRowMutations = (WriteRowMutations) o;

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/SerializableDataFile.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/SerializableDataFile.java
@@ -227,7 +227,7 @@ abstract class SerializableDataFile {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof SerializableDataFile)) {
       return false;
     }
     SerializableDataFile that = (SerializableDataFile) o;

--- a/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcTestHelper.java
+++ b/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcTestHelper.java
@@ -52,7 +52,7 @@ class JdbcTestHelper {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof TestDto)) {
         return false;
       }
       TestDto testDto = (TestDto) o;

--- a/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsCheckpointMark.java
+++ b/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsCheckpointMark.java
@@ -108,7 +108,7 @@ class JmsCheckpointMark implements UnboundedSource.CheckpointMark, Serializable 
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof JmsCheckpointMark)) {
       return false;
     }
     JmsCheckpointMark that = (JmsCheckpointMark) o;

--- a/sdks/java/io/redis/src/main/java/org/apache/beam/sdk/io/redis/RedisCursor.java
+++ b/sdks/java/io/redis/src/main/java/org/apache/beam/sdk/io/redis/RedisCursor.java
@@ -77,7 +77,7 @@ public class RedisCursor implements Comparable<RedisCursor>, Serializable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof RedisCursor)) {
       return false;
     }
     RedisCursor that = (RedisCursor) o;

--- a/sdks/java/io/rrio/src/test/java/org/apache/beam/io/requestresponse/CallTest.java
+++ b/sdks/java/io/rrio/src/test/java/org/apache/beam/io/requestresponse/CallTest.java
@@ -316,7 +316,7 @@ public class CallTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof Request)) {
         return false;
       }
       Request request = (Request) o;
@@ -341,7 +341,7 @@ public class CallTest {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof Response)) {
         return false;
       }
       Response response = (Response) o;

--- a/sdks/java/io/solace/src/test/java/org/apache/beam/sdk/io/solace/it/FixedCredentialsBasicAuthJcsmpSessionServiceFactory.java
+++ b/sdks/java/io/solace/src/test/java/org/apache/beam/sdk/io/solace/it/FixedCredentialsBasicAuthJcsmpSessionServiceFactory.java
@@ -47,7 +47,7 @@ public class FixedCredentialsBasicAuthJcsmpSessionServiceFactory extends Session
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof FixedCredentialsBasicAuthJcsmpSessionServiceFactory)) {
       return false;
     }
     FixedCredentialsBasicAuthJcsmpSessionServiceFactory that =

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkConfiguration.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkConfiguration.java
@@ -596,10 +596,7 @@ public class NexmarkConfiguration implements Serializable {
     if (this == obj) {
       return true;
     }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    if (!(obj instanceof NexmarkConfiguration)) {
       return false;
     }
     NexmarkConfiguration other = (NexmarkConfiguration) obj;

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Auction.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Auction.java
@@ -230,7 +230,7 @@ public class Auction implements KnownSize, Serializable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof Auction)) {
       return false;
     }
     Auction auction = (Auction) o;

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/AuctionBid.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/AuctionBid.java
@@ -92,7 +92,7 @@ public class AuctionBid implements KnownSize, Serializable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof AuctionBid)) {
       return false;
     }
     AuctionBid that = (AuctionBid) o;

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/AuctionCount.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/AuctionCount.java
@@ -81,7 +81,7 @@ public class AuctionCount implements KnownSize, Serializable {
     if (this == otherObject) {
       return true;
     }
-    if (otherObject == null || getClass() != otherObject.getClass()) {
+    if (!(otherObject instanceof AuctionCount)) {
       return false;
     }
 

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/AuctionPrice.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/AuctionPrice.java
@@ -81,7 +81,7 @@ public class AuctionPrice implements KnownSize, Serializable {
     if (this == otherObject) {
       return true;
     }
-    if (otherObject == null || getClass() != otherObject.getClass()) {
+    if (!(otherObject instanceof AuctionPrice)) {
       return false;
     }
 

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Bid.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Bid.java
@@ -151,7 +151,7 @@ public class Bid implements KnownSize, Serializable {
     if (this == otherObject) {
       return true;
     }
-    if (otherObject == null || getClass() != otherObject.getClass()) {
+    if (!(otherObject instanceof Bid)) {
       return false;
     }
 

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/BidsPerSession.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/BidsPerSession.java
@@ -94,7 +94,7 @@ public class BidsPerSession implements KnownSize, Serializable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof BidsPerSession)) {
       return false;
     }
     BidsPerSession that = (BidsPerSession) o;

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/CategoryPrice.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/CategoryPrice.java
@@ -104,7 +104,7 @@ public class CategoryPrice implements KnownSize, Serializable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof CategoryPrice)) {
       return false;
     }
     CategoryPrice that = (CategoryPrice) o;

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Done.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Done.java
@@ -91,7 +91,7 @@ public class Done implements KnownSize, Serializable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof Done)) {
       return false;
     }
     Done done = (Done) o;

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Event.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Event.java
@@ -44,7 +44,7 @@ public class Event implements KnownSize, Serializable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof Event)) {
       return false;
     }
     Event event = (Event) o;

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/IdNameReserve.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/IdNameReserve.java
@@ -107,7 +107,7 @@ public class IdNameReserve implements KnownSize, Serializable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof IdNameReserve)) {
       return false;
     }
     IdNameReserve that = (IdNameReserve) o;

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/NameCityStateId.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/NameCityStateId.java
@@ -101,7 +101,7 @@ public class NameCityStateId implements KnownSize, Serializable {
     if (this == otherObject) {
       return true;
     }
-    if (otherObject == null || getClass() != otherObject.getClass()) {
+    if (!(otherObject instanceof NameCityStateId)) {
       return false;
     }
 

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Person.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Person.java
@@ -193,7 +193,7 @@ public class Person implements KnownSize, Serializable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof Person)) {
       return false;
     }
     Person person = (Person) o;

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/SellerPrice.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/SellerPrice.java
@@ -96,7 +96,7 @@ public class SellerPrice implements KnownSize, Serializable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof SellerPrice)) {
       return false;
     }
     SellerPrice that = (SellerPrice) o;

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/Query5.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/Query5.java
@@ -122,7 +122,7 @@ public class Query5 extends NexmarkQueryTransform<AuctionCount> {
         if (this == o) {
           return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof Accum)) {
           return false;
         }
 

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/WinningBids.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/WinningBids.java
@@ -153,7 +153,7 @@ public class WinningBids extends PTransform<PCollection<Event>, PCollection<Auct
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof AuctionOrBidWindow)) {
         return false;
       }
       if (!super.equals(o)) {
@@ -396,7 +396,7 @@ public class WinningBids extends PTransform<PCollection<Event>, PCollection<Auct
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof WinningBids)) {
       return false;
     }
 

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/sources/generator/Generator.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/sources/generator/Generator.java
@@ -86,7 +86,7 @@ public class Generator implements Iterator<TimestampedValue<Event>>, Serializabl
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof NextEvent)) {
         return false;
       }
 


### PR DESCRIPTION
What this PR does: This pull request enables the EqualsGetClass check from Error Prone and resolves all existing violations across the codebase.

Specific changes:

-Removed `EqualsGetClass` from the disabledChecks list in the `BeamModulePlugin.groovy` configuration to enforce it going forward.
- Refactored `equals`  methods in numerous classes across various modules (including nexmark, flink runners, and others) to use standard `instanceof` checks rather than exact runtime class matching `(getClass() != o.getClass())`. 

This change better aligns with standard Java equality semantics and addresses the Error Prone warning Prefer instanceof to getClass when implementing Object#equals
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
