### PR TITLE
[ErrorProne] Fix `MissingSummary`  Warnings Across Codebase

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -1556,7 +1556,6 @@ class BeamModulePlugin implements Plugin<Project> {
             "JavaUtilDate",
             "JodaConstructors",
             "MalformedInlineTag",
-            "MissingSummary",
             "MixedMutabilityReturnType",
             "PreferJavaTimeOverload",
             "MutablePublicArray",

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/datastream/DatastreamResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/datastream/DatastreamResourceManager.java
@@ -182,9 +182,10 @@ public final class DatastreamResourceManager implements ResourceManager {
   }
 
   /**
+   * Returns a SourceConfig object which is required to configure a Stream.
+   *
    * @param sourceConnectionProfileId The ID of the connection profile.
    * @param source An object representing the JDBC source.
-   * @return a SourceConfig object which is required to configure a Stream.
    */
   public synchronized SourceConfig buildSourceConfig(
       String sourceConnectionProfileId, JDBCSource source) {
@@ -214,11 +215,12 @@ public final class DatastreamResourceManager implements ResourceManager {
   }
 
   /**
+   * Returns a Datastream GCS destination connection profile.
+   *
    * @param connectionProfileId The ID of the GCS connection profile.
    * @param gcsBucketName The GCS Bucket to connect to.
    * @param gcsRootPath The Path prefix to specific gcs location. Can either be empty or must start
    *     with '/'.
-   * @return A Datastream GCS destination connection profile.
    */
   public synchronized ConnectionProfile createGCSDestinationConnectionProfile(
       String connectionProfileId, String gcsBucketName, String gcsRootPath) {
@@ -266,11 +268,12 @@ public final class DatastreamResourceManager implements ResourceManager {
   }
 
   /**
+   * Returns a DestinationConfig object representing a GCS destination configuration.
+   *
    * @param connectionProfileId The ID of the connection profile.
    * @param path The Path prefix to specific GCS location. Can either be empty or must start with
    *     '/'.
    * @param destinationOutputFormat The format of the files written to GCS.
-   * @return A DestinationConfig object representing a GCS destination configuration.
    */
   public synchronized DestinationConfig buildGCSDestinationConfig(
       String connectionProfileId, String path, DestinationOutputFormat destinationOutputFormat) {
@@ -294,8 +297,9 @@ public final class DatastreamResourceManager implements ResourceManager {
   }
 
   /**
+   * Returns a Datastream BigQuery destination connection profile.
+   *
    * @param connectionProfileId The ID of the connection profile.
-   * @return A Datastream BigQuery destination connection profile.
    */
   public synchronized ConnectionProfile createBQDestinationConnectionProfile(
       String connectionProfileId) {
@@ -334,10 +338,11 @@ public final class DatastreamResourceManager implements ResourceManager {
   }
 
   /**
+   * Returns a DestinationConfig object representing a BigQuery destination configuration.
+   *
    * @param connectionProfileId The ID of the connection profile.
    * @param stalenessLimitSeconds The desired data freshness in seconds.
    * @param datasetId The ID of the BigQuery dataset.
-   * @return A DestinationConfig object representing a BigQuery destination configuration.
    */
   public synchronized DestinationConfig buildBQDestinationConfig(
       String connectionProfileId, long stalenessLimitSeconds, String datasetId) {
@@ -358,10 +363,11 @@ public final class DatastreamResourceManager implements ResourceManager {
   }
 
   /**
+   * Returns a Datastream stream object.
+   *
    * @param streamId The ID of the stream.
    * @param sourceConfig A SourceConfig object representing the source configuration.
    * @param destinationConfig A DestinationConfig object representing the destination configuration.
-   * @return A Datastream stream object.
    */
   public synchronized Stream createStream(
       String streamId, SourceConfig sourceConfig, DestinationConfig destinationConfig) {

--- a/it/truthmatchers/src/main/java/org/apache/beam/it/truthmatchers/ListAccumulator.java
+++ b/it/truthmatchers/src/main/java/org/apache/beam/it/truthmatchers/ListAccumulator.java
@@ -54,7 +54,7 @@ public class ListAccumulator<T> {
     return this.backingList.size();
   }
 
-  /** @return the internal backing list being accumulated. */
+  /** Returns the internal backing list being accumulated. */
   public List<T> getBackingList() {
     return this.backingList;
   }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/DoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/DoFnRunner.java
@@ -64,8 +64,9 @@ public interface DoFnRunner<InputT extends @Nullable Object, OutputT extends @Nu
       BoundedWindow window, Instant timestamp, KeyT key);
 
   /**
+   * Returns the underlying fn instance.
+   *
    * @since 2.5.0
-   * @return the underlying fn instance.
    */
   DoFn<InputT, OutputT> getFn();
 }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/PushbackSideInputDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/PushbackSideInputDoFnRunner.java
@@ -61,8 +61,9 @@ public interface PushbackSideInputDoFnRunner<InputT, OutputT> {
   void finishBundle();
 
   /**
+   * Returns the underlying fn instance.
+   *
    * @since 2.5.0
-   * @return the underlying fn instance.
    */
   DoFn<InputT, OutputT> getFn();
 }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/BoundedTrieData.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/BoundedTrieData.java
@@ -276,7 +276,7 @@ public class BoundedTrieData implements Serializable {
     }
   }
 
-  /** @return true if this {@link BoundedTrieData} is empty else false. */
+  /** Returns true if this {@link BoundedTrieData} is empty else false. */
   public boolean isEmpty() {
     return (root == null || root.children.isEmpty()) && (singleton == null || singleton.isEmpty());
   }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MonitoringInfoMetricName.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MonitoringInfoMetricName.java
@@ -74,7 +74,7 @@ public class MonitoringInfoMetricName extends MetricName {
     return urn.split(":", 2)[1];
   }
 
-  /** @return the urn of this MonitoringInfo metric. */
+  /** Returns the urn of this MonitoringInfo metric. */
   public String getUrn() {
     return this.urn;
   }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/SimpleStateRegistry.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/SimpleStateRegistry.java
@@ -45,7 +45,7 @@ public class SimpleStateRegistry {
     }
   }
 
-  /** @return Execution Time MonitoringInfos based on the tracked start or finish function. */
+  /** Returns execution Time MonitoringInfos based on the tracked start or finish function. */
   public List<MonitoringInfo> getExecutionTimeMonitoringInfos() {
     List<MonitoringInfo> monitoringInfos = new ArrayList<MonitoringInfo>();
     for (SimpleExecutionState state : executionStates) {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterWatermarkStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterWatermarkStateMachine.java
@@ -66,7 +66,7 @@ public class AfterWatermarkStateMachine {
     return new FromEndOfWindow();
   }
 
-  /** @see AfterWatermarkStateMachine */
+  /** See {@link AfterWatermarkStateMachine}. */
   public static class AfterWatermarkEarlyAndLate extends TriggerStateMachine {
 
     private static final int EARLY_INDEX = 0;

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/PackageUtil.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/PackageUtil.java
@@ -469,20 +469,20 @@ public class PackageUtil implements Closeable {
           getSource(), getBytes(), newDestination, getSize(), getHash());
     }
 
-    /** @return the file to be uploaded, if any */
+    /** Returns the file to be uploaded, if any. */
     public abstract @Nullable File getSource();
 
-    /** @return the bytes to be uploaded, if any */
+    /** Returns the bytes to be uploaded, if any. */
     @SuppressWarnings("mutable")
     public abstract byte @Nullable [] getBytes();
 
-    /** @return the dataflowPackage */
+    /** Returns the dataflowPackage. */
     public abstract DataflowPackage getDestination();
 
-    /** @return the size */
+    /** Returns the size. */
     public abstract long getSize();
 
-    /** @return the hash */
+    /** Returns the hash. */
     public abstract String getHash();
 
     public String getSourceDescription() {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/BatchModeExecutionContext.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/BatchModeExecutionContext.java
@@ -263,7 +263,11 @@ public class BatchModeExecutionContext
     this.key = key;
   }
 
-  /** @param newKey the key being switched to */
+  /**
+   * Switches the state key.
+   *
+   * @param newKey the key being switched to
+   */
   protected void switchStateKey(Object newKey) {
     for (StepContext stepContext : getAllStepContexts()) {
       stepContext.setKey(newKey);

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/MetricsToPerStepNamespaceMetricsConverter.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/MetricsToPerStepNamespaceMetricsConverter.java
@@ -238,14 +238,15 @@ public class MetricsToPerStepNamespaceMetricsConverter {
   }
 
   /**
+   * Returns collection of {@code PerStepNamespaceMetrics} that represent these metric updates. Each
+   * {@code PerStepNamespaceMetrics} contains a list of {@code MetricUpdates} for a {unfused stage,
+   * metrics namespace} pair.
+   *
    * @param stepName The unfused stage that these metrics are associated with.
    * @param counters Counter updates to convert.
    * @param histograms Histogram updates to convert.
    * @param parsedPerWorkerMetricsCache cache of previously converted {@code ParsedMetricName}. The
    *     cache will be updated to include all valid metric names in counters and histograms.
-   * @return Collection of {@code PerStepNamespaceMetrics} that represent these metric updates. Each
-   *     {@code PerStepNamespaceMetrics} contains a list of {@code MetricUpdates} for a {unfused
-   *     stage, metrics namespace} pair.
    */
   public static Collection<PerStepNamespaceMetrics> convert(
       String stepName,

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingStepMetricsContainer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingStepMetricsContainer.java
@@ -420,9 +420,10 @@ public class StreamingStepMetricsContainer implements MetricsContainer {
   }
 
   /**
+   * Returns an iterable of {@link PerStepNamespaceMetrics} representing the changes to all
+   * PerWorkerMetrics that have changed since the last time this function was invoked.
+   *
    * @param metricsContainerRegistry Metrics will be extracted for all containers in this registry.
-   * @return An iterable of {@link PerStepNamespaceMetrics} representing the changes to all
-   *     PerWorkerMetrics that have changed since the last time this function was invoked.
    */
   public static Iterable<PerStepNamespaceMetrics> extractPerWorkerMetricUpdates(
       MetricsContainerRegistry<StreamingStepMetricsContainer> metricsContainerRegistry) {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/ThreadLocalByteStringOutputStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/ThreadLocalByteStringOutputStream.java
@@ -44,7 +44,7 @@ public class ThreadLocalByteStringOutputStream {
   // Private constructor to prevent instantiations from outside.
   private ThreadLocalByteStringOutputStream() {}
 
-  /** @return An AutoClosable StreamHandle that holds a cached ByteStringOutputStream. */
+  /** Returns an AutoClosable StreamHandle that holds a cached ByteStringOutputStream. */
   public static StreamHandle acquire() {
     StreamHandle streamHandle = getStreamHandleFromThreadLocal();
     if (streamHandle.inUse) {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/WorkProgressUpdater.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/WorkProgressUpdater.java
@@ -147,7 +147,11 @@ public abstract class WorkProgressUpdater {
     this.clock = clock;
   }
 
-  /** @param worker workexecutor for the updater. */
+  /**
+   * Sets the worker for the updater.
+   *
+   * @param worker workexecutor for the updater.
+   */
   public void setWorker(WorkExecutor worker) {
     this.worker = worker;
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/AbstractWindmillStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/AbstractWindmillStream.java
@@ -357,6 +357,8 @@ public abstract class AbstractWindmillStream<RequestT, ResponseT> implements Win
   protected abstract void sendHealthCheck() throws WindmillStreamShutdownException;
 
   /**
+   * Appends a summary of the stream to the given PrintWriter.
+   *
    * @implNote Care is taken that synchronization on this is unnecessary for all status page
    *     information. Blocking sends are made beneath this stream object's lock which could block
    *     status page rendering.

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/state/WindmillTagEncodingV1.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/state/WindmillTagEncodingV1.java
@@ -270,7 +270,7 @@ public class WindmillTagEncodingV1 extends WindmillTagEncoding {
     }
   }
 
-  /** @return the singleton WindmillStateTagUtil */
+  /** Returns the singleton WindmillStateTagUtil. */
   public static WindmillTagEncodingV1 instance() {
     return INSTANCE;
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/state/WindmillTagEncodingV2.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/state/WindmillTagEncodingV2.java
@@ -296,7 +296,7 @@ public class WindmillTagEncodingV2 extends WindmillTagEncoding {
     // todo add draining (https://github.com/apache/beam/issues/36884)
   }
 
-  /** @return the singleton WindmillStateTagUtil */
+  /** Returns the singleton WindmillStateTagUtil. */
   public static WindmillTagEncodingV2 instance() {
     return INSTANCE;
   }

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ProcessBundleDescriptors.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ProcessBundleDescriptors.java
@@ -511,7 +511,7 @@ public class ProcessBundleDescriptors {
     public abstract Coder<K> coder();
   }
 
-  /** */
+  /** ExecutableProcessBundleDescriptor. */
   @AutoValue
   @AutoValue.CopyAnnotations
   @SuppressWarnings({"rawtypes"})

--- a/runners/java-job-service/src/main/java/org/apache/beam/runners/jobsubmission/JobInvocation.java
+++ b/runners/java-job-service/src/main/java/org/apache/beam/runners/jobsubmission/JobInvocation.java
@@ -156,7 +156,7 @@ public class JobInvocation {
         executorService);
   }
 
-  /** @return Unique identifier for the job invocation. */
+  /** Returns unique identifier for the job invocation. */
   public String getId() {
     return jobInfo.jobId();
   }

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/ClassicBundleManager.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/ClassicBundleManager.java
@@ -40,10 +40,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @inheritDoc Implementation of BundleManager for non-portable mode. Keeps track of the async
- *     function completions.
- *     <p>This class is not thread safe and the current implementation relies on the assumption that
- *     messages are dispatched to BundleManager in a single threaded mode.
+ * Implementation of BundleManager for non-portable mode. Keeps track of the async function
+ * completions.
+ *
+ * <p>This class is not thread safe and the current implementation relies on the assumption that
+ * messages are dispatched to BundleManager in a single threaded mode.
+ *
+ * <p>{@inheritDoc}
  */
 @SuppressWarnings({
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/ConfigBuilder.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/ConfigBuilder.java
@@ -87,7 +87,7 @@ public class ConfigBuilder {
     config.putAll(properties);
   }
 
-  /** @return built configuration */
+  /** Returns built configuration. */
   public Config build() {
     try {
       // apply framework configs

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkInputDataProcessor.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkInputDataProcessor.java
@@ -43,8 +43,8 @@ import scala.Tuple2;
 public interface SparkInputDataProcessor<FnInputT, FnOutputT, OutputT> {
 
   /**
-   * @return {@link WindowedValueMultiReceiver} to be used by {@link
-   *     org.apache.beam.runners.core.DoFnRunner} for emitting processing results
+   * Returns {@link WindowedValueMultiReceiver} to be used by {@link
+   * org.apache.beam.runners.core.DoFnRunner} for emitting processing results.
    */
   WindowedValueMultiReceiver getOutputManager();
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/PipelineResult.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/PipelineResult.java
@@ -106,12 +106,12 @@ public interface PipelineResult {
       this.hasReplacement = hasReplacement;
     }
 
-    /** @return {@code true} if the job state can no longer complete work. */
+    /** Returns {@code true} if the job state can no longer complete work. */
     public final boolean isTerminal() {
       return terminal;
     }
 
-    /** @return {@code true} if this job state indicates that a replacement job exists. */
+    /** Returns {@code true} if this job state indicates that a replacement job exists. */
     public final boolean hasReplacementJob() {
       return hasReplacement;
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/CannotProvideCoderException.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/CannotProvideCoderException.java
@@ -51,7 +51,7 @@ public class CannotProvideCoderException extends Exception {
     this.reason = reason;
   }
 
-  /** @return the reason that Coder inference failed. */
+  /** Returns the reason that Coder inference failed. */
   public ReasonCode getReason() {
     return reason;
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
@@ -77,34 +77,34 @@ public class CompressedSource<T> extends FileBasedSource<T> {
   /** @deprecated Use {@link Compression} instead */
   @Deprecated
   public enum CompressionMode implements DecompressingChannelFactory {
-    /** @see Compression#UNCOMPRESSED */
+    /** See {@link Compression#UNCOMPRESSED}. */
     UNCOMPRESSED(Compression.UNCOMPRESSED),
 
-    /** @see Compression#AUTO */
+    /** See {@link Compression#AUTO}. */
     AUTO(Compression.AUTO),
 
-    /** @see Compression#GZIP */
+    /** See {@link Compression#GZIP}. */
     GZIP(Compression.GZIP),
 
-    /** @see Compression#BZIP2 */
+    /** See {@link Compression#BZIP2}. */
     BZIP2(Compression.BZIP2),
 
-    /** @see Compression#ZIP */
+    /** See {@link Compression#ZIP}. */
     ZIP(Compression.ZIP),
 
-    /** @see Compression#ZSTD */
+    /** See {@link Compression#ZSTD}. */
     ZSTD(Compression.ZSTD),
 
-    /** @see Compression#LZO */
+    /** See {@link Compression#LZO}. */
     LZO(Compression.LZO),
 
-    /** @see Compression#LZOP */
+    /** See {@link Compression#LZOP}. */
     LZOP(Compression.LZOP),
 
-    /** @see Compression#DEFLATE */
+    /** See {@link Compression#DEFLATE}. */
     DEFLATE(Compression.DEFLATE),
 
-    /** @see Compression#SNAPPY */
+    /** See {@link Compression#SNAPPY}. */
     SNAPPY(Compression.SNAPPY);
 
     private final Compression canonical;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
@@ -130,28 +130,28 @@ public abstract class FileBasedSink<UserT, DestinationT, OutputT>
   /** @deprecated use {@link Compression}. */
   @Deprecated
   public enum CompressionType implements WritableByteChannelFactory {
-    /** @see Compression#UNCOMPRESSED */
+    /** See {@link Compression#UNCOMPRESSED}. */
     UNCOMPRESSED(Compression.UNCOMPRESSED),
 
-    /** @see Compression#GZIP */
+    /** See {@link Compression#GZIP}. */
     GZIP(Compression.GZIP),
 
-    /** @see Compression#BZIP2 */
+    /** See {@link Compression#BZIP2}. */
     BZIP2(Compression.BZIP2),
 
-    /** @see Compression#ZSTD */
+    /** See {@link Compression#ZSTD}. */
     ZSTD(Compression.ZSTD),
 
-    /** @see Compression#LZO */
+    /** See {@link Compression#LZO}. */
     LZO(Compression.LZO),
 
-    /** @see Compression#LZOP */
+    /** See {@link Compression#LZOP}. */
     LZOP(Compression.LZOP),
 
-    /** @see Compression#DEFLATE */
+    /** See {@link Compression#DEFLATE}. */
     DEFLATE(Compression.DEFLATE),
 
-    /** @see Compression#SNAPPY */
+    /** See {@link Compression#SNAPPY}. */
     SNAPPY(Compression.SNAPPY);
 
     private final Compression canonical;
@@ -1252,7 +1252,7 @@ public abstract class FileBasedSink<UserT, DestinationT, OutputT>
     @Nullable
     String getMimeType();
 
-    /** @return an optional filename suffix, eg, ".gz" is returned for {@link Compression#GZIP} */
+    /** Returns an optional filename suffix, eg, ".gz" is returned for {@link Compression#GZIP}. */
     @Nullable
     String getSuggestedFilenameSuffix();
   }
@@ -1268,8 +1268,9 @@ public abstract class FileBasedSink<UserT, DestinationT, OutputT>
    */
   public interface WritableByteChannelFactory extends OutputFileHints {
     /**
+     * Returns the {@link WritableByteChannel} to be used during output.
+     *
      * @param channel the {@link WritableByteChannel} to wrap
-     * @return the {@link WritableByteChannel} to be used during output
      */
     WritableByteChannel create(WritableByteChannel channel) throws IOException;
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TFRecordIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TFRecordIO.java
@@ -463,16 +463,16 @@ public class TFRecordIO {
   /** @deprecated Use {@link Compression}. */
   @Deprecated
   public enum CompressionType {
-    /** @see Compression#AUTO */
+    /** See {@link Compression#AUTO}. */
     AUTO(Compression.AUTO),
 
-    /** @see Compression#UNCOMPRESSED */
+    /** See {@link Compression#UNCOMPRESSED}. */
     NONE(Compression.UNCOMPRESSED),
 
-    /** @see Compression#GZIP */
+    /** See {@link Compression#GZIP}. */
     GZIP(Compression.GZIP),
 
-    /** @see Compression#DEFLATE */
+    /** See {@link Compression#DEFLATE}. */
     ZLIB(Compression.DEFLATE);
 
     private final Compression canonical;
@@ -481,7 +481,7 @@ public class TFRecordIO {
       this.canonical = canonical;
     }
 
-    /** @see Compression#matches */
+    /** See {@link Compression#matches}. */
     public boolean matches(String filename) {
       return canonical.matches(filename);
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
@@ -1415,25 +1415,25 @@ public class TextIO {
   /** @deprecated Use {@link Compression}. */
   @Deprecated
   public enum CompressionType {
-    /** @see Compression#AUTO */
+    /** See {@link Compression#AUTO}. */
     AUTO(Compression.AUTO),
 
-    /** @see Compression#UNCOMPRESSED */
+    /** See {@link Compression#UNCOMPRESSED}. */
     UNCOMPRESSED(Compression.UNCOMPRESSED),
 
-    /** @see Compression#GZIP */
+    /** See {@link Compression#GZIP}. */
     GZIP(Compression.GZIP),
 
-    /** @see Compression#BZIP2 */
+    /** See {@link Compression#BZIP2}. */
     BZIP2(Compression.BZIP2),
 
-    /** @see Compression#ZIP */
+    /** See {@link Compression#ZIP}. */
     ZIP(Compression.ZIP),
 
-    /** @see Compression#ZSTD */
+    /** See {@link Compression#ZSTD}. */
     ZSTD(Compression.ZSTD),
 
-    /** @see Compression#DEFLATE */
+    /** See {@link Compression#DEFLATE}. */
     DEFLATE(Compression.DEFLATE);
 
     private final Compression canonical;
@@ -1442,7 +1442,7 @@ public class TextIO {
       this.canonical = canonical;
     }
 
-    /** @see Compression#matches */
+    /** See {@link Compression#matches}. */
     public boolean matches(String filename) {
       return canonical.matches(filename);
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextSource.java
@@ -495,9 +495,9 @@ public class TextSource extends FileBasedSource<String> {
   }
 
   /**
-   * @see <a
-   *     href="https://en.wikipedia.org/wiki/Knuth%E2%80%93Morris%E2%80%93Pratt_algorithm">Knuth–Morris–Pratt
-   *     algorithm</a>
+   * See <a
+   * href="https://en.wikipedia.org/wiki/Knuth%E2%80%93Morris%E2%80%93Pratt_algorithm">Knuth–Morris–Pratt
+   * algorithm</a>.
    */
   static class KMPDelimiterFinder {
     private final byte[] delimiter;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/BoundedTrieResult.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/BoundedTrieResult.java
@@ -50,7 +50,7 @@ public abstract class BoundedTrieResult {
         ImmutableSet.copyOf(s.stream().map(ImmutableList::copyOf).collect(Collectors.toSet())));
   }
 
-  /** @return an empty {@link BoundedTrieResult} */
+  /** Returns an empty {@link BoundedTrieResult}. */
   public static BoundedTrieResult empty() {
     return create(ImmutableSet.of());
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/StringSetResult.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/StringSetResult.java
@@ -40,7 +40,7 @@ public abstract class StringSetResult {
     return new AutoValue_StringSetResult(ImmutableSet.copyOf(s));
   }
 
-  /** @return a {@link EmptyStringSetResult} */
+  /** Returns a {@link EmptyStringSetResult}. */
   public static StringSetResult empty() {
     return EmptyStringSetResult.INSTANCE;
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/AppliedPTransform.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/AppliedPTransform.java
@@ -77,7 +77,7 @@ public abstract class AppliedPTransform<
 
   public abstract Pipeline getPipeline();
 
-  /** @return map of {@link TupleTag TupleTags} which are not side inputs. */
+  /** Returns map of {@link TupleTag TupleTags} which are not side inputs. */
   public Map<TupleTag<?>, PCollection<?>> getMainInputs() {
     Map<TupleTag<?>, PCollection<?>> sideInputs =
         PValues.fullyExpand(getTransform().getAdditionalInputs());

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/GroupIntoBatches.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/GroupIntoBatches.java
@@ -212,7 +212,7 @@ public class GroupIntoBatches<K, InputT>
     return super.toString() + ", params=" + params;
   }
 
-  /** @see #ofSize(long) */
+  /** See {@link #ofSize(long)}. */
   public GroupIntoBatches<K, InputT> withSize(long batchSize) {
     Preconditions.checkState(batchSize < Long.MAX_VALUE);
     return new GroupIntoBatches<>(
@@ -223,7 +223,7 @@ public class GroupIntoBatches<K, InputT>
             params.getMaxBufferingDuration()));
   }
 
-  /** @see #ofByteSize(long) */
+  /** See {@link #ofByteSize(long)}. */
   public GroupIntoBatches<K, InputT> withByteSize(long batchSizeBytes) {
     Preconditions.checkState(batchSizeBytes < Long.MAX_VALUE);
     return new GroupIntoBatches<>(
@@ -234,7 +234,7 @@ public class GroupIntoBatches<K, InputT>
             params.getMaxBufferingDuration()));
   }
 
-  /** @see #ofByteSize(long, SerializableFunction) */
+  /** See {@link #ofByteSize(long, SerializableFunction)}. */
   public GroupIntoBatches<K, InputT> withByteSize(
       long batchSizeBytes, SerializableFunction<InputT, Long> getElementByteSize) {
     Preconditions.checkState(batchSizeBytes < Long.MAX_VALUE);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Redistribute.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Redistribute.java
@@ -46,17 +46,19 @@ import org.joda.time.Duration;
  * is likely useful.
  */
 public class Redistribute {
-  /** @return a {@link RedistributeArbitrarily} transform with default configuration. */
+  /** Returns a {@link RedistributeArbitrarily} transform with default configuration. */
   public static <T> RedistributeArbitrarily<T> arbitrarily() {
     return new RedistributeArbitrarily<>(null, false);
   }
 
-  /** @return a {@link RedistributeByKey} transform with default configuration. */
+  /** Returns a {@link RedistributeByKey} transform with default configuration. */
   public static <K, V> RedistributeByKey<K, V> byKey() {
     return new RedistributeByKey<>(false);
   }
 
   /**
+   * A by-key redistribute transform.
+   *
    * @param <K> The type of key being reshuffled on.
    * @param <V> The type of value being reshuffled.
    */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
@@ -232,7 +232,7 @@ class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
 
   private ByteBuddyDoFnInvokerFactory() {}
 
-  /** @return the {@link DoFnInvoker} for the given {@link DoFn}. */
+  /** Returns the {@link DoFnInvoker} for the given {@link DoFn}. */
   @SuppressWarnings({"unchecked", "rawtypes"})
   public <InputT, OutputT> DoFnInvoker<InputT, OutputT> newByteBuddyInvoker(
       DoFn<InputT, OutputT> fn) {
@@ -309,7 +309,7 @@ class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
     }
   }
 
-  /** @return the {@link DoFnInvoker} for the given {@link DoFn}. */
+  /** Returns the {@link DoFnInvoker} for the given {@link DoFn}. */
   public <InputT, OutputT> DoFnInvoker<InputT, OutputT> newByteBuddyInvoker(
       DoFnSignature signature, DoFn<InputT, OutputT> fn) {
     checkArgument(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
@@ -291,12 +291,12 @@ public class DoFnSignatures {
               Parameter.PipelineOptionsParameter.class,
               Parameter.SideInputParameter.class);
 
-  /** @return the {@link DoFnSignature} for the given {@link DoFn} instance. */
+  /** Returns the {@link DoFnSignature} for the given {@link DoFn} instance. */
   public static <FnT extends DoFn<?, ?>> DoFnSignature signatureForDoFn(FnT fn) {
     return getSignature(fn.getClass());
   }
 
-  /** @return the {@link DoFnSignature} for the given {@link DoFn} subclass. */
+  /** Returns the {@link DoFnSignature} for the given {@link DoFn} subclass. */
   public static <FnT extends DoFn<?, ?>> DoFnSignature getSignature(Class<FnT> fn) {
     return signatureCache.computeIfAbsent(fn, DoFnSignatures::parseSignature);
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterWatermark.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterWatermark.java
@@ -69,7 +69,7 @@ public class AfterWatermark {
     return new FromEndOfWindow();
   }
 
-  /** @see AfterWatermark */
+  /** See {@link AfterWatermark}. */
   public static class AfterWatermarkEarlyAndLate extends Trigger {
 
     private final OnceTrigger earlyTrigger;
@@ -120,7 +120,7 @@ public class AfterWatermark {
       return window.maxTimestamp();
     }
 
-    /** @return true if there is no late firing set up, otherwise false */
+    /** Returns true if there is no late firing set up, otherwise false. */
     @Override
     public boolean mayFinish() {
       return lateTrigger == null;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/MutationDetector.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/MutationDetector.java
@@ -27,6 +27,6 @@ import org.apache.beam.sdk.annotations.Internal;
  */
 @Internal
 public interface MutationDetector extends AutoCloseable {
-  /** @throws IllegalMutationException if illegal mutations are detected. */
+  /** Throws {@link IllegalMutationException} if illegal mutations are detected. */
   void verifyUnmodified() throws IllegalMutationException;
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/PTransformReplacements.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/PTransformReplacements.java
@@ -27,7 +27,7 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
 
-/** */
+/** Utilty class for PTransform replacements. */
 @SuppressWarnings({"nullness", "keyfor"}) // TODO(https://github.com/apache/beam/issues/20497)
 public class PTransformReplacements {
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/WindowedValues.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/WindowedValues.java
@@ -416,7 +416,7 @@ public class WindowedValues {
   /** A {@link WindowedValues} which holds exactly single window per value. */
   public interface SingleWindowedValue {
 
-    /** @return the single window associated with this value. */
+    /** Returns the single window associated with this value. */
     BoundedWindow getWindow();
   }
 

--- a/sdks/java/extensions/euphoria/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/annotation/operator/Basic.java
+++ b/sdks/java/extensions/euphoria/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/annotation/operator/Basic.java
@@ -29,9 +29,9 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface Basic {
 
-  /** @return the state complexity */
+  /** Returns the state complexity. */
   StateComplexity state();
 
-  /** @return number of global repartition operations */
+  /** Returns number of global repartition operations. */
   int repartitions();
 }

--- a/sdks/java/extensions/euphoria/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/annotation/operator/Derived.java
+++ b/sdks/java/extensions/euphoria/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/annotation/operator/Derived.java
@@ -29,9 +29,9 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface Derived {
 
-  /** @return the state complexity */
+  /** Returns the state complexity. */
   StateComplexity state();
 
-  /** @return the number of global repartition operations */
+  /** Returns the number of global repartition operations. */
   int repartitions();
 }

--- a/sdks/java/extensions/euphoria/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/annotation/operator/Recommended.java
+++ b/sdks/java/extensions/euphoria/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/annotation/operator/Recommended.java
@@ -30,14 +30,14 @@ import java.lang.annotation.Target;
 public @interface Recommended {
 
   /**
-   * @return a human readable explanation why the annotated operator is recommendation for native
-   *     implementation by an executor
+   * Returns a human readable explanation why the annotated operator is recommendation for native
+   * implementation by an executor.
    */
   String reason();
 
-  /** @return the state complexity */
+  /** Returns the state complexity. */
   StateComplexity state();
 
-  /** @return the number of global repartition operations */
+  /** Returns the number of global repartition operations. */
   int repartitions();
 }

--- a/sdks/java/extensions/euphoria/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/client/lib/Split.java
+++ b/sdks/java/extensions/euphoria/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/client/lib/Split.java
@@ -110,12 +110,12 @@ public class Split {
       this.negative = Objects.requireNonNull(negative);
     }
 
-    /** @return positive split result */
+    /** Returns positive split result. */
     public PCollection<T> positive() {
       return positive;
     }
 
-    /** @return negative split result */
+    /** Returns negative split result. */
     public PCollection<T> negative() {
       return negative;
     }

--- a/sdks/java/extensions/euphoria/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/client/operator/AssignEventTime.java
+++ b/sdks/java/extensions/euphoria/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/client/operator/AssignEventTime.java
@@ -93,18 +93,20 @@ public class AssignEventTime<InputT> extends Operator<InputT>
   public interface UsingBuilder<InputT> {
 
     /**
+     * See {@link FlatMap.EventTimeBuilder#eventTimeBy(ExtractEventTime)}.
+     *
      * @param fn the event time extraction function
      * @return the next builder to complete the setup
-     * @see FlatMap.EventTimeBuilder#eventTimeBy(ExtractEventTime)
      */
     Builders.Output<InputT> using(ExtractEventTime<InputT> fn);
 
     /**
+     * See {@link FlatMap.EventTimeBuilder#eventTimeBy(ExtractEventTime)}.
+     *
      * @param fn the event time extraction function
      * @param allowedTimestampSkew allowed timestamp skew when assigning timestamps back in time
      *     {@link DoFn#getAllowedTimestampSkew}.
      * @return the next builder to complete the setup
-     * @see FlatMap.EventTimeBuilder#eventTimeBy(ExtractEventTime)
      */
     Builders.Output<InputT> using(ExtractEventTime<InputT> fn, Duration allowedTimestampSkew);
   }
@@ -166,7 +168,8 @@ public class AssignEventTime<InputT> extends Operator<InputT>
   }
 
   /**
-   * @return the user defined event time assigner
+   * Returns the user defined event time assigner.
+   *
    * @see FlatMap#getEventTimeExtractor()
    */
   public ExtractEventTime<InputT> getEventTimeExtractor() {

--- a/sdks/java/extensions/euphoria/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/client/operator/ReduceByKey.java
+++ b/sdks/java/extensions/euphoria/src/main/java/org/apache/beam/sdk/extensions/euphoria/core/client/operator/ReduceByKey.java
@@ -113,10 +113,10 @@ public class ReduceByKey<InputT, KeyT, ValueT, AccT, OutputT>
    */
   public interface CombineFunctionWithIdentity<T> extends CombinableBinaryFunction<T> {
 
-    /** @return identity value with respect to the combining function. */
+    /** Returns identity value with respect to the combining function. */
     T identity();
 
-    /** @return type descriptor of the value */
+    /** Returns type descriptor of the value. */
     default TypeDescriptor<T> valueDesc() {
       return null;
     }

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/CustomHttpErrors.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/CustomHttpErrors.java
@@ -132,7 +132,7 @@ public class CustomHttpErrors {
     }
   }
 
-  /** @return The first custom error for the failing request and response to match, or null. */
+  /** Returns the first custom error for the failing request and response to match, or null. */
   public String getCustomError(HttpRequestWrapper req, HttpResponseWrapper res) {
     for (MatcherAndError m : matchersAndLogs) {
       if (m.getMatcher().matchResponse(req, res)) {

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/GceMetadataUtil.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/GceMetadataUtil.java
@@ -33,7 +33,7 @@ import org.apache.http.params.HttpParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** */
+/** Utility class for fetching Google Compute Engine metadata. */
 public class GceMetadataUtil {
   private static final String BASE_METADATA_URL = "http://metadata/computeMetadata/v1/";
 

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/HttpCallCustomError.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/HttpCallCustomError.java
@@ -20,6 +20,6 @@ package org.apache.beam.sdk.extensions.gcp.util;
 /** Lambda interface for defining a custom error to log based on an http request and response. */
 interface HttpCallCustomError {
 
-  /** @return A string which represents a custom error to be logged for the request and response. */
+  /** Returns a string which represents a custom error to be logged for the request and response. */
   String customError(HttpRequestWrapper request, HttpResponseWrapper response);
 }

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/HttpCallMatcher.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/HttpCallMatcher.java
@@ -23,6 +23,6 @@ package org.apache.beam.sdk.extensions.gcp.util;
  */
 interface HttpCallMatcher {
 
-  /** @return true iff the request and response represent a matching http c\all. */
+  /** Returns true iff the request and response represent a matching http call. */
   boolean matchResponse(HttpRequestWrapper req, HttpResponseWrapper response);
 }

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/RetryHttpRequestInitializer.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/RetryHttpRequestInitializer.java
@@ -289,7 +289,11 @@ public class RetryHttpRequestInitializer implements HttpRequestInitializer {
     this.customHttpErrors = customErrors;
   }
 
-  /** @param writeTimeout in milliseconds. */
+  /**
+   * Sets the write timeout.
+   *
+   * @param writeTimeout in milliseconds.
+   */
   public void setWriteTimeout(int writeTimeout) {
     this.writeTimeout = writeTimeout;
   }
@@ -298,7 +302,11 @@ public class RetryHttpRequestInitializer implements HttpRequestInitializer {
     this.httpHeaders = httpHeaders;
   }
 
-  /** @param readTimeout in milliseconds. */
+  /**
+   * Sets the read timeout.
+   *
+   * @param readTimeout in milliseconds.
+   */
   public void setReadTimeout(int readTimeout) {
     this.readTimeout = readTimeout;
   }

--- a/sdks/java/extensions/kafka-factories/src/main/java/org/apache/beam/sdk/extensions/kafka/factories/FileAwareFactoryFn.java
+++ b/sdks/java/extensions/kafka-factories/src/main/java/org/apache/beam/sdk/extensions/kafka/factories/FileAwareFactoryFn.java
@@ -221,9 +221,11 @@ public abstract class FileAwareFactoryFn<T>
   }
 
   /**
-   * @throws IOException A hook for subclasses to download and process specific files before the
-   *     main configuration is handled. For example, the kerberos factory can use this to download a
-   *     krb5.conf and set a system property.
+   * A hook for subclasses to download and process specific files before the main configuration is
+   * handled. For example, the kerberos factory can use this to download a krb5.conf and set a
+   * system property.
+   *
+   * @throws IOException If downloading or processing the file fails.
    */
   protected void downloadAndProcessExtraFiles() throws IOException {
     // Default implementation should do nothing.

--- a/sdks/java/extensions/ml/src/main/java/org/apache/beam/sdk/extensions/ml/DLPDeidentifyText.java
+++ b/sdks/java/extensions/ml/src/main/java/org/apache/beam/sdk/extensions/ml/DLPDeidentifyText.java
@@ -67,63 +67,88 @@ public abstract class DLPDeidentifyText
 
   public static final Integer DLP_PAYLOAD_LIMIT_BYTES = 524000;
 
-  /** @return Template name for data inspection. */
+  /** Returns template name for data inspection. */
   public abstract @Nullable String getInspectTemplateName();
 
-  /** @return Template name for data deidentification. */
+  /** Returns template name for data deidentification. */
   public abstract @Nullable String getDeidentifyTemplateName();
 
   /**
-   * @return Configuration object for data inspection. If present, supersedes the template settings.
+   * Returns configuration object for data inspection. If present, supersedes the template settings.
    */
   public abstract @Nullable InspectConfig getInspectConfig();
 
-  /** @return Configuration object for deidentification. If present, supersedes the template. */
+  /** Returns configuration object for deidentification. If present, supersedes the template. */
   public abstract @Nullable DeidentifyConfig getDeidentifyConfig();
 
-  /** @return List of column names if the input KV value is a delimited row. */
+  /** Returns list of column names if the input KV value is a delimited row. */
   public abstract @Nullable PCollectionView<List<String>> getHeaderColumns();
 
-  /** @return Delimiter to be used when splitting values from input strings into columns. */
+  /** Returns delimiter to be used when splitting values from input strings into columns. */
   public abstract @Nullable String getColumnDelimiter();
 
-  /** @return Size of input elements batch to be sent to Cloud DLP service in one request. */
+  /** Returns size of input elements batch to be sent to Cloud DLP service in one request. */
   public abstract Integer getBatchSizeBytes();
 
-  /** @return ID of Google Cloud project to be used when deidentifying data. */
+  /** Returns ID of Google Cloud project to be used when deidentifying data. */
   public abstract String getProjectId();
 
   @AutoValue.Builder
   public abstract static class Builder {
-    /** @param inspectTemplateName Template name for data inspection. */
+    /**
+     * Sets template name for data inspection.
+     *
+     * @param inspectTemplateName Template name for data inspection.
+     */
     public abstract Builder setInspectTemplateName(String inspectTemplateName);
 
-    /** @param headerColumns List of column names if the input KV value is a delimited row. */
+    /**
+     * Sets list of column names if the input KV value is a delimited row.
+     *
+     * @param headerColumns List of column names if the input KV value is a delimited row.
+     */
     public abstract Builder setHeaderColumns(PCollectionView<List<String>> headerColumns);
 
     /**
+     * Sets delimiter to be used when splitting values from input strings into columns.
+     *
      * @param delimiter Delimiter to be used when splitting values from input strings into columns.
      */
     public abstract Builder setColumnDelimiter(String delimiter);
 
     /**
+     * Sets size of input elements batch to be sent to Cloud DLP service in one request.
+     *
      * @param batchSize Size of input elements batch to be sent to Cloud DLP service in one request.
      */
     public abstract Builder setBatchSizeBytes(Integer batchSize);
 
-    /** @param projectId ID of Google Cloud project to be used when deidentifying data. */
+    /**
+     * Sets ID of Google Cloud project to be used when deidentifying data.
+     *
+     * @param projectId ID of Google Cloud project to be used when deidentifying data.
+     */
     public abstract Builder setProjectId(String projectId);
 
-    /** @param deidentifyTemplateName Template name for data deidentification. */
+    /**
+     * Sets template name for data deidentification.
+     *
+     * @param deidentifyTemplateName Template name for data deidentification.
+     */
     public abstract Builder setDeidentifyTemplateName(String deidentifyTemplateName);
 
     /**
+     * Sets configuration object for data inspection. If present, supersedes the template settings.
+     *
      * @param inspectConfig Configuration object for data inspection. If present, supersedes the
      *     template settings.
      */
     public abstract Builder setInspectConfig(InspectConfig inspectConfig);
 
     /**
+     * Sets configuration object for data deidentification. If present, supersedes the template
+     * settings.
+     *
      * @param deidentifyConfig Configuration object for data deidentification. If present,
      *     supersedes the template settings.
      */

--- a/sdks/java/extensions/ml/src/main/java/org/apache/beam/sdk/extensions/ml/DLPInspectText.java
+++ b/sdks/java/extensions/ml/src/main/java/org/apache/beam/sdk/extensions/ml/DLPInspectText.java
@@ -68,51 +68,69 @@ public abstract class DLPInspectText
 
   public static final Integer DLP_PAYLOAD_LIMIT_BYTES = 524000;
 
-  /** @return Template name for data inspection. */
+  /** Returns template name for data inspection. */
   public abstract @Nullable String getInspectTemplateName();
 
   /**
-   * @return Configuration object for data inspection. If present, supersedes the template settings.
+   * Returns configuration object for data inspection. If present, supersedes the template settings.
    */
   public abstract @Nullable InspectConfig getInspectConfig();
 
-  /** @return Size of input elements batch to be sent to Cloud DLP service in one request. */
+  /** Returns size of input elements batch to be sent to Cloud DLP service in one request. */
   public abstract Integer getBatchSizeBytes();
 
-  /** @return ID of Google Cloud project to be used when deidentifying data. */
+  /** Returns ID of Google Cloud project to be used when deidentifying data. */
   public abstract String getProjectId();
 
-  /** @return Delimiter to be used when splitting values from input strings into columns. */
+  /** Returns delimiter to be used when splitting values from input strings into columns. */
   public abstract @Nullable String getColumnDelimiter();
 
-  /** @return List of column names if the input KV value is a delimited row. */
+  /** Returns list of column names if the input KV value is a delimited row. */
   public abstract @Nullable PCollectionView<List<String>> getHeaderColumns();
 
   @AutoValue.Builder
   public abstract static class Builder {
-    /** @param inspectTemplateName Template name for data inspection. */
+    /**
+     * Sets template name for data inspection.
+     *
+     * @param inspectTemplateName Template name for data inspection.
+     */
     public abstract Builder setInspectTemplateName(String inspectTemplateName);
 
     /**
+     * Sets configuration object for data inspection. If present, supersedes the template settings.
+     *
      * @param inspectConfig Configuration object for data inspection. If present, supersedes the
      *     template settings.
      */
     public abstract Builder setInspectConfig(InspectConfig inspectConfig);
 
     /**
+     * Sets size of input elements batch to be sent to Cloud DLP service in one request.
+     *
      * @param batchSize Size of input elements batch to be sent to Cloud DLP service in one request.
      */
     public abstract Builder setBatchSizeBytes(Integer batchSize);
 
-    /** @param projectId ID of Google Cloud project to be used when deidentifying data. */
+    /**
+     * Sets ID of Google Cloud project to be used when deidentifying data.
+     *
+     * @param projectId ID of Google Cloud project to be used when deidentifying data.
+     */
     public abstract Builder setProjectId(String projectId);
 
     /**
+     * Sets delimiter to be used when splitting values from input strings into columns.
+     *
      * @param delimiter Delimiter to be used when splitting values from input strings into columns.
      */
     public abstract Builder setColumnDelimiter(String delimiter);
 
-    /** @param headerColumns List of column names if the input KV value is a delimited row. */
+    /**
+     * Sets list of column names if the input KV value is a delimited row.
+     *
+     * @param headerColumns List of column names if the input KV value is a delimited row.
+     */
     public abstract Builder setHeaderColumns(PCollectionView<List<String>> headerColumns);
 
     abstract DLPInspectText autoBuild();

--- a/sdks/java/extensions/ml/src/main/java/org/apache/beam/sdk/extensions/ml/DLPReidentifyText.java
+++ b/sdks/java/extensions/ml/src/main/java/org/apache/beam/sdk/extensions/ml/DLPReidentifyText.java
@@ -73,65 +73,89 @@ public abstract class DLPReidentifyText
 
   public static final Integer DLP_PAYLOAD_LIMIT_BYTES = 524000;
 
-  /** @return Template name for data inspection. */
+  /** Returns template name for data inspection. */
   public abstract @Nullable String getInspectTemplateName();
 
-  /** @return Template name for data reidentification. */
+  /** Returns template name for data reidentification. */
   public abstract @Nullable String getReidentifyTemplateName();
 
   /**
-   * @return Configuration object for data inspection. If present, supersedes the template settings.
+   * Returns configuration object for data inspection. If present, supersedes the template settings.
    */
   public abstract @Nullable InspectConfig getInspectConfig();
 
-  /** @return Configuration object for reidentification. If present, supersedes the template. */
+  /** Returns configuration object for reidentification. If present, supersedes the template. */
   public abstract @Nullable DeidentifyConfig getReidentifyConfig();
 
-  /** @return Delimiter to be used when splitting values from input strings into columns. */
+  /** Returns delimiter to be used when splitting values from input strings into columns. */
   public abstract @Nullable String getColumnDelimiter();
 
-  /** @return List of column names if the input KV value is a delimited row. */
+  /** Returns list of column names if the input KV value is a delimited row. */
   public abstract @Nullable PCollectionView<List<String>> getHeaderColumns();
 
-  /** @return Size of input elements batch to be sent to Cloud DLP service in one request. */
+  /** Returns size of input elements batch to be sent to Cloud DLP service in one request. */
   public abstract Integer getBatchSizeBytes();
 
-  /** @return ID of Google Cloud project to be used when deidentifying data. */
+  /** Returns ID of Google Cloud project to be used when deidentifying data. */
   public abstract String getProjectId();
 
   @AutoValue.Builder
   public abstract static class Builder {
-    /** @param inspectTemplateName Template name for data inspection. */
+    /**
+     * Sets template name for data inspection.
+     *
+     * @param inspectTemplateName Template name for data inspection.
+     */
     public abstract Builder setInspectTemplateName(String inspectTemplateName);
 
     /**
+     * Sets configuration object for data inspection.
+     *
      * @param inspectConfig Configuration object for data inspection. If present, supersedes the
      *     template settings.
      */
     public abstract Builder setInspectConfig(InspectConfig inspectConfig);
 
     /**
+     * Sets configuration object for data deidentification.
+     *
      * @param reidentifyConfig Configuration object for data deidentification. If present,
      *     supersedes the template settings.
      */
     public abstract Builder setReidentifyConfig(DeidentifyConfig reidentifyConfig);
 
-    /** @param reidentifyTemplateName Template name for data deidentification. */
+    /**
+     * Sets template name for data deidentification.
+     *
+     * @param reidentifyTemplateName Template name for data deidentification.
+     */
     public abstract Builder setReidentifyTemplateName(String reidentifyTemplateName);
 
     /**
+     * Sets size of input elements batch to be sent to Cloud DLP service in one request.
+     *
      * @param batchSize Size of input elements batch to be sent to Cloud DLP service in one request.
      */
     public abstract Builder setBatchSizeBytes(Integer batchSize);
-    /** @param headerColumns List of column names if the input KV value is a delimited row. */
+    /**
+     * Sets list of column names if the input KV value is a delimited row.
+     *
+     * @param headerColumns List of column names if the input KV value is a delimited row.
+     */
     public abstract Builder setHeaderColumns(PCollectionView<List<String>> headerColumns);
 
     /**
+     * Sets delimiter to be used when splitting values from input strings into columns.
+     *
      * @param delimiter Delimiter to be used when splitting values from input strings into columns.
      */
     public abstract Builder setColumnDelimiter(String delimiter);
 
-    /** @param projectId ID of Google Cloud project to be used when deidentifying data. */
+    /**
+     * Sets ID of Google Cloud project to be used when deidentifying data.
+     *
+     * @param projectId ID of Google Cloud project to be used when deidentifying data.
+     */
     public abstract Builder setProjectId(String projectId);
 
     abstract DLPReidentifyText autoBuild();

--- a/sdks/java/extensions/ml/src/main/java/org/apache/beam/sdk/extensions/ml/RecommendationAICreateCatalogItem.java
+++ b/sdks/java/extensions/ml/src/main/java/org/apache/beam/sdk/extensions/ml/RecommendationAICreateCatalogItem.java
@@ -49,12 +49,12 @@ import org.json.JSONObject;
 public abstract class RecommendationAICreateCatalogItem
     extends PTransform<PCollection<GenericJson>, PCollectionTuple> {
 
-  /** @return ID of Google Cloud project to be used for creating catalog items. */
+  /** Returns ID of Google Cloud project to be used for creating catalog items. */
   public abstract @Nullable String projectId();
 
   /**
-   * @return Name of the catalog where the catalog items will be created (defaults to
-   *     "default_catalog").
+   * Returns name of the catalog where the catalog items will be created (defaults to
+   * "default_catalog").
    */
   public abstract @Nullable String catalogName();
 
@@ -66,10 +66,18 @@ public abstract class RecommendationAICreateCatalogItem
 
   @AutoValue.Builder
   abstract static class Builder {
-    /** @param projectId ID of Google Cloud project to be used for creating catalog items. */
+    /**
+     * Sets ID of Google Cloud project to be used for creating catalog items.
+     *
+     * @param projectId ID of Google Cloud project to be used for creating catalog items.
+     */
     public abstract Builder setProjectId(@Nullable String projectId);
 
-    /** @param catalogName Name of the catalog where the catalog items will be created. */
+    /**
+     * Sets name of the catalog where the catalog items will be created.
+     *
+     * @param catalogName Name of the catalog where the catalog items will be created.
+     */
     public abstract Builder setCatalogName(@Nullable String catalogName);
 
     public abstract RecommendationAICreateCatalogItem build();

--- a/sdks/java/extensions/ml/src/main/java/org/apache/beam/sdk/extensions/ml/RecommendationAIImportCatalogItems.java
+++ b/sdks/java/extensions/ml/src/main/java/org/apache/beam/sdk/extensions/ml/RecommendationAIImportCatalogItems.java
@@ -72,18 +72,18 @@ public abstract class RecommendationAIImportCatalogItems
 
   abstract Builder toBuilder();
 
-  /** @return ID of Google Cloud project to be used for creating catalog items. */
+  /** Returns ID of Google Cloud project to be used for creating catalog items. */
   public abstract @Nullable String projectId();
 
-  /** @return Name of the catalog where the catalog items will be created. */
+  /** Returns name of the catalog where the catalog items will be created. */
   public abstract @Nullable String catalogName();
 
-  /** @return Size of input elements batch to be sent in one request. */
+  /** Returns size of input elements batch to be sent in one request. */
   public abstract Integer batchSize();
 
   /**
-   * @return Time limit (in processing time) on how long an incomplete batch of elements is allowed
-   *     to be buffered.
+   * Returns time limit (in processing time) on how long an incomplete batch of elements is allowed
+   * to be buffered.
    */
   public abstract Duration maxBufferingDuration();
 
@@ -122,19 +122,32 @@ public abstract class RecommendationAIImportCatalogItems
 
   @AutoValue.Builder
   abstract static class Builder {
-    /** @param projectId ID of Google Cloud project to be used for creating catalog items. */
+    /**
+     * Sets ID of Google Cloud project to be used for creating catalog items.
+     *
+     * @param projectId ID of Google Cloud project to be used for creating catalog items.
+     */
     public abstract Builder setProjectId(@Nullable String projectId);
 
-    /** @param catalogName Name of the catalog where the catalog items will be created. */
+    /**
+     * Sets name of the catalog where the catalog items will be created.
+     *
+     * @param catalogName Name of the catalog where the catalog items will be created.
+     */
     public abstract Builder setCatalogName(@Nullable String catalogName);
 
     /**
+     * Sets amount of input elements to be sent to Recommendation AI service in one request.
+     *
      * @param batchSize Amount of input elements to be sent to Recommendation AI service in one
      *     request.
      */
     public abstract Builder setBatchSize(Integer batchSize);
 
     /**
+     * Sets time limit (in processing time) on how long an incomplete batch of elements is allowed
+     * to be buffered.
+     *
      * @param maxBufferingDuration Time limit (in processing time) on how long an incomplete batch
      *     of elements is allowed to be buffered.
      */

--- a/sdks/java/extensions/ml/src/main/java/org/apache/beam/sdk/extensions/ml/RecommendationAIImportUserEvents.java
+++ b/sdks/java/extensions/ml/src/main/java/org/apache/beam/sdk/extensions/ml/RecommendationAIImportUserEvents.java
@@ -75,21 +75,21 @@ public abstract class RecommendationAIImportUserEvents
 
   abstract Builder toBuilder();
 
-  /** @return ID of Google Cloud project to be used for creating user events. */
+  /** Returns ID of Google Cloud project to be used for creating user events. */
   public abstract @Nullable String projectId();
 
-  /** @return Name of the catalog where the user events will be created. */
+  /** Returns name of the catalog where the user events will be created. */
   public abstract @Nullable String catalogName();
 
-  /** @return Name of the event store where the user events will be created. */
+  /** Returns name of the event store where the user events will be created. */
   public abstract @Nullable String eventStore();
 
-  /** @return Size of input elements batch to be sent in one request. */
+  /** Returns size of input elements batch to be sent in one request. */
   public abstract Integer batchSize();
 
   /**
-   * @return Time limit (in processing time) on how long an incomplete batch of elements is allowed
-   *     to be buffered.
+   * Returns time limit (in processing time) on how long an incomplete batch of elements is allowed
+   * to be buffered.
    */
   public abstract Duration maxBufferingDuration();
 
@@ -132,22 +132,39 @@ public abstract class RecommendationAIImportUserEvents
 
   @AutoValue.Builder
   abstract static class Builder {
-    /** @param projectId ID of Google Cloud project to be used for creating user events. */
+    /**
+     * Sets ID of Google Cloud project to be used for creating user events.
+     *
+     * @param projectId ID of Google Cloud project to be used for creating user events.
+     */
     public abstract Builder setProjectId(@Nullable String projectId);
 
-    /** @param catalogName Name of the catalog where the user events will be created. */
+    /**
+     * Sets name of the catalog where the user events will be created.
+     *
+     * @param catalogName Name of the catalog where the user events will be created.
+     */
     public abstract Builder setCatalogName(@Nullable String catalogName);
 
-    /** @param eventStore Name of the event store where the user events will be created. */
+    /**
+     * Sets name of the event store where the user events will be created.
+     *
+     * @param eventStore Name of the event store where the user events will be created.
+     */
     public abstract Builder setEventStore(@Nullable String eventStore);
 
     /**
+     * Sets amount of input elements to be sent to Recommendation AI service in one request.
+     *
      * @param batchSize Amount of input elements to be sent to Recommendation AI service in one
      *     request.
      */
     public abstract Builder setBatchSize(Integer batchSize);
 
     /**
+     * Sets time limit (in processing time) on how long an incomplete batch of elements is allowed
+     * to be buffered.
+     *
      * @param maxBufferingDuration Time limit (in processing time) on how long an incomplete batch
      *     of elements is allowed to be buffered.
      */

--- a/sdks/java/extensions/ml/src/main/java/org/apache/beam/sdk/extensions/ml/RecommendationAIPredict.java
+++ b/sdks/java/extensions/ml/src/main/java/org/apache/beam/sdk/extensions/ml/RecommendationAIPredict.java
@@ -51,16 +51,16 @@ import org.json.JSONObject;
 public abstract class RecommendationAIPredict
     extends PTransform<PCollection<GenericJson>, PCollectionTuple> {
 
-  /** @return ID of Google Cloud project to be used for creating catalog items. */
+  /** Returns ID of Google Cloud project to be used for creating catalog items. */
   public abstract @Nullable String projectId();
 
-  /** @return Name of the catalog where the catalog items will be created. */
+  /** Returns name of the catalog where the catalog items will be created. */
   public abstract @Nullable String catalogName();
 
-  /** @return Name of the event store where the user events will be created. */
+  /** Returns name of the event store where the user events will be created. */
   public abstract @Nullable String eventStore();
 
-  /** @return ID of the recommendation engine placement. */
+  /** Returns ID of the recommendation engine placement. */
   public abstract String placementId();
 
   public static final TupleTag<PredictResponse.PredictionResult> SUCCESS_TAG =
@@ -70,16 +70,32 @@ public abstract class RecommendationAIPredict
 
   @AutoValue.Builder
   abstract static class Builder {
-    /** @param projectId ID of Google Cloud project to be used for the predictions. */
+    /**
+     * Sets ID of Google Cloud project to be used for the predictions.
+     *
+     * @param projectId ID of Google Cloud project to be used for the predictions.
+     */
     public abstract Builder setProjectId(@Nullable String projectId);
 
-    /** @param catalogName Name of the catalog to be used for predictions. */
+    /**
+     * Sets name of the catalog to be used for predictions.
+     *
+     * @param catalogName Name of the catalog to be used for predictions.
+     */
     public abstract Builder setCatalogName(@Nullable String catalogName);
 
-    /** @param eventStore Name of the event store to be used for predictions. */
+    /**
+     * Sets name of the event store to be used for predictions.
+     *
+     * @param eventStore Name of the event store to be used for predictions.
+     */
     public abstract Builder setEventStore(@Nullable String eventStore);
 
-    /** @param placementId of the recommendation engine placement. */
+    /**
+     * Sets ID of the recommendation engine placement.
+     *
+     * @param placementId of the recommendation engine placement.
+     */
     public abstract Builder setPlacementId(String placementId);
 
     public abstract RecommendationAIPredict build();

--- a/sdks/java/extensions/ml/src/main/java/org/apache/beam/sdk/extensions/ml/RecommendationAIWriteUserEvent.java
+++ b/sdks/java/extensions/ml/src/main/java/org/apache/beam/sdk/extensions/ml/RecommendationAIWriteUserEvent.java
@@ -59,13 +59,13 @@ public abstract class RecommendationAIWriteUserEvent
         .setEventStore("default_event_store");
   }
 
-  /** @return ID of Google Cloud project to be used for creating user events. */
+  /** Returns ID of Google Cloud project to be used for creating user events. */
   public abstract @Nullable String projectId();
 
-  /** @return Name of the catalog where the user events will be created. */
+  /** Returns name of the catalog where the user events will be created. */
   public abstract @Nullable String catalogName();
 
-  /** @return Name of the event store where the user events will be created. */
+  /** Returns name of the event store where the user events will be created. */
   public abstract @Nullable String eventStore();
 
   /**
@@ -84,13 +84,25 @@ public abstract class RecommendationAIWriteUserEvent
 
   @AutoValue.Builder
   abstract static class Builder {
-    /** @param projectId ID of Google Cloud project to be used for creating user events. */
+    /**
+     * Sets ID of Google Cloud project to be used for creating user events.
+     *
+     * @param projectId ID of Google Cloud project to be used for creating user events.
+     */
     public abstract Builder setProjectId(@Nullable String projectId);
 
-    /** @param catalogName Name of the catalog where the user events will be created. */
+    /**
+     * Sets name of the catalog where the user events will be created.
+     *
+     * @param catalogName Name of the catalog where the user events will be created.
+     */
     public abstract Builder setCatalogName(@Nullable String catalogName);
 
-    /** @param eventStore Name of the event store where the user events will be created. */
+    /**
+     * Sets name of the event store where the user events will be created.
+     *
+     * @param eventStore Name of the event store where the user events will be created.
+     */
     public abstract Builder setEventStore(@Nullable String eventStore);
 
     public abstract RecommendationAIWriteUserEvent build();

--- a/sdks/java/extensions/ordered/src/main/java/org/apache/beam/sdk/extensions/ordered/ContiguousSequenceRange.java
+++ b/sdks/java/extensions/ordered/src/main/java/org/apache/beam/sdk/extensions/ordered/ContiguousSequenceRange.java
@@ -41,13 +41,13 @@ public abstract class ContiguousSequenceRange
       ContiguousSequenceRange.of(
           Long.MIN_VALUE, Long.MIN_VALUE, Instant.ofEpochMilli(Long.MIN_VALUE));
 
-  /** @return inclusive starting sequence */
+  /** Returns inclusive starting sequence. */
   public abstract long getStart();
 
-  /** @return exclusive end sequence */
+  /** Returns exclusive end sequence. */
   public abstract long getEnd();
 
-  /** @return latest timestamp of all events in the range */
+  /** Returns latest timestamp of all events in the range. */
   public abstract Instant getTimestamp();
 
   @Override

--- a/sdks/java/extensions/ordered/src/main/java/org/apache/beam/sdk/extensions/ordered/OrderedEventProcessorResult.java
+++ b/sdks/java/extensions/ordered/src/main/java/org/apache/beam/sdk/extensions/ordered/OrderedEventProcessorResult.java
@@ -120,27 +120,27 @@ public class OrderedEventProcessorResult<KeyT, ResultT, EventT> implements POutp
       String transformName, PInput input, PTransform<?, ?> transform) {}
 
   /**
-   * @return processing status for a particular key. The elements will have the timestamp of the
-   *     instant the status was emitted.
+   * Returns processing status for a particular key. The elements will have the timestamp of the
+   * instant the status was emitted.
    */
   public PCollection<KV<KeyT, OrderedProcessingStatus>> processingStatuses() {
     return eventProcessingStatusPCollection;
   }
 
-  /** @return processed states keyed by the original key */
+  /** Returns processed states keyed by the original key. */
   public PCollection<KV<KeyT, ResultT>> output() {
     return outputPCollection;
   }
 
-  /** @return events which failed to process, including the reasons for failure. */
+  /** Returns events which failed to process, including the reasons for failure. */
   public PCollection<KV<KeyT, KV<Long, UnprocessedEvent<EventT>>>> unprocessedEvents() {
     return unprocessedEventPCollection;
   }
 
   /**
-   * @return a view to a calculated side input with the last contiguous range. Note: an iterator is
-   *     returned instead of a single value. Use {@link
-   *     ContiguousSequenceRange#largestRange(Iterable)} to get the largest range.
+   * Returns a view to a calculated side input with the last contiguous range. Note: an iterator is
+   * returned instead of a single value. Use {@link ContiguousSequenceRange#largestRange(Iterable)}
+   * to get the largest range.
    */
   public @Nullable PCollectionView<Iterable<ContiguousSequenceRange>> latestContiguousRange() {
     return latestContiguousRange;

--- a/sdks/java/extensions/ordered/src/main/java/org/apache/beam/sdk/extensions/ordered/OrderedProcessingHandler.java
+++ b/sdks/java/extensions/ordered/src/main/java/org/apache/beam/sdk/extensions/ordered/OrderedProcessingHandler.java
@@ -83,7 +83,7 @@ public abstract class OrderedProcessingHandler<
     this.resultTClass = resultTClass;
   }
 
-  /** @return the event examiner instance which will be used by the transform. */
+  /** Returns the event examiner instance which will be used by the transform. */
   public abstract @NonNull EventExaminer<EventT, StateT> getEventExaminer();
 
   /**

--- a/sdks/java/extensions/ordered/src/main/java/org/apache/beam/sdk/extensions/ordered/OrderedProcessingStatus.java
+++ b/sdks/java/extensions/ordered/src/main/java/org/apache/beam/sdk/extensions/ordered/OrderedProcessingStatus.java
@@ -54,44 +54,44 @@ public abstract class OrderedProcessingStatus {
   }
 
   /**
-   * @return Last sequence processed. If null is returned - no elements for the given key and window
-   *     have been processed yet.
+   * Returns last sequence processed. If null is returned - no elements for the given key and window
+   * have been processed yet.
    */
   public abstract @Nullable Long getLastProcessedSequence();
 
-  /** @return Number of events received out of sequence and buffered. */
+  /** Returns number of events received out of sequence and buffered. */
   public abstract long getNumberOfBufferedEvents();
 
-  /** @return Earliest buffered sequence. If null is returned - there are no buffered events. */
+  /** Returns earliest buffered sequence. If null is returned - there are no buffered events. */
   @Nullable
   public abstract Long getEarliestBufferedSequence();
 
-  /** @return Latest buffered sequence. If null is returned - there are no buffered events. */
+  /** Returns latest buffered sequence. If null is returned - there are no buffered events. */
   @Nullable
   public abstract Long getLatestBufferedSequence();
 
-  /** @return Total number of events received for the given key and window. */
+  /** Returns total number of events received for the given key and window. */
   public abstract long getNumberOfReceivedEvents();
 
   /**
-   * @return Number of duplicate events which were output in {@link
-   *     OrderedEventProcessorResult#unprocessedEvents()} PCollection
+   * Returns number of duplicate events which were output in {@link
+   * OrderedEventProcessorResult#unprocessedEvents()} PCollection.
    */
   public abstract long getDuplicateCount();
 
-  /** @return Number of output results produced. */
+  /** Returns number of output results produced. */
   public abstract long getResultCount();
 
   /**
-   * @return Indicator that the last event for the given key and window has been received. It
-   *     doesn't necessarily mean that all the events for the given key and window have been
-   *     processed. Use {@link OrderedProcessingStatus#getNumberOfBufferedEvents()} == 0 and this
-   *     indicator as the sign that the processing is complete.
+   * Returns indicator that the last event for the given key and window has been received. It
+   * doesn't necessarily mean that all the events for the given key and window have been processed.
+   * Use {@link OrderedProcessingStatus#getNumberOfBufferedEvents()} == 0 and this indicator as the
+   * sign that the processing is complete.
    */
   public abstract boolean isLastEventReceived();
 
   /**
-   * @return Timestamp of when the status was produced. It is not related to the event's timestamp.
+   * Returns timestamp of when the status was produced. It is not related to the event's timestamp.
    */
   public abstract Instant getStatusDate();
 

--- a/sdks/java/extensions/ordered/src/main/java/org/apache/beam/sdk/extensions/ordered/ProcessorDoFn.java
+++ b/sdks/java/extensions/ordered/src/main/java/org/apache/beam/sdk/extensions/ordered/ProcessorDoFn.java
@@ -93,7 +93,7 @@ abstract class ProcessorDoFn<
     numberOfResultsBeforeBundleStart = null;
   }
 
-  /** @return true if each event needs to be examined. */
+  /** Returns true if each event needs to be examined. */
   abstract boolean checkForFirstOrLastEvent();
 
   /**

--- a/sdks/java/extensions/sketching/src/main/java/org/apache/beam/sdk/extensions/sketching/ApproximateDistinct.java
+++ b/sdks/java/extensions/sketching/src/main/java/org/apache/beam/sdk/extensions/sketching/ApproximateDistinct.java
@@ -583,9 +583,10 @@ public final class ApproximateDistinct {
   }
 
   /**
+   * Returns the Mean squared error of the Estimation of cardinality to expect for the given value
+   * of p.
+   *
    * @param p the precision i.e. the number of bits used for indexing the buckets
-   * @return the Mean squared error of the Estimation of cardinality to expect for the given value
-   *     of p.
    */
   public static double relativeErrorForPrecision(int p) {
     if (p < 4) {

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/data/PTransformFunctionRegistry.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/data/PTransformFunctionRegistry.java
@@ -119,8 +119,8 @@ public class PTransformFunctionRegistry {
   }
 
   /**
-   * @return A list of wrapper functions which will invoke the registered functions indirectly. The
-   *     order of registry is maintained.
+   * Returns a list of wrapper functions which will invoke the registered functions indirectly. The
+   * order of registry is maintained.
    */
   public List<ThrowingRunnable> getFunctions() {
     return runnables;

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/logging/QuotaEvent.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/logging/QuotaEvent.java
@@ -51,13 +51,19 @@ public class QuotaEvent {
   }
 
   public static class Builder {
-    /** @param messageText Any additional description for the event. */
+    /**
+     * Sets any additional description for the event.
+     *
+     * @param messageText Any additional description for the event.
+     */
     public Builder withMessageText(String messageText) {
       data.put("quota_event.message_text", messageText);
       return this;
     }
 
     /**
+     * Sets the full path for the resource involved.
+     *
      * @param fullResourceName The full path for the resource involved. For GCP, this would follow
      *     https://google.aip.dev/122#full-resource-names.
      */
@@ -67,6 +73,8 @@ public class QuotaEvent {
     }
 
     /**
+     * Sets the full quota name.
+     *
      * @param quotaName The full quota name. For GCP, this would look like:
      *     example.googleapis.com/quota/name
      */
@@ -75,7 +83,11 @@ public class QuotaEvent {
       return this;
     }
 
-    /** @param operation Name of the operation that generated this quota event, in snake-case. */
+    /**
+     * Sets the name of the operation that generated this quota event.
+     *
+     * @param operation Name of the operation that generated this quota event, in snake-case.
+     */
     public Builder withOperation(String operation) {
       data.put("quota_event.operation", operation);
       return this;

--- a/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/kinesis/KinesisRecord.java
+++ b/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/kinesis/KinesisRecord.java
@@ -91,7 +91,7 @@ public class KinesisRecord {
     return new ExtendedSequenceNumber(getSequenceNumber(), getSubSequenceNumber());
   }
 
-  /** @return The unique identifier of the record based on its position in the stream. */
+  /** Returns the unique identifier of the record based on its position in the stream. */
   public byte[] getUniqueId() {
     return getExtendedSequenceNumber().toString().getBytes(StandardCharsets.UTF_8);
   }
@@ -131,17 +131,17 @@ public class KinesisRecord {
     return subSequenceNumber;
   }
 
-  /** @return The unique identifier of the record within its shard. */
+  /** Returns the unique identifier of the record within its shard. */
   public String getSequenceNumber() {
     return sequenceNumber;
   }
 
-  /** @return The approximate time that the record was inserted into the stream. */
+  /** Returns the approximate time that the record was inserted into the stream. */
   public Instant getApproximateArrivalTimestamp() {
     return approximateArrivalTimestamp;
   }
 
-  /** @return The data blob. */
+  /** Returns the data blob. */
   public ByteBuffer getData() {
     return data;
   }

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/RingRange.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/RingRange.java
@@ -51,7 +51,9 @@ public final class RingRange implements Serializable {
     return (start.compareTo(end) >= 0) ? end.subtract(start).add(ringSize) : end.subtract(start);
   }
 
-  /** @return true if 0 is inside of this range. Note that if start == end, then wrapping is true */
+  /**
+   * Returns true if 0 is inside of this range. Note that if start == end, then wrapping is true.
+   */
   public boolean isWrapping() {
     return start.compareTo(end) >= 0;
   }

--- a/sdks/java/io/common/src/main/java/org/apache/beam/sdk/io/common/NetworkTestHelper.java
+++ b/sdks/java/io/common/src/main/java/org/apache/beam/sdk/io/common/NetworkTestHelper.java
@@ -22,7 +22,7 @@ import java.net.ServerSocket;
 
 /** This class contains helper methods for networking related tasks in tests. */
 public class NetworkTestHelper {
-  /** @return Next available port in local interface */
+  /** Returns next available port in local interface. */
   public static synchronized int getAvailableLocalPort() throws IOException {
     try (ServerSocket socket = new ServerSocket(0); ) {
       return socket.getLocalPort();

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySinkMetrics.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySinkMetrics.java
@@ -80,13 +80,14 @@ public class BigQuerySinkMetrics {
   private static final String ROW_STATUS = "row_status";
 
   /**
+   * Returns a Counter in namespace BigQuerySink and name
+   * 'RpcRequests-Method:{method}RpcStatus:{status};TableId:{tableId}'. TableId label is dropped if
+   * 'supportsMetricsDeletion' is not enabled.
+   *
    * @param method StorageWriteAPI method associated with this metric.
    * @param rpcStatus RPC return status.
    * @param tableId Table pertaining to the write method. Only included in the metric key if
    *     'supportsMetricsDeletion' is enabled.
-   * @return Counter in namespace BigQuerySink and name
-   *     'RpcRequests-Method:{method}RpcStatus:{status};TableId:{tableId}' TableId label is dropped
-   *     if 'supportsMetricsDeletion' is not enabled.
    */
   @VisibleForTesting
   static Counter createRPCRequestCounter(RpcMethod method, String rpcStatus, String tableId) {
@@ -144,11 +145,12 @@ public class BigQuerySinkMetrics {
   }
 
   /**
+   * Returns a metric that tracks the status of BigQuery rows after making an AppendRows RPC call.
+   *
    * @param rowStatus Status of these BigQuery rows.
    * @param rpcStatus rpcStatus
    * @param tableId Table pertaining to the write method. Only included in the metric key if
    *     'supportsMetricsDeletion' is enabled.
-   * @return Metric that tracks the status of BigQuery rows after making an AppendRows RPC call.
    */
   public static Counter appendRowsRowStatusCounter(
       RowStatus rowStatus, String rpcStatus, String tableId) {
@@ -166,8 +168,9 @@ public class BigQuerySinkMetrics {
   }
 
   /**
+   * Returns a Counter that tracks throttled time due to RPC retries.
+   *
    * @param method StorageWriteAPI write method.
-   * @return Counter that tracks throttled time due to RPC retries.
    */
   public static Counter throttledTimeCounter(RpcMethod method) {
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
@@ -1217,6 +1217,9 @@ public class BigQueryUtils {
   }
 
   /**
+   * Returns a {@link TableReference} by parsing the {@code fullTableId}. If it cannot be parsed
+   * properly null is returned.
+   *
    * @param fullTableId - Is one of the two forms commonly used to refer to bigquery tables in the
    *     beam codebase:
    *     <ul>
@@ -1224,9 +1227,6 @@ public class BigQueryUtils {
    *       <li>myproject:mydataset.mytable
    *       <li>myproject.mydataset.mytable
    *     </ul>
-   *
-   * @return a BigQueryTableIdentifier by parsing the fullTableId. If it cannot be parsed properly
-   *     null is returned.
    */
   public static @Nullable TableReference toTableReference(String fullTableId) {
     // Try parsing the format:
@@ -1253,9 +1253,10 @@ public class BigQueryUtils {
   }
 
   /**
+   * Returns a String representation of the table destination in the form:
+   * `myproject.mydataset.mytable`.
+   *
    * @param tableReference - a BigQueryTableIdentifier that may or may not include the project.
-   * @return a String representation of the table destination in the form:
-   *     `myproject.mydataset.mytable`
    */
   public static @Nullable String toTableSpec(TableReference tableReference) {
     if (tableReference.getDatasetId() == null || tableReference.getTableId() == null) {
@@ -1339,11 +1340,12 @@ public class BigQueryUtils {
   }
 
   /**
+   * Returns a ServiceCallMetric for recording statuses for all BQ API responses related to reading
+   * elements directly from BigQuery in a process-wide metric. Such as: calls to readRows,
+   * splitReadStream, createReadSession.
+   *
    * @param tableReference - The table being read from. Can be a temporary BQ table used to read
    *     from a SQL query.
-   * @return a ServiceCallMetric for recording statuses for all BQ API responses related to reading
-   *     elements directly from BigQuery in a process-wide metric. Such as: calls to readRows,
-   *     splitReadStream, createReadSession.
    */
   public static @Nullable ServiceCallMetric readCallMetric(
       @Nullable TableReference tableReference) {
@@ -1351,9 +1353,10 @@ public class BigQueryUtils {
   }
 
   /**
+   * Returns a ServiceCallMetric for recording statuses for all BQ responses related to writing
+   * elements directly to BigQuery in a process-wide metric. Such as: insertAll.
+   *
    * @param tableReference - The table being written to.
-   * @return a ServiceCallMetric for recording statuses for all BQ responses related to writing
-   *     elements directly to BigQuery in a process-wide metric. Such as: insertAll.
    */
   public static ServiceCallMetric writeCallMetric(TableReference tableReference) {
     return callMetricForMethod(tableReference, "BigQueryBatchWrite");

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dao/MetadataTableAdminDao.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dao/MetadataTableAdminDao.java
@@ -128,7 +128,7 @@ public class MetadataTableAdminDao {
     return false;
   }
 
-  /** @return true if metadata table exists, otherwise false. */
+  /** Returns true if metadata table exists, otherwise false. */
   public boolean doesMetadataTableExist() {
     return tableAdminClient.exists(tableId);
   }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dao/MetadataTableDao.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dao/MetadataTableDao.java
@@ -97,7 +97,7 @@ public class MetadataTableDao {
     this.changeStreamNamePrefix = changeStreamNamePrefix;
   }
 
-  /** @return the prefix that is prepended to every row belonging to this beam job. */
+  /** Returns the prefix that is prepended to every row belonging to this beam job. */
   public ByteString getChangeStreamNamePrefix() {
     return changeStreamNamePrefix;
   }
@@ -208,8 +208,8 @@ public class MetadataTableDao {
   }
 
   /**
-   * @return all the new partitions resulting from splits and merges waiting to be streamed
-   *     including ones marked for deletion.
+   * Returns all the new partitions resulting from splits and merges waiting to be streamed
+   * including ones marked for deletion.
    */
   public List<NewPartition> readNewPartitionsIncludingDeleted()
       throws InvalidProtocolBufferException {
@@ -243,7 +243,7 @@ public class MetadataTableDao {
     return newPartitions;
   }
 
-  /** @return list the new partitions resulting from splits and merges waiting to be streamed. */
+  /** Returns list the new partitions resulting from splits and merges waiting to be streamed. */
   public List<NewPartition> readNewPartitions() throws InvalidProtocolBufferException {
     List<NewPartition> newPartitions = new ArrayList<>();
     Query query =

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/firestore/FirestoreDoFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/firestore/FirestoreDoFn.java
@@ -38,11 +38,11 @@ abstract class FirestoreDoFn<InT, OutT> extends DoFn<InT, OutT> {
   @Override
   public abstract void populateDisplayData(DisplayData.Builder builder);
 
-  /** @see org.apache.beam.sdk.transforms.DoFn.Setup */
+  /** See {@link org.apache.beam.sdk.transforms.DoFn.Setup}. */
   @Setup
   public abstract void setup() throws Exception;
 
-  /** @see org.apache.beam.sdk.transforms.DoFn.StartBundle */
+  /** See {@link org.apache.beam.sdk.transforms.DoFn.StartBundle}. */
   @StartBundle
   public abstract void startBundle(DoFn<InT, OutT>.StartBundleContext context) throws Exception;
 
@@ -62,7 +62,7 @@ abstract class FirestoreDoFn<InT, OutT> extends DoFn<InT, OutT> {
     @ProcessElement
     public abstract void processElement(DoFn<InT, OutT>.ProcessContext context) throws Exception;
 
-    /** @see org.apache.beam.sdk.transforms.DoFn.FinishBundle */
+    /** See {@link org.apache.beam.sdk.transforms.DoFn.FinishBundle}. */
     @FinishBundle
     public abstract void finishBundle() throws Exception;
   }
@@ -86,7 +86,7 @@ abstract class FirestoreDoFn<InT, OutT> extends DoFn<InT, OutT> {
     public abstract void processElement(
         DoFn<InT, OutT>.ProcessContext context, BoundedWindow window) throws Exception;
 
-    /** @see org.apache.beam.sdk.transforms.DoFn.FinishBundle */
+    /** See {@link org.apache.beam.sdk.transforms.DoFn.FinishBundle}. */
     @FinishBundle
     public abstract void finishBundle(FinishBundleContext context) throws Exception;
   }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/firestore/RpcQos.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/firestore/RpcQos.java
@@ -225,15 +225,15 @@ interface RpcQos {
        */
       boolean offer(ElementT newElement);
 
-      /** @return the number of elements that are currently buffered in this instance */
+      /** Returns the number of elements that are currently buffered in this instance. */
       int getBufferedElementsCount();
 
-      /** @return the number of bytes that are currently buffered in this instance */
+      /** Returns the number of bytes that are currently buffered in this instance. */
       long getBufferedElementsBytes();
 
       /**
-       * @return true if the buffer contains enough {@link Element}s such that a flush should
-       *     happen, false otherwise
+       * Returns true if the buffer contains enough {@link Element}s such that a flush should
+       * happen, false otherwise.
        */
       boolean isFull();
 
@@ -253,7 +253,7 @@ interface RpcQos {
      */
     interface Element<T> {
 
-      /** @return the value that will be sent in a request */
+      /** Returns the value that will be sent in a request. */
       T getValue();
 
       /**

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/healthcare/FhirIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/healthcare/FhirIO.java
@@ -342,7 +342,7 @@ public class FhirIO {
     return new Export(StaticValueProvider.of(fhirStore), StaticValueProvider.of(exportUri));
   }
 
-  /** @see FhirIO#exportResources(String, String) */
+  /** See {@link FhirIO#exportResources(String, String)}. */
   public static Export exportResources(
       ValueProvider<String> fhirStore, ValueProvider<String> exportUri) {
     return new Export(fhirStore, exportUri);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/OrderedCode.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/OrderedCode.java
@@ -298,7 +298,7 @@ class OrderedCode {
     return BITS_TO_LENGTH[log2Floor(n < 0 ? ~n : n) + 1];
   }
 
-  /** @see #readSignedNumIncreasing() */
+  /** See {@link #readSignedNumIncreasing()}. */
   public void writeSignedNumIncreasing(long val) {
     long x = val < 0 ? ~val : val;
     if (x < 64) { // Fast path for encoding length == 1.

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcUtil.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcUtil.java
@@ -455,7 +455,9 @@ public class JdbcUtil {
     return calendar;
   }
 
-  /** @return a {@code JdbcReadPartitionsHelper} instance associated with the given {@param type} */
+  /**
+   * Returns a {@code JdbcReadPartitionsHelper} instance associated with the given {@param type}.
+   */
   static <T> @Nullable JdbcReadWithPartitionsHelper<T> getPartitionsHelper(TypeDescriptor<T> type) {
     // This cast is unchecked, thus this is a small type-checking risk. We just need
     // to make sure that all preset helpers in `JdbcUtil.PRESET_HELPERS` are matched

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIOReadImplementationCompatibility.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIOReadImplementationCompatibility.java
@@ -239,16 +239,16 @@ class KafkaIOReadImplementationCompatibility {
     }
 
     /**
-     * @return true, if the implementation can "use" every configuration,<br>
-     *     false, otherwise
+     * Returns true, if the implementation can "use" every configuration,<br>
+     * false, otherwise.
      */
     boolean supports(KafkaIOReadImplementation implementation) {
       return !notSupported.containsKey(implementation);
     }
 
     /**
-     * @return true, if the implementation - and only that - can "use" every configuration, <br>
-     *     false, otherwise
+     * Returns true, if the implementation - and only that - can "use" every configuration, <br>
+     * false, otherwise.
      */
     boolean supportsOnly(KafkaIOReadImplementation implementation) {
       return EnumSet.complementOf(EnumSet.of(implementation)).equals(notSupported.keySet());

--- a/sdks/java/io/sparkreceiver/3/src/main/java/org/apache/beam/sdk/io/sparkreceiver/HasOffset.java
+++ b/sdks/java/io/sparkreceiver/3/src/main/java/org/apache/beam/sdk/io/sparkreceiver/HasOffset.java
@@ -23,10 +23,14 @@ package org.apache.beam.sdk.io.sparkreceiver;
  */
 public interface HasOffset {
 
-  /** @param offset inclusive start offset from which the reading should be started. */
+  /**
+   * Sets the start offset.
+   *
+   * @param offset inclusive start offset from which the reading should be started.
+   */
   void setStartOffset(Long offset);
 
-  /** @return exclusive end offset to which the reading from current page will occur. */
+  /** Returns exclusive end offset to which the reading from current page will occur. */
   Long getEndOffset();
 
   /**

--- a/sdks/java/io/sparkreceiver/3/src/main/java/org/apache/beam/sdk/io/sparkreceiver/ReceiverBuilder.java
+++ b/sdks/java/io/sparkreceiver/3/src/main/java/org/apache/beam/sdk/io/sparkreceiver/ReceiverBuilder.java
@@ -47,8 +47,8 @@ public class ReceiverBuilder<X, T extends Receiver<X>> implements Serializable {
   }
 
   /**
-   * @return Proxy for given {@param receiver} that doesn't use Spark environment and uses Apache
-   *     Beam mechanisms instead.
+   * Returns proxy for given {@param receiver} that doesn't use Spark environment and uses Apache
+   * Beam mechanisms instead.
    */
   public T build()
       throws InvocationTargetException, InstantiationException, IllegalAccessException {

--- a/sdks/java/io/xml/src/main/java/org/apache/beam/sdk/io/xml/XmlIO.java
+++ b/sdks/java/io/xml/src/main/java/org/apache/beam/sdk/io/xml/XmlIO.java
@@ -255,22 +255,22 @@ public class XmlIO {
     /** @deprecated Use {@link Compression} instead. */
     @Deprecated
     public enum CompressionType {
-      /** @see Compression#AUTO */
+      /** See {@link Compression#AUTO}. */
       AUTO(Compression.AUTO),
 
-      /** @see Compression#UNCOMPRESSED */
+      /** See {@link Compression#UNCOMPRESSED}. */
       UNCOMPRESSED(Compression.UNCOMPRESSED),
 
-      /** @see Compression#GZIP */
+      /** See {@link Compression#GZIP}. */
       GZIP(Compression.GZIP),
 
-      /** @see Compression#BZIP2 */
+      /** See {@link Compression#BZIP2}. */
       BZIP2(Compression.BZIP2),
 
-      /** @see Compression#ZIP */
+      /** See {@link Compression#ZIP}. */
       ZIP(Compression.ZIP),
 
-      /** @see Compression#DEFLATE */
+      /** See {@link Compression#DEFLATE}. */
       DEFLATE(Compression.DEFLATE);
 
       private final Compression canonical;
@@ -279,7 +279,7 @@ public class XmlIO {
         this.canonical = canonical;
       }
 
-      /** @see Compression#matches */
+      /** See {@link Compression#matches}. */
       public boolean matches(String filename) {
         return canonical.matches(filename);
       }

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkQueryName.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkQueryName.java
@@ -88,8 +88,8 @@ public enum NexmarkQueryName {
   }
 
   /**
-   * @return The given {@link NexmarkQueryName} for the id. The id can be the query number (for
-   *     backwards compatibility) or its name.
+   * Returns the given {@link NexmarkQueryName} for the id. The id can be the query number (for
+   * backwards compatibility) or its name.
    */
   public static NexmarkQueryName fromId(String id) {
     NexmarkQueryName query;


### PR DESCRIPTION
his PR addresses all outstanding `MissingSummary` warnings across the codebase reported by Error Prone. 
The `MissingSummary` check enforces that every Javadoc comment must have a proper summary fragment—typically the first sentence, which describes the objective of the method or class. Previously, several method Javadocs were either lacking this summary or relying entirely on `@return`/`@param`/`@see` tags without a preceding descriptive sentence. 
Changes in this PR include:
*   Converting standalone `@return ...` blocks into complete descriptive sentences (e.g. `Returns ...`).
*   Converting standalone `@see ...` blocks into complete descriptive sentences (e.g. `See {@link ...}`).
*   Ensuring that constructors, getters, and standard methods have a clear, standalone opening description fragment before listing annotations.
A wide array of modules have been updated, including Dataflow runners, various I/O connectors, extensions, and core SDK components.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
