### PR TITLE
Move FileIO close from RecordWriter to RecordWriterManager

### DIFF
--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/RecordWriter.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/RecordWriter.java
@@ -71,7 +71,7 @@ class RecordWriter {
     }
     OutputFile outputFile;
     EncryptionKeyMetadata keyMetadata;
-    // table.io() returns the catalog's shared FileIO instance.
+    // table.io() may return a shared FileIO instance.
     // FileIO lifecycle is managed by RecordWriterManager.close().
     OutputFile tmpFile = table.io().newOutputFile(absoluteFilename);
     EncryptedOutputFile encryptedOutputFile = table.encryption().encrypt(tmpFile);

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/RecordWriterManager.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/RecordWriterManager.java
@@ -435,7 +435,7 @@ class RecordWriterManager implements AutoCloseable {
       }
     } finally {
       // Close unique FileIO instances now that all writers are done.
-      // table.io() returns the catalog's shared FileIO; we deduplicate by identity
+      // table.io() may return a shared FileIO; we deduplicate by identity
       // so we close each underlying connection pool exactly once.
       Set<FileIO> closedIOs = new HashSet<>();
       for (DestinationState state : destinations.values()) {

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/RecordWriterManagerTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/RecordWriterManagerTest.java
@@ -981,7 +981,7 @@ public class RecordWriterManagerTest {
     writer.write(IcebergUtils.beamRowToIcebergRecord(ICEBERG_SCHEMA, row));
     writer.close();
 
-    // RecordWriter must NOT close FileIO — it's the catalog's shared instance.
+    // RecordWriter must NOT close FileIO — it may be a shared instance.
     assertFalse("RecordWriter.close() must not close the shared FileIO", trackingFileIO.closed);
   }
 
@@ -1004,8 +1004,8 @@ public class RecordWriterManagerTest {
     Table table1 = warehouse.createTable(tableId1, ICEBERG_SCHEMA);
     Table table2 = warehouse.createTable(tableId2, ICEBERG_SCHEMA);
 
-    // Both tables share the same CloseTrackingFileIO — mirrors how a catalog returns
-    // the same shared FileIO instance for all tables
+    // Both tables share the same CloseTrackingFileIO — mirrors how some catalogs
+    // return a shared FileIO instance across tables
     CloseTrackingFileIO sharedFileIO = new CloseTrackingFileIO(table1.io());
     Table spyTable1 = Mockito.spy(table1);
     Table spyTable2 = Mockito.spy(table2);
@@ -1036,19 +1036,36 @@ public class RecordWriterManagerTest {
   }
 
   /**
-   * Verifies that RecordWriterManager.close() successfully flushes data files from multiple
-   * destinations.
+   * Verifies that RecordWriterManager.close() flushes data files from multiple destinations and
+   * closes the shared FileIO.
    */
   @Test
-  public void testRecordWriterManagerCloseFlushesAllDestinations() throws IOException {
+  public void testRecordWriterManagerClosesSharedFileIOAfterFlush() throws IOException {
     String tableName1 =
         "table_mgr_io_a_" + UUID.randomUUID().toString().replace("-", "").substring(0, 6);
     String tableName2 =
         "table_mgr_io_b_" + UUID.randomUUID().toString().replace("-", "").substring(0, 6);
+    TableIdentifier tableId1 = TableIdentifier.of("default", tableName1);
+    TableIdentifier tableId2 = TableIdentifier.of("default", tableName2);
+
+    Table realTable1 = warehouse.createTable(tableId1, ICEBERG_SCHEMA);
+    Table realTable2 = warehouse.createTable(tableId2, ICEBERG_SCHEMA);
+
+    CloseTrackingFileIO sharedTrackingIO = new CloseTrackingFileIO(realTable1.io());
+    Table spyTable1 = Mockito.spy(realTable1);
+    Table spyTable2 = Mockito.spy(realTable2);
+    Mockito.doReturn(sharedTrackingIO).when(spyTable1).io();
+    Mockito.doReturn(sharedTrackingIO).when(spyTable2).io();
+
+    Catalog spyCatalog = Mockito.spy(catalog);
+    Mockito.doReturn(spyTable1).when(spyCatalog).loadTable(tableId1);
+    Mockito.doReturn(spyTable2).when(spyCatalog).loadTable(tableId2);
+
     WindowedValue<IcebergDestination> dest1 = getWindowedDestination(tableName1, null);
     WindowedValue<IcebergDestination> dest2 = getWindowedDestination(tableName2, null);
 
-    RecordWriterManager writerManager = new RecordWriterManager(catalog, "test_file_name", 1000, 3);
+    RecordWriterManager writerManager =
+        new RecordWriterManager(spyCatalog, "test_file_name", 1000, 3);
 
     Row row = Row.withSchema(BEAM_SCHEMA).addValues(1, "aaa", true).build();
     assertTrue(writerManager.write(dest1, row));
@@ -1061,6 +1078,7 @@ public class RecordWriterManagerTest {
         writerManager.getSerializableDataFiles();
     assertTrue("Should have data files for dest1", dataFiles.containsKey(dest1));
     assertTrue("Should have data files for dest2", dataFiles.containsKey(dest2));
+    assertTrue("Shared FileIO should be closed", sharedTrackingIO.closed);
   }
 
   private static final class CloseTrackingFileIO implements FileIO {


### PR DESCRIPTION
### Summary

- Remove FileIO field and close logic from `RecordWriter` - it no longer owns the FileIO lifecycle
- Move FileIO cleanup to `RecordWriterManager.close()`, which collects unique FileIO instances across all destinations and closes each once in a finally block
- Add tests covering the fix

### Root Cause
- `table.io()` returns the catalog's shared `FileIO` instance. Catalogs like `RESTSessionCatalog` track and reuse a single FileIO across tables via `FileIOTracker` ([ref][1]). When `RecordWriter.close()` called `io.close()`, it shut down the shared connection pool.
- This manifests when using dynamic destinations: `RecordWriterManager.close()` iterates destinations and calls `cache.invalidateAll()` on each, which triggers `RecordWriter.close()` via the removal listener. The first destination's writers close successfully but kill the shared pool - subsequent destinations fail with:
```
IllegalStateException: Encountered 12 failed writer(s).
  Caused by: IOException: Failed to close PARQUET writer for table ...
    Caused by: IOException: Connection pool shut down
      Caused by: IllegalStateException: Connection pool shut down
  Suppressed: RuntimeException: Encountered an error when closing data writer for table ...
  Suppressed: RuntimeException: ...  
```

The fix moves FileIO close to `RecordWriterManager.close()`, which deduplicates by identity and closes each shared instance exactly once after all writers have flushed.

[1]: https://github.com/apache/iceberg/blob/88d460425ab6a0e4c938e90665b4b772d7b57c41/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java#L1167

Related: #36438

I can confirm this works fix works great when running in Dataflow. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
