### PR TITLE
[ErrorProne] Fix UnnecessaryMethodReference Check Findings

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -1558,7 +1558,6 @@ class BeamModulePlugin implements Plugin<Project> {
             "TimeUnitConversionChecker",
             "UndefinedEquals",
             "UnescapedEntity",
-            "UnnecessaryMethodReference",
             "UnnecessaryParentheses",
             "UnrecognisedJavadocTag",
             // errorprone 3.2.0+ checks

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOWriteTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOWriteTest.java
@@ -319,21 +319,21 @@ public class TextIOWriteTest {
 
     Iterable<String> aElements =
         elements.stream()
-            .filter(Predicates.compose(new StartsWith("a"), new ExtractWriteDestination())::apply)
+            .filter(Predicates.compose(new StartsWith("a"), new ExtractWriteDestination()))
             .collect(Collectors.toList())
             .stream()
             .map(Functions.toStringFunction())
             .collect(Collectors.toList());
     Iterable<String> bElements =
         elements.stream()
-            .filter(Predicates.compose(new StartsWith("b"), new ExtractWriteDestination())::apply)
+            .filter(Predicates.compose(new StartsWith("b"), new ExtractWriteDestination()))
             .collect(Collectors.toList())
             .stream()
             .map(Functions.toStringFunction())
             .collect(Collectors.toList());
     Iterable<String> cElements =
         elements.stream()
-            .filter(Predicates.compose(new StartsWith("c"), new ExtractWriteDestination())::apply)
+            .filter(Predicates.compose(new StartsWith("c"), new ExtractWriteDestination()))
             .collect(Collectors.toList())
             .stream()
             .map(Functions.toStringFunction())

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/CombineRunners.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/CombineRunners.java
@@ -123,11 +123,11 @@ public class CombineRunners {
     }
 
     void processElement(WindowedValue<KV<KeyT, InputT>> elem) throws Exception {
-      getGroupingTable().put(elem, output::accept);
+      getGroupingTable().put(elem, output);
     }
 
     void finishBundle() throws Exception {
-      getGroupingTable().flush(output::accept);
+      getGroupingTable().flush(output);
       groupingTable = null;
     }
   }


### PR DESCRIPTION
This PR enables Error Prone's UnnecessaryMethodReference check and addresses the resulting violations across the codebase.

Changes Included:
- Configuration: Removed UnnecessaryMethodReference from the disabledChecks list in  BeamModulePlugin.groovy to enforce the rule explicitly.
- Java Harness: Addressed violations in  `CombineRunners` where output::accept was passed unnecessarily—simplified directly to output.
- Java Core Tests: Fixed violations in `TextIOWriteTest`  by substituting unnecessary method references on variables (e.g., Functions.toStringFunction()::apply to Functions.toStringFunction()).
All tests in the impacted modules pass locally. Formatted files via Spotless.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
