### PR TITLE
Add Python example for slowly updating global window side input pattern

### DIFF
--- a/website/www/site/content/en/documentation/patterns/side-inputs.md
+++ b/website/www/site/content/en/documentation/patterns/side-inputs.md
@@ -48,7 +48,40 @@ For instance, the following code sample uses a `Map` to create a `DoFn`. The `Ma
 {{< /highlight >}}
 
 {{< highlight py >}}
-No sample present.
+import apache_beam as beam
+from apache_beam.options.pipeline_options import PipelineOptions
+
+class FetchSideInput(beam.DoFn):
+    def process(self, element):
+        # simulate fetching external data
+        yield {"threshold": 10}
+
+def run():
+    with beam.Pipeline(options=PipelineOptions()) as p:
+
+        main_input = (
+            p
+            | "CreateMainInput" >> beam.Create([1, 5, 10, 20])
+        )
+
+        side_input = (
+            p
+            | "GenerateSignal" >> beam.Create([None])
+            | "FetchSideInput" >> beam.ParDo(FetchSideInput())
+            | beam.combiners.Latest.Globally().without_defaults()
+        )
+
+        result = (
+            main_input
+            | "ApplySideInput" >> beam.Map(
+                lambda x, s: x > s["threshold"],
+                beam.pvalue.AsSingleton(side_input))
+        )
+
+        result | beam.Map(print)
+
+if __name__ == "__main__":
+    run()
 {{< /highlight >}}
 
 


### PR DESCRIPTION
### Summary

Adds a Python example for the **“Slowly updating global window side inputs”** section in the documentation.

Previously the Python block contained `No sample present.`. This PR replaces it with a Python example demonstrating how to create and use a side input with `Latest.Globally().without_defaults()`.

### Issue

Addresses #35935

### Changes

* Added Python example in `website/www/site/content/en/documentation/patterns/side-inputs.md`
* Demonstrates creation and usage of side input in a Beam pipeline.

### Testing

Documentation-only change.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
