### PR TITLE
Fix 36181 cloudml benchmarks job

### DIFF
--- a/.github/workflows/load-tests-pipeline-options/beam_CloudML_Benchmarks_Dataflow_arguments.txt
+++ b/.github/workflows/load-tests-pipeline-options/beam_CloudML_Benchmarks_Dataflow_arguments.txt
@@ -14,17 +14,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
---region=us-central1
---machine_type=n1-standard-4
---element_processing_timeout_minutes=90
---num_workers=4
---max_num_workers=20
---disk_size_gb=50
---autoscaling_algorithm=THROUGHPUT_BASED
---staging_location=gs://temp-storage-for-perf-tests/loadtests
---temp_location=gs://temp-storage-for-perf-tests/loadtests
 --metrics_dataset=beam_cloudml
 --publish_to_big_query=true
+--region=us-central1
+--staging_location=gs://temp-storage-for-perf-tests/loadtests
+--temp_location=gs://temp-storage-for-perf-tests/loadtests
 --runner=DataflowRunner
 --requirements_file=apache_beam/testing/benchmarks/cloudml/requirements.txt
---experiments=prebuild_sdk_container_engine=cloud_build

--- a/sdks/python/apache_beam/testing/benchmarks/cloudml/pipelines/workflow.py
+++ b/sdks/python/apache_beam/testing/benchmarks/cloudml/pipelines/workflow.py
@@ -117,7 +117,6 @@ def setup_pipeline(p, args):
                           use_deep_copy_optimization=True):
       decoded_input_data = (
           input_data | 'DecodeForAnalyze' >> input_tfxio.BeamSource())
-      decoded_input_data |= 'Reshuffle' >> beam.transforms.Reshuffle()  # pylint: disable=no-value-for-parameter
       transform_fn = ((decoded_input_data, input_tfxio.TensorAdapterConfig())
                       | 'Analyze' >> tft_beam.AnalyzeDataset(preprocessing_fn))
 


### PR DESCRIPTION
Fixes: #36181
Successful run: https://github.com/aIbrahiim/beam/actions/runs/22893917594/job/66423181236

Root cause
Dataflow workers never became healthy because pip install -r requirements.txt (CloudML benchmark deps) was hitting pip’s resolution-too-deep error and never finishing. The SDK harness stayed down (healthz 500, “no running task”), so workers never registered. That led to InitializeWrite failing and the job eventually timing out with “no worker activity in the last 1h.”

i found out that from Dataflow/worker logs as the worker startup step was stuck in dependency resolution (pip resolution-too-deep), so the harness never came up. The 1h timeout and “stuck job” were symptoms of workers never finishing install.

So I used [pip’s guidance for resolution-too-deep](https://pip.pypa.io/en/stable/topics/dependency-resolution/#handling-resolution-too-deep-errors): add explicit transitive bounds to narrow the resolver’s search space instead of leaving everything open.

And this approach fixes because I kept the existing pins (dill, tfx_bsl, tensorflow-transform) and added bounds for key transitives (tensorflow, numpy, tensorflow-metadata, pyarrow, and optionally tensorflow-serving-api, tf-keras). That reduces the depth of version combinations pip has to explore, so resolution completes instead of hitting the depth limit. 

https://console.cloud.google.com/dataflow/jobs/us-central1/2026-03-08_16_34_17-5467336742577685172;expandBottomPanel=false;logsSeverity=INFO;graphView=0?project=apache-beam-testing&pageState=(%22dfTime%22:(%22l%22:%22dfJobMaxTime%22))
<img width="1919" height="879" alt="image" src="https://github.com/user-attachments/assets/6c81cd24-a4ed-49d6-9810-8161d1363e95" />

<img width="1919" height="851" alt="image" src="https://github.com/user-attachments/assets/68b64bdb-aae1-4869-9ba3-6ac4ed427da2" />


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
