### PR TITLE
Fix #21317: Replace colons with underscores in window filenames for Windows compatibility

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/DefaultFilenamePolicy.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/DefaultFilenamePolicy.java
@@ -357,7 +357,8 @@ public final class DefaultFilenamePolicy extends FilenamePolicy {
       // since colons are illegal characters in Windows file paths.
       String startStr = iw.start().toString();
       String endStr = iw.end().toString();
-      if (System.getProperty("os.name").startsWith("Windows")) {
+      String osName = System.getProperty("os.name");
+      if (osName != null && osName.startsWith("Windows")) {
         startStr = startStr.replace(':', '_');
         endStr = endStr.replace(':', '_');
       }


### PR DESCRIPTION
The default FilenamePolicy uses Instant.toString() for Beam Windows, which
produces ISO-8601 format (e.g., 2021-12-31T23:00:00.000Z) containing colons.
Colons are illegal characters in Windows file paths, causing
InvalidPathException when using TextIO.write().withWindowedWrites() on Windows.

This fix replaces colons with underscores in the window string format to
ensure cross-platform compatibility.

Fixes #21317