### PR TITLE
[Dataflow Logging handler] Change @LazyInit to AtomicBoolean

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/logging/DataflowWorkerLoggingHandler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/logging/DataflowWorkerLoggingHandler.java
@@ -145,7 +145,7 @@ public class DataflowWorkerLoggingHandler extends Handler {
   }
 
   /** If true, add SLF4J MDC to custom_data of the log message. */
-  private AtomicBoolean logCustomMdc = new AtomicBoolean(false);
+  private final AtomicBoolean logCustomMdc = new AtomicBoolean(false);
 
   // Only instantiated and set if enableDirectLogging is called.
   private static class DirectLoggingState {


### PR DESCRIPTION
IIUC, @LazyInit does not provide visibility guarantees. @LazyInit for things like hash code is fine, since the end results are the same.

Here if the thread calling publish didn't see the updated field logs will miss the custom payload.
 