### PR TITLE
[Dataflow Streaming] Prevent commit threads from sharing commit streams

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -463,6 +463,8 @@ public final class StreamingDataflowWorker {
     @SuppressWarnings("methodref.receiver.bound")
     WorkCommitter workCommitter =
         StreamingEngineWorkCommitter.builder()
+            // Use a separate stream pool for each committer. This ensures the commit
+            // threads are fully isolated.
             .setCommitWorkStreamFactory(
                 () ->
                     WindmillStreamPool.create(


### PR DESCRIPTION
Since the commit threads were sharing the WindmillStreamPool, the different commit streams can end up sharing commit streams.

This change gives each commit thread its own WindmillStreamPool and avoids the commit stream sharing problem.
 