### PR TITLE
Fixes metadata propagation from doFn output to next parDo by introducing new interface and plumbing propagation

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvoker.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvoker.java
@@ -477,6 +477,26 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
               element.causedByDrain()));
     }
 
+    @Override
+    public void outputWindowedValue(WindowedValue<OutputT> windowedValue) {
+      noteOutput();
+      if (watermarkEstimator instanceof TimestampObservingWatermarkEstimator) {
+        ((TimestampObservingWatermarkEstimator) watermarkEstimator)
+            .observeTimestamp(windowedValue.getTimestamp());
+      }
+      outputReceiver.output(mainOutputTag, windowedValue);
+    }
+
+    @Override
+    public <T> void outputWindowedValue(TupleTag<T> tag, WindowedValue<T> windowedValue) {
+      noteOutput();
+      if (watermarkEstimator instanceof TimestampObservingWatermarkEstimator) {
+        ((TimestampObservingWatermarkEstimator) watermarkEstimator)
+            .observeTimestamp(windowedValue.getTimestamp());
+      }
+      outputReceiver.output(tag, windowedValue);
+    }
+
     private void noteOutput() {
       checkState(!hasClaimFailed, "Output is not allowed after a failed tryClaim()");
       checkState(numClaimedBlocks > 0, "Output is not allowed before tryClaim()");

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvoker.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvoker.java
@@ -479,12 +479,7 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
 
     @Override
     public void outputWindowedValue(WindowedValue<OutputT> windowedValue) {
-      noteOutput();
-      if (watermarkEstimator instanceof TimestampObservingWatermarkEstimator) {
-        ((TimestampObservingWatermarkEstimator) watermarkEstimator)
-            .observeTimestamp(windowedValue.getTimestamp());
-      }
-      outputReceiver.output(mainOutputTag, windowedValue);
+      outputWindowedValue(mainOutputTag, windowedValue);
     }
 
     @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/ReduceFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/ReduceFnRunner.java
@@ -376,7 +376,7 @@ public class ReduceFnRunner<K, InputT, OutputT, W extends BoundedWindow> {
       emit(
           contextFactory.base(window, StateStyle.DIRECT),
           contextFactory.base(window, StateStyle.RENAMED),
-          null);
+          CausedByDrain.NORMAL);
     }
 
     // We're all done with merging and emitting elements so can compress the activeWindow state.

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
@@ -445,11 +445,13 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
 
     @Override
     public void outputWindowedValue(WindowedValue<OutputT> windowedValue) {
+      checkTimestamp(elem.getTimestamp(), windowedValue.getTimestamp());
       SimpleDoFnRunner.this.outputWindowedValue(mainOutputTag, windowedValue);
     }
 
     @Override
     public <T> void outputWindowedValue(TupleTag<T> tag, WindowedValue<T> windowedValue) {
+      checkTimestamp(elem.getTimestamp(), windowedValue.getTimestamp());
       SimpleDoFnRunner.this.outputWindowedValue(tag, windowedValue);
     }
 
@@ -1039,11 +1041,13 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
 
     @Override
     public void outputWindowedValue(WindowedValue<OutputT> windowedValue) {
+      checkTimestamp(timestamp(), windowedValue.getTimestamp());
       SimpleDoFnRunner.this.outputWindowedValue(mainOutputTag, windowedValue);
     }
 
     @Override
     public <T> void outputWindowedValue(TupleTag<T> tag, WindowedValue<T> windowedValue) {
+      checkTimestamp(timestamp(), windowedValue.getTimestamp());
       SimpleDoFnRunner.this.outputWindowedValue(tag, windowedValue);
     }
 
@@ -1308,11 +1312,13 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
 
     @Override
     public void outputWindowedValue(WindowedValue<OutputT> windowedValue) {
+      checkTimestamp(this.timestamp, windowedValue.getTimestamp());
       SimpleDoFnRunner.this.outputWindowedValue(mainOutputTag, windowedValue);
     }
 
     @Override
     public <T> void outputWindowedValue(TupleTag<T> tag, WindowedValue<T> windowedValue) {
+      checkTimestamp(this.timestamp, windowedValue.getTimestamp());
       SimpleDoFnRunner.this.outputWindowedValue(tag, windowedValue);
     }
 

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
@@ -444,6 +444,16 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     }
 
     @Override
+    public void outputWindowedValue(WindowedValue<OutputT> windowedValue) {
+      SimpleDoFnRunner.this.outputWindowedValue(mainOutputTag, windowedValue);
+    }
+
+    @Override
+    public <T> void outputWindowedValue(TupleTag<T> tag, WindowedValue<T> windowedValue) {
+      SimpleDoFnRunner.this.outputWindowedValue(tag, windowedValue);
+    }
+
+    @Override
     public <T> void outputWithTimestamp(TupleTag<T> tag, T output, Instant timestamp) {
       checkNotNull(tag, "Tag passed to outputWithTimestamp cannot be null");
       checkTimestamp(elem.getTimestamp(), timestamp);
@@ -1028,6 +1038,16 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     }
 
     @Override
+    public void outputWindowedValue(WindowedValue<OutputT> windowedValue) {
+      SimpleDoFnRunner.this.outputWindowedValue(mainOutputTag, windowedValue);
+    }
+
+    @Override
+    public <T> void outputWindowedValue(TupleTag<T> tag, WindowedValue<T> windowedValue) {
+      SimpleDoFnRunner.this.outputWindowedValue(tag, windowedValue);
+    }
+
+    @Override
     public BundleFinalizer bundleFinalizer() {
       throw new UnsupportedOperationException(
           "Bundle finalization is not supported in non-portable pipelines.");
@@ -1284,6 +1304,16 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
           .setPaneInfo(paneInfo)
           .setReceiver(wv -> SimpleDoFnRunner.this.outputWindowedValue(tag, wv))
           .output();
+    }
+
+    @Override
+    public void outputWindowedValue(WindowedValue<OutputT> windowedValue) {
+      SimpleDoFnRunner.this.outputWindowedValue(mainOutputTag, windowedValue);
+    }
+
+    @Override
+    public <T> void outputWindowedValue(TupleTag<T> tag, WindowedValue<T> windowedValue) {
+      SimpleDoFnRunner.this.outputWindowedValue(tag, windowedValue);
     }
 
     @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
@@ -445,8 +445,7 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
 
     @Override
     public void outputWindowedValue(WindowedValue<OutputT> windowedValue) {
-      checkTimestamp(elem.getTimestamp(), windowedValue.getTimestamp());
-      SimpleDoFnRunner.this.outputWindowedValue(mainOutputTag, windowedValue);
+      outputWindowedValue(mainOutputTag, windowedValue);
     }
 
     @Override
@@ -1041,8 +1040,7 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
 
     @Override
     public void outputWindowedValue(WindowedValue<OutputT> windowedValue) {
-      checkTimestamp(timestamp(), windowedValue.getTimestamp());
-      SimpleDoFnRunner.this.outputWindowedValue(mainOutputTag, windowedValue);
+      outputWindowedValue(mainOutputTag, windowedValue);
     }
 
     @Override
@@ -1312,8 +1310,7 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
 
     @Override
     public void outputWindowedValue(WindowedValue<OutputT> windowedValue) {
-      checkTimestamp(this.timestamp, windowedValue.getTimestamp());
-      SimpleDoFnRunner.this.outputWindowedValue(mainOutputTag, windowedValue);
+      outputWindowedValue(mainOutputTag, windowedValue);
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestOutputReceiver.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestOutputReceiver.java
@@ -23,6 +23,7 @@ import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
+import org.apache.beam.sdk.values.CausedByDrain;
 import org.apache.beam.sdk.values.OutputBuilder;
 import org.apache.beam.sdk.values.WindowedValues;
 import org.joda.time.Instant;
@@ -54,6 +55,7 @@ public class TestOutputReceiver<T> implements DoFn.OutputReceiver<T> {
         .setWindow(fakeWindow)
         .setPaneInfo(PaneInfo.NO_FIRING)
         .setTimestamp(BoundedWindow.TIMESTAMP_MIN_VALUE)
+        .setCausedByDrain(CausedByDrain.NORMAL)
         .setReceiver(windowedValue -> records.add(windowedValue.getValue()));
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -51,6 +51,7 @@ import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.sdk.values.WindowedValue;
 import org.apache.beam.sdk.values.WindowingStrategy;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.qual.Pure;
@@ -284,6 +285,10 @@ public abstract class DoFn<InputT extends @Nullable Object, OutputT extends @Nul
         Instant timestamp,
         Collection<? extends BoundedWindow> windows,
         PaneInfo paneInfo);
+
+    public abstract <T> void outputWindowedValue(TupleTag<T> tag, WindowedValue<T> windowedValue);
+
+    public abstract void outputWindowedValue(WindowedValue<OutputT> windowedValue);
   }
 
   /** Information accessible when running a {@link DoFn.ProcessElement} method. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnOutputReceivers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnOutputReceivers.java
@@ -120,19 +120,9 @@ public class DoFnOutputReceivers {
     @Override
     public void output(WindowedValue<T> windowedValue) {
       if (outputTag != null) {
-        context.outputWindowedValue(
-            outputTag,
-            windowedValue.getValue(),
-            windowedValue.getTimestamp(),
-            windowedValue.getWindows(),
-            windowedValue.getPaneInfo());
+        context.outputWindowedValue(outputTag, windowedValue);
       } else {
-        ((DoFn<?, T>.WindowedContext) context)
-            .outputWindowedValue(
-                windowedValue.getValue(),
-                windowedValue.getTimestamp(),
-                windowedValue.getWindows(),
-                windowedValue.getPaneInfo());
+        ((DoFn<?, T>.WindowedContext) context).outputWindowedValue(windowedValue);
       }
     }
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnOutputReceivers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnOutputReceivers.java
@@ -70,10 +70,8 @@ public class DoFnOutputReceivers {
                 rowWithMetadata -> {
                   ((DoFn<?, T>.WindowedContext) context)
                       .outputWindowedValue(
-                          schemaCoder.getFromRowFunction().apply(rowWithMetadata.getValue()),
-                          rowWithMetadata.getTimestamp(),
-                          rowWithMetadata.getWindows(),
-                          rowWithMetadata.getPaneInfo());
+                          rowWithMetadata.withValue(
+                              schemaCoder.getFromRowFunction().apply(rowWithMetadata.getValue())));
                 });
 
       } else {
@@ -84,10 +82,8 @@ public class DoFnOutputReceivers {
                 rowWithMetadata -> {
                   context.outputWindowedValue(
                       tag,
-                      schemaCoder.getFromRowFunction().apply(rowWithMetadata.getValue()),
-                      rowWithMetadata.getTimestamp(),
-                      rowWithMetadata.getWindows(),
-                      rowWithMetadata.getPaneInfo());
+                      rowWithMetadata.withValue(
+                          schemaCoder.getFromRowFunction().apply(rowWithMetadata.getValue())));
                 });
       }
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnTester.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnTester.java
@@ -650,6 +650,38 @@ public class DoFnTester<InputT, OutputT> implements AutoCloseable {
     }
 
     @Override
+    public void outputWindowedValue(WindowedValue<OutputT> windowedValue) {
+      for (BoundedWindow w : windowedValue.getWindows()) {
+        getMutableOutput(mainOutputTag)
+            .add(
+                ValueInSingleWindow.of(
+                    windowedValue.getValue(),
+                    windowedValue.getTimestamp(),
+                    w,
+                    windowedValue.getPaneInfo(),
+                    windowedValue.getRecordId(),
+                    windowedValue.getRecordOffset(),
+                    windowedValue.causedByDrain()));
+      }
+    }
+
+    @Override
+    public <T> void outputWindowedValue(TupleTag<T> tag, WindowedValue<T> windowedValue) {
+      for (BoundedWindow w : windowedValue.getWindows()) {
+        getMutableOutput(tag)
+            .add(
+                ValueInSingleWindow.of(
+                    windowedValue.getValue(),
+                    windowedValue.getTimestamp(),
+                    w,
+                    windowedValue.getPaneInfo(),
+                    windowedValue.getRecordId(),
+                    windowedValue.getRecordOffset(),
+                    windowedValue.causedByDrain()));
+      }
+    }
+
+    @Override
     public <T> void outputWindowedValue(
         TupleTag<T> tag,
         T output,

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnTester.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnTester.java
@@ -651,18 +651,7 @@ public class DoFnTester<InputT, OutputT> implements AutoCloseable {
 
     @Override
     public void outputWindowedValue(WindowedValue<OutputT> windowedValue) {
-      for (BoundedWindow w : windowedValue.getWindows()) {
-        getMutableOutput(mainOutputTag)
-            .add(
-                ValueInSingleWindow.of(
-                    windowedValue.getValue(),
-                    windowedValue.getTimestamp(),
-                    w,
-                    windowedValue.getPaneInfo(),
-                    windowedValue.getRecordId(),
-                    windowedValue.getRecordOffset(),
-                    windowedValue.causedByDrain()));
-      }
+      outputWindowedValue(mainOutputTag, windowedValue);
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Redistribute.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Redistribute.java
@@ -187,6 +187,7 @@ public class Redistribute {
                       .setTimestamp(kv.getValue().getTimestamp())
                       .setWindow(kv.getValue().getWindow())
                       .setPaneInfo(kv.getValue().getPaneInfo())
+                      .setCausedByDrain(kv.getValue().getCausedByDrain())
                       .output();
                 }
               }));

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Reify.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Reify.java
@@ -22,6 +22,7 @@ import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.VoidCoder;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
+import org.apache.beam.sdk.values.CausedByDrain;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
@@ -141,16 +142,24 @@ public class Reify {
                   new DoFn<KV<K, V>, KV<K, ValueInSingleWindow<V>>>() {
                     @ProcessElement
                     public void processElement(
+                        ProcessContext pc,
                         @Element KV<K, V> element,
                         @DoFn.Timestamp Instant timestamp,
                         BoundedWindow window,
                         PaneInfo paneInfo,
+                        CausedByDrain causedByDrain,
                         OutputReceiver<KV<K, ValueInSingleWindow<V>>> r) {
                       r.output(
                           KV.of(
                               element.getKey(),
                               ValueInSingleWindow.of(
-                                  element.getValue(), timestamp, window, paneInfo)));
+                                  element.getValue(),
+                                  timestamp,
+                                  window,
+                                  paneInfo,
+                                  pc.currentRecordId(),
+                                  pc.currentRecordOffset(),
+                                  causedByDrain)));
                     }
                   }))
           .setCoder(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/SplittableParDoNaiveBounded.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/SplittableParDoNaiveBounded.java
@@ -56,6 +56,7 @@ import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.WindowedValue;
 import org.apache.beam.sdk.values.WindowedValues;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.Uninterruptibles;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -560,13 +561,7 @@ public class SplittableParDoNaiveBounded {
           public OutputBuilder<OutputT> builder(OutputT value) {
             return outputBuilderSupplier
                 .builder(value)
-                .setReceiver(
-                    windowedValue ->
-                        outerContext.outputWindowedValue(
-                            windowedValue.getValue(),
-                            windowedValue.getTimestamp(),
-                            windowedValue.getWindows(),
-                            windowedValue.getPaneInfo()));
+                .setReceiver(windowedValue -> outerContext.outputWindowedValue(windowedValue));
           }
         };
       }
@@ -657,6 +652,16 @@ public class SplittableParDoNaiveBounded {
           Collection<? extends BoundedWindow> windows,
           PaneInfo paneInfo) {
         outerContext.outputWindowedValue(tag, output, timestamp, windows, paneInfo);
+      }
+
+      @Override
+      public void outputWindowedValue(WindowedValue<OutputT> windowedValue) {
+        outerContext.outputWindowedValue(windowedValue);
+      }
+
+      @Override
+      public <T> void outputWindowedValue(TupleTag<T> tag, WindowedValue<T> windowedValue) {
+        outerContext.outputWindowedValue(tag, windowedValue);
       }
 
       @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/SplittableParDoNaiveBounded.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/SplittableParDoNaiveBounded.java
@@ -577,13 +577,7 @@ public class SplittableParDoNaiveBounded {
                 return outputBuilderSupplier
                     .builder(value)
                     .setReceiver(
-                        windowedValue ->
-                            outerContext.outputWindowedValue(
-                                tag,
-                                windowedValue.getValue(),
-                                windowedValue.getTimestamp(),
-                                windowedValue.getWindows(),
-                                windowedValue.getPaneInfo()));
+                        windowedValue -> outerContext.outputWindowedValue(tag, windowedValue));
               }
             };
           }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/Timer.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/Timer.java
@@ -126,7 +126,7 @@ public abstract class Timer<K> {
    */
   public abstract @Nullable PaneInfo getPaneInfo();
 
-  public abstract @Nullable CausedByDrain causedByDrain();
+  public abstract CausedByDrain causedByDrain();
 
   @Override
   public final boolean equals(@Nullable Object other) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/ValueInSingleWindow.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/ValueInSingleWindow.java
@@ -123,6 +123,10 @@ public abstract class ValueInSingleWindow<T> {
         BeamFnApi.Elements.ElementMetadata.Builder builder =
             BeamFnApi.Elements.ElementMetadata.newBuilder();
         // todo #33176 specify additional metadata in the future
+        builder.setDrain(
+            windowedElem.getCausedByDrain() == CausedByDrain.CAUSED_BY_DRAIN
+                ? BeamFnApi.Elements.DrainMode.Enum.DRAINING
+                : BeamFnApi.Elements.DrainMode.Enum.NOT_DRAINING);
         BeamFnApi.Elements.ElementMetadata metadata = builder.build();
         ByteArrayCoder.of().encode(metadata.toByteArray(), outStream);
       }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/WindowedValues.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/WindowedValues.java
@@ -77,7 +77,10 @@ public class WindowedValues {
         .setValue(template.getValue())
         .setTimestamp(template.getTimestamp())
         .setWindows(template.getWindows())
-        .setPaneInfo(template.getPaneInfo());
+        .setPaneInfo(template.getPaneInfo())
+        .setRecordOffset(template.getRecordOffset())
+        .setRecordId(template.getRecordId())
+        .setCausedByDrain(template.causedByDrain());
   }
 
   public static class Builder<T> implements OutputBuilder<T> {
@@ -271,7 +274,14 @@ public class WindowedValues {
     checkArgument(windows.size() > 0, "WindowedValue requires windows, but there were none");
 
     if (windows.size() == 1) {
-      return of(value, timestamp, windows.iterator().next(), paneInfo, causedByDrain);
+      return of(
+          value,
+          timestamp,
+          windows.iterator().next(),
+          paneInfo,
+          currentRecordId,
+          currentRecordOffset,
+          causedByDrain);
     } else {
       return new TimestampedValueInMultipleWindows<>(
           value, timestamp, windows, paneInfo, currentRecordId, currentRecordOffset, causedByDrain);
@@ -287,7 +297,7 @@ public class WindowedValues {
       PaneInfo paneInfo,
       CausedByDrain causedByDrain) {
     if (windows.size() == 1) {
-      return of(value, timestamp, windows.iterator().next(), paneInfo, causedByDrain);
+      return of(value, timestamp, windows.iterator().next(), paneInfo, null, null, causedByDrain);
     } else {
       return new TimestampedValueInMultipleWindows<>(
           value, timestamp, windows, paneInfo, null, null, causedByDrain);
@@ -299,7 +309,7 @@ public class WindowedValues {
       T value, Instant timestamp, BoundedWindow window, PaneInfo paneInfo) {
     checkArgument(paneInfo != null, "WindowedValue requires PaneInfo, but it was null");
 
-    return of(value, timestamp, window, paneInfo, CausedByDrain.NORMAL);
+    return of(value, timestamp, window, paneInfo, null, null, CausedByDrain.NORMAL);
   }
 
   /** Returns a {@code WindowedValue} with the given value, timestamp, and window. */
@@ -308,18 +318,21 @@ public class WindowedValues {
       Instant timestamp,
       BoundedWindow window,
       PaneInfo paneInfo,
+      @Nullable String currentRecordId,
+      @Nullable Long currentRecordOffset,
       CausedByDrain causedByDrain) {
     checkArgument(paneInfo != null, "WindowedValue requires PaneInfo, but it was null");
 
     boolean isGlobal = GlobalWindow.INSTANCE.equals(window);
     if (isGlobal && BoundedWindow.TIMESTAMP_MIN_VALUE.equals(timestamp)) {
-      return new ValueInGlobalWindow<>(value, paneInfo, null, null, causedByDrain);
+      return new ValueInGlobalWindow<>(
+          value, paneInfo, currentRecordId, currentRecordOffset, causedByDrain);
     } else if (isGlobal) {
       return new TimestampedValueInGlobalWindow<>(
-          value, timestamp, paneInfo, null, null, causedByDrain);
+          value, timestamp, paneInfo, currentRecordId, currentRecordOffset, causedByDrain);
     } else {
       return new TimestampedValueInSingleWindow<>(
-          value, timestamp, window, paneInfo, null, null, causedByDrain);
+          value, timestamp, window, paneInfo, currentRecordId, currentRecordOffset, causedByDrain);
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/WindowedValues.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/WindowedValues.java
@@ -148,6 +148,7 @@ public class WindowedValues {
 
     @Override
     public Builder<T> setCausedByDrain(CausedByDrain causedByDrain) {
+      checkStateNotNull(causedByDrain, "CausedByDrain is null");
       this.causedByDrain = causedByDrain;
       return this;
     }
@@ -202,6 +203,7 @@ public class WindowedValues {
 
     @Override
     public CausedByDrain causedByDrain() {
+      checkStateNotNull(causedByDrain, "CausedByDrain not set");
       return causedByDrain;
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/WindowedValues.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/WindowedValues.java
@@ -272,7 +272,7 @@ public class WindowedValues {
       CausedByDrain causedByDrain) {
     checkArgument(paneInfo != null, "WindowedValue requires PaneInfo, but it was null");
     checkArgument(windows.size() > 0, "WindowedValue requires windows, but there were none");
-
+    checkArgument(causedByDrain != null, "WindowedValue requires CausedByDrain, but it was null");
     if (windows.size() == 1) {
       return of(
           value,
@@ -322,6 +322,7 @@ public class WindowedValues {
       @Nullable Long currentRecordOffset,
       CausedByDrain causedByDrain) {
     checkArgument(paneInfo != null, "WindowedValue requires PaneInfo, but it was null");
+    checkArgument(causedByDrain != null, "WindowedValue requires CausedByDrain, but it was null");
 
     boolean isGlobal = GlobalWindow.INSTANCE.equals(window);
     if (isGlobal && BoundedWindow.TIMESTAMP_MIN_VALUE.equals(timestamp)) {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/MetadataPropagationTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/MetadataPropagationTest.java
@@ -30,9 +30,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 public class MetadataPropagationTest {
-  private static final Integer[] EMPTY = new Integer[] {};
-  private static final Integer[] DATA = new Integer[] {1, 2, 3, 4, 5};
-  private static final Integer[] REPEATED_DATA = new Integer[] {1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
 
   @RunWith(JUnit4.class)
   public static class MiscTest {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/MetadataPropagationTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/MetadataPropagationTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.transforms;
+
+import org.apache.beam.sdk.testing.NeedsRunner;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.values.CausedByDrain;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.WindowedValues;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+public class MetadataPropagationTest {
+  private static final Integer[] EMPTY = new Integer[] {};
+  private static final Integer[] DATA = new Integer[] {1, 2, 3, 4, 5};
+  private static final Integer[] REPEATED_DATA = new Integer[] {1, 1, 2, 2, 3, 3, 4, 4, 5, 5};
+
+  @RunWith(JUnit4.class)
+  public static class MiscTest {
+
+    /** Tests for metadata propagation. */
+    @Rule public final transient TestPipeline pipeline = TestPipeline.create();
+
+    static class CausedByDrainSettingDoFn extends DoFn<Integer, String> {
+      @ProcessElement
+      public void process(OutputReceiver<String> r) {
+        r.builder("value").setCausedByDrain(CausedByDrain.CAUSED_BY_DRAIN).output();
+      }
+    }
+
+    static class CausedByDrainExtractingDoFn extends DoFn<String, String> {
+      @ProcessElement
+      public void process(ProcessContext pc, OutputReceiver<String> r) {
+        r.output(pc.causedByDrain().toString());
+      }
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testMetadataPropagationAcrossShuffleParameter() {
+      WindowedValues.WindowedValueCoder.setMetadataSupported();
+      PCollection<String> results =
+          pipeline
+              .apply(Create.of(1))
+              .apply(ParDo.of(new CausedByDrainSettingDoFn()))
+              .apply(Redistribute.arbitrarily())
+              .apply(ParDo.of(new CausedByDrainExtractingDoFn()));
+
+      PAssert.that(results).containsInAnyOrder("CAUSED_BY_DRAIN");
+
+      pipeline.run();
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testMetadataPropagationParameter() {
+      PCollection<String> results =
+          pipeline
+              .apply(Create.of(1))
+              .apply(ParDo.of(new CausedByDrainSettingDoFn()))
+              .apply(ParDo.of(new CausedByDrainExtractingDoFn()));
+
+      PAssert.that(results).containsInAnyOrder("CAUSED_BY_DRAIN");
+
+      pipeline.run();
+    }
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
@@ -77,6 +77,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.util.UserCodeException;
+import org.apache.beam.sdk.values.CausedByDrain;
 import org.apache.beam.sdk.values.OutputBuilder;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.sdk.values.TypeDescriptors;
@@ -561,6 +562,7 @@ public class DoFnInvokersTest {
                     .setTimestamp(mockTimestamp)
                     .setWindow(mockWindow)
                     .setPaneInfo(PaneInfo.NO_FIRING)
+                    .setCausedByDrain(CausedByDrain.NORMAL)
                     .setReceiver(windowedValue -> outputs.add(windowedValue.getValue()));
               }
             };
@@ -801,6 +803,7 @@ public class DoFnInvokersTest {
                     .setTimestamp(mockTimestamp)
                     .setWindow(mockWindow)
                     .setPaneInfo(PaneInfo.NO_FIRING)
+                    .setCausedByDrain(CausedByDrain.NORMAL)
                     .setReceiver(
                         windowedValue -> {
                           assertFalse(invoked);

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -1788,6 +1788,16 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
     }
 
     @Override
+    public void outputWindowedValue(WindowedValue<OutputT> windowedValue) {
+      outputTo(mainOutputConsumer, windowedValue);
+    }
+
+    @Override
+    public <T> void outputWindowedValue(TupleTag<T> tag, WindowedValue<T> windowedValue) {
+      outputTo((FnDataReceiver) localNameToConsumer.get(tag.getId()), windowedValue);
+    }
+
+    @Override
     public <T> void outputWindowedValue(
         TupleTag<T> tag,
         T output,
@@ -1935,6 +1945,16 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
         throw new IllegalArgumentException(String.format("Unknown output tag %s", tag));
       }
       outputTo(consumer, WindowedValues.of(output, timestamp, windows, paneInfo));
+    }
+
+    @Override
+    public void outputWindowedValue(WindowedValue<OutputT> windowedValue) {
+      outputTo(mainOutputConsumer, windowedValue);
+    }
+
+    @Override
+    public <T> void outputWindowedValue(TupleTag<T> tag, WindowedValue<T> windowedValue) {
+      outputTo((FnDataReceiver) localNameToConsumer.get(tag.getId()), windowedValue);
     }
 
     @Override
@@ -2354,6 +2374,16 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
         outputTo(consumer, WindowedValues.of(output, timestamp, windows, paneInfo));
       }
 
+      @Override
+      public void outputWindowedValue(WindowedValue<OutputT> windowedValue) {
+        outputTo(mainOutputConsumer, windowedValue);
+      }
+
+      @Override
+      public <T> void outputWindowedValue(TupleTag<T> tag, WindowedValue<T> windowedValue) {
+        outputTo((FnDataReceiver) localNameToConsumer.get(tag.getId()), windowedValue);
+      }
+
       @SuppressWarnings(
           "deprecation") // Allowed Skew is deprecated for users, but must be respected
       private void checkOnWindowExpirationTimestamp(Instant timestamp) {
@@ -2642,6 +2672,16 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
         outputTo(
             consumer,
             WindowedValues.of(output, timestamp, currentWindow, currentTimer.getPaneInfo()));
+      }
+
+      @Override
+      public void outputWindowedValue(WindowedValue<OutputT> windowedValue) {
+        outputTo(mainOutputConsumer, windowedValue);
+      }
+
+      @Override
+      public <T> void outputWindowedValue(TupleTag<T> tag, WindowedValue<T> windowedValue) {
+        outputTo((FnDataReceiver) localNameToConsumer.get(tag.getId()), windowedValue);
       }
 
       @Override

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -2098,10 +2098,8 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                     .setReceiver(
                         windowedRow ->
                             ProcessBundleContextBase.this.outputWindowedValue(
-                                fromRowFunction.apply(windowedRow.getValue()),
-                                windowedRow.getTimestamp(),
-                                windowedRow.getWindows(),
-                                windowedRow.getPaneInfo()));
+                                windowedRow.withValue(
+                                    fromRowFunction.apply(windowedRow.getValue()))));
               }
             };
 
@@ -2134,12 +2132,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                     .withValue(value)
                     .setReceiver(
                         windowedValue ->
-                            ProcessBundleContextBase.this.outputWindowedValue(
-                                tag,
-                                windowedValue.getValue(),
-                                windowedValue.getTimestamp(),
-                                windowedValue.getWindows(),
-                                windowedValue.getPaneInfo()));
+                            ProcessBundleContextBase.this.outputWindowedValue(tag, windowedValue));
               }
             };
           }
@@ -2174,10 +2167,8 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                         windowedRow ->
                             ProcessBundleContextBase.this.outputWindowedValue(
                                 tag,
-                                fromRowFunction.apply(windowedRow.getValue()),
-                                windowedRow.getTimestamp(),
-                                windowedRow.getWindows(),
-                                windowedRow.getPaneInfo()));
+                                windowedRow.withValue(
+                                    fromRowFunction.apply(windowedRow.getValue()))));
               }
             };
           }
@@ -2456,10 +2447,8 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                     .setReceiver(
                         windowedValue ->
                             context.outputWindowedValue(
-                                fromRowFunction.apply(windowedValue.getValue()),
-                                windowedValue.getTimestamp(),
-                                windowedValue.getWindows(),
-                                windowedValue.getPaneInfo()));
+                                windowedValue.withValue(
+                                    fromRowFunction.apply(windowedValue.getValue()))));
               }
             };
 
@@ -2490,14 +2479,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                     .setTimestamp(currentTimer.getHoldTimestamp())
                     .setWindow(currentWindow)
                     .setCausedByDrain(causedByDrain)
-                    .setReceiver(
-                        windowedValue ->
-                            context.outputWindowedValue(
-                                tag,
-                                windowedValue.getValue(),
-                                windowedValue.getTimestamp(),
-                                windowedValue.getWindows(),
-                                windowedValue.getPaneInfo()));
+                    .setReceiver(windowedValue -> context.outputWindowedValue(tag, windowedValue));
               }
             };
           }
@@ -2532,10 +2514,8 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                         windowedValue ->
                             context.outputWindowedValue(
                                 tag,
-                                fromRowFunction.apply(windowedValue.getValue()),
-                                windowedValue.getTimestamp(),
-                                windowedValue.getWindows(),
-                                windowedValue.getPaneInfo()));
+                                windowedValue.withValue(
+                                    fromRowFunction.apply(windowedValue.getValue()))));
               }
             };
           }
@@ -2775,10 +2755,8 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                     .setReceiver(
                         windowedValue ->
                             context.outputWindowedValue(
-                                fromRowFunction.apply(windowedValue.getValue()),
-                                windowedValue.getTimestamp(),
-                                windowedValue.getWindows(),
-                                windowedValue.getPaneInfo()));
+                                windowedValue.withValue(
+                                    fromRowFunction.apply(windowedValue.getValue()))));
               }
             };
 
@@ -2810,13 +2788,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                     .setWindow(currentWindow)
                     .setCausedByDrain(causedByDrain)
                     .setPaneInfo(currentTimer.getPaneInfo())
-                    .setReceiver(
-                        windowedValue ->
-                            context.outputWindowedValue(
-                                windowedValue.getValue(),
-                                windowedValue.getTimestamp(),
-                                windowedValue.getWindows(),
-                                windowedValue.getPaneInfo()));
+                    .setReceiver(windowedValue -> context.outputWindowedValue(windowedValue));
               }
             };
           }
@@ -2851,10 +2823,8 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                     .setReceiver(
                         windowedValue ->
                             context.outputWindowedValue(
-                                fromRowFunction.apply(windowedValue.getValue()),
-                                windowedValue.getTimestamp(),
-                                windowedValue.getWindows(),
-                                windowedValue.getPaneInfo()));
+                                windowedValue.withValue(
+                                    fromRowFunction.apply(windowedValue.getValue()))));
               }
             };
           }

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -624,15 +624,18 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
 
   private void processElementForParDo(WindowedValue<InputT> elem) {
     currentElement = elem;
+    causedByDrain = currentElement.causedByDrain();
     try {
       doFnInvoker.invokeProcessElement(processContext);
     } finally {
       currentElement = null;
+      causedByDrain = null;
     }
   }
 
   private void processElementForWindowObservingParDo(WindowedValue<InputT> elem) {
     currentElement = elem;
+    causedByDrain = currentElement.causedByDrain();
     try {
       Iterator<BoundedWindow> windowIterator =
           (Iterator<BoundedWindow>) elem.getWindows().iterator();
@@ -643,12 +646,14 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
     } finally {
       currentElement = null;
       currentWindow = null;
+      causedByDrain = null;
     }
   }
 
   private void processElementForWindowObservingSizedElementAndRestriction(
       WindowedValue<KV<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>, Double>> elem) {
     currentElement = elem.withValue(elem.getValue().getKey().getKey());
+    causedByDrain = elem.causedByDrain();
     windowCurrentIndex = -1;
     windowStopIndex = currentElement.getWindows().size();
     currentWindows = ImmutableList.copyOf(currentElement.getWindows());
@@ -660,6 +665,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
           windowCurrentIndex = -1;
           windowStopIndex = 0;
           currentElement = null;
+          causedByDrain = null;
           currentWindows = null;
           currentRestriction = null;
           currentWatermarkEstimatorState = null;
@@ -1202,7 +1208,8 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
     checkNotNull(timerBundleTracker);
     try {
       currentKey = timer.getUserKey();
-      causedByDrain = timer.causedByDrain();
+      causedByDrain = Preconditions.checkNotNull(timer.causedByDrain());
+
       // add drain
       Iterator<BoundedWindow> windowIterator =
           (Iterator<BoundedWindow>) timer.getWindows().iterator();
@@ -1286,6 +1293,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
     try {
       currentKey = timer.getUserKey();
       currentTimer = timer;
+      causedByDrain = timer.causedByDrain();
       Iterator<BoundedWindow> windowIterator =
           (Iterator<BoundedWindow>) timer.getWindows().iterator();
       while (windowIterator.hasNext()) {
@@ -1296,6 +1304,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
       currentKey = null;
       currentTimer = null;
       currentWindow = null;
+      causedByDrain = null;
     }
   }
 
@@ -2315,7 +2324,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
             .setWindow(currentWindow)
             .setTimestamp(currentTimer.getHoldTimestamp())
             .setPaneInfo(currentTimer.getPaneInfo())
-            .setCausedByDrain(causedByDrain)
+            .setCausedByDrain(currentTimer.causedByDrain())
             .setReceiver(
                 windowedValue -> {
                   checkOnWindowExpirationTimestamp(windowedValue.getTimestamp());
@@ -2336,7 +2345,10 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                 output,
                 currentTimer.getHoldTimestamp(),
                 currentWindow,
-                currentTimer.getPaneInfo()));
+                currentTimer.getPaneInfo(),
+                null,
+                null,
+                currentTimer.causedByDrain()));
       }
 
       @Override
@@ -2786,7 +2798,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                     .setValue(value)
                     .setTimestamp(currentTimer.getHoldTimestamp())
                     .setWindow(currentWindow)
-                    .setCausedByDrain(causedByDrain)
+                    .setCausedByDrain(currentTimer.causedByDrain())
                     .setPaneInfo(currentTimer.getPaneInfo())
                     .setReceiver(windowedValue -> context.outputWindowedValue(windowedValue));
               }
@@ -2819,7 +2831,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                     .setTimestamp(currentTimer.getHoldTimestamp())
                     .setWindow(currentWindow)
                     .setPaneInfo(currentTimer.getPaneInfo())
-                    .setCausedByDrain(causedByDrain)
+                    .setCausedByDrain(currentTimer.causedByDrain())
                     .setReceiver(
                         windowedValue ->
                             context.outputWindowedValue(


### PR DESCRIPTION
When data is outputted with processContext, outputReceiver or builder, it's going through sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnOutputReceivers.java which was still using context.outputWindowedValue(element, ts, windows, pane ...) interface which we decided to abandon as adding new metadata requires changing this interface and we should use builder and windowedValue interface. 

- adds new outputWindowedValue(WV) public interface with implementations
- add tests to cover metadata propagation across parDos in single and mulitple stages for direct runner
- plumbs metadata propagation, where it was lost previously.



------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
