### PR TITLE
Revert "upgrade vllm for vuln"

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -627,7 +627,7 @@ if __name__ == '__main__':
           'xgboost': ['xgboost>=1.6.0,<2.1.3', 'datatable==1.0.0'],
           'tensorflow-hub': ['tensorflow-hub>=0.14.0,<0.16.0'],
           'milvus': milvus_dependency,
-          'vllm': ['openai==1.107.1', 'vllm==0.14', 'triton==3.3.1']
+          'vllm': ['openai==1.107.1', 'vllm==0.10.1.1', 'triton==3.3.1']
       },
       zip_safe=False,
       # PyPI package information.


### PR DESCRIPTION
Reverts apache/beam#37843

Rationale:

1.  vllm==0.14 is not compatible with the current  'transformers' extra, and we install both extras when building python ml containers
2. (for the future change) we should rebuild containers to actually remediate the vulnerability. updating setup.py is not sufficient