### PR TITLE
Add DATE/TIME/DATETIME to portable LogicalTypes.Enum in schema.proto

### DIFF
--- a/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/schema.proto
+++ b/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/schema.proto
@@ -174,6 +174,26 @@ message LogicalTypes {
     //     A variable-length string with its maximum length as the argument.
     VAR_CHAR = 7 [(org.apache.beam.model.pipeline.v1.beam_urn) =
       "beam:logical_type:var_char:v1"];
+
+    // A URN for Date type
+    //   - Representation type: INT64
+    //   - A date without a time-zone, stored as incrementing count of days
+    //     where day 0 is 1970-01-01 (ISO).
+    DATE = 8 [(org.apache.beam.model.pipeline.v1.beam_urn) =
+      "beam:logical_type:date:v1"];
+
+    // A URN for Time type
+    //   - Representation type: INT64
+    //   - A time without a time-zone, stored as a count of time in
+    //     nanoseconds.
+    TIME = 9 [(org.apache.beam.model.pipeline.v1.beam_urn) =
+      "beam:logical_type:time:v1"];
+
+    // A URN for DateTime type
+    //   - Representation type: ROW<Date: INT64, Time: INT64>
+    //   - A date-time without a time-zone, combining Date and Time.
+    DATETIME = 10 [(org.apache.beam.model.pipeline.v1.beam_urn) =
+      "beam:logical_type:datetime:v1"];
   }
 }
 


### PR DESCRIPTION
## Summary

Add `DATE`, `TIME`, and `DATETIME` as standard portable logical types in `LogicalTypes.Enum` in `schema.proto`.

## Motivation

The Java SDK already defines Date, Time, and DateTime logical types (`SqlTypes.DATE/TIME/DATETIME`) using `java.time` with portable URNs (`beam:logical_type:date:v1`, etc.), but these were never added to the proto's `LogicalTypes.Enum`. This means they can't be recognized as standard types during cross-language serialization — they degrade to `UnknownLogicalType`.

This is the first step toward full portable Date/Time support, which will unblock IcebergIO date type usage from the Python SDK.

## Changes

- `DATE = 8` — epoch days as INT64 (matching `Date.java`)
- `TIME = 9` — nanoseconds as INT64 (matching `Time.java`)
- `DATETIME = 10` — ROW<Date: INT64, Time: INT64> (matching `DateTime.java`)

## Follow-up PRs

1. Register these in `SchemaTranslation.STANDARD_LOGICAL_TYPES` (Java)
2. Add matching logical type classes in the Python SDK
3. Update `JdbcUtil.java` to recognize the portable URNs alongside legacy identifiers

## Related Issues

- Fixes #37823 (IcebergIO Date type support from Python SDK)
- Addresses #25946 (Support more portable schema types in Python)
- Moves toward #28359 (Switch to portable Date/Time for JdbcIO)