### PR TITLE
Revert "[Dataflow Streaming] Prevent commit threads from sharing commit streams"

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -464,13 +464,10 @@ public final class StreamingDataflowWorker {
     @SuppressWarnings("methodref.receiver.bound")
     WorkCommitter workCommitter =
         StreamingEngineWorkCommitter.builder()
-            // Use a separate stream pool for each committer. This ensures the commit
-            // threads are fully isolated.
             .setCommitWorkStreamFactory(
-                () ->
-                    WindmillStreamPool.create(
-                            1, COMMIT_STREAM_TIMEOUT, windmillServer::commitWorkStream)
-                        .getCloseableStream())
+                WindmillStreamPool.create(
+                        numCommitThreads, COMMIT_STREAM_TIMEOUT, windmillServer::commitWorkStream)
+                    ::getCloseableStream)
             .setCommitByteSemaphore(Commits.maxCommitByteSemaphore())
             .setNumCommitSenders(numCommitThreads)
             .setOnCommitComplete(this::onCompleteCommit)


### PR DESCRIPTION
Reverts apache/beam#37847

The change is causing StreamingEngineWorkCommitter to create a new WindmillStreamPool per commit.

<img width="3368" height="1676" alt="image" src="https://github.com/user-attachments/assets/09ff1d33-c710-47e7-9561-3fb4cb2feccf" />
