### PR TITLE
Handle Flink 2 job server tag in releases and SDK snapshot

### DIFF
--- a/.github/workflows/finalize_release.yml
+++ b/.github/workflows/finalize_release.yml
@@ -80,6 +80,12 @@ jobs:
           docker buildx imagetools create --tag "${IMAGE}:latest" "${IMAGE}:${RELEASE}"
         done
 
+        # Flink 2 images have different tagging, add latest tag to latest supported Flink version
+        echo "================Confirming Runner container Release and RC version==========="
+        BEAM_FLINK_REPO=apache/beam_flink_job_server
+        LATEST_FLINK_VERSION=$(wget -qO- https://raw.githubusercontent.com/apache/beam/refs/tags/v${RELEASE}-RC${RC_NUM}/gradle.properties | grep -E flink_versions |  tr ',' '\n' | tail -1)
+        docker buildx imagetools create --tag "${BEAM_FLINK_REPO}:latest" "${BEAM_FLINK_REPO}:${RELEASE}${RC_VERSION}-flink${LATEST_FLINK_VERSION}"
+
   publish_python_artifacts:
     if: ${{github.event.inputs.PUBLISH_PYTHON_ARTIFACTS == 'yes'}}
     runs-on: [self-hosted, ubuntu-20.04, main]

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamDockerPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamDockerPlugin.groovy
@@ -48,6 +48,7 @@ class BeamDockerPlugin implements Plugin<Project> {
     String dockerComposeFile = 'docker-compose.yml'
     Set<Task> dependencies = [] as Set
     Set<String> tags = [] as Set
+    String tagSuffix = null
     Map<String, String> namedTags = [:]
     Map<String, String> labels = [:]
     Map<String, String> buildArgs = [:]
@@ -100,7 +101,11 @@ class BeamDockerPlugin implements Plugin<Project> {
     }
 
     Set<String> getTags() {
-      return this.tags + project.getVersion().toString()
+      def allTags = this.tags + project.getVersion().toString()
+      if (tagSuffix) {
+        allTags = allTags.collect { it.endsWith(tagSuffix) ? it : it + tagSuffix }.toSet()
+      }
+      return allTags
     }
 
     Set<String> getPlatform() {

--- a/runners/flink/job-server-container/flink_job_server_container.gradle
+++ b/runners/flink/job-server-container/flink_job_server_container.gradle
@@ -55,8 +55,10 @@ task copyDockerfileDependencies(type: Copy) {
 def pushContainers = project.rootProject.hasProperty(["isRelease"]) || project.rootProject.hasProperty("push-containers")
 def containerName = project.parent.name.startsWith("2") ? "flink_job_server" : "flink${project.parent.name}_job_server"
 def containerTag = project.rootProject.hasProperty(["docker-tag"]) ? project.rootProject["docker-tag"] : project.sdk_version
+String verInSuffix = null
 if (project.parent.name.startsWith("2")) {
   containerTag += "-flink${project.parent.name}"
+  verInSuffix = "-flink${project.parent.name}"
 }
 
 docker {
@@ -68,6 +70,7 @@ docker {
           tag: containerTag)
   // tags used by dockerTag task
   tags containerImageTags()
+  tagSuffix verInSuffix
   files "./build/"
   buildx project.useBuildx()
   platform(*project.containerPlatforms())


### PR DESCRIPTION
**Please** add a meaningful description for your change here

Apparently the tag added locally and used for push uses different configuration

Locally it's tagged via `containerImageName(tag)`, but for push it uses tags config in `BeamDockerPlugin`.

Tested locally using `./gradlew :runners:flink:2.0:job-server-container:dockerPush -Pdocker-repository-root=gcr.io/apache-beam-testing/beam_portability -Pdocker-tag-list=testtag,latest`,

gcr.io/apache-beam-testing/beam_portability/beam_flink_job_server 

has `-flink2.0` suffixed tags added.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
