### PR TITLE
[Security] Bump ActiveMQ from 5.14.5 to 5.19.2 (fixes CVE-2023-46604)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -85,6 +85,10 @@
 
 * Fixed X (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
 
+## Security Fixes
+
+* Fixed [CVE-2023-46604](https://www.cve.org/CVERecord?id=CVE-2023-46604) (CVSS 10.0) and [CVE-2022-41678](https://www.cve.org/CVERecord?id=CVE-2022-41678) by upgrading ActiveMQ from 5.14.5 to 5.19.2 (Java) ([#37943](https://github.com/apache/beam/issues/37943)).
+
 ## Known Issues
 
 [comment]: # ( When updating known issues after release, make sure also update website blog in website/www/site/content/blog.)

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -597,7 +597,7 @@ class BeamModulePlugin implements Plugin<Project> {
     //
     // There are a few versions are determined by the BOMs by running scripts/tools/bomupgrader.py
     // marked as [bomupgrader]. See the documentation of that script for detail.
-    def activemq_version = "5.14.5"
+    def activemq_version = "5.19.2"
     def autovalue_version = "1.9"
     def autoservice_version = "1.0.1"
     def aws_java_sdk2_version = "2.20.162"

--- a/sdks/java/io/amqp/build.gradle
+++ b/sdks/java/io/amqp/build.gradle
@@ -30,7 +30,9 @@ dependencies {
   testImplementation library.java.slf4j_api
   testImplementation library.java.junit
   testImplementation library.java.activemq_broker
-  testImplementation library.java.activemq_amqp
+  testImplementation(library.java.activemq_amqp) {
+    exclude group: 'org.apache.qpid', module: 'proton-j'
+  }
   testImplementation library.java.activemq_junit
   testImplementation library.java.hamcrest
   testRuntimeOnly library.java.slf4j_jdk14

--- a/sdks/java/io/jms/build.gradle
+++ b/sdks/java/io/jms/build.gradle
@@ -32,7 +32,7 @@ dependencies {
   implementation project(path: ":sdks:java:core", configuration: "shadow")
   implementation library.java.slf4j_api
   implementation library.java.joda_time
-  implementation "org.apache.geronimo.specs:geronimo-jms_1.1_spec:1.1.1"
+  implementation "org.apache.geronimo.specs:geronimo-jms_2.0_spec:1.0-alpha-2"
   testImplementation library.java.activemq_amqp
   testImplementation library.java.activemq_broker
   testImplementation library.java.activemq_jaas

--- a/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/MockNonSerializableConnectionFactory.java
+++ b/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/MockNonSerializableConnectionFactory.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.io.jms;
 
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
+import javax.jms.JMSContext;
 import javax.jms.JMSException;
 
 public class MockNonSerializableConnectionFactory implements ConnectionFactory {
@@ -30,5 +31,25 @@ public class MockNonSerializableConnectionFactory implements ConnectionFactory {
   @Override
   public Connection createConnection(String userName, String password) throws JMSException {
     return null;
+  }
+
+  @Override
+  public JMSContext createContext() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public JMSContext createContext(String userName, String password) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public JMSContext createContext(String userName, String password, int sessionMode) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public JMSContext createContext(int sessionMode) {
+    throw new UnsupportedOperationException();
   }
 }


### PR DESCRIPTION
## Summary

Upgrades ActiveMQ from **5.14.5** to **5.19.2** to remediate critical security vulnerabilities. ActiveMQ is used exclusively as a **test dependency** in Beam (embedded broker for JMS, MQTT, and AMQP IO connector tests).

### CVEs Fixed

| CVE | CVSS | Severity | Description |
|-----|------|----------|-------------|
| [CVE-2023-46604](https://www.cve.org/CVERecord?id=CVE-2023-46604) | **10.0** | 🔴 Critical | Remote Code Execution via ClassInfo manipulation in OpenWire protocol. **Actively exploited in the wild by ransomware.** |
| [CVE-2022-41678](https://www.cve.org/CVERecord?id=CVE-2022-41678) | **8.8** | 🔴 High | RCE via Jolokia and REST API |

### Changes Required for Compatibility

1. **JMS spec upgrade** (JMS IO): `geronimo-jms_1.1_spec:1.1.1` → `geronimo-jms_2.0_spec:1.0-alpha-2`
   - ActiveMQ 5.19.x uses JMS 2.0 API internally (`setJMSDeliveryTime`). JMS 2.0 is fully backward-compatible with JMS 1.1 — only adds new methods.
2. **MockNonSerializableConnectionFactory** (JMS IO test): Added JMS 2.0 `createContext()` stubs.
3. **proton-j exclusion** (AMQP IO): Excluded transitive `proton-j:0.34.1` from `activemq-amqp` to avoid conflict with the directly declared `proton-j:0.16.0`.

### Testing

All three affected test modules pass locally:
- ✅ `:sdks:java:io:jms:test` (54 tests)
- ✅ `:sdks:java:io:mqtt:test`
- ✅ `:sdks:java:io:amqp:test`

Fixes #37943

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
