### PR TITLE
Update Google BOM to 26.79.0

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -608,14 +608,14 @@ class BeamModulePlugin implements Plugin<Project> {
     def dbcp2_version = "2.9.0"
     def errorprone_version = "2.31.0"
     // [bomupgrader] determined by: com.google.api:gax, consistent with: google_cloud_platform_libraries_bom
-    def gax_version = "2.74.1"
+    def gax_version = "2.76.0"
     def google_ads_version = "33.0.0"
     def google_clients_version = "2.0.0"
     def google_cloud_bigdataoss_version = "2.2.26"
     def google_code_gson_version = "2.10.1"
     def google_oauth_clients_version = "1.34.1"
     // [bomupgrader] determined by: io.grpc:grpc-netty, consistent with: google_cloud_platform_libraries_bom
-    def grpc_version = "1.76.2"
+    def grpc_version = "1.76.3"
     def guava_version = "33.1.0-jre"
     def hadoop_version = "3.4.2"
     def hamcrest_version = "2.1"
@@ -743,7 +743,7 @@ class BeamModulePlugin implements Plugin<Project> {
         google_api_services_dataflow                : "com.google.apis:google-api-services-dataflow:v1b3-rev20260118-$google_clients_version",
         google_api_services_healthcare              : "com.google.apis:google-api-services-healthcare:v1-rev20240130-$google_clients_version",
         google_api_services_pubsub                  : "com.google.apis:google-api-services-pubsub:v1-rev20220904-$google_clients_version",
-        google_api_services_storage                 : "com.google.apis:google-api-services-storage:v1-rev20251118-2.0.0",  // [bomupgrader] sets version
+        google_api_services_storage                 : "com.google.apis:google-api-services-storage:v1-rev20260204-2.0.0",  // [bomupgrader] sets version
         google_auth_library_credentials             : "com.google.auth:google-auth-library-credentials", // google_cloud_platform_libraries_bom sets version
         google_auth_library_oauth2_http             : "com.google.auth:google-auth-library-oauth2-http", // google_cloud_platform_libraries_bom sets version
         google_cloud_bigquery                       : "com.google.cloud:google-cloud-bigquery", // google_cloud_platform_libraries_bom sets version
@@ -755,13 +755,13 @@ class BeamModulePlugin implements Plugin<Project> {
         google_cloud_core_grpc                      : "com.google.cloud:google-cloud-core-grpc", // google_cloud_platform_libraries_bom sets version
         google_cloud_datacatalog_v1beta1            : "com.google.cloud:google-cloud-datacatalog", // google_cloud_platform_libraries_bom sets version
         google_cloud_dataflow_java_proto_library_all: "com.google.cloud.dataflow:google-cloud-dataflow-java-proto-library-all:0.5.160304",
-        google_cloud_datastore_v1_proto_client      : "com.google.cloud.datastore:datastore-v1-proto-client:2.34.0",   // [bomupgrader] sets version
+        google_cloud_datastore_v1_proto_client      : "com.google.cloud.datastore:datastore-v1-proto-client:2.37.0",   // [bomupgrader] sets version
         google_cloud_firestore                      : "com.google.cloud:google-cloud-firestore", // google_cloud_platform_libraries_bom sets version
         google_cloud_kms                            : "com.google.cloud:google-cloud-kms", // google_cloud_platform_libraries_bom sets version
         google_cloud_pubsub                         : "com.google.cloud:google-cloud-pubsub", // google_cloud_platform_libraries_bom sets version
         // [bomupgrader] the BOM version is set by scripts/tools/bomupgrader.py. If update manually, also update
         // libraries-bom version on sdks/java/container/license_scripts/dep_urls_java.yaml
-        google_cloud_platform_libraries_bom         : "com.google.cloud:libraries-bom:26.76.0",
+        google_cloud_platform_libraries_bom         : "com.google.cloud:libraries-bom:26.79.0",
         google_cloud_secret_manager                 : "com.google.cloud:google-cloud-secretmanager", // google_cloud_platform_libraries_bom sets version
         google_cloud_spanner                        : "com.google.cloud:google-cloud-spanner", // google_cloud_platform_libraries_bom sets version
         google_cloud_storage                        : "com.google.cloud:google-cloud-storage", // google_cloud_platform_libraries_bom sets version

--- a/sdks/java/container/license_scripts/dep_urls_java.yaml
+++ b/sdks/java/container/license_scripts/dep_urls_java.yaml
@@ -46,7 +46,7 @@ jaxen:
   '1.1.6':
     type: "3-Clause BSD"
 libraries-bom:
-  '26.76.0':
+  '26.79.0':
     license: "https://raw.githubusercontent.com/GoogleCloudPlatform/cloud-opensource-java/master/LICENSE"
     type: "Apache License 2.0"
 paranamer:


### PR DESCRIPTION
Used `bomupgrader.py` to update BOM and checked with `beam-linkage-check.sh origin/master update-google-bom ""`

```
> Task :checkJavaLinkage
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Mar 31, 2026 7:18:55 PM com.google.cloud.tools.opensource.classpath.ClassDumper findSymbolReferences
WARNING: com.fasterxml.jackson.core:jackson-annotations:2.15.4 has 1 (out of 73) incompatible class files (class file major version is outside 45 <= v <= 52).
Mar 31, 2026 7:18:56 PM com.google.cloud.tools.opensource.classpath.ClassDumper findSymbolReferences
WARNING: com.github.luben:zstd-jni:1.5.6-3 has 1 (out of 36) incompatible class files (class file major version is outside 45 <= v <= 52).
Mar 31, 2026 7:18:58 PM com.google.cloud.tools.opensource.classpath.ClassDumper findSymbolReferences
WARNING: org.codehaus.woodstox:stax2-api:4.2.1 has 1 (out of 125) incompatible class files (class file major version is outside 45 <= v <= 52).
Mar 31, 2026 7:19:01 PM com.google.cloud.tools.opensource.classpath.ClassDumper findSymbolReferences
WARNING: org.projectlombok:lombok:1.18.34 has 1 (out of 178) incompatible class files (class file major version is outside 45 <= v <= 52).
Mar 31, 2026 7:19:02 PM com.google.cloud.tools.opensource.classpath.ClassDumper findSymbolReferences
WARNING: jaxen:jaxen:1.1.6 has 1 (out of 214) incompatible class files (class file major version is outside 45 <= v <= 52).
Mar 31, 2026 7:19:02 PM com.google.cloud.tools.opensource.classpath.ClassDumper findSymbolReferences
WARNING: javax.xml.stream:stax-api:1.0-2 has 35 (out of 37) incompatible class files (class file major version is outside 45 <= v <= 52).
Mar 31, 2026 7:19:02 PM com.google.cloud.tools.opensource.classpath.ClassDumper findSymbolReferences
WARNING: org.glassfish:javax.transaction:3.1 has 3 (out of 18) incompatible class files (class file major version is outside 45 <= v <= 52).
Mar 31, 2026 7:19:02 PM com.google.cloud.tools.opensource.classpath.ClassDumper findSymbolReferences
WARNING: jakarta.xml.bind:jakarta.xml.bind-api:2.3.2 has 1 (out of 111) incompatible class files (class file major version is outside 45 <= v <= 52).
Mar 31, 2026 7:19:02 PM com.google.cloud.tools.opensource.classpath.ClassDumper findSymbolReferences
WARNING: javax.ws.rs:javax.ws.rs-api:2.1.1 has 1 (out of 138) incompatible class files (class file major version is outside 45 <= v <= 52).
NOTE: This task published artifacts into your local Maven repository. You may want to remove them manually.
[Incubating] Problems report is available at: file:///usr/local/google/home/klk/GitHub/apache/beam-release/build/reports/problems/problems-report.html
Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.
You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
For more on this, please refer to https://docs.gradle.org/8.14.3/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
BUILD SUCCESSFUL in 2m 41s
1933 actionable tasks: 319 executed, 1614 up-to-date
+ RESULT=0
+ set -e
+ set +x
Tue Mar 31 07:19:22 PM UTC 2026: Done: 0
No new linkage errors
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
