### PR TITLE
[BigQuery] Handle 409 Conflict in BigqueryClient testing client for dataset and table creation

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/testing/BigqueryClient.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/testing/BigqueryClient.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.io.gcp.testing;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
 
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.util.BackOff;
@@ -451,6 +452,12 @@ public class BigqueryClient {
               new IOException(
                   "Expected valid response from insert dataset job, but received null.");
         }
+      } catch (GoogleJsonResponseException e) {
+        if (e.getStatusCode() == 409) {
+          LOG.info("Dataset {} already exists, treating as success.", datasetId);
+          return;
+        }
+        lastException = e;
       } catch (IOException e) {
         // ignore and retry
         lastException = e;
@@ -509,6 +516,16 @@ public class BigqueryClient {
           lastException =
               new IOException("Expected valid response from create table job, but received null.");
         }
+      } catch (GoogleJsonResponseException e) {
+        if (e.getStatusCode() == 409) {
+          LOG.info(
+              "Table {}:{}.{} already exists, treating as success.",
+              projectId,
+              datasetId,
+              newTable.getTableReference().getTableId());
+          return;
+        }
+        lastException = e;
       } catch (IOException e) {
         // ignore and retry
         lastException = e;


### PR DESCRIPTION
Update the test-specific BigqueryClient to catch GoogleJsonResponseException and treat 409 (ALREADY_EXISTS) as a success during dataset and table creation. 

This prevents transient failures where an initial creation request succeeds on the server but the client fails to receive the response. Without this  fix, the subsequent retry would fail with a conflict, eventually causing 
the test to fail despite the resource being successfully created.

Example test failure - testExactlyOnceWithAutoSchemaUpdate[0] (org.apache.beam.sdk.io.gcp.bigquery.StorageApiSinkSchemaUpdateIT)
 https://github.com/apache/beam/pull/38009/checks?check_run_id=69455316406

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
