### PR TITLE
Fix BigQueryEnrichmentHandler batch handling for duplicate keys

### DIFF
--- a/sdks/python/apache_beam/transforms/enrichment_handlers/bigquery.py
+++ b/sdks/python/apache_beam/transforms/enrichment_handlers/bigquery.py
@@ -214,7 +214,8 @@ class BigQueryEnrichmentHandler(EnrichmentSourceHandler[Union[Row, list[Row]],
 
       responses_dict = self._execute_query(query)
       unmatched_requests = {
-          key: list(reqs) for key, reqs in requests_map.items()
+          key: list(reqs)
+          for key, reqs in requests_map.items()
       }
       if responses_dict:
         for response in responses_dict:

--- a/sdks/python/apache_beam/transforms/enrichment_handlers/bigquery_test.py
+++ b/sdks/python/apache_beam/transforms/enrichment_handlers/bigquery_test.py
@@ -77,15 +77,11 @@ class TestBigQueryEnrichment(unittest.TestCase):
         min_batch_size=2,
         max_batch_size=2,
     )
-    requests = [
-        beam.Row(id='1', name='first'),
-        beam.Row(id='1', name='second')
-    ]
+    requests = [beam.Row(id='1', name='first'), beam.Row(id='1', name='second')]
 
-    with mock.patch.object(
-        handler,
-        '_execute_query',
-        return_value=[{'id': '1', 'value': 'enriched'}]):
+    with mock.patch.object(handler,
+                           '_execute_query',
+                           return_value=[{'id': '1', 'value': 'enriched'}]):
       responses = handler(requests)
 
     self.assertEqual(
@@ -106,10 +102,7 @@ class TestBigQueryEnrichment(unittest.TestCase):
         max_batch_size=2,
         throw_exception_on_empty_results=False,
     )
-    requests = [
-        beam.Row(id='1', name='first'),
-        beam.Row(id='1', name='second')
-    ]
+    requests = [beam.Row(id='1', name='first'), beam.Row(id='1', name='second')]
 
     with mock.patch.object(handler, '_execute_query', return_value=None):
       responses = handler(requests)


### PR DESCRIPTION

Fixes #38035

## What does this PR do?

Fixes a bug in `BigQueryEnrichmentHandler` batch mode where requests sharing the
same enrichment key overwrite each other during request bookkeeping.

Previously, batched requests were stored as a single request per key:

```python
requests_map[self.create_row_key(req)] = req
````

This caused earlier requests with the same key to be lost.

This PR updates the batch path to store all requests for a given key and fan out one matching BigQuery response row to every request with that key.

It also updates unmatched handling so all duplicate requests receive empty rows when `throw_exception_on_empty_results=False`.
