### PR TITLE
Migrate Jupyter Sidepanel extension to pip-based installation

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/README.md
+++ b/sdks/python/apache_beam/runners/interactive/README.md
@@ -244,23 +244,10 @@ a quick reference). For a more general and complete getting started guide, see
     jupyter kernelspec list
     ```
 
-*   Extend JupyterLab through labextension. **Note**: labextension is different from nbextension
-    from pre-lab jupyter notebooks.
-
-    All jupyter labextensions need nodejs
-
-    ```bash
-    # Homebrew users do
-    brew install node
-    # Or Conda users do
-    conda install -c conda-forge nodejs
-    ```
-
-    Enable ipywidgets
+*   Install ipywidgets (includes the JupyterLab widget manager as a prebuilt extension):
 
     ```bash
     pip install ipywidgets
-    jupyter labextension install @jupyter-widgets/jupyterlab-manager
     ```
 
 ### Start the notebook

--- a/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/README.md
+++ b/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/README.md
@@ -31,41 +31,22 @@ Includes two different side panels:
 
 ## Installation
 
-There are two ways to install the extension:
-
-### 1. Via pip (recommended)
-
-The extension is now available as a Python package on PyPI. You can install it with:
+This extension is distributed as a prebuilt Python package. Install it with pip:
 
 ```bash
 pip install apache-beam-jupyterlab-sidepanel
 ```
 
-After installation, rebuild JupyterLab to activate the extension:
+Then restart JupyterLab. The side panels will be available automatically — no
+`jupyter lab build` step is needed.
+
+You can verify the extension is installed:
 
 ```bash
-jupyter lab clean
-jupyter lab build
+jupyter labextension list
 ```
 
-Then restart JupyterLab. The side panels will be available automatically.
-
-
-### 2. Via JupyterLab Extension Manager (legacy, will be deprecated soon)
-
-```bash
-jupyter labextension install apache-beam-jupyterlab-sidepanel
-```
-
-This installs the extension using JupyterLab's legacy extension system.
-
----
-
-## Notes
-
-- Pip installation is now the preferred method as it handles Python packaging and JupyterLab extension registration seamlessly.
-- After any upgrade or reinstallation, always rebuild JupyterLab to ensure the extension is activated.
-- For detailed usage and development, refer to the source code and issues on [GitHub](https://github.com/apache/beam).
+The extension should appear under the **prebuilt extensions** section.
 
 ---
 
@@ -90,15 +71,12 @@ The `jlpm` command is JupyterLab's pinned version of
 
 # Install dependencies
 jlpm
-# Build Typescript source
-jlpm build
-# Link your development version of the extension with JupyterLab
-jupyter labextension link .
 
-# Rebuild Typescript source after making changes
-jlpm build
-# Rebuild JupyterLab after making any changes
-jupyter lab build
+# Install the extension in editable mode (runs an initial JS build)
+pip install -e .
+
+# Verify installation
+jupyter labextension list
 ```
 
 You can watch the source directory and run JupyterLab in watch mode to watch for changes in the extension's source and automatically rebuild the extension and application.
@@ -110,7 +88,7 @@ jlpm watch
 jupyter lab --watch
 ```
 
-Now every change will be built locally and bundled into JupyterLab. Be sure to refresh your browser page after saving file changes to reload the extension (note: you'll need to wait for webpack to finish, which can take 10s+ at times).
+Now every change will be built locally and bundled into JupyterLab. Be sure to refresh your browser page after saving file changes to reload the extension (note: you'll need to wait for the build to finish, which can take 10s+ at times).
 
 ### Test
 
@@ -214,9 +192,5 @@ $PREFIX/share/jupyter/labextensions/apache-beam-jupyterlab-sidepanel/
 ### Uninstall
 
 ```bash
-jupyter labextension uninstall apache-beam-jupyterlab-sidepanel
-```
-or
-```bash
-pip uninstall apache-beam-jupyterlab-sidepanel
+pip uninstall apache_beam_jupyterlab_sidepanel
 ```

--- a/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/install.json
+++ b/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/install.json
@@ -1,0 +1,5 @@
+{
+  "packageManager": "python",
+  "packageName": "apache_beam_jupyterlab_sidepanel",
+  "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package apache_beam_jupyterlab_sidepanel"
+}

--- a/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/package.json
+++ b/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/package.json
@@ -15,7 +15,7 @@
   "author": "apache-beam",
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
-    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
+    "style/**/*.{css,js,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -100,6 +100,7 @@
     "style/*.css",
     "style/index.js"
   ],
+  "styleModule": "style/index.js",
   "jupyterlab": {
     "extension": true,
     "outputDir": "apache_beam_jupyterlab_sidepanel/labextension"

--- a/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/pyproject.toml
+++ b/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/pyproject.toml
@@ -33,6 +33,8 @@ classifiers = [
     "Framework :: Jupyter",
     "Framework :: Jupyter :: JupyterLab",
     "Framework :: Jupyter :: JupyterLab :: 4",
+    "Framework :: Jupyter :: JupyterLab :: Extensions",
+    "Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
 ]

--- a/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/style/index.css
+++ b/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/style/index.css
@@ -18,6 +18,3 @@
 @import './inspector/Inspectables.css';
 @import './inspector/InspectableView.css';
 @import './inspector/InteractiveInspector.css';
-@import './yaml/Yaml.css';
-@import './yaml/YamlEditor.css';
-@import './yaml/YamlFlow.css';

--- a/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/style/index.js
+++ b/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/style/index.js
@@ -1,0 +1,16 @@
+// Licensed under the Apache License, Version 2.0 (the 'License'); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+import './index.css';
+import './yaml/Yaml.css';
+import './yaml/YamlEditor.css';
+import './yaml/YamlFlow.css';

--- a/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/tsconfig.json
+++ b/sdks/python/apache_beam/runners/interactive/extensions/apache-beam-jupyterlab-sidepanel/tsconfig.json
@@ -29,6 +29,7 @@
     "src/common/*",
     "src/kernel/*",
     "src/inspector/*",
+    "src/yaml/*",
     "src/__tests__/**/*"
   ]
 }


### PR DESCRIPTION
Addresses #37977.

## Summary
This PR migrates the Jupyter Sidepanel extension to the pip-based JupyterLab 4
prebuilt installation flow.

## What Changed
- add `install.json` so JupyterLab recognizes the extension as Python-managed
- add `style/index.js` and `styleModule` so stylesheet assets are bundled correctly for the prebuilt extension
- make the prebuilt style entrypoint explicitly import the YAML panel styles to avoid ambiguity about whether they are included in the bundle
- update `package.json` packaging globs so the new style entrypoint is included in published artifacts
- add JupyterLab prebuilt-extension classifiers to `pyproject.toml`
- include `src/yaml/*` in `tsconfig.json` so the YAML panel sources are compiled
- update the sidepanel extension README to document the prebuilt `pip install` workflow and remove unnecessary legacy `jupyter lab build` steps
- update the interactive Beam README to replace `jupyter labextension install @jupyter-widgets/jupyterlab-manager` with `pip install ipywidgets`

## Testing
- `jlpm run build:lib`
- `jlpm run build:prod`
- `jlpm jest --runInBand`
- `python -m pip install -e .`
- `jupyter labextension list`
- `python -m build --sdist --wheel`

## Context
JupyterLab 4 favors prebuilt extensions distributed through Python packages instead of the legacy `labextension install/link` workflow.

This change makes the sidepanel extension discoverable and installable through the expected Python packaging path, and aligns the docs with the supported installation flow.

## Checklist
- [x] This PR addresses #37977.
- [ ] Update `CHANGES.md` with noteworthy changes.
- [ ] If this contribution is large, file an Apache Individual Contributor License Agreement.
