### PR TITLE
Fix flaky FileIOTest.testMatchWatchForNewFiles test under CI filesystems

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileIOTest.java
@@ -249,7 +249,9 @@ public class FileIOTest implements Serializable {
       context.output(Objects.requireNonNull(context.element()).getValue());
 
       CopyOption[] cpOptions = {StandardCopyOption.COPY_ATTRIBUTES};
-      CopyOption[] updOptions = {StandardCopyOption.REPLACE_EXISTING};
+      CopyOption[] updOptions = {
+        StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES
+      };
       final Path sourcePath = Paths.get(sourcePathStr);
       final Path watchPath = Paths.get(watchPathStr);
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileIOTest.java
@@ -232,9 +232,10 @@ public class FileIOTest implements Serializable {
   /** DoFn that copy test files from source to watch path. */
   private static class CopyFilesFn
       extends DoFn<KV<String, MatchResult.Metadata>, MatchResult.Metadata> {
-    public CopyFilesFn(Path sourcePath, Path watchPath) {
+    public CopyFilesFn(Path sourcePath, Path watchPath, long baseTimestampMillis) {
       this.sourcePathStr = sourcePath.toString();
       this.watchPathStr = watchPath.toString();
+      this.baseTimestampMillis = baseTimestampMillis;
     }
 
     @StateId("count")
@@ -257,10 +258,16 @@ public class FileIOTest implements Serializable {
 
       if (0 == current) {
         Thread.sleep(100);
+        // Ensure overwrite updates get a distinct mtime even when COPY_ATTRIBUTES is enabled.
+        Files.setLastModifiedTime(
+            sourcePath.resolve("first"), FileTime.fromMillis(baseTimestampMillis + 2000));
         Files.copy(sourcePath.resolve("first"), watchPath.resolve("first"), updOptions);
         Files.copy(sourcePath.resolve("second"), watchPath.resolve("second"), cpOptions);
       } else if (1 == current) {
         Thread.sleep(100);
+        FileTime updateTime = FileTime.fromMillis(baseTimestampMillis + 4000);
+        Files.setLastModifiedTime(sourcePath.resolve("first"), updateTime);
+        Files.setLastModifiedTime(sourcePath.resolve("second"), updateTime);
         Files.copy(sourcePath.resolve("first"), watchPath.resolve("first"), updOptions);
         Files.copy(sourcePath.resolve("second"), watchPath.resolve("second"), updOptions);
         Files.copy(sourcePath.resolve("third"), watchPath.resolve("third"), cpOptions);
@@ -271,6 +278,7 @@ public class FileIOTest implements Serializable {
     // Member variables need to be serializable.
     private final String sourcePathStr;
     private final String watchPathStr;
+    private final long baseTimestampMillis;
   }
 
   @Test
@@ -282,6 +290,12 @@ public class FileIOTest implements Serializable {
     Files.write(sourcePath.resolve("first"), new byte[42]);
     Files.write(sourcePath.resolve("second"), new byte[37]);
     Files.write(sourcePath.resolve("third"), new byte[99]);
+    // Keep controlled mtimes in the past so updates are distinct without future timestamps.
+    long baseTimestampMillis = System.currentTimeMillis() - Duration.standardMinutes(1).getMillis();
+    FileTime baseTimestamp = FileTime.fromMillis(baseTimestampMillis);
+    Files.setLastModifiedTime(sourcePath.resolve("first"), baseTimestamp);
+    Files.setLastModifiedTime(sourcePath.resolve("second"), baseTimestamp);
+    Files.setLastModifiedTime(sourcePath.resolve("third"), baseTimestamp);
 
     // Create a "watch" directory that the pipeline will copy files into.
     final Path watchPath = tmpFolder.getRoot().toPath().resolve("watch");
@@ -336,7 +350,7 @@ public class FileIOTest implements Serializable {
                             TypeDescriptors.strings(),
                             TypeDescriptor.of(MatchResult.Metadata.class)))
                     .via((metadata) -> KV.of("dumb key", metadata)))
-            .apply(ParDo.of(new CopyFilesFn(sourcePath, watchPath)));
+            .apply(ParDo.of(new CopyFilesFn(sourcePath, watchPath, baseTimestampMillis)));
 
     assertEquals(PCollection.IsBounded.UNBOUNDED, matchMetadata.isBounded());
     assertEquals(PCollection.IsBounded.UNBOUNDED, matchAllMetadata.isBounded());


### PR DESCRIPTION
**Please** add a meaningful description for your change here

addresses #19480

The `FileIOTest.testMatchWatchForNewFiles` test occasionally flakes in the CI environment because the `updOptions` configuration in `CopyFilesFn` does not preserve file attributes when overwriting existing files. In some CI filesystems, this causes the copied file to register a `lastModifiedMillis` timestamp of `0`. Thus, when `ExtractFilenameAndLastUpdateFn` parses this file, it throws a `RuntimeException` at `FileIO.java:800`, failing the pipeline run.

This PR adds `StandardCopyOption.COPY_ATTRIBUTES` to preserve the file's original timestamps, avoiding the exception.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).
