### PR TITLE
add support for bigtable materialized view source

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,6 +65,7 @@
 ## I/Os
 
 * Support for X source added (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
+* Support for Bigtable materialized view source added (Java) ([#38053](https://github.com/apache/beam/issues/38053)).
 
 ## New Features / Improvements
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -395,6 +395,12 @@ public class BigtableIO {
       return tableId != null && tableId.isAccessible() ? tableId.get() : null;
     }
 
+    /** Returns the materialized view being read from. */
+    public @Nullable String getMaterializedViewName() {
+      ValueProvider<String> mvName = getBigtableReadOptions().getMaterializedViewName();
+      return mvName != null && mvName.isAccessible() ? mvName.get() : null;
+    }
+
     /**
      * Returns the Google Cloud Bigtable instance being read from, and other parameters.
      *
@@ -415,7 +421,6 @@ public class BigtableIO {
           .setBigtableConfig(config)
           .setBigtableReadOptions(
               BigtableReadOptions.builder()
-                  .setTableId(StaticValueProvider.of(""))
                   .setKeyRanges(
                       StaticValueProvider.of(Collections.singletonList(ByteKeyRange.ALL_KEYS)))
                   .build())
@@ -519,6 +524,30 @@ public class BigtableIO {
      */
     public Read withAppProfileId(String appProfileId) {
       return withAppProfileId(StaticValueProvider.of(appProfileId));
+    }
+
+    /**
+     * Returns a new {@link BigtableIO.Read} that will read from the specified materialized view.
+     * Mutually exclusive with {@link #withTableId}.
+     *
+     * <p>Does not modify this object.
+     */
+    public Read withMaterializedViewName(ValueProvider<String> materializedViewName) {
+      BigtableReadOptions bigtableReadOptions = getBigtableReadOptions();
+      return toBuilder()
+          .setBigtableReadOptions(
+              bigtableReadOptions.toBuilder().setMaterializedViewName(materializedViewName).build())
+          .build();
+    }
+
+    /**
+     * Returns a new {@link BigtableIO.Read} that will read from the specified materialized view.
+     * Mutually exclusive with {@link #withTableId}.
+     *
+     * <p>Does not modify this object.
+     */
+    public Read withMaterializedViewName(String materializedViewName) {
+      return withMaterializedViewName(StaticValueProvider.of(materializedViewName));
     }
 
     /**
@@ -769,6 +798,11 @@ public class BigtableIO {
     private void validateTableExists(
         BigtableConfig config, BigtableReadOptions readOptions, PipelineOptions options) {
       if (config.getValidate() && config.isDataAccessible() && readOptions.isDataAccessible()) {
+        // Skip table existence validation for materialized views since the standard
+        // readRow-based check only works for tables.
+        if (readOptions.getMaterializedViewName() != null) {
+          return;
+        }
         ValueProvider<String> tableIdProvider = checkArgumentNotNull(readOptions.getTableId());
         String tableId = checkArgumentNotNull(tableIdProvider.get());
         try {
@@ -1890,16 +1924,24 @@ public class BigtableIO {
       }
 
       ValueProvider<String> tableId = readOptions.getTableId();
-      checkArgument(
-          tableId != null && tableId.isAccessible() && !tableId.get().isEmpty(),
-          "tableId was not supplied");
+      ValueProvider<String> mvName = readOptions.getMaterializedViewName();
+      boolean hasTableId = tableId != null && tableId.isAccessible() && !tableId.get().isEmpty();
+      boolean hasMvName = mvName != null && mvName.isAccessible() && !mvName.get().isEmpty();
+      checkArgument(hasTableId || hasMvName, "tableId or materializedViewName was not supplied");
     }
 
     @Override
     public void populateDisplayData(DisplayData.Builder builder) {
       super.populateDisplayData(builder);
 
-      builder.add(DisplayData.item("tableId", readOptions.getTableId()).withLabel("Table ID"));
+      if (readOptions.getTableId() != null) {
+        builder.add(DisplayData.item("tableId", readOptions.getTableId()).withLabel("Table ID"));
+      }
+      if (readOptions.getMaterializedViewName() != null) {
+        builder.add(
+            DisplayData.item("materializedViewName", readOptions.getMaterializedViewName())
+                .withLabel("Materialized View Name"));
+      }
 
       if (getRowFilter() != null) {
         builder.add(
@@ -1984,8 +2026,12 @@ public class BigtableIO {
       return readOptions.getMaxBufferElementCount();
     }
 
-    public ValueProvider<String> getTableId() {
+    public @Nullable ValueProvider<String> getTableId() {
       return readOptions.getTableId();
+    }
+
+    public @Nullable ValueProvider<String> getMaterializedViewName() {
+      return readOptions.getMaterializedViewName();
     }
 
     void reportLineageOnce(BigtableService.Reader reader) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableReadOptions.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableReadOptions.java
@@ -39,7 +39,10 @@ import org.joda.time.Duration;
 abstract class BigtableReadOptions implements Serializable {
 
   /** Returns the table id. */
-  abstract ValueProvider<String> getTableId();
+  abstract @Nullable ValueProvider<String> getTableId();
+
+  /** Returns the materialized view name. */
+  abstract @Nullable ValueProvider<String> getMaterializedViewName();
 
   /** Returns the row filter to use. */
   abstract @Nullable ValueProvider<RowFilter> getRowFilter();
@@ -72,7 +75,9 @@ abstract class BigtableReadOptions implements Serializable {
   @AutoValue.Builder
   abstract static class Builder {
 
-    abstract Builder setTableId(ValueProvider<String> tableId);
+    abstract Builder setTableId(@Nullable ValueProvider<String> tableId);
+
+    abstract Builder setMaterializedViewName(@Nullable ValueProvider<String> materializedViewName);
 
     abstract Builder setRowFilter(ValueProvider<RowFilter> rowFilter);
 
@@ -108,12 +113,18 @@ abstract class BigtableReadOptions implements Serializable {
   }
 
   boolean isDataAccessible() {
+    if (getMaterializedViewName() != null) {
+      return getMaterializedViewName().isAccessible();
+    }
     return getTableId() != null && getTableId().isAccessible();
   }
 
   void populateDisplayData(DisplayData.Builder builder) {
     builder
         .addIfNotNull(DisplayData.item("tableId", getTableId()).withLabel("Bigtable Table Id"))
+        .addIfNotNull(
+            DisplayData.item("materializedViewName", getMaterializedViewName())
+                .withLabel("Bigtable Materialized View Name"))
         .addIfNotNull(DisplayData.item("rowFilter", getRowFilter()).withLabel("Row Filter"))
         .addIfNotNull(
             DisplayData.item("rowFilterTextProto", getRowFilterTextProto()).withLabel("Row Filter"))
@@ -127,9 +138,19 @@ abstract class BigtableReadOptions implements Serializable {
   }
 
   void validate() {
+    boolean hasTableId =
+        getTableId() != null && (!getTableId().isAccessible() || !getTableId().get().isEmpty());
+    boolean hasMaterializedViewName =
+        getMaterializedViewName() != null
+            && (!getMaterializedViewName().isAccessible()
+                || !getMaterializedViewName().get().isEmpty());
+
     checkArgument(
-        getTableId() != null && (!getTableId().isAccessible() || !getTableId().get().isEmpty()),
-        "Could not obtain Bigtable table id");
+        hasTableId || hasMaterializedViewName,
+        "Either a Bigtable table id or a materialized view name must be set");
+    checkArgument(
+        !(hasTableId && hasMaterializedViewName),
+        "Only one of Bigtable table id or materialized view name can be set, not both");
 
     if (getRowFilter() != null && getRowFilter().isAccessible()) {
       checkArgument(getRowFilter().get() != null, "rowFilter can not be null");

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableReadSchemaTransformProvider.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableReadSchemaTransformProvider.java
@@ -92,9 +92,9 @@ public class BigtableReadSchemaTransformProvider
 
   @Override
   public String description() {
-    return "Reads data from a Google Cloud Bigtable table.\n"
-        + "The transform requires the project ID, instance ID, and table ID parameters.\n"
-        + "Optionally, the output can be flattened or nested rows.\n"
+    return "Reads data from a Google Cloud Bigtable table or materialized view.\n"
+        + "The transform requires the project ID, instance ID, and either table ID or\n"
+        + "materialized view name. Optionally, the output can be flattened or nested rows.\n"
         + "Example usage:\n"
         + "  - type: ReadFromBigTable\n"
         + "    config:\n"
@@ -116,9 +116,17 @@ public class BigtableReadSchemaTransformProvider
     public void validate() {
       String emptyStringMessage =
           "Invalid Bigtable Read configuration: %s should not be a non-empty String";
-      checkArgument(!this.getTableId().isEmpty(), String.format(emptyStringMessage, "table"));
       checkArgument(!this.getInstanceId().isEmpty(), String.format(emptyStringMessage, "instance"));
       checkArgument(!this.getProjectId().isEmpty(), String.format(emptyStringMessage, "project"));
+
+      String tableId = this.getTableId();
+      String mvName = this.getMaterializedViewName();
+      boolean hasTableId = tableId != null && !tableId.isEmpty();
+      boolean hasMvName = mvName != null && !mvName.isEmpty();
+      checkArgument(hasTableId || hasMvName, "Either table or materializedViewName must be set");
+      checkArgument(
+          !(hasTableId && hasMvName),
+          "Only one of table or materializedViewName can be set, not both");
     }
 
     public static Builder builder() {
@@ -128,7 +136,11 @@ public class BigtableReadSchemaTransformProvider
     }
 
     @SchemaFieldDescription("Bigtable table ID to read from.")
-    public abstract String getTableId();
+    public abstract @Nullable String getTableId();
+
+    @SchemaFieldDescription(
+        "Bigtable materialized view name to read from. Mutually exclusive with table.")
+    public abstract @Nullable String getMaterializedViewName();
 
     @SchemaFieldDescription("Bigtable instance ID to connect to.")
     public abstract String getInstanceId();
@@ -144,6 +156,8 @@ public class BigtableReadSchemaTransformProvider
     @AutoValue.Builder
     public abstract static class Builder {
       public abstract Builder setTableId(String tableId);
+
+      public abstract Builder setMaterializedViewName(String materializedViewName);
 
       public abstract Builder setInstanceId(String instanceId);
 
@@ -176,14 +190,19 @@ public class BigtableReadSchemaTransformProvider
           String.format(
               "Input to %s is expected to be empty, but is not.", getClass().getSimpleName()));
 
-      PCollection<com.google.bigtable.v2.Row> bigtableRows =
-          input
-              .getPipeline()
-              .apply(
-                  BigtableIO.read()
-                      .withTableId(configuration.getTableId())
-                      .withInstanceId(configuration.getInstanceId())
-                      .withProjectId(configuration.getProjectId()));
+      BigtableIO.Read read =
+          BigtableIO.read()
+              .withInstanceId(configuration.getInstanceId())
+              .withProjectId(configuration.getProjectId());
+      String mvName = configuration.getMaterializedViewName();
+      String tableId = configuration.getTableId();
+      if (mvName != null && !mvName.isEmpty()) {
+        read = read.withMaterializedViewName(mvName);
+      } else if (tableId != null) {
+        read = read.withTableId(tableId);
+      }
+
+      PCollection<com.google.bigtable.v2.Row> bigtableRows = input.getPipeline().apply(read);
 
       Schema outputSchema =
           Boolean.FALSE.equals(configuration.getFlatten()) ? ROW_SCHEMA : FLATTENED_ROW_SCHEMA;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
@@ -44,6 +44,7 @@ import com.google.cloud.bigtable.data.v2.internal.ByteStringComparator;
 import com.google.cloud.bigtable.data.v2.internal.NameUtil;
 import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.data.v2.models.KeyOffset;
+import com.google.cloud.bigtable.data.v2.models.MaterializedViewId;
 import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.cloud.bigtable.data.v2.models.RowAdapter;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
@@ -139,6 +140,7 @@ class BigtableServiceImpl implements BigtableService {
     private final String projectId;
     private final String instanceId;
     private final String tableId;
+    private final @Nullable String materializedViewName;
 
     private final List<ByteKeyRange> ranges;
     private final RowFilter rowFilter;
@@ -160,10 +162,24 @@ class BigtableServiceImpl implements BigtableService {
         List<ByteKeyRange> ranges,
         @Nullable RowFilter rowFilter,
         boolean skipLargeRows) {
+      this(client, projectId, instanceId, tableId, null, ranges, rowFilter, skipLargeRows);
+    }
+
+    @VisibleForTesting
+    BigtableReaderImpl(
+        BigtableDataClient client,
+        String projectId,
+        String instanceId,
+        @Nullable String tableId,
+        @Nullable String materializedViewName,
+        List<ByteKeyRange> ranges,
+        @Nullable RowFilter rowFilter,
+        boolean skipLargeRows) {
       this.client = client;
       this.projectId = projectId;
       this.instanceId = instanceId;
       this.tableId = tableId;
+      this.materializedViewName = materializedViewName;
       this.ranges = ranges;
       this.rowFilter = rowFilter;
       this.skipLargeRows = skipLargeRows;
@@ -171,9 +187,15 @@ class BigtableServiceImpl implements BigtableService {
 
     @Override
     public boolean start() throws IOException {
-      ServiceCallMetric serviceCallMetric = createCallMetric(projectId, instanceId, tableId);
+      String metricId = materializedViewName != null ? materializedViewName : tableId;
+      ServiceCallMetric serviceCallMetric = createCallMetric(projectId, instanceId, metricId);
 
-      Query query = Query.create(tableId);
+      Query query;
+      if (materializedViewName != null) {
+        query = Query.create(MaterializedViewId.of(materializedViewName));
+      } else {
+        query = Query.create(tableId);
+      }
       for (ByteKeyRange sourceRange : ranges) {
         query.range(
             ByteString.copyFrom(sourceRange.getStartKey().getValue()),
@@ -233,7 +255,8 @@ class BigtableServiceImpl implements BigtableService {
 
     @Override
     public void reportLineage() {
-      Lineage.getSources().add("bigtable", ImmutableList.of(projectId, instanceId, tableId));
+      String targetName = materializedViewName != null ? materializedViewName : tableId;
+      Lineage.getSources().add("bigtable", ImmutableList.of(projectId, instanceId, targetName));
     }
   }
 
@@ -250,7 +273,8 @@ class BigtableServiceImpl implements BigtableService {
     private ServiceCallMetric serviceCallMetric;
     private final String projectId;
     private final String instanceId;
-    private final String tableId;
+    private final @Nullable String tableId;
+    private final @Nullable String materializedViewName;
 
     private static class UpstreamResults {
       private final List<Row> rows;
@@ -266,7 +290,8 @@ class BigtableServiceImpl implements BigtableService {
         BigtableDataClient client,
         String projectId,
         String instanceId,
-        String tableId,
+        @Nullable String tableId,
+        @Nullable String materializedViewName,
         List<ByteKeyRange> ranges,
         @Nullable RowFilter rowFilter,
         int maxBufferedElementCount) {
@@ -292,16 +317,18 @@ class BigtableServiceImpl implements BigtableService {
                   MIN_BYTE_BUFFER_SIZE,
                   (Runtime.getRuntime().totalMemory() * DEFAULT_BYTE_LIMIT_PERCENTAGE));
 
+      String metricId = materializedViewName != null ? materializedViewName : tableId;
       return new BigtableSegmentReaderImpl(
           client,
           projectId,
           instanceId,
           tableId,
+          materializedViewName,
           rowSet,
           filter,
           maxBufferedElementCount,
           maxSegmentByteSize,
-          createCallMetric(projectId, instanceId, tableId));
+          createCallMetric(projectId, instanceId, metricId));
     }
 
     @VisibleForTesting
@@ -315,16 +342,45 @@ class BigtableServiceImpl implements BigtableService {
         int maxRowsInBuffer,
         long maxSegmentByteSize,
         ServiceCallMetric serviceCallMetric) {
+      this(
+          client,
+          projectId,
+          instanceId,
+          tableId,
+          null,
+          rowSet,
+          filter,
+          maxRowsInBuffer,
+          maxSegmentByteSize,
+          serviceCallMetric);
+    }
+
+    @VisibleForTesting
+    BigtableSegmentReaderImpl(
+        BigtableDataClient client,
+        String projectId,
+        String instanceId,
+        @Nullable String tableId,
+        @Nullable String materializedViewName,
+        RowSet rowSet,
+        @Nullable RowFilter filter,
+        int maxRowsInBuffer,
+        long maxSegmentByteSize,
+        ServiceCallMetric serviceCallMetric) {
       if (rowSet.equals(rowSet.getDefaultInstanceForType())) {
         rowSet = RowSet.newBuilder().addRowRanges(RowRange.getDefaultInstance()).build();
       }
+
+      ReadRowsRequest.Builder requestBuilder = ReadRowsRequest.newBuilder();
+      if (materializedViewName != null) {
+        requestBuilder.setMaterializedViewName(
+            NameUtil.formatMaterializedViewName(projectId, instanceId, materializedViewName));
+      } else {
+        requestBuilder.setTableName(NameUtil.formatTableName(projectId, instanceId, tableId));
+      }
+
       ReadRowsRequest request =
-          ReadRowsRequest.newBuilder()
-              .setTableName(NameUtil.formatTableName(projectId, instanceId, tableId))
-              .setRows(rowSet)
-              .setFilter(filter)
-              .setRowsLimit(maxRowsInBuffer)
-              .build();
+          requestBuilder.setRows(rowSet).setFilter(filter).setRowsLimit(maxRowsInBuffer).build();
 
       this.client = client;
       this.nextRequest = request;
@@ -337,6 +393,7 @@ class BigtableServiceImpl implements BigtableService {
       this.projectId = projectId;
       this.instanceId = instanceId;
       this.tableId = tableId;
+      this.materializedViewName = materializedViewName;
     }
 
     @Override
@@ -344,7 +401,8 @@ class BigtableServiceImpl implements BigtableService {
 
     @Override
     public void reportLineage() {
-      Lineage.getSources().add("bigtable", ImmutableList.of(projectId, instanceId, tableId));
+      String targetName = materializedViewName != null ? materializedViewName : tableId;
+      Lineage.getSources().add("bigtable", ImmutableList.of(projectId, instanceId, targetName));
     }
 
     @Override
@@ -669,12 +727,22 @@ class BigtableServiceImpl implements BigtableService {
 
   @Override
   public Reader createReader(BigtableSource source) throws IOException {
+    String tableId =
+        source.getTableId() != null && source.getTableId().isAccessible()
+            ? source.getTableId().get()
+            : null;
+    String mvName =
+        source.getMaterializedViewName() != null && source.getMaterializedViewName().isAccessible()
+            ? source.getMaterializedViewName().get()
+            : null;
+
     if (source.getMaxBufferElementCount() != null) {
       return BigtableSegmentReaderImpl.create(
           client,
           projectId,
           instanceId,
-          source.getTableId().get(),
+          tableId,
+          mvName,
           source.getRanges(),
           source.getRowFilter(),
           source.getMaxBufferElementCount());
@@ -683,7 +751,8 @@ class BigtableServiceImpl implements BigtableService {
           client,
           projectId,
           instanceId,
-          source.getTableId().get(),
+          tableId,
+          mvName,
           source.getRanges(),
           source.getRowFilter(),
           skipLargeRows);
@@ -692,6 +761,10 @@ class BigtableServiceImpl implements BigtableService {
 
   @Override
   public List<KeyOffset> getSampleRowKeys(BigtableSource source) {
+    if (source.getMaterializedViewName() != null
+        && source.getMaterializedViewName().isAccessible()) {
+      return client.sampleRowKeys(MaterializedViewId.of(source.getMaterializedViewName().get()));
+    }
     return client.sampleRowKeys(source.getTableId().get());
   }
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
@@ -232,6 +232,41 @@ public class BigtableIOTest {
   }
 
   @Test
+  public void testReadWithMaterializedViewBuildsCorrectly() {
+    BigtableIO.Read read =
+        BigtableIO.read()
+            .withInstanceId("instance")
+            .withProjectId("project")
+            .withMaterializedViewName("my-mv");
+    assertEquals("instance", read.getBigtableConfig().getInstanceId().get());
+    assertEquals("project", read.getBigtableConfig().getProjectId().get());
+    assertEquals("my-mv", read.getMaterializedViewName());
+  }
+
+  @Test
+  public void testReadValidationFailsMissingTableAndMaterializedView() {
+    BigtableIO.Read read = BigtableIO.read().withInstanceId("instance").withProjectId("project");
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Either a Bigtable table id or a materialized view name must be set");
+    read.expand(null);
+  }
+
+  @Test
+  public void testReadValidationFailsBothTableAndMaterializedView() {
+    BigtableIO.Read read =
+        BigtableIO.read()
+            .withInstanceId("instance")
+            .withProjectId("project")
+            .withTableId("table")
+            .withMaterializedViewName("my-mv");
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Only one of Bigtable table id or materialized view name can be set");
+    read.expand(null);
+  }
+
+  @Test
   public void testReadValidationFailsMissingTable() {
     BigtableIO.Read read = BigtableIO.read().withBigtableOptions(BIGTABLE_OPTIONS);
 
@@ -288,7 +323,7 @@ public class BigtableIOTest {
             .withTableId(options.getBigtableTableId());
 
     thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("tableId was not supplied");
+    thrown.expectMessage("tableId or materializedViewName was not supplied");
 
     p.apply(read);
   }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImplTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImplTest.java
@@ -188,6 +188,95 @@ public class BigtableServiceImplTest {
     verifyMetricWasSet("google.bigtable.v2.ReadRows", "ok", 1);
   }
 
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testReadWithMaterializedView() throws IOException {
+    ByteKey start = ByteKey.copyFrom("a".getBytes(StandardCharsets.UTF_8));
+    ByteKey end = ByteKey.copyFrom("b".getBytes(StandardCharsets.UTF_8));
+
+    Row expectedRow = Row.newBuilder().setKey(ByteString.copyFromUtf8("a")).build();
+
+    Iterator<Row> mockIterator = Mockito.mock(Iterator.class);
+    when(mockIterator.next()).thenReturn(expectedRow).thenReturn(null);
+    when(mockIterator.hasNext()).thenReturn(true).thenReturn(false);
+    ServerStream<Row> mockRows = Mockito.mock(ServerStream.class);
+    when(mockRows.iterator()).thenReturn(mockIterator);
+    ServerStreamingCallable<Query, Row> mockCallable = Mockito.mock(ServerStreamingCallable.class);
+    when(mockCallable.call(
+            any(com.google.cloud.bigtable.data.v2.models.Query.class), any(ApiCallContext.class)))
+        .thenReturn(mockRows);
+    when(mockStub.createReadRowsCallable(any(RowAdapter.class))).thenReturn(mockCallable);
+    ServerStreamingCallable<Query, Row> callable =
+        mockStub.createReadRowsCallable(new BigtableServiceImpl.BigtableRowProtoAdapter());
+    when(mockBigtableDataClient.readRowsCallable(any(RowAdapter.class))).thenReturn(callable);
+
+    BigtableService.Reader underTest =
+        new BigtableServiceImpl.BigtableReaderImpl(
+            mockBigtableDataClient,
+            PROJECT_ID,
+            INSTANCE_ID,
+            null,
+            "my-materialized-view",
+            Arrays.asList(ByteKeyRange.of(start, end)),
+            null,
+            false);
+
+    underTest.start();
+    Assert.assertEquals(expectedRow, underTest.getCurrentRow());
+    Assert.assertFalse(underTest.advance());
+
+    verifyMetricWasSet("google.bigtable.v2.ReadRows", "ok", 1, "my-materialized-view");
+  }
+
+  @Test
+  public void testReadSegmentWithMaterializedView() throws Exception {
+    RowSet.Builder ranges = RowSet.newBuilder();
+    ranges.addRowRanges(
+        generateRowRange(
+            generateByteString(DEFAULT_PREFIX, 0), generateByteString(DEFAULT_PREFIX, 1)));
+
+    Row expectedRow = Row.newBuilder().setKey(ByteString.copyFromUtf8("a")).build();
+
+    ServerStreamingCallable<Query, Row> mockCallable = Mockito.mock(ServerStreamingCallable.class);
+    doAnswer(
+            new Answer<Void>() {
+              @Override
+              public Void answer(InvocationOnMock invocation) throws Throwable {
+                ((ResponseObserver) invocation.getArgument(1)).onResponse(expectedRow);
+                ((ResponseObserver) invocation.getArgument(1)).onComplete();
+                return null;
+              }
+            })
+        .when(mockCallable)
+        .call(
+            any(com.google.cloud.bigtable.data.v2.models.Query.class),
+            any(ResponseObserver.class),
+            any(ApiCallContext.class));
+    when(mockStub.createReadRowsCallable(any(RowAdapter.class))).thenReturn(mockCallable);
+    ServerStreamingCallable<Query, Row> callable =
+        mockStub.createReadRowsCallable(new BigtableServiceImpl.BigtableRowProtoAdapter());
+    when(mockBigtableDataClient.readRowsCallable(any(RowAdapter.class))).thenReturn(callable);
+
+    BigtableService.Reader underTest =
+        new BigtableServiceImpl.BigtableSegmentReaderImpl(
+            mockBigtableDataClient,
+            PROJECT_ID,
+            INSTANCE_ID,
+            null,
+            "my-materialized-view",
+            ranges.build(),
+            RowFilter.getDefaultInstance(),
+            SEGMENT_SIZE,
+            DEFAULT_BYTE_SEGMENT_SIZE,
+            mockCallMetric);
+
+    underTest.start();
+    Assert.assertEquals(expectedRow, underTest.getCurrentRow());
+    Assert.assertFalse(underTest.advance());
+
+    Mockito.verify(mockCallMetric, Mockito.times(2)).call("ok");
+  }
+
   /**
    * This test ensures that protobuf creation and interactions with {@link BigtableDataClient} work
    * as expected. This test checks that a single row is returned from the future.
@@ -877,6 +966,10 @@ public class BigtableServiceImplTest {
   }
 
   private void verifyMetricWasSet(String method, String status, long count) {
+    verifyMetricWasSet(method, status, count, TABLE_ID);
+  }
+
+  private void verifyMetricWasSet(String method, String status, long count, String targetId) {
     // Verify the metric as reported.
     HashMap<String, String> labels = new HashMap<>();
     labels.put(MonitoringInfoConstants.Labels.PTRANSFORM, "");
@@ -884,12 +977,12 @@ public class BigtableServiceImplTest {
     labels.put(MonitoringInfoConstants.Labels.METHOD, method);
     labels.put(
         MonitoringInfoConstants.Labels.RESOURCE,
-        GcpResourceIdentifiers.bigtableResource(PROJECT_ID, INSTANCE_ID, TABLE_ID));
+        GcpResourceIdentifiers.bigtableResource(PROJECT_ID, INSTANCE_ID, targetId));
     labels.put(MonitoringInfoConstants.Labels.BIGTABLE_PROJECT_ID, PROJECT_ID);
     labels.put(MonitoringInfoConstants.Labels.INSTANCE_ID, INSTANCE_ID);
     labels.put(
         MonitoringInfoConstants.Labels.TABLE_ID,
-        GcpResourceIdentifiers.bigtableTableID(PROJECT_ID, INSTANCE_ID, TABLE_ID));
+        GcpResourceIdentifiers.bigtableTableID(PROJECT_ID, INSTANCE_ID, targetId));
     labels.put(MonitoringInfoConstants.Labels.STATUS, status);
 
     MonitoringInfoMetricName name =


### PR DESCRIPTION
Adds support in the BigTable IO Java connector for [BigTables new materialized views](https://docs.cloud.google.com/bigtable/docs/continuous-materialized-views). Fixes #38053 

  - Adds BigtableIO.read().withMaterializedViewName() as an alternative to withTableId() for reading from Bigtable Continuous Materialized Views
  - Uses the client library's MaterializedViewId / TargetId APIs for correct resource path construction
  - Reuses all the existing logic and plumbing from table reads as materialized view reads use almost all the same concepts
  - Updates schema transform provider, validation, and both reader implementations

Testing
  - Tested against a real BigTable materialized view (manual testing outside of this repo)
  - Unit tests for builder, mutual exclusivity validation, and both reader implementations with MV name
------------------------


 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf). --> not large 

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
