### PR TITLE
Add CHANGES.md note for BigQueryEnrichmentHandler duplicate-key batch fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -80,7 +80,7 @@
 
 ## Bugfixes
 
-* Fixed X (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
+* Fixed BigQueryEnrichmentHandler batch mode dropping earlier requests when multiple requests share the same enrichment key (Python) ([#38035](https://github.com/apache/beam/issues/38035)).
 
 ## Security Fixes
 
@@ -118,7 +118,6 @@
 ## Bugfixes
 
 * Fixed ProcessManager not reaping child processes, causing zombie process accumulation on long-running Flink deployments (Java) ([#37930](https://github.com/apache/beam/issues/37930)).
-* Fixed BigQueryEnrichmentHandler batch mode dropping earlier requests when multiple requests share the same enrichment key (Python) ([#38035](https://github.com/apache/beam/issues/38035)).
 
 ## Security Fixes
 


### PR DESCRIPTION
## What this PR does
Adds a follow-up  entry for the recently merged BigQuery enrichment handler fix

## Why
A reviewer requested a follow-up change to document the fix in release notes.

## Context
Follow-up to the merged PR that fixed duplicate-key handling in  batch mode.

Ref: https://github.com/apache/beam/pull/38040