### PR TITLE
Fix NameError when pydot is not installed in Beam Playground

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/display/pipeline_graph.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pipeline_graph.py
@@ -237,6 +237,12 @@ class PipelineGraph(object):
       default_edge_attrs: (Dict[str, str]) a dict of attributes
     """
     with self._lock:
+      try:
+        pydot.Dot()
+      except NameError:
+        raise RuntimeError(
+            'pydot is required for pipeline graph generation. '
+            'Install it with: pip install pydot')
       self._graph = pydot.Dot()
 
       if default_vertex_attrs:


### PR DESCRIPTION
## What

When pydot is not installed, the import in pipeline_graph.py fails silently (caught by except ImportError: pass), and subsequent calls to pydot.Dot() raise a confusing NameError with no context about what is missing or how to fix it.

## How

_construct_graph() now checks if pydot is available before use and raises a clear RuntimeError with install instructions instead.

## Testing

Manually verified the fix works by importing the module with and without pydot installed.

Fixes apache/beam#37829