### PR TITLE
fix: correct typo "occured" to "occurred" in data_sampler.py

### DIFF
--- a/sdks/python/apache_beam/runners/worker/data_sampler.py
+++ b/sdks/python/apache_beam/runners/worker/data_sampler.py
@@ -81,10 +81,10 @@ class ExceptionMetadata:
   # The repr-ified Exception.
   msg: str
 
-  # The transform where the exception occured.
+  # The transform where the exception occurred.
   transform_id: str
 
-  # The instruction when the exception occured.
+  # The instruction when the exception occurred.
   instruction_id: str
 
 


### PR DESCRIPTION
## Summary

Fix typo "occured" → "occurred" in `sdks/python/apache_beam/runners/worker/data_sampler.py` (2 occurrences in comments).

**Changes:**
```python
# Before
# The transform where the exception occured.
# The instruction when the exception occured.

# After
# The transform where the exception occurred.
# The instruction when the exception occurred.
```

## Testing
No behavior change — typo fix in comments only.