### PR TITLE
Revert "Fix NameError when pydot is not installed in Beam Playground"

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/display/pipeline_graph.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pipeline_graph.py
@@ -237,12 +237,6 @@ class PipelineGraph(object):
       default_edge_attrs: (Dict[str, str]) a dict of attributes
     """
     with self._lock:
-      try:
-        pydot.Dot()
-      except NameError:
-        raise RuntimeError(
-            'pydot is required for pipeline graph generation. '
-            'Install it with: pip install pydot')
       self._graph = pydot.Dot()
 
       if default_vertex_attrs:


### PR DESCRIPTION
Reverts apache/beam#38074

breaks python unit test workflows

We should install pydot in Beam Playground as a fix to #37829