### PR TITLE
Set consuming_received_data=True during bundle setup

### DIFF
--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -1245,6 +1245,9 @@ class BundleProcessor(object):
         expected_input_ops.append(op)
 
     try:
+      # Indicate that we are busy (setup or processing) so that runners can
+      # distinguish setup/processing from being idle and caught up.
+      self.consuming_received_data = True
       execution_context = ExecutionContext(instruction_id=instruction_id)
       self.current_instruction_id = instruction_id
       self.state_sampler.start()
@@ -1283,7 +1286,7 @@ class BundleProcessor(object):
           self.ops[transform_id].add_timer_info(timer_family_id, timer_info)
 
       # Process data and timer inputs
-      # We are currently not consuming received data.
+      # Setup is complete; signal that we are caught up until data arrives.
       self.consuming_received_data = False
       for data_channel, expected_inputs in data_channels.items():
         for element in data_channel.input_elements(instruction_id,


### PR DESCRIPTION
## Problem

If an sdk worker is processing a stage with long bundle startup times, it's not currently possible for a runner to tell whether the worker is idle and ready for work or if it's still running `setup_bundle`. Consider the following order of events:

Runner sends `ProcessBundleRequest`
Runner sends data on the input data channel
Runner sends a `ProcessBundleProgressRequest` to see if the worker is done and ready for more inputs

If the worker returns a `ProcessBundleProgressResponse` with `consuming_received_data=False`, the worker might actually still be just running `setup_bundle`. In the worse case, a runner may misinterpret this signal and repeatedly queue up a large queue of work for the worker that it could've distributed over many workers


## Summary of changes

- Initialize `consuming_received_data` to `True` at the start of `process_bundle`, so runners polling `ProcessBundleProgress` can distinguish "still setting up / actively processing" from "idle and caught up with all received data."
- Previously both setup and idle reported `False`, making them indistinguishable.
- After setup completes, the flag is set to `False` before entering the data processing loop.

The semantic meaning of `consuming_received_data` is not really respected now (for example, a runner could send a `ProcessBundleRequest` and never send any input data and yet the worker would briefly report that it's "consuming received data" when it has received no data), but I think this better implements the intent of the field.

Without this change, it's impossible for a runner to definitively know whether a python sdk worker is actually idle