### PR TITLE
Cherry-pick PR #37954 into 2.73 release

### DIFF
--- a/.github/trigger_files/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming.json
+++ b/.github/trigger_files/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run!",
-  "modification":  6,
+  "modification":  7,
 }

--- a/.github/trigger_files/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming_Engine.json
+++ b/.github/trigger_files/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming_Engine.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run!",
-  "modification":  1,
+  "modification":  2,
 }

--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -491,8 +491,6 @@ task validatesRunnerStreaming {
   description "Validates Dataflow runner forcing streaming mode"
   dependsOn(createLegacyWorkerValidatesRunnerTest(validatesRunnerStreamingConfig + [
     name: 'validatesRunnerLegacyWorkerTestStreaming',
-    // Streaming appliance currently fails bundle finalizer tests.
-    excludedCategories: validatesRunnerStreamingConfig.excludedCategories + [ 'org.apache.beam.sdk.testing.UsesBundleFinalizer', ],
   ]))
 }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -401,12 +401,14 @@ public final class StreamingDataflowWorker {
                 watermarks,
                 processingContext,
                 drainMode,
+                appliedFinalizeIds,
                 getWorkStreamLatencies) ->
                 checkNotNull(computationStateCache)
                     .get(processingContext.computationId())
                     .ifPresent(
                         computationState -> {
                           memoryMonitor.waitForResources("GetWork");
+                          streamingWorkScheduler.queueAppliedFinalizeIds(appliedFinalizeIds);
                           streamingWorkScheduler.scheduleWork(
                               computationState,
                               workItem,

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/SingleSourceWorkerHarness.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/SingleSourceWorkerHarness.java
@@ -158,12 +158,16 @@ public final class SingleSourceWorkerHarness implements StreamingWorkerHarness {
                   drainMode,
                   workItem,
                   serializedWorkItemSize,
+                  appliedFinalizeIds,
                   getWorkStreamLatencies) ->
                   computationStateFetcher
                       .apply(computationId)
                       .ifPresent(
                           computationState -> {
                             waitForResources.run();
+                            if (!appliedFinalizeIds.isEmpty()) {
+                              streamingWorkScheduler.queueAppliedFinalizeIds(appliedFinalizeIds);
+                            }
                             streamingWorkScheduler.scheduleWork(
                                 computationState,
                                 workItem,
@@ -214,6 +218,12 @@ public final class SingleSourceWorkerHarness implements StreamingWorkerHarness {
         sleepUninterruptibly(backoff, TimeUnit.MILLISECONDS);
         backoff = Math.min(1000, backoff * 2);
       } while (isRunning.get());
+      ImmutableList<Long> appliedFinalizeIds =
+          ImmutableList.copyOf(
+              Preconditions.checkNotNull(workResponse).getAppliedFinalizeIdsList());
+      if (!appliedFinalizeIds.isEmpty()) {
+        streamingWorkScheduler.queueAppliedFinalizeIds(appliedFinalizeIds);
+      }
       for (Windmill.ComputationWorkItems computationWork :
           Preconditions.checkNotNull(workResponse).getWorkList()) {
         String computationId = computationWork.getComputationId();

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GetWorkResponseChunkAssembler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GetWorkResponseChunkAssembler.java
@@ -100,12 +100,12 @@ final class GetWorkResponseChunkAssembler {
   private Optional<AssembledWorkItem> flushToWorkItem() {
     try {
       workItemBuilder.mergeFrom(data);
-      workItemBuilder.addAllAppliedFinalizeIds(appliedFinalizeIds);
       return Optional.of(
           AssembledWorkItem.create(
               workItemBuilder.build(),
               Preconditions.checkNotNull(metadata),
               workTimingInfosTracker.getLatencyAttributions(),
+              ImmutableList.copyOf(appliedFinalizeIds),
               bufferedSize));
     } catch (IOException e) {
       LOG.error("Failed to parse work item from stream: ", e);
@@ -149,9 +149,10 @@ final class GetWorkResponseChunkAssembler {
         WorkItem workItem,
         ComputationMetadata computationMetadata,
         ImmutableList<LatencyAttribution> latencyAttributions,
+        ImmutableList<Long> appliedFinalizeIds,
         long size) {
       return new AutoValue_GetWorkResponseChunkAssembler_AssembledWorkItem(
-          workItem, computationMetadata, latencyAttributions, size);
+          workItem, computationMetadata, latencyAttributions, appliedFinalizeIds, size);
     }
 
     abstract WorkItem workItem();
@@ -159,6 +160,8 @@ final class GetWorkResponseChunkAssembler {
     abstract ComputationMetadata computationMetadata();
 
     abstract ImmutableList<LatencyAttribution> latencyAttributions();
+
+    abstract ImmutableList<Long> appliedFinalizeIds();
 
     abstract long bufferedSize();
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDirectGetWorkStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDirectGetWorkStream.java
@@ -282,6 +282,7 @@ final class GrpcDirectGetWorkStream
         createWatermarks(workItem, metadata),
         createProcessingContext(metadata.computationId()),
         metadata.drainMode(),
+        assembledWorkItem.appliedFinalizeIds(),
         assembledWorkItem.latencyAttributions());
     budgetTracker.recordBudgetReceived(assembledWorkItem.bufferedSize());
     GetWorkBudget extension = budgetTracker.computeBudgetExtension();

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetWorkStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcGetWorkStream.java
@@ -206,6 +206,7 @@ final class GrpcGetWorkStream
         assembledWorkItem.computationMetadata().drainMode(),
         assembledWorkItem.workItem(),
         assembledWorkItem.bufferedSize(),
+        assembledWorkItem.appliedFinalizeIds(),
         assembledWorkItem.latencyAttributions());
 
     // Record the fact that there are now fewer outstanding messages and bytes on the stream.

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/WorkItemReceiver.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/WorkItemReceiver.java
@@ -33,5 +33,6 @@ public interface WorkItemReceiver {
       boolean drainMode,
       Windmill.WorkItem workItem,
       long serializedWorkItemSize,
+      ImmutableList<Long> appliedFinalizeIds,
       ImmutableList<LatencyAttribution> getWorkStreamLatencies);
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/WorkItemScheduler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/WorkItemScheduler.java
@@ -36,6 +36,7 @@ public interface WorkItemScheduler {
    * @param watermarks processing watermarks for the workItem.
    * @param processingContext for processing the workItem.
    * @param drainMode is job is draining.
+   * @param appliedFinalizeIds Any applied finalize ids that should have their callbacks run.
    * @param getWorkStreamLatencies Latencies per processing stage for the WorkItem for reporting
    *     back to Streaming Engine backend.
    */
@@ -45,5 +46,6 @@ public interface WorkItemScheduler {
       Watermarks watermarks,
       Work.ProcessingContext processingContext,
       boolean drainMode,
+      ImmutableList<Long> appliedFinalizeIds,
       ImmutableList<LatencyAttribution> getWorkStreamLatencies);
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/StreamingWorkScheduler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/StreamingWorkScheduler.java
@@ -219,6 +219,11 @@ public class StreamingWorkScheduler {
             work -> processWork(computationState, work, getWorkStreamLatencies)));
   }
 
+  /** Adds any applied finalize ids to the commit finalizer to have their callbacks executed. */
+  public void queueAppliedFinalizeIds(ImmutableList<Long> appliedFinalizeIds) {
+    commitFinalizer.finalizeCommits(appliedFinalizeIds);
+  }
+
   /**
    * Executes the user DoFns processing {@link Work} then queues the {@link Commit}(s) to be sent to
    * backing persistent store to mark that the {@link Work} has finished processing. May retry
@@ -246,7 +251,6 @@ public class StreamingWorkScheduler {
     // Before any processing starts, call any pending OnCommit callbacks.  Nothing that requires
     // cleanup should be done before this, since we might exit early here.
     commitFinalizer.finalizeCommits(workItem.getSourceState().getFinalizeIdsList());
-    commitFinalizer.finalizeCommits(workItem.getAppliedFinalizeIdsList());
     if (workItem.getSourceState().getOnlyFinalize()) {
       Windmill.WorkItemCommitRequest.Builder outputBuilder = initializeOutputBuilder(key, workItem);
       outputBuilder.setSourceStateUpdates(Windmill.SourceState.newBuilder().setOnlyFinalize(true));

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/FakeWindmillServer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/FakeWindmillServer.java
@@ -278,6 +278,7 @@ public final class FakeWindmillServer extends WindmillServerStub {
                   computationWork.getDrainMode(),
                   workItem,
                   workItem.getSerializedSize(),
+                  ImmutableList.of(),
                   ImmutableList.of(
                       LatencyAttribution.newBuilder()
                           .setState(State.GET_WORK_IN_TRANSIT_TO_USER_WORKER)

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/harness/FanOutStreamingEngineWorkerHarnessTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/harness/FanOutStreamingEngineWorkerHarnessTest.java
@@ -126,6 +126,7 @@ public class FanOutStreamingEngineWorkerHarnessTest {
         watermarks,
         processingContext,
         drainMode,
+        appliedFinalizeIds,
         getWorkStreamLatencies) -> {};
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/harness/WindmillStreamSenderTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/harness/WindmillStreamSenderTest.java
@@ -69,6 +69,7 @@ public class WindmillStreamSenderTest {
           watermarks,
           processingContext,
           drainMode,
+          appliedFinalizeIds,
           getWorkStreamLatencies) -> {};
   @Rule public transient Timeout globalTimeout = Timeout.seconds(600);
   private ManagedChannel inProcessChannel;

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDirectGetWorkStreamTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDirectGetWorkStreamTest.java
@@ -71,6 +71,7 @@ public class GrpcDirectGetWorkStreamTest {
           watermarks,
           processingContext,
           drainMode,
+          appliedFinalizeIds,
           getWorkStreamLatencies) -> {};
   private static final Windmill.JobHeader TEST_JOB_HEADER =
       Windmill.JobHeader.newBuilder()
@@ -285,6 +286,7 @@ public class GrpcDirectGetWorkStreamTest {
                 watermarks,
                 processingContext,
                 drainMode,
+                appliedFinalizeIds,
                 getWorkStreamLatencies) -> {
               scheduledWorkItems.add(work);
             });
@@ -334,6 +336,7 @@ public class GrpcDirectGetWorkStreamTest {
                 watermarks,
                 processingContext,
                 drainMode,
+                appliedFinalizeIds,
                 getWorkStreamLatencies) -> scheduledWorkItems.add(work));
     Windmill.WorkItem workItem =
         Windmill.WorkItem.newBuilder()
@@ -372,6 +375,7 @@ public class GrpcDirectGetWorkStreamTest {
                 watermarks,
                 processingContext,
                 drainMode,
+                appliedFinalizeIds,
                 getWorkStreamLatencies) -> {
               scheduledWorkItems.add(work);
             });
@@ -416,6 +420,7 @@ public class GrpcDirectGetWorkStreamTest {
                 watermarks,
                 processingContext,
                 drainMode,
+                appliedFinalizeIds,
                 getWorkStreamLatencies) -> {
               scheduledWorkItems.add(work);
             });

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillServerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillServerTest.java
@@ -339,6 +339,7 @@ public class GrpcWindmillServerTest {
                 boolean drainMode,
                 WorkItem workItem,
                 long serializedWorkItemSize,
+                ImmutableList<Long> appliedFinalizeIds,
                 ImmutableList<LatencyAttribution> getWorkStreamLatencies) -> {
               latch.countDown();
               assertEquals(inputDataWatermark, new Instant(18));
@@ -474,6 +475,7 @@ public class GrpcWindmillServerTest {
                 boolean drainMode,
                 WorkItem workItem,
                 long serializedWorkItemSize,
+                ImmutableList<Long> appliedFinalizeIds,
                 ImmutableList<LatencyAttribution> getWorkStreamLatencies) -> {
               assertEquals(inputDataWatermark, new Instant(18));
               assertEquals(synchronizedProcessingTime, new Instant(17));

--- a/runners/google-cloud-dataflow-java/worker/windmill/src/main/proto/windmill.proto
+++ b/runners/google-cloud-dataflow-java/worker/windmill/src/main/proto/windmill.proto
@@ -448,9 +448,7 @@ message WorkItem {
   // present, this field includes metadata associated with any hot key.
   optional HotKeyInfo hot_key_info = 11;
 
-  repeated int64 applied_finalize_ids = 16;
-
-  reserved 12, 13, 14, 15;
+  reserved 12, 13, 14, 15, 16;
 }
 
 message ComputationWorkItems {
@@ -481,6 +479,8 @@ message GetWorkRequest {
 
 message GetWorkResponse {
   repeated ComputationWorkItems work = 1;
+  // Finalize ids associated with successfully applied work from this worker
+  repeated int64 applied_finalize_ids = 2 [packed = true];
 }
 
 // GetData


### PR DESCRIPTION
Moves finalize ids out of WorkItem proto and into AssembledWorkItem class:

* Moves applied finalize ids out of windmill WorkItem proto since that field isn't present in internal version. Moves it to AssembledWorkItem. Also adds internal GetWorkResponse.applied_finalize_ids, which is used by Appliance, so now validates runner tests pass.

* Reserves previously used proto field and manually triggers post submits.

This is part of a fix of changes in PR #37723.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
