### PR TITLE
Changes cleanup thread to forceExecute.  (#38073)

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -182,6 +182,7 @@ public final class StreamingDataflowWorker {
   private final ComputationConfig.Fetcher configFetcher;
   private final ComputationStateCache computationStateCache;
   private final BoundedQueueExecutor workUnitExecutor;
+  private final ScheduledExecutorService commitFinalizerCleanupExecutor;
   private final AtomicReference<StreamingWorkerHarness> streamingWorkerHarness =
       new AtomicReference<>();
   private final AtomicBoolean running = new AtomicBoolean();
@@ -208,6 +209,7 @@ public final class StreamingDataflowWorker {
       ComputationStateCache computationStateCache,
       WindmillStateCache windmillStateCache,
       BoundedQueueExecutor workUnitExecutor,
+      ScheduledExecutorService commitFinalizerCleanupExecutor,
       DataflowMapTaskExecutorFactory mapTaskExecutorFactory,
       DataflowWorkerHarnessOptions options,
       HotKeyLogger hotKeyLogger,
@@ -232,6 +234,7 @@ public final class StreamingDataflowWorker {
             Executors.newCachedThreadPool());
     this.options = options;
     this.workUnitExecutor = workUnitExecutor;
+    this.commitFinalizerCleanupExecutor = commitFinalizerCleanupExecutor;
     this.harnessSwitchExecutor =
         Executors.newSingleThreadExecutor(
             new ThreadFactoryBuilder().setNameFormat("HarnessSwitchExecutor").build());
@@ -252,6 +255,7 @@ public final class StreamingDataflowWorker {
             readerCache,
             mapTaskExecutorFactory,
             workUnitExecutor,
+            commitFinalizerCleanupExecutor,
             this.stateCache::forComputation,
             failureTracker,
             workFailureProcessor,
@@ -616,6 +620,13 @@ public final class StreamingDataflowWorker {
     StreamingCounters streamingCounters = StreamingCounters.create();
     WorkUnitClient dataflowServiceClient = new DataflowWorkUnitClient(options, LOG);
     BoundedQueueExecutor workExecutor = createWorkUnitExecutor(options);
+    ScheduledExecutorService commitFinalizerCleanupExecutor =
+        Executors.newScheduledThreadPool(
+            1,
+            new ThreadFactoryBuilder()
+                .setNameFormat("FinalizationCallbackCleanup-%d")
+                .setDaemon(true)
+                .build());
     WindmillStateCache windmillStateCache =
         WindmillStateCache.builder()
             .setSizeMb(options.getWorkerCacheMb())
@@ -680,6 +691,7 @@ public final class StreamingDataflowWorker {
         computationStateCache,
         windmillStateCache,
         workExecutor,
+        commitFinalizerCleanupExecutor,
         IntrinsicMapTaskExecutorFactory.defaultFactory(),
         options,
         new HotKeyLogger(),
@@ -842,6 +854,13 @@ public final class StreamingDataflowWorker {
       WindmillStubFactoryFactory stubFactory) {
     ConcurrentMap<String, StageInfo> stageInfo = new ConcurrentHashMap<>();
     BoundedQueueExecutor workExecutor = createWorkUnitExecutor(options);
+    ScheduledExecutorService commitFinalizerCleanupExecutor =
+        Executors.newScheduledThreadPool(
+            1,
+            new ThreadFactoryBuilder()
+                .setNameFormat("FinalizationCallbackCleanup-%d")
+                .setDaemon(true)
+                .build());
     WindmillStateCache stateCache =
         WindmillStateCache.builder()
             .setSizeMb(options.getWorkerCacheMb())
@@ -930,6 +949,7 @@ public final class StreamingDataflowWorker {
         computationStateCache,
         stateCache,
         workExecutor,
+        commitFinalizerCleanupExecutor,
         mapTaskExecutorFactory,
         options,
         hotKeyLogger,
@@ -1121,6 +1141,7 @@ public final class StreamingDataflowWorker {
       streamingWorkerHarness.get().shutdown();
       memoryMonitor.shutdown();
       workUnitExecutor.shutdown();
+      commitFinalizerCleanupExecutor.shutdown();
       computationStateCache.closeAndInvalidateAll();
       workerStatusReporter.stop();
     } catch (Exception e) {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/StreamingCommitFinalizer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/StreamingCommitFinalizer.java
@@ -17,17 +17,14 @@
  */
 package org.apache.beam.runners.dataflow.worker.windmill.work.processing;
 
-import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
-
 import com.google.auto.value.AutoValue;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.PriorityQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
@@ -56,61 +53,34 @@ final class StreamingCommitFinalizer {
 
     public abstract Runnable getCallback();
 
-    public static FinalizationInfo create(Long id, Instant expiryTime, Runnable callback) {
-      return new AutoValue_StreamingCommitFinalizer_FinalizationInfo(id, expiryTime, callback);
+    public abstract ScheduledFuture<?> getCleanupFuture();
+
+    public static FinalizationInfo create(
+        Long id, Instant expiryTime, Runnable callback, ScheduledFuture<?> cleanupFuture) {
+      return new AutoValue_StreamingCommitFinalizer_FinalizationInfo(
+          id, expiryTime, callback, cleanupFuture);
     }
   }
 
   private final ReentrantLock lock = new ReentrantLock();
-  private final Condition queueMinChanged = lock.newCondition();
 
   @GuardedBy("lock")
   private final HashMap<Long, FinalizationInfo> commitFinalizationCallbacks = new HashMap<>();
 
-  @GuardedBy("lock")
-  private final PriorityQueue<FinalizationInfo> cleanUpQueue =
-      new PriorityQueue<>(11, Comparator.comparing(FinalizationInfo::getExpiryTime));
-
-  @GuardedBy("lock")
-  private boolean cleanUpThreadStarted = false;
-
   private final BoundedQueueExecutor finalizationExecutor;
 
-  private StreamingCommitFinalizer(BoundedQueueExecutor finalizationCleanupExecutor) {
-    finalizationExecutor = finalizationCleanupExecutor;
+  // The cleanup threads run in their own Executor, so they don't block processing.
+  private final ScheduledExecutorService cleanupExecutor;
+
+  private StreamingCommitFinalizer(
+      BoundedQueueExecutor finalizationExecutor, ScheduledExecutorService cleanupExecutor) {
+    this.finalizationExecutor = finalizationExecutor;
+    this.cleanupExecutor = cleanupExecutor;
   }
 
-  private void cleanupThreadBody() {
-    lock.lock();
-    try {
-      while (true) {
-        final @Nullable FinalizationInfo minValue = cleanUpQueue.peek();
-        if (minValue == null) {
-          // Wait for an element to be added and loop to re-examine the min.
-          queueMinChanged.await();
-          continue;
-        }
-
-        Instant now = Instant.now();
-        Duration timeDifference = new Duration(now, minValue.getExpiryTime());
-        if (timeDifference.getMillis() < 0
-            || (queueMinChanged.await(timeDifference.getMillis(), TimeUnit.MILLISECONDS)
-                && cleanUpQueue.peek() == minValue)) {
-          // The minimum element has an expiry time before now, either because it had elapsed when
-          // we pulled it or because we awaited it, and it is still the minimum.
-          checkState(minValue == cleanUpQueue.poll());
-          checkState(commitFinalizationCallbacks.remove(minValue.getId()) == minValue);
-        }
-      }
-    } catch (InterruptedException e) {
-      // We're being shutdown.
-    } finally {
-      lock.unlock();
-    }
-  }
-
-  static StreamingCommitFinalizer create(BoundedQueueExecutor workExecutor) {
-    return new StreamingCommitFinalizer(workExecutor);
+  static StreamingCommitFinalizer create(
+      BoundedQueueExecutor workExecutor, ScheduledExecutorService cleanupExecutor) {
+    return new StreamingCommitFinalizer(workExecutor, cleanupExecutor);
   }
 
   /**
@@ -118,37 +88,47 @@ final class StreamingCommitFinalizer {
    * has been successfully committed to the backing state store.
    */
   public void cacheCommitFinalizers(Map<Long, Pair<Instant, Runnable>> callbacks) {
-    for (Map.Entry<Long, Pair<Instant, Runnable>> entry : callbacks.entrySet()) {
-      Long finalizeId = entry.getKey();
-      final FinalizationInfo info =
-          FinalizationInfo.create(
-              finalizeId, entry.getValue().getLeft(), entry.getValue().getRight());
-
-      lock.lock();
-      try {
-        FinalizationInfo existingInfo = commitFinalizationCallbacks.put(finalizeId, info);
+    if (callbacks.isEmpty()) {
+      return;
+    }
+    Instant now = Instant.now();
+    lock.lock();
+    try {
+      for (Map.Entry<Long, Pair<Instant, Runnable>> entry : callbacks.entrySet()) {
+        Instant cleanupTime = entry.getValue().getLeft();
+        // Ignore finalizers that have already expired.
+        if (cleanupTime.isBefore(now)) {
+          continue;
+        }
+        ScheduledFuture<?> cleanupFuture =
+            cleanupExecutor.schedule(
+                () -> {
+                  lock.lock();
+                  try {
+                    commitFinalizationCallbacks.remove(entry.getKey());
+                  } finally {
+                    lock.unlock();
+                  }
+                },
+                new Duration(now, cleanupTime).getMillis(),
+                TimeUnit.MILLISECONDS);
+        FinalizationInfo info =
+            FinalizationInfo.create(
+                entry.getKey(),
+                entry.getValue().getLeft(),
+                entry.getValue().getRight(),
+                cleanupFuture);
+        FinalizationInfo existingInfo = commitFinalizationCallbacks.put(info.getId(), info);
         if (existingInfo != null) {
           throw new IllegalStateException(
               "Expected to not have any past callbacks for bundle "
-                  + finalizeId
+                  + info.getId()
                   + " but had "
                   + existingInfo);
         }
-        if (!cleanUpThreadStarted) {
-          // Start the cleanup thread lazily for pipelines that don't use finalization callbacks
-          // and some tests.
-          cleanUpThreadStarted = true;
-          finalizationExecutor.execute(this::cleanupThreadBody, 0);
-        }
-        cleanUpQueue.add(info);
-        @SuppressWarnings("ReferenceEquality")
-        boolean newMin = cleanUpQueue.peek() == info;
-        if (newMin) {
-          queueMinChanged.signal();
-        }
-      } finally {
-        lock.unlock();
       }
+    } finally {
+      lock.unlock();
     }
   }
 
@@ -167,8 +147,8 @@ final class StreamingCommitFinalizer {
       for (long finalizeId : finalizeIds) {
         @Nullable FinalizationInfo info = commitFinalizationCallbacks.remove(finalizeId);
         if (info != null) {
-          checkState(cleanUpQueue.remove(info));
           callbacksToExecute.add(info.getCallback());
+          info.getCleanupFuture().cancel(true);
         }
       }
     } finally {
@@ -186,10 +166,10 @@ final class StreamingCommitFinalizer {
   }
 
   @VisibleForTesting
-  int cleanupQueueSize() {
+  int pendingCallbacksSize() {
     lock.lock();
     try {
-      return cleanUpQueue.size();
+      return commitFinalizationCallbacks.size();
     } finally {
       lock.unlock();
     }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/StreamingWorkScheduler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/StreamingWorkScheduler.java
@@ -23,6 +23,7 @@ import com.google.api.services.dataflow.model.MapTask;
 import com.google.auto.value.AutoValue;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -121,6 +122,7 @@ public class StreamingWorkScheduler {
       ReaderCache readerCache,
       DataflowMapTaskExecutorFactory mapTaskExecutorFactory,
       BoundedQueueExecutor workExecutor,
+      ScheduledExecutorService commitFinalizerCleanupExecutor,
       Function<String, WindmillStateCache.ForComputation> stateCacheFactory,
       FailureTracker failureTracker,
       WorkFailureProcessor workFailureProcessor,
@@ -148,7 +150,7 @@ public class StreamingWorkScheduler {
         SideInputStateFetcherFactory.fromOptions(options),
         failureTracker,
         workFailureProcessor,
-        StreamingCommitFinalizer.create(workExecutor),
+        StreamingCommitFinalizer.create(workExecutor, commitFinalizerCleanupExecutor),
         streamingCounters,
         hotKeyLogger,
         stageInfoMap,

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
@@ -669,6 +669,45 @@ public class StreamingDataflowWorkerTest {
   }
 
   private Windmill.GetWorkResponse makeInput(
+      int index, long timestamp, String key, long shardingKey, Long finalizeId) throws Exception {
+    return buildInput(
+        "work {"
+            + "  computation_id: \""
+            + DEFAULT_COMPUTATION_ID
+            + "\""
+            + "  input_data_watermark: 0"
+            + "  work {"
+            + "    key: \""
+            + key
+            + "\""
+            + "    sharding_key: "
+            + shardingKey
+            + "    work_token: "
+            + index
+            + "    cache_token: "
+            + (index + 1)
+            + "    message_bundles {"
+            + "      source_computation_id: \""
+            + DEFAULT_SOURCE_COMPUTATION_ID
+            + "\""
+            + "      messages {"
+            + "        timestamp: "
+            + timestamp
+            + "        data: \"data"
+            + index
+            + "\""
+            + "      }"
+            + "    }"
+            + "  }"
+            + "}"
+            + "applied_finalize_ids: "
+            + finalizeId,
+        CoderUtils.encodeToByteArray(
+            CollectionCoder.of(IntervalWindow.getCoder()),
+            Collections.singletonList(DEFAULT_WINDOW)));
+  }
+
+  private Windmill.GetWorkResponse makeInput(
       int workToken, int cacheToken, long timestamp, String key, long shardingKey)
       throws Exception {
     return buildInput(
@@ -4277,6 +4316,39 @@ public class StreamingDataflowWorkerTest {
     worker.stop();
   }
 
+  @Test
+  public void testBundleFinalizersAreCalled() throws Exception {
+    List<ParallelInstruction> instructions =
+        Arrays.asList(
+            makeSourceInstruction(StringUtf8Coder.of()),
+            makeDoFnInstruction(new BundleFinalizerFn(), 0, StringUtf8Coder.of()),
+            makeSinkInstruction(StringUtf8Coder.of(), 0));
+
+    StreamingDataflowWorker worker =
+        makeWorker(
+            defaultWorkerParams("--activeWorkRefreshPeriodMillis=10")
+                .setInstructions(instructions)
+                .build());
+    worker.start();
+
+    server.whenGetWorkCalled().thenReturn(makeInput(0, 0L, "key", DEFAULT_SHARDING_KEY));
+
+    Map<Long, Windmill.WorkItemCommitRequest> result = server.waitForAndGetCommits(1);
+    List<Long> finalizeIds = new ArrayList<>();
+    for (Windmill.WorkItemCommitRequest commit : result.values()) {
+      finalizeIds.addAll(commit.getFinalizeIdsList());
+    }
+    assertEquals(1, finalizeIds.size());
+    server
+        .whenGetWorkCalled()
+        .thenReturn(makeInput(1, 0L, "key", DEFAULT_SHARDING_KEY, finalizeIds.get(0)));
+    server.waitForAndGetCommits(1);
+    assertThat(
+        "At least one commit finalizer called", BundleFinalizerFn.bundleFinalizerCount.get() > 0);
+
+    worker.stop();
+  }
+
   private void runNumCommitThreadsTest(int configNumCommitThreads, int expectedNumCommitThreads) {
     List<ParallelInstruction> instructions =
         Arrays.asList(
@@ -4618,6 +4690,18 @@ public class StreamingDataflowWorkerTest {
     public void processElement(ProcessContext c) throws Exception {
       Thread.sleep(1000);
       c.output(c.element());
+    }
+  }
+
+  private static class BundleFinalizerFn extends DoFn<String, String> {
+    public static AtomicInteger bundleFinalizerCount = new AtomicInteger();
+
+    @ProcessElement
+    public void processElement(ProcessContext c, BundleFinalizer bundleFinalizer) {
+      c.output(c.element());
+      bundleFinalizer.afterBundleCommit(
+          Instant.now().plus(Duration.standardMinutes(5)),
+          () -> bundleFinalizerCount.incrementAndGet());
     }
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/StreamingCommitFinalizerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/work/processing/StreamingCommitFinalizerTest.java
@@ -29,6 +29,8 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.apache.beam.repackaged.core.org.apache.commons.lang3.tuple.Pair;
 import org.apache.beam.runners.dataflow.worker.util.BoundedQueueExecutor;
@@ -45,6 +47,7 @@ public class StreamingCommitFinalizerTest {
 
   private StreamingCommitFinalizer finalizer;
   private BoundedQueueExecutor executor;
+  private ScheduledExecutorService cleanupExecutor;
 
   @Before
   public void setUp() {
@@ -60,12 +63,20 @@ public class StreamingCommitFinalizerTest {
                 .setDaemon(true)
                 .build(),
             /*useFairMonitor=*/ false);
-    finalizer = StreamingCommitFinalizer.create(executor);
+
+    cleanupExecutor =
+        Executors.newScheduledThreadPool(
+            1,
+            new ThreadFactoryBuilder()
+                .setNameFormat("FinalizationCallbackCleanup-%d")
+                .setDaemon(true)
+                .build());
+    finalizer = StreamingCommitFinalizer.create(executor, cleanupExecutor);
   }
 
   @Test
   public void testCreateAndInit() {
-    assertEquals(0, finalizer.cleanupQueueSize());
+    assertEquals(0, finalizer.pendingCallbacksSize());
   }
 
   @Test
@@ -73,7 +84,7 @@ public class StreamingCommitFinalizerTest {
     Runnable callback = mock(Runnable.class);
     finalizer.cacheCommitFinalizers(
         ImmutableMap.of(1L, Pair.of(Instant.now().plus(Duration.standardHours(1)), callback)));
-    assertEquals(1, finalizer.cleanupQueueSize());
+    assertEquals(1, finalizer.pendingCallbacksSize());
     verify(callback, never()).run();
   }
 
@@ -101,7 +112,7 @@ public class StreamingCommitFinalizerTest {
                 () -> callbackExecuted.countDown())));
     finalizer.finalizeCommits(Collections.singletonList(1L));
     assertTrue(callbackExecuted.await(30, TimeUnit.SECONDS));
-    assertEquals(0, finalizer.cleanupQueueSize());
+    assertEquals(0, finalizer.pendingCallbacksSize());
   }
 
   @Test
@@ -127,7 +138,7 @@ public class StreamingCommitFinalizerTest {
     finalizer.finalizeCommits(Collections.singletonList(1L));
     assertTrue(callback1Executed.await(30, TimeUnit.SECONDS));
 
-    assertEquals(0, finalizer.cleanupQueueSize());
+    assertEquals(0, finalizer.pendingCallbacksSize());
   }
 
   @Test
@@ -135,10 +146,10 @@ public class StreamingCommitFinalizerTest {
     Runnable callback = mock(Runnable.class);
     finalizer.cacheCommitFinalizers(
         ImmutableMap.of(1L, Pair.of(Instant.now().plus(Duration.standardHours(1)), callback)));
+    assertEquals(1, finalizer.pendingCallbacksSize());
     finalizer.finalizeCommits(Collections.singletonList(2L));
-    assertEquals(1, executor.elementsOutstanding());
     verify(callback, never()).run();
-    assertEquals(1, finalizer.cleanupQueueSize());
+    assertEquals(1, finalizer.pendingCallbacksSize());
   }
 
   @Test
@@ -150,7 +161,7 @@ public class StreamingCommitFinalizerTest {
             Pair.of(
                 Instant.now().plus(Duration.standardHours(1)),
                 () -> callback1Executed.countDown())));
-    assertEquals(1, finalizer.cleanupQueueSize());
+    assertEquals(1, finalizer.pendingCallbacksSize());
 
     Runnable callback2 = mock(Runnable.class);
     Runnable callback3 = mock(Runnable.class);
@@ -161,17 +172,17 @@ public class StreamingCommitFinalizerTest {
             .put(3L, Pair.of(shortTimeout, callback3))
             .build());
 
-    while (finalizer.cleanupQueueSize() > 1) {
+    while (finalizer.pendingCallbacksSize() > 1) {
       // Wait until the two 100ms timeouts expire.
       Thread.sleep(200);
     }
-    assertEquals(1, executor.elementsOutstanding());
+    assertEquals(1, finalizer.pendingCallbacksSize());
     finalizer.finalizeCommits(ImmutableList.of(2L, 3L));
     verify(callback2, never()).run();
     verify(callback3, never()).run();
 
     finalizer.finalizeCommits(Collections.singletonList(1L));
     assertTrue(callback1Executed.await(30, TimeUnit.SECONDS));
-    assertEquals(0, finalizer.cleanupQueueSize());
+    assertEquals(0, finalizer.pendingCallbacksSize());
   }
 }


### PR DESCRIPTION
Runs cleanup thread in its own executor.

Otherwise, we can deadlock if all finalization threads are running. This can happen if e.g. a worker starts up and the pipeline has already been running. It then first gets a bunch of ids to execute and then gets gets a callback to register, which starts up the cleanup thread.

This PR also moves cleanups to a separate ScheduledExecutorService to simplify the cleanup logic as well as prevent it from blocking WorkItem processing.

This is part of a fix of changes in PR #37723.
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
