### PR TITLE
Support annotationlib in native_type_compatibility

### DIFF
--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -83,7 +83,12 @@ _CONVERTED_COLLECTIONS = [
     collections.abc.Mapping,
 ]
 
-_CONVERTED_MODULES = ('typing', 'collections', 'collections.abc')
+_CONVERTED_MODULES = (
+    'typing',
+    'collections',
+    'collections.abc',
+    'annotationlib',
+)
 
 
 def _get_args(typ):

--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -346,6 +346,10 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
     self.assertEqual(
         typehints.List[typehints.Any], convert_to_beam_type(list['int']))
 
+  def test_annotationlib_forward_ref(self):
+    beam_type = convert_to_beam_type(dict[str, typing.ForwardRef('foo.Bar')])
+    self.assertEqual(typehints.Dict[str, typehints.Any], beam_type)
+
   def test_convert_nested_to_beam_type(self):
     self.assertEqual(typehints.List[typing.Any], typehints.List[typehints.Any])
     self.assertEqual(


### PR DESCRIPTION
In Python 3.14 the object `typing.ForwardRef` was moved from `typing` to the new `annotationlib` module and `typing.ForwardRef` became an alias of `annotationlib.ForwardRef`. This is causing failures in `native_type_compatibility.py`.

Fix the issue by adding `annotationlib` to the `_CONVERTED_MODULES` list to ensure `ForwardRef` objects get processed and converted to `typehints.Any` as intended.

Add a unit test that verifies the correct behaviour in Python 3.14. Use `typing.ForwardRef` in the test to be backwards-compatible with older Python versions.

This is fix towards support Python 3.14 (#37247)

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] ~Update `CHANGES.md` with noteworthy changes.~
 - [ ] ~If this contribution is large, please file an Apache [Individual Contributor License Agreement]~(https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
