### PR TITLE
[ErrorProne] Enable UndefinedEquals check

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -1546,7 +1546,6 @@ class BeamModulePlugin implements Plugin<Project> {
             "PreferJavaTimeOverload",
             "NonCanonicalType",
             "Slf4jSignOnlyFormat",
-            "UndefinedEquals",
             "UnescapedEntity",
             "UnrecognisedJavadocTag",
             // errorprone 3.2.0+ checks

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/InMemoryMultimapSideInputViewTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/InMemoryMultimapSideInputViewTest.java
@@ -27,6 +27,7 @@ import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.transforms.Materializations.MultimapView;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
 import org.hamcrest.Description;
 import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
@@ -43,9 +44,9 @@ public class InMemoryMultimapSideInputViewTest {
         InMemoryMultimapSideInputView.fromIterable(
             ByteArrayCoder.of(),
             ImmutableList.of(KV.of(new byte[] {0x00}, 0), KV.of(new byte[] {0x01}, 1)));
-    assertEquals(view.get(new byte[] {0x00}), ImmutableList.of(0));
-    assertEquals(view.get(new byte[] {0x01}), ImmutableList.of(1));
-    assertEquals(view.get(new byte[] {0x02}), ImmutableList.of());
+    assertEquals(Lists.newArrayList(view.get(new byte[] {0x00})), ImmutableList.of(0));
+    assertEquals(Lists.newArrayList(view.get(new byte[] {0x01})), ImmutableList.of(1));
+    assertEquals(Lists.newArrayList(view.get(new byte[] {0x02})), ImmutableList.of());
     assertThat(
         view.get(),
         Matchers.containsInAnyOrder(
@@ -77,9 +78,9 @@ public class InMemoryMultimapSideInputViewTest {
         InMemoryMultimapSideInputView.fromIterable(
             StringUtf8Coder.of(),
             ImmutableList.of(KV.of("A", "a1"), KV.of("A", "a2"), KV.of("B", "b1")));
-    assertEquals(view.get("A"), ImmutableList.of("a1", "a2"));
-    assertEquals(view.get("B"), ImmutableList.of("b1"));
-    assertEquals(view.get("C"), ImmutableList.of());
+    assertEquals(Lists.newArrayList(view.get("A")), ImmutableList.of("a1", "a2"));
+    assertEquals(Lists.newArrayList(view.get("B")), ImmutableList.of("b1"));
+    assertEquals(Lists.newArrayList(view.get("C")), ImmutableList.of());
     assertThat(view.get(), containsInAnyOrder("A", "B"));
   }
 }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WatermarkManager.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WatermarkManager.java
@@ -1699,7 +1699,10 @@ class WatermarkManager<ExecutableT, CollectionT> {
       }
       TimerUpdate that = (TimerUpdate) other;
       return Objects.equals(this.key, that.key)
-          && Objects.equals(this.completedTimers, that.completedTimers)
+          && (this.completedTimers == that.completedTimers
+              || (this.completedTimers != null
+                  && that.completedTimers != null
+                  && Iterables.elementsEqual(this.completedTimers, that.completedTimers)))
           && Objects.equals(this.setTimers, that.setTimers)
           && Objects.equals(this.deletedTimers, that.deletedTimers);
     }

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRegistrarTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRegistrarTest.java
@@ -38,14 +38,14 @@ public class DirectRegistrarTest {
   public void testCorrectOptionsAreReturned() {
     assertEquals(
         ImmutableList.of(DirectOptions.class, DirectTestOptions.class),
-        new Options().getPipelineOptions());
+        Lists.newArrayList(new Options().getPipelineOptions()));
   }
 
   @Test
   public void testCorrectRunnersAreReturned() {
     assertEquals(
         ImmutableList.of(org.apache.beam.runners.direct.DirectRunner.class),
-        new Runner().getPipelineRunners());
+        Lists.newArrayList(new Runner().getPipelineRunners()));
   }
 
   @Test

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineRegistrarTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineRegistrarTest.java
@@ -37,14 +37,14 @@ public class DataflowPipelineRegistrarTest {
   public void testCorrectOptionsAreReturned() {
     assertEquals(
         ImmutableList.of(DataflowPipelineOptions.class),
-        new DataflowPipelineRegistrar.Options().getPipelineOptions());
+        Lists.newArrayList(new DataflowPipelineRegistrar.Options().getPipelineOptions()));
   }
 
   @Test
   public void testCorrectRunnersAreReturned() {
     assertEquals(
         ImmutableList.of(DataflowRunner.class, TestDataflowRunner.class),
-        new DataflowPipelineRegistrar.Runner().getPipelineRunners());
+        Lists.newArrayList(new DataflowPipelineRegistrar.Runner().getPipelineRunners()));
   }
 
   @Test

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/ShuffleSinkTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/ShuffleSinkTest.java
@@ -117,7 +117,8 @@ public class ShuffleSinkTest {
       ByteString valueBytes = record.getValue();
       WindowedValue<Integer> value =
           CoderUtils.decodeFromByteString(windowedValueCoder, valueBytes);
-      Assert.assertEquals(Lists.newArrayList(GlobalWindow.INSTANCE), value.getWindows());
+      Assert.assertEquals(
+          Lists.newArrayList(GlobalWindow.INSTANCE), Lists.newArrayList(value.getWindows()));
       actual.add(value.getValue());
     }
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
@@ -1940,7 +1940,7 @@ public class StreamingDataflowWorkerTest {
         PaneInfo.createPane(true, true, Timing.ON_TIME), PaneInfoCoder.INSTANCE.decode(inStream));
     assertEquals(
         Collections.singletonList(WINDOW_AT_ZERO),
-        DEFAULT_WINDOW_COLLECTION_CODER.decode(inStream, Coder.Context.OUTER));
+        Lists.newArrayList(DEFAULT_WINDOW_COLLECTION_CODER.decode(inStream, Coder.Context.OUTER)));
 
     // Data was deleted
     assertThat(
@@ -2230,7 +2230,7 @@ public class StreamingDataflowWorkerTest {
         PaneInfo.createPane(true, true, Timing.ON_TIME), PaneInfoCoder.INSTANCE.decode(inStream));
     assertEquals(
         Collections.singletonList(WINDOW_AT_ZERO),
-        DEFAULT_WINDOW_COLLECTION_CODER.decode(inStream, Coder.Context.OUTER));
+        Lists.newArrayList(DEFAULT_WINDOW_COLLECTION_CODER.decode(inStream, Coder.Context.OUTER)));
 
     // Data was deleted
     assertThat(

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/UngroupedShuffleReaderTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/UngroupedShuffleReaderTest.java
@@ -106,7 +106,7 @@ public class UngroupedShuffleReaderTest {
       for (boolean more = iter.start(); more; more = iter.advance()) {
         WindowedValue<Integer> elem = iter.getCurrent();
         Assert.assertEquals(timestamp, elem.getTimestamp());
-        Assert.assertEquals(Lists.newArrayList(window), elem.getWindows());
+        Assert.assertEquals(Lists.newArrayList(window), Lists.newArrayList(elem.getWindows()));
         actual.add(elem.getValue());
       }
       Assert.assertFalse(iter.advance());

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/state/WindmillStateInternalsTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/state/WindmillStateInternalsTest.java
@@ -3540,7 +3540,10 @@ public class WindmillStateInternalsTest {
       MultimapEntryUpdate that = (MultimapEntryUpdate) o;
       return deleteAll == that.deleteAll
           && Objects.equals(key, that.key)
-          && Objects.equals(values, that.values);
+          && (values == that.values
+              || (values != null
+                  && that.values != null
+                  && Iterables.elementsEqual(values, that.values)));
     }
 
     @Override

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/artifact/ArtifactStagingServiceTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/artifact/ArtifactStagingServiceTest.java
@@ -20,7 +20,6 @@ package org.apache.beam.runners.fnexecution.artifact;
 import static org.junit.Assert.assertEquals;
 
 import java.nio.file.Path;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -168,7 +167,7 @@ public class ArtifactStagingServiceTest {
   }
 
   private void checkArtifacts(
-      Collection<String> expectedContents, List<RunnerApi.ArtifactInformation> staged) {
+      List<String> expectedContents, List<RunnerApi.ArtifactInformation> staged) {
     assertEquals(
         expectedContents, Lists.transform(staged, RunnerApi.ArtifactInformation::getRoleUrn));
     assertEquals(expectedContents, Lists.transform(staged, this::getArtifact));

--- a/runners/prism/java/src/test/java/org/apache/beam/runners/prism/PrismRegistrarTest.java
+++ b/runners/prism/java/src/test/java/org/apache/beam/runners/prism/PrismRegistrarTest.java
@@ -38,14 +38,14 @@ public class PrismRegistrarTest {
   public void testCorrectOptionsAreReturned() {
     assertEquals(
         ImmutableList.of(PrismPipelineOptions.class, TestPrismPipelineOptions.class),
-        new Options().getPipelineOptions());
+        Lists.newArrayList(new Options().getPipelineOptions()));
   }
 
   @Test
   public void testCorrectRunnersAreReturned() {
     assertEquals(
         ImmutableList.of(PrismRunner.class, TestPrismRunner.class),
-        new Runner().getPipelineRunners());
+        Lists.newArrayList(new Runner().getPipelineRunners()));
   }
 
   @Test

--- a/runners/samza/src/test/java/org/apache/beam/runners/samza/runtime/SamzaTimerInternalsFactoryTest.java
+++ b/runners/samza/src/test/java/org/apache/beam/runners/samza/runtime/SamzaTimerInternalsFactoryTest.java
@@ -249,7 +249,8 @@ public class SamzaTimerInternalsFactoryTest {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     StringUtf8Coder.of().encode(key, baos);
     byte[] keyBytes = baos.toByteArray();
-    assertEquals(readyTimers, Arrays.asList(new KeyedTimerData<>(keyBytes, key, timer2)));
+    assertEquals(
+        new ArrayList<>(readyTimers), Arrays.asList(new KeyedTimerData<>(keyBytes, key, timer2)));
 
     store.close();
   }
@@ -301,7 +302,7 @@ public class SamzaTimerInternalsFactoryTest {
     StringUtf8Coder.of().encode(key, baos);
     byte[] keyBytes = baos.toByteArray();
     assertEquals(
-        readyTimers,
+        new ArrayList<>(readyTimers),
         Arrays.asList(
             new KeyedTimerData<>(keyBytes, key, timer1),
             new KeyedTimerData<>(keyBytes, key, timer2)));

--- a/runners/samza/src/test/java/org/apache/beam/runners/samza/util/FutureUtilsTest.java
+++ b/runners/samza/src/test/java/org/apache/beam/runners/samza/util/FutureUtilsTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -42,7 +43,9 @@ public final class FutureUtilsTest {
         resultFuture.thenAccept(
             actualResults -> {
               Assert.assertEquals(
-                  "Expected flattened results to contain {hello, world}", RESULTS, actualResults);
+                  "Expected flattened results to contain {hello, world}",
+                  RESULTS,
+                  Lists.newArrayList(actualResults));
             });
 
     validationFuture.toCompletableFuture().join();
@@ -93,7 +96,9 @@ public final class FutureUtilsTest {
         resultFuture.thenAccept(
             actualResults -> {
               Assert.assertEquals(
-                  "Expected flattened results to contain {hello, world}", RESULTS, actualResults);
+                  "Expected flattened results to contain {hello, world}",
+                  RESULTS,
+                  Lists.newArrayList(actualResults));
             });
 
     validationFuture.toCompletableFuture().join();

--- a/runners/spark/3/src/test/java/org/apache/beam/runners/spark/structuredstreaming/SparkStructuredStreamingRunnerRegistrarTest.java
+++ b/runners/spark/3/src/test/java/org/apache/beam/runners/spark/structuredstreaming/SparkStructuredStreamingRunnerRegistrarTest.java
@@ -36,14 +36,16 @@ public class SparkStructuredStreamingRunnerRegistrarTest {
   public void testOptions() {
     assertEquals(
         ImmutableList.of(SparkStructuredStreamingPipelineOptions.class),
-        new SparkStructuredStreamingRunnerRegistrar.Options().getPipelineOptions());
+        Lists.newArrayList(
+            new SparkStructuredStreamingRunnerRegistrar.Options().getPipelineOptions()));
   }
 
   @Test
   public void testRunners() {
     assertEquals(
         ImmutableList.of(SparkStructuredStreamingRunner.class),
-        new SparkStructuredStreamingRunnerRegistrar.Runner().getPipelineRunners());
+        Lists.newArrayList(
+            new SparkStructuredStreamingRunnerRegistrar.Runner().getPipelineRunners()));
   }
 
   @Test

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/SparkRunnerRegistrarTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/SparkRunnerRegistrarTest.java
@@ -36,14 +36,14 @@ public class SparkRunnerRegistrarTest {
   public void testOptions() {
     assertEquals(
         ImmutableList.of(SparkPipelineOptions.class, SparkPortableStreamingPipelineOptions.class),
-        new SparkRunnerRegistrar.Options().getPipelineOptions());
+        Lists.newArrayList(new SparkRunnerRegistrar.Options().getPipelineOptions()));
   }
 
   @Test
   public void testRunners() {
     assertEquals(
         ImmutableList.of(SparkRunner.class, TestSparkRunner.class),
-        new SparkRunnerRegistrar.Runner().getPipelineRunners());
+        Lists.newArrayList(new SparkRunnerRegistrar.Runner().getPipelineRunners()));
   }
 
   @Test

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/ValueAndCoderLazySerializableTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/ValueAndCoderLazySerializableTest.java
@@ -34,6 +34,7 @@ import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.values.WindowedValue;
 import org.apache.beam.sdk.values.WindowedValues;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
 import org.joda.time.Instant;
 import org.junit.Test;
 
@@ -67,7 +68,9 @@ public class ValueAndCoderLazySerializableTest {
     @SuppressWarnings("unchecked")
     ValueAndCoderLazySerializable<Iterable<WindowedValue<Integer>>> materialized =
         (ValueAndCoderLazySerializable<Iterable<WindowedValue<Integer>>>) ois.readObject();
-    assertEquals(accumulatedValue, materialized.getOrDecode(iterAccumCoder));
+    assertEquals(
+        Lists.newArrayList(accumulatedValue),
+        Lists.newArrayList(materialized.getOrDecode(iterAccumCoder)));
   }
 
   @Test
@@ -101,7 +104,9 @@ public class ValueAndCoderLazySerializableTest {
             kryo.readObject(input, ValueAndCoderLazySerializable.class);
     input.close();
 
-    assertEquals(accumulatedValue, materialized.getOrDecode(iterAccumCoder));
+    assertEquals(
+        Lists.newArrayList(accumulatedValue),
+        Lists.newArrayList(materialized.getOrDecode(iterAccumCoder)));
   }
 
   private <T> WindowedValue<T> winVal(T val) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/StaticWindows.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/StaticWindows.java
@@ -21,7 +21,6 @@ import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Pr
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Objects;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.IncompatibleWindowException;
@@ -94,7 +93,7 @@ final class StaticWindows extends NonMergingWindowFn<Object, BoundedWindow> {
       return false;
     }
     StaticWindows that = (StaticWindows) other;
-    return Objects.equals(this.windows.get(), that.windows.get());
+    return Iterables.elementsEqual(this.windows.get(), that.windows.get());
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/Timer.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/Timer.java
@@ -37,6 +37,7 @@ import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo.PaneInfoCoder;
 import org.apache.beam.sdk.util.common.ElementByteSizeObserver;
 import org.apache.beam.sdk.values.CausedByDrain;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.Instant;
 
@@ -136,7 +137,7 @@ public abstract class Timer<K> {
     Timer<?> that = (Timer<?>) other;
     return Objects.equals(this.getUserKey(), that.getUserKey())
         && Objects.equals(this.getDynamicTimerTag(), that.getDynamicTimerTag())
-        && Objects.equals(this.getWindows(), that.getWindows())
+        && Iterables.elementsEqual(this.getWindows(), that.getWindows())
         && (this.getClearBit() == that.getClearBit())
         && Objects.equals(this.getFireTimestamp(), that.getFireTimestamp())
         && Objects.equals(this.getHoldTimestamp(), that.getHoldTimestamp())

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionViews.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionViews.java
@@ -2052,6 +2052,7 @@ public class PCollectionViews {
         }
 
         @Override
+        @SuppressWarnings("UndefinedEquals")
         public boolean contains(Object o) {
           if (!(o instanceof Entry)) {
             return false;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/WindowedValues.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/WindowedValues.java
@@ -790,6 +790,7 @@ public class WindowedValues {
     }
 
     @Override
+    @SuppressWarnings("UndefinedEquals")
     public boolean equals(@Nullable Object o) {
       if (o instanceof TimestampedValueInMultipleWindows) {
         TimestampedValueInMultipleWindows<?> that = (TimestampedValueInMultipleWindows<?>) o;
@@ -801,7 +802,7 @@ public class WindowedValues {
             && Objects.equals(that.getPaneInfo(), this.getPaneInfo())) {
           ensureWindowsAreASet();
           that.ensureWindowsAreASet();
-          return ((Set<?>) that.windows).equals((Set<?>) this.windows);
+          return that.windows.equals(this.windows);
         } else {
           return false;
         }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/WindowedValues.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/WindowedValues.java
@@ -52,6 +52,7 @@ import org.apache.beam.sdk.util.WindowedValueReceiver;
 import org.apache.beam.sdk.util.common.ElementByteSizeObserver;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.MoreObjects;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.qual.Pure;
@@ -413,7 +414,7 @@ public class WindowedValues {
     // comparisons are made on their Chronology objects.
     return left.getTimestamp().isEqual(right.getTimestamp())
         && Objects.equals(left.getValue(), right.getValue())
-        && Objects.equals(left.getWindows(), right.getWindows())
+        && Iterables.elementsEqual(left.getWindows(), right.getWindows())
         && Objects.equals(left.getPaneInfo(), right.getPaneInfo());
   }
 
@@ -800,7 +801,7 @@ public class WindowedValues {
             && Objects.equals(that.getPaneInfo(), this.getPaneInfo())) {
           ensureWindowsAreASet();
           that.ensureWindowsAreASet();
-          return that.windows.equals(this.windows);
+          return ((Set<?>) that.windows).equals((Set<?>) this.windows);
         } else {
           return false;
         }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/SerializableCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/SerializableCoderTest.java
@@ -45,6 +45,7 @@ import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hamcrest.Description;
 import org.hamcrest.Matchers;
@@ -121,7 +122,7 @@ public class SerializableCoderTest implements Serializable {
     byte[] encoded = CoderUtils.encodeToByteArray(coder, records);
     Iterable<MyRecord> decoded = CoderUtils.decodeFromByteArray(coder, encoded);
 
-    assertEquals(records, decoded);
+    assertEquals(records, Lists.newArrayList(decoded));
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JavaBeanSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JavaBeanSchemaTest.java
@@ -330,9 +330,9 @@ public class JavaBeanSchemaTest {
     Long[] longArray = {42L, 43L, 44L};
     PrimitiveArrayBean bean = new PrimitiveArrayBean(strList, intArray, longArray);
     Row row = registry.getToRowFunction(PrimitiveArrayBean.class).apply(bean);
-    assertEquals(strList, row.getArray("strings"));
-    assertEquals(Ints.asList(intArray), row.getArray("integers"));
-    assertEquals(Arrays.asList(longArray), row.getArray("longs"));
+    assertEquals(strList, (List) row.getArray("strings"));
+    assertEquals(Ints.asList(intArray), (List) row.getArray("integers"));
+    assertEquals(Arrays.asList(longArray), (List) row.getArray("longs"));
 
     // Ensure that list caching works.
     assertSame(row.getArray("strings"), row.getArray("strings"));
@@ -350,9 +350,9 @@ public class JavaBeanSchemaTest {
             .addArray(42L, 43L, 44L, 45L)
             .build();
     PrimitiveArrayBean bean = registry.getFromRowFunction(PrimitiveArrayBean.class).apply(row);
-    assertEquals(row.getArray("strings"), bean.getStrings());
-    assertEquals(row.getArray("integers"), Ints.asList(bean.getIntegers()));
-    assertEquals(row.getArray("longs"), Arrays.asList(bean.getLongs()));
+    assertEquals((List) row.getArray("strings"), bean.getStrings());
+    assertEquals((List) row.getArray("integers"), Ints.asList(bean.getIntegers()));
+    assertEquals((List) row.getArray("longs"), Arrays.asList(bean.getLongs()));
   }
 
   @Test
@@ -402,7 +402,7 @@ public class JavaBeanSchemaTest {
             Lists.newArrayList("g", "h", "i"));
     NestedArraysBean bean = new NestedArraysBean(listOfLists);
     Row row = registry.getToRowFunction(NestedArraysBean.class).apply(bean);
-    assertEquals(listOfLists, row.getArray("lists"));
+    assertEquals(listOfLists, (List) row.getArray("lists"));
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JavaFieldSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JavaFieldSchemaTest.java
@@ -355,9 +355,9 @@ public class JavaFieldSchemaTest {
     Long[] longArray = {42L, 43L, 44L};
     PrimitiveArrayPOJO pojo = new PrimitiveArrayPOJO(strList, intArray, longArray);
     Row row = registry.getToRowFunction(PrimitiveArrayPOJO.class).apply(pojo);
-    assertEquals(strList, row.getArray("strings"));
-    assertEquals(Ints.asList(intArray), row.getArray("integers"));
-    assertEquals(Arrays.asList(longArray), row.getArray("longs"));
+    assertEquals(strList, (List) row.getArray("strings"));
+    assertEquals(Ints.asList(intArray), (List) row.getArray("integers"));
+    assertEquals(Arrays.asList(longArray), (List) row.getArray("longs"));
 
     // Ensure that list caching works.
     assertSame(row.getArray("strings"), row.getArray("strings"));
@@ -375,9 +375,9 @@ public class JavaFieldSchemaTest {
             .addArray(42L, 43L, 44L, 45L)
             .build();
     PrimitiveArrayPOJO pojo = registry.getFromRowFunction(PrimitiveArrayPOJO.class).apply(row);
-    assertEquals(row.getArray("strings"), pojo.strings);
-    assertEquals(row.getArray("integers"), Ints.asList(pojo.integers));
-    assertEquals(row.getArray("longs"), Arrays.asList(pojo.longs));
+    assertEquals((List) row.getArray("strings"), pojo.strings);
+    assertEquals((List) row.getArray("integers"), Ints.asList(pojo.integers));
+    assertEquals((List) row.getArray("longs"), Arrays.asList(pojo.longs));
   }
 
   @Test
@@ -428,7 +428,7 @@ public class JavaFieldSchemaTest {
             Lists.newArrayList("g", "h", "i"));
     NestedArraysPOJO pojo = new NestedArraysPOJO(listOfLists);
     Row row = registry.getToRowFunction(NestedArraysPOJO.class).apply(pojo);
-    assertEquals(listOfLists, row.getArray("lists"));
+    assertEquals(listOfLists, (List) row.getArray("lists"));
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestJavaBeans.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestJavaBeans.java
@@ -34,6 +34,7 @@ import org.apache.beam.sdk.schemas.annotations.SchemaFieldName;
 import org.apache.beam.sdk.schemas.annotations.SchemaFieldNumber;
 import org.apache.beam.sdk.schemas.annotations.SchemaIgnore;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.CaseFormat;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.DateTime;
 import org.joda.time.Instant;
@@ -905,7 +906,7 @@ public class TestJavaBeans {
       }
       NestedCollectionBean that = (NestedCollectionBean) o;
       return Objects.equals(simples, that.simples)
-          && Objects.equals(iterableSimples, that.iterableSimples);
+          && Iterables.elementsEqual(iterableSimples, that.iterableSimples);
     }
 
     @Override
@@ -1178,7 +1179,7 @@ public class TestJavaBeans {
         return false;
       }
       IterableBean that = (IterableBean) o;
-      return Objects.equals(strings, that.strings);
+      return Iterables.elementsEqual(strings, that.strings);
     }
 
     @Override

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestPOJOs.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestPOJOs.java
@@ -35,6 +35,7 @@ import org.apache.beam.sdk.schemas.annotations.SchemaFieldNumber;
 import org.apache.beam.sdk.schemas.annotations.SchemaIgnore;
 import org.apache.beam.sdk.schemas.logicaltypes.EnumerationType;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.CaseFormat;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.DateTime;
 import org.joda.time.Instant;
@@ -664,7 +665,10 @@ public class TestPOJOs {
       }
       NestedCollectionPOJO that = (NestedCollectionPOJO) o;
       return Objects.equals(simples, that.simples)
-          && Objects.equals(iterableSimples, that.iterableSimples);
+          && (iterableSimples == that.iterableSimples
+              || (iterableSimples != null
+                  && that.iterableSimples != null
+                  && Iterables.elementsEqual(iterableSimples, that.iterableSimples)));
     }
 
     @Override
@@ -891,7 +895,10 @@ public class TestPOJOs {
         return false;
       }
       PojoWithIterable that = (PojoWithIterable) o;
-      return Objects.equals(strings, that.strings);
+      return strings == that.strings
+          || (strings != null
+              && that.strings != null
+              && Iterables.elementsEqual(strings, that.strings));
     }
 
     @Override

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataTest.java
@@ -60,6 +60,7 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMultimap;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Multimap;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hamcrest.CustomTypeSafeMatcher;
@@ -268,7 +269,7 @@ public class DisplayDataTest implements Serializable {
     Map<DisplayData.Identifier, DisplayData.Item> map = data.asMap();
     assertEquals(1, map.size());
     assertThat(data, hasDisplayItem("foo", "bar"));
-    assertEquals(map.values(), data.items());
+    assertEquals(Lists.newArrayList(map.values()), Lists.newArrayList(data.items()));
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/construction/TimerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/construction/TimerTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
+import java.util.Set;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.testing.CoderProperties;
@@ -46,7 +47,7 @@ public class TimerTest {
     assertTrue(clearedTimer.getClearBit());
     assertEquals("timer", clearedTimer.getUserKey());
     assertEquals("tag", clearedTimer.getDynamicTimerTag());
-    assertEquals(Collections.singleton(GlobalWindow.INSTANCE), clearedTimer.getWindows());
+    assertEquals(Collections.singleton(GlobalWindow.INSTANCE), (Set<?>) clearedTimer.getWindows());
   }
 
   @Test
@@ -64,7 +65,7 @@ public class TimerTest {
     assertEquals("tag", timer.getDynamicTimerTag());
     assertEquals(FIRE_TIME, timer.getFireTimestamp());
     assertEquals(HOLD_TIME, timer.getHoldTimestamp());
-    assertEquals(Collections.singleton(GlobalWindow.INSTANCE), timer.getWindows());
+    assertEquals(Collections.singleton(GlobalWindow.INSTANCE), (Set<?>) timer.getWindows());
     assertEquals(PaneInfo.NO_FIRING, timer.getPaneInfo());
     assertFalse(timer.getClearBit());
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/values/RowTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/values/RowTest.java
@@ -189,7 +189,7 @@ public class RowTest {
         Stream.of(Schema.Field.of("array", Schema.FieldType.array(Schema.FieldType.INT32)))
             .collect(toSchema());
     Row row = Row.withSchema(type).addArray(data).build();
-    assertEquals(data, row.getArray("array"));
+    assertEquals(data, (List) row.getArray("array"));
   }
 
   @Test
@@ -199,7 +199,7 @@ public class RowTest {
         Stream.of(Schema.Field.of("iter", Schema.FieldType.iterable(Schema.FieldType.INT32)))
             .collect(toSchema());
     Row row = Row.withSchema(type).addIterable(data).build();
-    assertEquals(data, row.getIterable("iter"));
+    assertEquals(data, Lists.newArrayList(row.getIterable("iter")));
   }
 
   @Test
@@ -209,7 +209,7 @@ public class RowTest {
         Stream.of(Schema.Field.nullable("array", Schema.FieldType.array(Schema.FieldType.INT32)))
             .collect(toSchema());
     Row row = Row.withSchema(type).addArray(data).build();
-    assertEquals(data, row.getArray("array"));
+    assertEquals(data, (List) row.getArray("array"));
 
     Row otherNonNull = Row.withSchema(type).addValue(ImmutableList.of(1, 2, 3)).build();
     Row otherNull = Row.withSchema(type).addValue(null).build();
@@ -224,7 +224,7 @@ public class RowTest {
         Stream.of(Schema.Field.nullable("iter", Schema.FieldType.iterable(Schema.FieldType.INT32)))
             .collect(toSchema());
     Row row = Row.withSchema(type).addIterable(data).build();
-    assertEquals(data, row.getArray("iter"));
+    assertEquals(data, (List) row.getArray("iter"));
 
     Row otherNonNull = Row.withSchema(type).addValue(ImmutableList.of(1, 2, 3)).build();
     Row otherNull = Row.withSchema(type).addValue(null).build();
@@ -241,7 +241,7 @@ public class RowTest {
                     "array", Schema.FieldType.array(Schema.FieldType.INT32.withNullable(true))))
             .collect(toSchema());
     Row row = Row.withSchema(type).addArray(data).build();
-    assertEquals(data, row.getArray("array"));
+    assertEquals(data, (List) row.getArray("array"));
   }
 
   @Test
@@ -253,7 +253,7 @@ public class RowTest {
                     "iter", Schema.FieldType.iterable(Schema.FieldType.INT32.withNullable(true))))
             .collect(toSchema());
     Row row = Row.withSchema(type).addIterable(data).build();
-    assertEquals(data, row.getIterable("iter"));
+    assertEquals(data, Lists.newArrayList(row.getIterable("iter")));
   }
 
   @Test
@@ -269,7 +269,7 @@ public class RowTest {
         Stream.of(Schema.Field.of("array", FieldType.array(FieldType.row(nestedType))))
             .collect(toSchema());
     Row row = Row.withSchema(type).addArray(data).build();
-    assertEquals(data, row.getArray("array"));
+    assertEquals(data, (List) row.getArray("array"));
   }
 
   @Test
@@ -285,7 +285,7 @@ public class RowTest {
         Stream.of(Schema.Field.of("iter", FieldType.iterable(FieldType.row(nestedType))))
             .collect(toSchema());
     Row row = Row.withSchema(type).addIterable(data).build();
-    assertEquals(data, row.getIterable("iter"));
+    assertEquals(data, Lists.newArrayList(row.getIterable("iter")));
   }
 
   @Test
@@ -295,7 +295,7 @@ public class RowTest {
         Stream.of(Schema.Field.of("array", FieldType.array(FieldType.array(FieldType.INT32))))
             .collect(toSchema());
     Row row = Row.withSchema(type).addArray(data).build();
-    assertEquals(data, row.getArray("array"));
+    assertEquals(data, (List) row.getArray("array"));
   }
 
   @Test
@@ -305,7 +305,7 @@ public class RowTest {
         Stream.of(Schema.Field.of("iter", FieldType.iterable(FieldType.array(FieldType.INT32))))
             .collect(toSchema());
     Row row = Row.withSchema(type).addIterable(data).build();
-    assertEquals(data, row.getIterable("iter"));
+    assertEquals(data, Lists.newArrayList(row.getIterable("iter")));
   }
 
   @Test
@@ -321,7 +321,7 @@ public class RowTest {
                         .withNullable(true)))
             .collect(toSchema());
     Row row = Row.withSchema(type).addArray(data).build();
-    assertEquals(data, row.getArray("array"));
+    assertEquals(data, (List) row.getArray("array"));
   }
 
   @Test
@@ -338,7 +338,7 @@ public class RowTest {
                         .withNullable(true)))
             .collect(toSchema());
     Row row = Row.withSchema(type).addIterable(data).build();
-    assertEquals(data, row.getIterable("iter"));
+    assertEquals(data, Lists.newArrayList(row.getIterable("iter")));
   }
 
   @Test
@@ -354,7 +354,7 @@ public class RowTest {
                     "array", FieldType.array(FieldType.map(FieldType.INT32, FieldType.STRING))))
             .collect(toSchema());
     Row row = Row.withSchema(type).addArray(data).build();
-    assertEquals(data, row.getArray("array"));
+    assertEquals(data, (List) row.getArray("array"));
   }
 
   @Test
@@ -370,7 +370,7 @@ public class RowTest {
                     "iter", FieldType.iterable(FieldType.map(FieldType.INT32, FieldType.STRING))))
             .collect(toSchema());
     Row row = Row.withSchema(type).addIterable(data).build();
-    assertEquals(data, row.getIterable("iter"));
+    assertEquals(data, Lists.newArrayList(row.getIterable("iter")));
   }
 
   @Test
@@ -396,7 +396,7 @@ public class RowTest {
         Stream.of(Schema.Field.nullable("map", FieldType.map(FieldType.INT32, FieldType.STRING)))
             .collect(toSchema());
     Row row = Row.withSchema(type).addValue(data).build();
-    assertEquals(data, row.getArray("map"));
+    assertEquals(data, (List) row.getArray("map"));
 
     Row otherNonNull = Row.withSchema(type).addValue(ImmutableMap.of(1, "value1")).build();
     Row otherNull = Row.withSchema(type).addValue(null).build();

--- a/sdks/java/extensions/sorter/src/test/java/org/apache/beam/sdk/extensions/sorter/BufferedExternalSorterTest.java
+++ b/sdks/java/extensions/sorter/src/test/java/org/apache/beam/sdk/extensions/sorter/BufferedExternalSorterTest.java
@@ -110,7 +110,7 @@ public class BufferedExternalSorterTest {
     testSorter.add(kvs[1]);
     testSorter.add(kvs[2]);
 
-    assertEquals(Arrays.asList(kvs[0], kvs[1], kvs[2]), testSorter.sort());
+    assertEquals(Arrays.asList(kvs[0], kvs[1], kvs[2]), (java.util.List) testSorter.sort());
 
     // Verify external sorter was never called
     verify(mockExternalSorter, never()).add(any(KV.class));
@@ -142,7 +142,7 @@ public class BufferedExternalSorterTest {
     testSorter.add(kvs[1]);
     testSorter.add(kvs[2]);
 
-    assertEquals(Arrays.asList(kvs[0], kvs[1], kvs[2]), testSorter.sort());
+    assertEquals(Arrays.asList(kvs[0], kvs[1], kvs[2]), (java.util.List) testSorter.sort());
 
     verify(mockExternalSorter, times(1)).add(kvs[0]);
     verify(mockExternalSorter, times(1)).add(kvs[1]);

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/PrecombineGroupingTable.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/PrecombineGroupingTable.java
@@ -41,6 +41,7 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.WindowedValue;
 import org.apache.beam.sdk.values.WindowedValues;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
 import org.joda.time.Instant;
 
 /**
@@ -219,7 +220,8 @@ public class PrecombineGroupingTable<K, InputT, AccumT>
         return false;
       }
       WindowedGroupingTableKey that = (WindowedGroupingTableKey) o;
-      return structuralKey.equals(that.structuralKey) && windows.equals(that.windows);
+      return structuralKey.equals(that.structuralKey)
+          && Iterables.elementsEqual(windows, that.windows);
     }
 
     @Override

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/WindowMergingFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/WindowMergingFnRunnerTest.java
@@ -100,7 +100,9 @@ public class WindowMergingFnRunnerTest {
     KV<Object, KV<Iterable<BoundedWindow>, Iterable<KV<BoundedWindow, Iterable<BoundedWindow>>>>>
         output = mapFunction.apply(input);
     assertEquals(input.getKey(), output.getKey());
-    assertEquals(expectedToBeUnmerged, output.getValue().getKey());
+    assertThat(
+        output.getValue().getKey(),
+        containsInAnyOrder(Iterables.toArray(expectedToBeUnmerged, BoundedWindow.class)));
     KV<BoundedWindow, Iterable<BoundedWindow>> mergedOutput =
         Iterables.getOnlyElement(output.getValue().getValue());
     assertEquals(new IntervalWindow(new Instant(7L), new Instant(11L)), mergedOutput.getKey());
@@ -123,7 +125,9 @@ public class WindowMergingFnRunnerTest {
 
     output = mapFunction.apply(input);
     assertEquals(input.getKey(), output.getKey());
-    assertEquals(expectedToBeUnmerged, output.getValue().getKey());
+    assertThat(
+        output.getValue().getKey(),
+        containsInAnyOrder(Iterables.toArray(expectedToBeUnmerged, BoundedWindow.class)));
     mergedOutput = Iterables.getOnlyElement(output.getValue().getValue());
     assertEquals(new IntervalWindow(new Instant(15L), new Instant(18L)), mergedOutput.getKey());
     assertThat(mergedOutput.getValue(), containsInAnyOrder(expectedToBeMergedGroup2));

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/LazyCachingIteratorToIterableTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/LazyCachingIteratorToIterableTest.java
@@ -81,12 +81,14 @@ public class LazyCachingIteratorToIterableTest {
 
   @Test
   public void testEqualsAndHashCode() {
-    Iterable<String> iterA =
+    LazyCachingIteratorToIterable<String> iterA =
         new LazyCachingIteratorToIterable<>(PrefetchableIterators.fromArray("A", "B", "C"));
-    Iterable<String> iterB =
+    LazyCachingIteratorToIterable<String> iterB =
         new LazyCachingIteratorToIterable<>(PrefetchableIterators.fromArray("A", "B", "C"));
-    Iterable<String> iterC = new LazyCachingIteratorToIterable<>(PrefetchableIterators.fromArray());
-    Iterable<String> iterD = new LazyCachingIteratorToIterable<>(PrefetchableIterators.fromArray());
+    LazyCachingIteratorToIterable<String> iterC =
+        new LazyCachingIteratorToIterable<>(PrefetchableIterators.fromArray());
+    LazyCachingIteratorToIterable<String> iterD =
+        new LazyCachingIteratorToIterable<>(PrefetchableIterators.fromArray());
     assertEquals(iterA, iterB);
     assertEquals(iterC, iterD);
     assertNotEquals(iterA, iterC);

--- a/sdks/java/io/file-schema-transform/src/test/java/org/apache/beam/sdk/io/fileschematransform/XmlRowValueTest.java
+++ b/sdks/java/io/file-schema-transform/src/test/java/org/apache/beam/sdk/io/fileschematransform/XmlRowValueTest.java
@@ -133,7 +133,7 @@ public class XmlRowValueTest {
       assertTrue(booleans, booleansValueList.isPresent());
       assertEquals(
           booleans,
-          row.getArray(booleans),
+          (List) row.getArray(booleans),
           booleansValueList.get().stream()
               .map(XmlRowValue::getPrimitiveValue)
               .collect(Collectors.toList()));
@@ -145,7 +145,7 @@ public class XmlRowValueTest {
       assertTrue(doubles, doublesValueList.isPresent());
       assertEquals(
           doubles,
-          row.getArray(doubles),
+          (List) row.getArray(doubles),
           doublesValueList.get().stream()
               .map(XmlRowValue::getPrimitiveValue)
               .collect(Collectors.toList()));
@@ -157,7 +157,7 @@ public class XmlRowValueTest {
       assertTrue(floats, floatsValueList.isPresent());
       assertEquals(
           floats,
-          row.getArray(floats),
+          (List) row.getArray(floats),
           floatsValueList.get().stream()
               .map(XmlRowValue::getPrimitiveValue)
               .collect(Collectors.toList()));
@@ -169,7 +169,7 @@ public class XmlRowValueTest {
       assertTrue(integers, integersValueList.isPresent());
       assertEquals(
           integers,
-          row.getArray(integers),
+          (List) row.getArray(integers),
           integersValueList.get().stream()
               .map(XmlRowValue::getPrimitiveValue)
               .collect(Collectors.toList()));
@@ -181,7 +181,7 @@ public class XmlRowValueTest {
       assertTrue(longs, longsValueList.isPresent());
       assertEquals(
           longs,
-          row.getArray(longs),
+          (List) row.getArray(longs),
           longsValueList.get().stream()
               .map(XmlRowValue::getPrimitiveValue)
               .collect(Collectors.toList()));
@@ -193,7 +193,7 @@ public class XmlRowValueTest {
       assertTrue(strings, stringsValueList.isPresent());
       assertEquals(
           strings,
-          row.getArray(strings),
+          (List) row.getArray(strings),
           stringsValueList.get().stream()
               .map(XmlRowValue::getPrimitiveValue)
               .collect(Collectors.toList()));
@@ -244,7 +244,7 @@ public class XmlRowValueTest {
       byteListValue.setValue(byteList, row);
       assertEquals(
           singleByte,
-          row.getArray(byteList),
+          (List) row.getArray(byteList),
           byteListValue.getValueList().stream()
               .map(XmlRowValue::getPrimitiveValue)
               .collect(Collectors.toList()));

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/RecordWriterManagerTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/RecordWriterManagerTest.java
@@ -341,7 +341,7 @@ public class RecordWriterManagerTest {
 
   /** DataFile doesn't implement a .equals() method. Check equality manually. */
   private static void checkDataFileEquality(DataFile d1, DataFile d2) {
-    assertEquals(d1.path(), d2.path());
+    assertEquals(d1.path().toString(), d2.path().toString());
     assertEquals(d1.format(), d2.format());
     assertEquals(d1.recordCount(), d2.recordCount());
     assertEquals(d1.partition(), d2.partition());

--- a/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcSchemaIOProviderTest.java
+++ b/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcSchemaIOProviderTest.java
@@ -35,6 +35,7 @@ import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Count;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -233,7 +234,7 @@ public class JdbcSchemaIOProviderTest {
         "connectionProp", Objects.requireNonNull(dataSourceConf.getConnectionProperties()).get());
     assertEquals(
         new ArrayList<>(Collections.singleton("initSql")),
-        Objects.requireNonNull(dataSourceConf.getConnectionInitSqls()).get());
+        Lists.newArrayList(Objects.requireNonNull(dataSourceConf.getConnectionInitSqls()).get()));
     assertEquals(3, (int) dataSourceConf.getMaxConnections().get());
     assertEquals("test.jar", Objects.requireNonNull(dataSourceConf.getDriverJars()).get());
     assertEquals(10L, schemaIO.config.getInt64("writeBatchSize").longValue());

--- a/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcUtilTest.java
+++ b/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcUtilTest.java
@@ -327,7 +327,7 @@ public class JdbcUtilTest {
     assertEquals("cloudsql_postgresql", components.getScheme());
     assertEquals(
         ImmutableList.of("example.com:project", "some-region", "instance-name", "postgres"),
-        components.getSegments());
+        Lists.newArrayList(components.getSegments()));
   }
 
   @Test
@@ -341,7 +341,7 @@ public class JdbcUtilTest {
     assertEquals("cloudsql_postgresql", components.getScheme());
     assertEquals(
         ImmutableList.of("example.com:project", "some-region", "instance-name", "postgres"),
-        components.getSegments());
+        Lists.newArrayList(components.getSegments()));
   }
 
   @Test
@@ -358,7 +358,8 @@ public class JdbcUtilTest {
     JdbcUtil.FQNComponents components = JdbcUtil.FQNComponents.of(dataSource);
     assertEquals("cloudsql_mysql", components.getScheme());
     assertEquals(
-        ImmutableList.of("some-project", "US", "instance-name", "db"), components.getSegments());
+        ImmutableList.of("some-project", "US", "instance-name", "db"),
+        Lists.newArrayList(components.getSegments()));
   }
 
   @Test

--- a/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqMessage.java
+++ b/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqMessage.java
@@ -327,7 +327,9 @@ public class RabbitMqMessage implements Serializable {
           && Objects.equals(replyTo, other.replyTo)
           && Objects.equals(expiration, other.expiration)
           && Objects.equals(messageId, other.messageId)
-          && Objects.equals(timestamp, other.timestamp)
+          && Objects.equals(
+              timestamp == null ? null : timestamp.toInstant(),
+              other.timestamp == null ? null : other.timestamp.toInstant())
           && Objects.equals(type, other.type)
           && Objects.equals(userId, other.userId)
           && Objects.equals(appId, other.appId)

--- a/sdks/java/io/solace/src/main/java/org/apache/beam/sdk/io/solace/read/SolaceCheckpointMark.java
+++ b/sdks/java/io/solace/src/main/java/org/apache/beam/sdk/io/solace/read/SolaceCheckpointMark.java
@@ -25,6 +25,7 @@ import org.apache.beam.sdk.coders.DefaultCoder;
 import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
 import org.apache.beam.sdk.io.UnboundedSource;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,7 +81,10 @@ public class SolaceCheckpointMark implements UnboundedSource.CheckpointMark {
       return false;
     }
     SolaceCheckpointMark that = (SolaceCheckpointMark) o;
-    return Objects.equals(safeToAck, that.safeToAck);
+    return safeToAck == that.safeToAck
+        || (safeToAck != null
+            && that.safeToAck != null
+            && Iterables.elementsEqual(safeToAck, that.safeToAck));
   }
 
   @Override


### PR DESCRIPTION
Enabled UndefinedEquals check

Registrars and Options comparing Iterables:

- DirectRegistrarTest.java: Wrapped test options in Lists.newArrayList.
- SparkStructuredStreamingRunnerRegistrarTest.java: Wrapped test options in Lists.newArrayList.
- SparkRunnerRegistrarTest.java: Wrapped test options and runners in Lists.newArrayList.
- DataflowPipelineRegistrarTest.java: Wrapped test options and runners in Lists.newArrayList.

Tests comparing raw Collections or Iterables:

- JdbcSchemaIOProviderTest.java: Converted expected set to list using Guava collections.
- LazyCachingIteratorToIterableTest.java: Declared proper concrete types on LazyCachingIteratorToIterable.
- FutureUtilsTest.java: Bound raw results explicitly inside Lists.newArrayList.
- ArtifactStagingServiceTest.java: Changed method signature bounds to List to support clean list equality.
- SamzaTimerInternalsFactoryTest.java: Wrapped source collections in clean ArrayList.
- ValueAndCoderLazySerializableTest.java: Wrapped accumulators in Lists.newArrayList.
- StreamingDataflowWorkerTest.java: Applied list wrapping around generic collection decoders on consecutive items.
- UngroupedShuffleReaderTest.java: Wrapped standard element windows arrays inside Lists.newArrayList to match list.
- ShuffleSinkTest.java: Applied exact equality matching lists on windows expectations.

Helper classes doing invalid raw checks:

- WindmillStateInternalsTest.java: Fixed an explicit equals method that used Objects.equals on target raw Iterable objects, by applying a null safe usage of Guava's Iterables.elementsEqual to enforce correct iteration based content checking.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
