### PR TITLE
Allow Python user type pass through Beam SQL

### DIFF
--- a/.github/trigger_files/beam_PostCommit_SQL.json
+++ b/.github/trigger_files/beam_PostCommit_SQL.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run ",
-  "modification": 1
+  "modification": 2
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoderGenerator.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoderGenerator.java
@@ -113,6 +113,7 @@ public abstract class RowCoderGenerator {
 
   private static final String CODERS_FIELD_NAME = "FIELD_CODERS";
   private static final String POSITIONS_FIELD_NAME = "FIELD_ENCODING_POSITIONS";
+  private static final String SCHEMA_OPTION_STATIC_ENCODING = "beam:option:row:static_encoding";
 
   static class WithStackTrace<T> {
     private final T value;
@@ -407,8 +408,13 @@ public abstract class RowCoderGenerator {
       checkState(value.getFieldCount() == value.getSchema().getFieldCount());
       checkState(encodingPosToIndex.length == value.getFieldCount());
 
+      boolean staticEncoding =
+          value.getSchema().getOptions().getValueOrDefault(SCHEMA_OPTION_STATIC_ENCODING, false);
+
       // Encode the field count. This allows us to handle compatible schema changes.
-      VAR_INT_CODER.encode(value.getFieldCount(), outputStream);
+      if (!staticEncoding) {
+        VAR_INT_CODER.encode(value.getFieldCount(), outputStream);
+      }
 
       if (hasNullableFields) {
         // If the row has null fields, extract the values out once so that both scanNullFields and
@@ -420,7 +426,9 @@ public abstract class RowCoderGenerator {
         }
 
         // Encode a bitmap for the null fields to save having to encode a bunch of nulls.
-        NULL_LIST_CODER.encode(scanNullFields(fieldValues, encodingPosToIndex), outputStream);
+        if (!staticEncoding) {
+          NULL_LIST_CODER.encode(scanNullFields(fieldValues, encodingPosToIndex), outputStream);
+        }
         for (int encodingPos = 0; encodingPos < fieldValues.length; ++encodingPos) {
           @Nullable Object fieldValue = fieldValues[encodingPosToIndex[encodingPos]];
           if (fieldValue != null) {
@@ -430,7 +438,9 @@ public abstract class RowCoderGenerator {
       } else {
         // Otherwise, we know all fields are non-null, so the null list is always empty.
 
-        NULL_LIST_CODER.encode(EMPTY_BIT_SET, outputStream);
+        if (!staticEncoding) {
+          NULL_LIST_CODER.encode(EMPTY_BIT_SET, outputStream);
+        }
         for (int encodingPos = 0; encodingPos < value.getFieldCount(); ++encodingPos) {
           @Nullable Object fieldValue = value.getValue(encodingPosToIndex[encodingPos]);
           if (fieldValue != null) {
@@ -511,9 +521,15 @@ public abstract class RowCoderGenerator {
     static Row decodeDelegate(
         Schema schema, Coder[] coders, int[] encodingPosToIndex, InputStream inputStream)
         throws IOException {
-      int fieldCount = VAR_INT_CODER.decode(inputStream);
-
-      BitSet nullFields = NULL_LIST_CODER.decode(inputStream);
+      int fieldCount;
+      BitSet nullFields;
+      if (schema.getOptions().getValueOrDefault(SCHEMA_OPTION_STATIC_ENCODING, false)) {
+        fieldCount = schema.getFieldCount();
+        nullFields = new BitSet();
+      } else {
+        fieldCount = VAR_INT_CODER.decode(inputStream);
+        nullFields = NULL_LIST_CODER.decode(inputStream);
+      }
       Object[] fieldValues = new Object[coders.length];
       for (int encodingPos = 0; encodingPos < fieldCount; ++encodingPos) {
         // In the case of a schema change going backwards, fieldCount might be > coders.length,

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/RowCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/RowCoderTest.java
@@ -626,4 +626,23 @@ public class RowCoderTest {
     Row decoded = RowCoder.of(schema2).decode(new ByteArrayInputStream(os.toByteArray()));
     assertEquals(expected, decoded);
   }
+
+  @Test
+  public void testStaticEncoding() throws Exception {
+    Schema schema =
+        Schema.builder()
+            .addInt32Field("f_int32")
+            .addStringField("f_string")
+            .setOptions(
+                Schema.Options.builder()
+                    .setOption("beam:option:row:static_encoding", FieldType.BOOLEAN, true)
+                    .build())
+            .build();
+    Row row = Row.withSchema(schema).addValues(42, "hello world!").build();
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    RowCoder.of(schema).encode(row, bos);
+    assertEquals(14, bos.toByteArray().length);
+
+    CoderProperties.coderDecodeEncodeEqual(RowCoder.of(schema), row);
+  }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamCalcRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamCalcRel.java
@@ -221,9 +221,10 @@ public class BeamCalcRel extends AbstractBeamCalcRel {
       BeamSqlPipelineOptions options =
           pinput.getPipeline().getOptions().as(BeamSqlPipelineOptions.class);
 
+      String builderString = builder.toBlock().toString();
       CalcFn calcFn =
           new CalcFn(
-              builder.toBlock().toString(),
+              builderString,
               outputSchema,
               options.getVerifyRowValues(),
               getJarPaths(program),
@@ -502,120 +503,109 @@ public class BeamCalcRel extends AbstractBeamCalcRel {
     @Override
     public Expression field(BlockBuilder list, int index, Type storageType) {
       this.referencedColumns.add(index);
-      return getBeamField(list, index, input, inputSchema);
+      return getBeamField(list, index, input, inputSchema, true);
     }
 
     // Read field from Beam Row
     private static Expression getBeamField(
-        BlockBuilder list, int index, Expression input, Schema schema) {
+        BlockBuilder list, int index, Expression input, Schema schema, boolean useByteString) {
       if (index >= schema.getFieldCount() || index < 0) {
         throw new IllegalArgumentException("Unable to find value #" + index);
       }
 
       final Expression expression = list.append(list.newName("current"), input);
-
       final Field field = schema.getField(index);
       final FieldType fieldType = field.getType();
       final Expression fieldName = Expressions.constant(field.getName());
+      Expression value = getBeamField(list, expression, fieldName, fieldType);
+
+      return toCalciteValue(value, fieldType, useByteString);
+    }
+
+    private static Expression getBeamField(
+        BlockBuilder list, Expression expression, Expression fieldName, FieldType fieldType) {
       final Expression value;
       switch (fieldType.getTypeName()) {
         case BYTE:
-          value = Expressions.call(expression, "getByte", fieldName);
-          break;
+          return Expressions.call(expression, "getByte", fieldName);
         case INT16:
-          value = Expressions.call(expression, "getInt16", fieldName);
-          break;
+          return Expressions.call(expression, "getInt16", fieldName);
         case INT32:
-          value = Expressions.call(expression, "getInt32", fieldName);
-          break;
+          return Expressions.call(expression, "getInt32", fieldName);
         case INT64:
-          value = Expressions.call(expression, "getInt64", fieldName);
-          break;
+          return Expressions.call(expression, "getInt64", fieldName);
         case DECIMAL:
-          value = Expressions.call(expression, "getDecimal", fieldName);
-          break;
+          return Expressions.call(expression, "getDecimal", fieldName);
         case FLOAT:
-          value = Expressions.call(expression, "getFloat", fieldName);
-          break;
+          return Expressions.call(expression, "getFloat", fieldName);
         case DOUBLE:
-          value = Expressions.call(expression, "getDouble", fieldName);
-          break;
+          return Expressions.call(expression, "getDouble", fieldName);
         case STRING:
-          value = Expressions.call(expression, "getString", fieldName);
-          break;
+          return Expressions.call(expression, "getString", fieldName);
         case DATETIME:
-          value = Expressions.call(expression, "getDateTime", fieldName);
-          break;
+          return Expressions.call(expression, "getDateTime", fieldName);
         case BOOLEAN:
-          value = Expressions.call(expression, "getBoolean", fieldName);
-          break;
+          return Expressions.call(expression, "getBoolean", fieldName);
         case BYTES:
-          value = Expressions.call(expression, "getBytes", fieldName);
-          break;
+          return Expressions.call(expression, "getBytes", fieldName);
         case ARRAY:
-          value = Expressions.call(expression, "getArray", fieldName);
-          break;
+          return Expressions.call(expression, "getArray", fieldName);
         case MAP:
-          value = Expressions.call(expression, "getMap", fieldName);
-          break;
+          return Expressions.call(expression, "getMap", fieldName);
         case ROW:
-          value = Expressions.call(expression, "getRow", fieldName);
-          break;
+          return Expressions.call(expression, "getRow", fieldName);
         case ITERABLE:
-          value = Expressions.call(expression, "getIterable", fieldName);
-          break;
+          return Expressions.call(expression, "getIterable", fieldName);
         case LOGICAL_TYPE:
-          String identifier = fieldType.getLogicalType().getIdentifier();
+          LogicalType logicalType = fieldType.getLogicalType();
+          String identifier = logicalType.getIdentifier();
           if (FixedString.IDENTIFIER.equals(identifier)
               || VariableString.IDENTIFIER.equals(identifier)) {
-            value = Expressions.call(expression, "getString", fieldName);
+            return Expressions.call(expression, "getString", fieldName);
           } else if (FixedBytes.IDENTIFIER.equals(identifier)
               || VariableBytes.IDENTIFIER.equals(identifier)) {
-            value = Expressions.call(expression, "getBytes", fieldName);
+            return Expressions.call(expression, "getBytes", fieldName);
           } else if (TimeWithLocalTzType.IDENTIFIER.equals(identifier)) {
-            value = Expressions.call(expression, "getDateTime", fieldName);
+            return Expressions.call(expression, "getDateTime", fieldName);
           } else if (SqlTypes.DATE.getIdentifier().equals(identifier)) {
-            value =
-                Expressions.convert_(
-                    Expressions.call(
-                        expression,
-                        "getLogicalTypeValue",
-                        fieldName,
-                        Expressions.constant(LocalDate.class)),
-                    LocalDate.class);
+            return Expressions.convert_(
+                Expressions.call(
+                    expression,
+                    "getLogicalTypeValue",
+                    fieldName,
+                    Expressions.constant(LocalDate.class)),
+                LocalDate.class);
           } else if (SqlTypes.TIME.getIdentifier().equals(identifier)) {
-            value =
-                Expressions.convert_(
-                    Expressions.call(
-                        expression,
-                        "getLogicalTypeValue",
-                        fieldName,
-                        Expressions.constant(LocalTime.class)),
-                    LocalTime.class);
+            return Expressions.convert_(
+                Expressions.call(
+                    expression,
+                    "getLogicalTypeValue",
+                    fieldName,
+                    Expressions.constant(LocalTime.class)),
+                LocalTime.class);
           } else if (SqlTypes.DATETIME.getIdentifier().equals(identifier)) {
-            value =
-                Expressions.convert_(
-                    Expressions.call(
-                        expression,
-                        "getLogicalTypeValue",
-                        fieldName,
-                        Expressions.constant(LocalDateTime.class)),
-                    LocalDateTime.class);
+            return Expressions.convert_(
+                Expressions.call(
+                    expression,
+                    "getLogicalTypeValue",
+                    fieldName,
+                    Expressions.constant(LocalDateTime.class)),
+                LocalDateTime.class);
           } else if (FixedPrecisionNumeric.IDENTIFIER.equals(identifier)) {
-            value = Expressions.call(expression, "getDecimal", fieldName);
+            return Expressions.call(expression, "getDecimal", fieldName);
+          } else if (logicalType instanceof PassThroughLogicalType) {
+            return getBeamField(list, expression, fieldName, logicalType.getBaseType());
           } else {
             throw new UnsupportedOperationException("Unable to get logical type " + identifier);
           }
-          break;
         default:
           throw new UnsupportedOperationException("Unable to get " + fieldType.getTypeName());
       }
-
-      return toCalciteValue(value, fieldType);
     }
 
     // Value conversion: Beam => Calcite
-    private static Expression toCalciteValue(Expression value, FieldType fieldType) {
+    private static Expression toCalciteValue(
+        Expression value, FieldType fieldType, boolean useByteString) {
       switch (fieldType.getTypeName()) {
         case BYTE:
           return Expressions.convert_(value, Byte.class);
@@ -642,7 +632,10 @@ public class BeamCalcRel extends AbstractBeamCalcRel {
               Expressions.call(Expressions.convert_(value, AbstractInstant.class), "getMillis"));
         case BYTES:
           return nullOr(
-              value, Expressions.new_(ByteString.class, Expressions.convert_(value, byte[].class)));
+              value,
+              useByteString
+                  ? Expressions.new_(ByteString.class, Expressions.convert_(value, byte[].class))
+                  : Expressions.convert_(value, byte[].class));
         case ARRAY:
         case ITERABLE:
           return nullOr(value, toCalciteList(value, fieldType.getCollectionElementType()));
@@ -651,7 +644,8 @@ public class BeamCalcRel extends AbstractBeamCalcRel {
         case ROW:
           return nullOr(value, toCalciteRow(value, fieldType.getRowSchema()));
         case LOGICAL_TYPE:
-          String identifier = fieldType.getLogicalType().getIdentifier();
+          LogicalType logicalType = fieldType.getLogicalType();
+          String identifier = logicalType.getIdentifier();
           if (FixedString.IDENTIFIER.equals(identifier)
               || VariableString.IDENTIFIER.equals(identifier)) {
             return Expressions.convert_(value, String.class);
@@ -692,6 +686,8 @@ public class BeamCalcRel extends AbstractBeamCalcRel {
             return nullOr(value, returnValue);
           } else if (FixedPrecisionNumeric.IDENTIFIER.equals(identifier)) {
             return Expressions.convert_(value, BigDecimal.class);
+          } else if (logicalType instanceof PassThroughLogicalType) {
+            return toCalciteValue(value, logicalType.getBaseType(), useByteString);
           } else {
             throw new UnsupportedOperationException("Unable to convert logical type " + identifier);
           }
@@ -704,7 +700,7 @@ public class BeamCalcRel extends AbstractBeamCalcRel {
       ParameterExpression value = Expressions.parameter(Object.class);
 
       BlockBuilder block = new BlockBuilder();
-      block.add(toCalciteValue(value, elementType));
+      block.add(toCalciteValue(value, elementType, false));
 
       return Expressions.new_(
           WrappedList.class,
@@ -722,7 +718,7 @@ public class BeamCalcRel extends AbstractBeamCalcRel {
       ParameterExpression value = Expressions.parameter(Object.class);
 
       BlockBuilder block = new BlockBuilder();
-      block.add(toCalciteValue(value, mapValueType));
+      block.add(toCalciteValue(value, mapValueType, false));
 
       return Expressions.new_(
           WrappedMap.class,
@@ -745,7 +741,8 @@ public class BeamCalcRel extends AbstractBeamCalcRel {
 
       for (int i = 0; i < schema.getFieldCount(); i++) {
         BlockBuilder list = new BlockBuilder(/* optimizing= */ false, body);
-        Expression returnValue = getBeamField(list, i, row, schema);
+        // instruct conversion of BYTES to byte[], required by BeamJavaTypeFactory
+        Expression returnValue = getBeamField(list, i, row, schema, false);
 
         list.append(returnValue);
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
@@ -315,6 +315,12 @@ public class CalciteUtils {
         Schema schema = fieldType.getRowSchema();
         Preconditions.checkArgumentNotNull(schema);
         return toCalciteRowType(schema, dataTypeFactory);
+      case LOGICAL_TYPE:
+        Schema.LogicalType<?, ?> logicalType = fieldType.getLogicalType();
+        if (logicalType instanceof PassThroughLogicalType) {
+          return toRelDataType(dataTypeFactory, logicalType.getBaseType());
+        }
+        return dataTypeFactory.createSqlType(toSqlTypeName(fieldType));
       default:
         return dataTypeFactory.createSqlType(toSqlTypeName(fieldType));
     }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
@@ -22,6 +22,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Date;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.IntStream;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
@@ -169,6 +170,12 @@ public class CalciteUtils {
           FieldType.DATETIME, SqlTypeName.TIMESTAMP,
           FieldType.STRING, SqlTypeName.VARCHAR);
 
+  // Associating FieldType to generated RelDataType objects for Beam logical types. Used for
+  // recovering the original type in output schema after full Beam FieldType->Calcite Type->Beam
+  // FieldType trip
+  private static final Map<RelDataType, FieldType> LOGICAL_TYPE_REL_DATA_MAPPING =
+      new ConcurrentHashMap<>();
+
   /** Generate {@link Schema} from {@code RelDataType} which is used to create table. */
   public static Schema toSchema(RelDataType tableInfo) {
     return tableInfo.getFieldList().stream().map(CalciteUtils::toField).collect(Schema.toSchema());
@@ -254,6 +261,9 @@ public class CalciteUtils {
   }
 
   public static FieldType toFieldType(RelDataType calciteType) {
+    if (LOGICAL_TYPE_REL_DATA_MAPPING.containsKey(calciteType)) {
+      return LOGICAL_TYPE_REL_DATA_MAPPING.get(calciteType);
+    }
     switch (calciteType.getSqlTypeName()) {
       case ARRAY:
       case MULTISET:
@@ -317,10 +327,27 @@ public class CalciteUtils {
         return toCalciteRowType(schema, dataTypeFactory);
       case LOGICAL_TYPE:
         Schema.LogicalType<?, ?> logicalType = fieldType.getLogicalType();
+        RelDataType relDataType;
         if (logicalType instanceof PassThroughLogicalType) {
-          return toRelDataType(dataTypeFactory, logicalType.getBaseType());
+          relDataType =
+              toRelDataType(
+                  dataTypeFactory, logicalType.getBaseType().withNullable(fieldType.getNullable()));
+        } else {
+          relDataType = dataTypeFactory.createSqlType(toSqlTypeName(fieldType));
         }
-        return dataTypeFactory.createSqlType(toSqlTypeName(fieldType));
+        // For backward-compatibility, exclude logical types registered in
+        // CALCITE_TO_BEAM_TYPE_MAPPING,
+        // e.g., primitive types, date time types, etc.
+        SqlTypeName typeName = relDataType.getSqlTypeName();
+        if (typeName != null && !CALCITE_TO_BEAM_TYPE_MAPPING.containsKey(typeName)) {
+          // register both nullable and non-nullable variants.
+          boolean flipNullable = !relDataType.isNullable();
+          LOGICAL_TYPE_REL_DATA_MAPPING.put(relDataType, fieldType);
+          LOGICAL_TYPE_REL_DATA_MAPPING.put(
+              dataTypeFactory.createTypeWithNullability(relDataType, flipNullable),
+              fieldType.withNullable(flipNullable));
+        }
+        return relDataType;
       default:
         return dataTypeFactory.createSqlType(toSqlTypeName(fieldType));
     }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamComplexTypeTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamComplexTypeTest.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.sdk.extensions.sql;
 
+import static org.junit.Assert.assertEquals;
+
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -792,6 +794,7 @@ public class BeamComplexTypeTest {
             .apply(SqlTransform.query("select * from PCOLLECTION"));
 
     PAssert.that(outputRow).containsInAnyOrder(inputRow);
+    assertEquals(inputRow.getSchema(), outputRow.getSchema());
     pipeline.run().waitUntilFinish(Duration.standardMinutes(1));
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamComplexTypeTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamComplexTypeTest.java
@@ -300,7 +300,6 @@ public class BeamComplexTypeTest {
     pipeline.run().waitUntilFinish(Duration.standardMinutes(2));
   }
 
-  @Ignore("https://github.com/apache/beam/issues/21024")
   @Test
   public void testNestedBytes() {
     byte[] bytes = new byte[] {-70, -83, -54, -2};
@@ -325,7 +324,6 @@ public class BeamComplexTypeTest {
     pipeline.run();
   }
 
-  @Ignore("https://github.com/apache/beam/issues/21024")
   @Test
   public void testNestedArrayOfBytes() {
     byte[] bytes = new byte[] {-70, -83, -54, -2};
@@ -771,6 +769,29 @@ public class BeamComplexTypeTest {
             .addValues("str", null, null)
             .build();
     PAssert.that(outputRow).containsInAnyOrder(expectedRow);
+    pipeline.run().waitUntilFinish(Duration.standardMinutes(1));
+  }
+
+  @Test
+  public void testUnknownLogicalType() {
+    Schema.FieldType rowType = Schema.FieldType.row(innerRowSchema);
+
+    Schema.LogicalType<Row, Row> logicalType =
+        new org.apache.beam.sdk.schemas.logicaltypes.UnknownLogicalType<Row>(
+            "RowBackedLogicalType", new byte[] {}, Schema.FieldType.STRING, "", rowType);
+
+    Schema inputSchema = Schema.builder().addLogicalTypeField("logical_field", logicalType).build();
+
+    Row nestedRow = Row.withSchema(innerRowSchema).addValue("abc").addValue(42L).build();
+    Row inputRow = Row.withSchema(inputSchema).addValue(nestedRow).build();
+
+    PCollection<Row> outputRow =
+        pipeline
+            .apply(Create.of(inputRow))
+            .setRowSchema(inputSchema)
+            .apply(SqlTransform.query("select * from PCOLLECTION"));
+
+    PAssert.that(outputRow).containsInAnyOrder(inputRow);
     pipeline.run().waitUntilFinish(Duration.standardMinutes(1));
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtilsTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtilsTest.java
@@ -178,4 +178,23 @@ public class CalciteUtilsTest {
     thrown.expectMessage("Cannot find a matching Beam FieldType for Calcite type: UNKNOWN");
     CalciteUtils.toFieldType(relDataType);
   }
+
+  @Test
+  public void testToRelDataTypeWithRowBackedLogicalType() {
+    Schema nestedSchema = Schema.builder().addField("nested_f1", Schema.FieldType.INT32).build();
+    Schema.FieldType rowType = Schema.FieldType.row(nestedSchema);
+
+    Schema.LogicalType<org.apache.beam.sdk.values.Row, org.apache.beam.sdk.values.Row> logicalType =
+        new org.apache.beam.sdk.schemas.logicaltypes.PassThroughLogicalType<
+            org.apache.beam.sdk.values.Row>(
+            "RowBackedLogicalType", Schema.FieldType.STRING, "", rowType) {};
+
+    Schema.FieldType logicalFieldType = Schema.FieldType.logicalType(logicalType);
+
+    RelDataType relDataType = CalciteUtils.toRelDataType(dataTypeFactory, logicalFieldType);
+
+    assertEquals(SqlTypeName.ROW, relDataType.getSqlTypeName());
+    assertEquals(1, relDataType.getFieldCount());
+    assertEquals("nested_f1", relDataType.getFieldList().get(0).getName());
+  }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtilsTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtilsTest.java
@@ -24,6 +24,8 @@ import static org.junit.Assert.assertTrue;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.logicaltypes.PassThroughLogicalType;
+import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.calcite.v1_40_0.org.apache.calcite.rel.type.RelDataType;
 import org.apache.beam.vendor.calcite.v1_40_0.org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.beam.vendor.calcite.v1_40_0.org.apache.calcite.rel.type.RelDataTypeSystem;
@@ -184,9 +186,8 @@ public class CalciteUtilsTest {
     Schema nestedSchema = Schema.builder().addField("nested_f1", Schema.FieldType.INT32).build();
     Schema.FieldType rowType = Schema.FieldType.row(nestedSchema);
 
-    Schema.LogicalType<org.apache.beam.sdk.values.Row, org.apache.beam.sdk.values.Row> logicalType =
-        new org.apache.beam.sdk.schemas.logicaltypes.PassThroughLogicalType<
-            org.apache.beam.sdk.values.Row>(
+    Schema.LogicalType<Row, Row> logicalType =
+        new PassThroughLogicalType<Row>(
             "RowBackedLogicalType", Schema.FieldType.STRING, "", rowType) {};
 
     Schema.FieldType logicalFieldType = Schema.FieldType.logicalType(logicalType);

--- a/sdks/python/apache_beam/coders/coder_impl.pxd
+++ b/sdks/python/apache_beam/coders/coder_impl.pxd
@@ -117,6 +117,10 @@ cdef class BigEndianShortCoderImpl(StreamCoderImpl):
   pass
 
 
+cdef class ByteCoderImpl(StreamCoderImpl):
+  pass
+
+
 cdef class SinglePrecisionFloatCoderImpl(StreamCoderImpl):
   pass
 

--- a/sdks/python/apache_beam/coders/coder_impl.py
+++ b/sdks/python/apache_beam/coders/coder_impl.py
@@ -841,7 +841,7 @@ class BigEndianShortCoderImpl(StreamCoderImpl):
     out.write_bigendian_int16(value)
 
   def decode_from_stream(self, in_stream, nested):
-    # type: (create_InputStream, bool) -> float
+    # type: (create_InputStream, bool) -> int
     return in_stream.read_bigendian_int16()
 
   def estimate_size(self, unused_value, nested=False):
@@ -857,12 +857,12 @@ class ByteCoderImpl(StreamCoderImpl):
     out.write_byte(value)
 
   def decode_from_stream(self, in_stream, nested):
-    # type: (create_InputStream, bool) -> float
+    # type: (create_InputStream, bool) -> int
     return in_stream.read_byte()
 
   def estimate_size(self, unused_value, nested=False):
     # type: (Any, bool) -> int
-    # A short is encoded as 2 bytes, regardless of nesting.
+    # A byte is encoded as 1 byte, regardless of nesting.
     return 1
 
 

--- a/sdks/python/apache_beam/coders/coder_impl.py
+++ b/sdks/python/apache_beam/coders/coder_impl.py
@@ -850,6 +850,22 @@ class BigEndianShortCoderImpl(StreamCoderImpl):
     return 2
 
 
+class ByteCoderImpl(StreamCoderImpl):
+  """For internal use only; no backwards-compatibility guarantees."""
+  def encode_to_stream(self, value, out, nested):
+    # type: (int, create_OutputStream, bool) -> None
+    out.write_byte(value)
+
+  def decode_from_stream(self, in_stream, nested):
+    # type: (create_InputStream, bool) -> float
+    return in_stream.read_byte()
+
+  def estimate_size(self, unused_value, nested=False):
+    # type: (Any, bool) -> int
+    # A short is encoded as 2 bytes, regardless of nesting.
+    return 1
+
+
 class SinglePrecisionFloatCoderImpl(StreamCoderImpl):
   """For internal use only; no backwards-compatibility guarantees."""
   def encode_to_stream(self, value, out, nested):

--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -91,6 +91,7 @@ __all__ = [
     'Coder',
     'AvroGenericCoder',
     'BooleanCoder',
+    'ByteCoder',
     'BytesCoder',
     'CloudpickleCoder',
     'DillCoder',
@@ -683,6 +684,25 @@ class BigEndianShortCoder(FastCoder):
   """A coder used for big-endian int16 values."""
   def _create_impl(self):
     return coder_impl.BigEndianShortCoderImpl()
+
+  def is_deterministic(self):
+    # type: () -> bool
+    return True
+
+  def to_type_hint(self):
+    return int
+
+  def __eq__(self, other):
+    return type(self) == type(other)
+
+  def __hash__(self):
+    return hash(type(self))
+
+
+class ByteCoder(FastCoder):
+  """A coder used for single byte values"""
+  def _create_impl(self):
+    return coder_impl.ByteCoderImpl()
 
   def is_deterministic(self):
     # type: () -> bool

--- a/sdks/python/apache_beam/coders/coders_test_common.py
+++ b/sdks/python/apache_beam/coders/coders_test_common.py
@@ -191,6 +191,7 @@ class CodersTest(unittest.TestCase):
         coders.ProtoCoder,
         coders.ProtoPlusCoder,
         coders.BigEndianShortCoder,
+        coders.ByteCoder,
         coders.SinglePrecisionFloatCoder,
         coders.ToBytesCoder,
         coders.BigIntegerCoder,  # tested in DecimalCoder
@@ -1071,6 +1072,16 @@ class CodersTest(unittest.TestCase):
 
     self.check_coder(test_coder, *test_values)
 
+    for idx, value in enumerate(test_values):
+      self.assertEqual(
+          test_encodings[idx],
+          base64.b64encode(test_coder.encode(value)).decode().rstrip("="))
+
+  def test_byte_coder(self):
+    test_coder = coders.ByteCoder()
+    test_values = [0, 80, 127, 128, 255]
+    test_encodings = ("AA", "UA", "fw", "gA", "/w")
+    self.check_coder(test_coder, *test_values)
     for idx, value in enumerate(test_values):
       self.assertEqual(
           test_encodings[idx],

--- a/sdks/python/apache_beam/coders/row_coder.py
+++ b/sdks/python/apache_beam/coders/row_coder.py
@@ -22,6 +22,7 @@ from apache_beam.coders.coder_impl import LogicalTypeCoderImpl
 from apache_beam.coders.coder_impl import RowCoderImpl
 from apache_beam.coders.coders import BigEndianShortCoder
 from apache_beam.coders.coders import BooleanCoder
+from apache_beam.coders.coders import ByteCoder
 from apache_beam.coders.coders import BytesCoder
 from apache_beam.coders.coders import Coder
 from apache_beam.coders.coders import DecimalCoder
@@ -147,8 +148,10 @@ def _nonnull_coder_from_type(field_type):
       return VarIntCoder()
     elif field_type.atomic_type == schema_pb2.INT32:
       return VarInt32Coder()
-    if field_type.atomic_type == schema_pb2.INT16:
+    elif field_type.atomic_type == schema_pb2.INT16:
       return BigEndianShortCoder()
+    elif field_type.atomic_type == schema_pb2.BYTE:
+      return ByteCoder()
     elif field_type.atomic_type == schema_pb2.FLOAT:
       return SinglePrecisionFloatCoder()
     elif field_type.atomic_type == schema_pb2.DOUBLE:

--- a/sdks/python/apache_beam/transforms/sql_test.py
+++ b/sdks/python/apache_beam/transforms/sql_test.py
@@ -45,6 +45,19 @@ Shopper = typing.NamedTuple(
 coders.registry.register_coder(Shopper, coders.RowCoder)
 
 
+class Aribitrary:
+  def __init__(self, obj):
+    self.obj = obj
+
+  def __eq__(self, other):
+    return self.obj == other.obj
+
+
+UserTypeRow = typing.NamedTuple(
+    "UserTypeRow", [("id", int), ("arb", Aribitrary), ("complex", complex)])
+coders.registry.register_coder(UserTypeRow, coders.RowCoder)
+
+
 @pytest.mark.xlang_sql_expansion_service
 @unittest.skipIf(
     TestPipeline().get_pipeline_options().view_as(StandardOptions).runner
@@ -148,6 +161,34 @@ class SqlTransformTest(unittest.TestCase):
           | beam.Map(lambda x: beam.Row(a=x, b=str(x)))
           | SqlTransform("SELECT a*a as s, LENGTH(b) AS c FROM PCOLLECTION"))
       assert_that(out, equal_to([(1, 1), (4, 1), (100, 2)]))
+
+  @staticmethod
+  def recover_to_python_type(input):
+    fields = []
+    for field in input:
+      print(field)
+      if hasattr(field, 'type_byte') and hasattr(field, 'payload'):
+        obj = coders.FastPrimitivesCoder().decode(
+            field.type_byte.to_bytes() + field.payload)
+        fields.append(obj)
+      else:
+        fields.append(field)
+    return tuple(fields)
+
+  def test_row_user_type(self):
+    with TestPipeline() as p:
+      out = (
+          p | beam.Create([
+              UserTypeRow(1, Aribitrary(1.0), 1 + 2.5j),
+              UserTypeRow(1, Aribitrary("abc"), -1j),
+          ])
+          | SqlTransform("SELECT arb, complex FROM PCOLLECTION")
+          # TODO: recover to user type. Currently pipeline can run,
+          # but elements returned back to Python are generated rows
+          | beam.Map(self.recover_to_python_type))
+      assert_that(
+          out,
+          equal_to([(Aribitrary(1.0), 1 + 2.5j), (Aribitrary("abc"), -1j)]))
 
   def test_windowing_before_sql(self):
     with TestPipeline() as p:

--- a/sdks/python/apache_beam/transforms/sql_test.py
+++ b/sdks/python/apache_beam/transforms/sql_test.py
@@ -162,19 +162,6 @@ class SqlTransformTest(unittest.TestCase):
           | SqlTransform("SELECT a*a as s, LENGTH(b) AS c FROM PCOLLECTION"))
       assert_that(out, equal_to([(1, 1), (4, 1), (100, 2)]))
 
-  @staticmethod
-  def recover_to_python_type(input):
-    fields = []
-    for field in input:
-      print(field)
-      if hasattr(field, 'type_byte') and hasattr(field, 'payload'):
-        obj = coders.FastPrimitivesCoder().decode(
-            field.type_byte.to_bytes() + field.payload)
-        fields.append(obj)
-      else:
-        fields.append(field)
-    return tuple(fields)
-
   def test_row_user_type(self):
     with TestPipeline() as p:
       out = (
@@ -183,9 +170,7 @@ class SqlTransformTest(unittest.TestCase):
               UserTypeRow(1, Aribitrary("abc"), -1j),
           ])
           | SqlTransform("SELECT arb, complex FROM PCOLLECTION")
-          # TODO: recover to user type. Currently pipeline can run,
-          # but elements returned back to Python are generated rows
-          | beam.Map(self.recover_to_python_type))
+          | beam.Map(tuple))
       assert_that(
           out,
           equal_to([(Aribitrary(1.0), 1 + 2.5j), (Aribitrary("abc"), -1j)]))

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -106,6 +106,7 @@ from apache_beam.utils.python_callable import PythonCallableWithSource
 from apache_beam.utils.timestamp import Timestamp
 
 PYTHON_ANY_URN = "beam:logical:pythonsdk_any:v1"
+_SCHEMA_OPTION_STATIC_ENCODING = "beam:option:row:static_encoding"
 
 # Bi-directional mappings
 _PRIMITIVES = (
@@ -255,6 +256,36 @@ def schema_field(
       description=description)
 
 
+def _python_any_schema_pb2():
+  return schema_pb2.FieldType(
+      logical_type=schema_pb2.LogicalType(
+          urn=PYTHON_ANY_URN,
+          representation=schema_pb2.FieldType(
+              nullable=False,
+              row_type=schema_pb2.RowType(
+                  schema=schema_pb2.Schema(
+                      fields=[
+                          schema_pb2.Field(
+                              name="type_byte",
+                              type=schema_pb2.FieldType(
+                                  atomic_type=schema_pb2.BYTE, nullable=False)),
+                          schema_pb2.Field(
+                              name="payload",
+                              type=schema_pb2.FieldType(
+                                  atomic_type=schema_pb2.BYTES, nullable=False))
+                      ],
+                      options=[
+                          schema_pb2.Option(
+                              name=_SCHEMA_OPTION_STATIC_ENCODING,
+                              type=schema_pb2.FieldType(
+                                  atomic_type=schema_pb2.BOOLEAN),
+                              value=schema_pb2.FieldValue(
+                                  atomic_value=schema_pb2.AtomicTypeValue(
+                                      boolean=True)))
+                      ])))),
+      nullable=True)
+
+
 class SchemaTranslation(object):
   def __init__(self, schema_registry: SchemaTypeRegistry = SCHEMA_REGISTRY):
     self.schema_registry = schema_registry
@@ -361,9 +392,7 @@ class SchemaTranslation(object):
         logical_type = LogicalType.from_typing(type_)
     except ValueError:
       # Unknown type, just treat it like Any
-      return schema_pb2.FieldType(
-          logical_type=schema_pb2.LogicalType(urn=PYTHON_ANY_URN),
-          nullable=True)
+      return _python_any_schema_pb2()
     else:
       argument_type = None
       argument = None

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -106,6 +106,8 @@ from apache_beam.utils.python_callable import PythonCallableWithSource
 from apache_beam.utils.timestamp import Timestamp
 
 PYTHON_ANY_URN = "beam:logical:pythonsdk_any:v1"
+_PYTHON_ANY_FIELD_TYPE_BYTE = "_pythonsdk_any_type_byte"
+_PYTHON_ANY_FIELD_PAYLOAD = "payload"
 _SCHEMA_OPTION_STATIC_ENCODING = "beam:option:row:static_encoding"
 
 # Bi-directional mappings
@@ -257,6 +259,7 @@ def schema_field(
 
 
 def _python_any_schema_pb2():
+  # A portable schema matches FastPrimitivesCoder encoded values
   return schema_pb2.FieldType(
       logical_type=schema_pb2.LogicalType(
           urn=PYTHON_ANY_URN,
@@ -266,11 +269,11 @@ def _python_any_schema_pb2():
                   schema=schema_pb2.Schema(
                       fields=[
                           schema_pb2.Field(
-                              name="type_byte",
+                              name=_PYTHON_ANY_FIELD_TYPE_BYTE,
                               type=schema_pb2.FieldType(
                                   atomic_type=schema_pb2.BYTE, nullable=False)),
                           schema_pb2.Field(
-                              name="payload",
+                              name=_PYTHON_ANY_FIELD_PAYLOAD,
                               type=schema_pb2.FieldType(
                                   atomic_type=schema_pb2.BYTES, nullable=False))
                       ],

--- a/sdks/python/apache_beam/typehints/schemas_test.py
+++ b/sdks/python/apache_beam/typehints/schemas_test.py
@@ -43,6 +43,7 @@ from apache_beam.internal.cloudpickle import cloudpickle
 from apache_beam.portability import common_urns
 from apache_beam.portability.api import schema_pb2
 from apache_beam.typehints import row_type
+from apache_beam.typehints import schemas
 from apache_beam.typehints import typehints
 from apache_beam.typehints.native_type_compatibility import match_is_named_tuple
 from apache_beam.typehints.schemas import SchemaTypeRegistry
@@ -583,11 +584,7 @@ class SchemaTest(unittest.TestCase):
 
   def test_unknown_primitive_maps_to_any(self):
     self.assertEqual(
-        typing_to_runner_api(np.uint32),
-        schema_pb2.FieldType(
-            logical_type=schema_pb2.LogicalType(
-                urn="beam:logical:pythonsdk_any:v1"),
-            nullable=True))
+        typing_to_runner_api(np.uint32), schemas._python_any_schema_pb2())
 
   def test_unknown_atomic_raise_valueerror(self):
     self.assertRaises(

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -171,7 +171,7 @@ milvus_dependency = ['pymilvus>=2.5.10,<3.0.0']
 # ml_test is pinned to versions that require protobuf<5 on Python 3.10. Those
 # cannot be installed together, so ADK deps stay out of ml_test (use ml_base).
 ml_base_core = [
-    'embeddings>=0.0.4', # 0.0.3 crashes setuptools
+    'embeddings>=0.0.4',  # 0.0.3 crashes setuptools
     'onnxruntime',
     # onnx 1.12–1.13 cap protobuf in ways that trigger huge backtracking with
     # Beam[gcp]+ml_test; pip can fall back to onnx 1.11 sdist which needs cmake.
@@ -303,8 +303,7 @@ def generate_external_transform_wrappers():
   except subprocess.CalledProcessError as err:
     raise RuntimeError(
         'Could not generate external transform wrappers due to '
-        'error: %s',
-        err.stderr)
+        'error: {}'.format(err.stderr))
 
 
 def get_portability_package_data():


### PR DESCRIPTION
Currently Python SDK's Row can have arbitrary type and work within Python SDK, but not language boundary. There are many missing connections to make it work from Python->Java/Beam SQL->Python end-to-end.

After this change, Beam Row with Python user type (backed by FastPrimitiveCoder and with pythonsdk_any logical type urn) can now be recognized decoded by Java, pass through Beam SQL and encode/decode back in Python and recovers the original user type.

* Complete pythonsdk_any logical type representation def. Otherwise Java side SchemaTranslation for this logical type would fail

* Handle PassthroughLogicalType in Beam SQL. This includes
  * Allow Beam SQL treat PassthroughLogicalType as its base type
  * Make Beam Logical Type->Calcite Type reverse conversion restoring the original logical type

* Fix nested bytes in Beam SQL

* Introduce a schema option for compact encoding for static non-null schema

* Support BYTE atomic type in Python

**Please** add a meaningful description for your change here

~However due to Beam Row->Calcite Row->Beam Row mapping losing the originally logical type schema, the output Row becomes a Row instead of language type (this limitation is related to #24019). At least the pipeline expansion no longer fail for xlang pipeline involving Any typehints~ (fixed by the second commit)

Fix #21024; fix #20738

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
