### PR TITLE
Bump log4j version to 2.25.4 

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -628,7 +628,7 @@ class BeamModulePlugin implements Plugin<Project> {
     def jsr305_version = "3.0.2"
     def everit_json_version = "1.14.2"
     def kafka_version = "2.4.1"
-    def log4j2_version = "2.25.3"
+    def log4j2_version = "2.25.4"
     def nemo_version = "0.1"
     // [bomupgrader] determined by: io.grpc:grpc-netty, consistent with: google_cloud_platform_libraries_bom
     def netty_version = "4.1.124.Final"

--- a/sdks/java/io/expansion-service/build.gradle
+++ b/sdks/java/io/expansion-service/build.gradle
@@ -91,6 +91,12 @@ dependencies {
 
   runtimeOnly library.java.kafka_clients
   runtimeOnly library.java.slf4j_jdk14
+
+  // Force log4j-core version in shadow jar to fix CVE-2026-34477 in the shaded jar
+  // `org.apache.beam:beam-sdks-java-io-expansion-service`
+  // Currently, it has a transitive dependency of `org.apache.iceberg:iceberg-aws-bundle:1.10.0`,
+  // which includes a vulnerable log4j-core (2.20.0).
+  runtimeOnly library.java.log4j2_core
 }
 
 task runExpansionService (type: JavaExec) {


### PR DESCRIPTION
This is to fix CVE-2026-34477.

The `beam-sdks-java-io-expansion-service` shaded JAR was found to contain a vulnerable version of log4j-core (2.20.0), introduced transitively via `org.apache.iceberg:iceberg-aws-bundle:1.10.0`.

To resolve this, the change:
1. Updates the global log4j version to 2.25.4.
2. Enforces the inclusion of the patched log4j-core in the expansion service's shaded JAR to override the version bundled in `iceberg-aws-bundle`.

Internal bug id: 502837070