### PR TITLE
sdks/python: fix 'occured' -> 'occurred' in data_sampler.py comments

### DIFF
--- a/sdks/python/apache_beam/runners/worker/data_sampler.py
+++ b/sdks/python/apache_beam/runners/worker/data_sampler.py
@@ -81,10 +81,10 @@ class ExceptionMetadata:
   # The repr-ified Exception.
   msg: str
 
-  # The transform where the exception occured.
+  # The transform where the exception occurred.
   transform_id: str
 
-  # The instruction when the exception occured.
+  # The instruction when the exception occurred.
   instruction_id: str
 
 


### PR DESCRIPTION
Two comments in `sdks/python/apache_beam/runners/worker/data_sampler.py` (lines 84, 87) read `exception occured`. Fixed to `occurred`. Comment-only change.

---

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Addresses an existing issue: N/A (typo fix)
 - [ ] Includes tests
 - [x] Documentation update: N/A