### PR TITLE
[post 2.72.0] apt-get upgrade in container images to install security fixes. (#37841)

### DIFF
--- a/sdks/python/container/Dockerfile
+++ b/sdks/python/container/Dockerfile
@@ -34,6 +34,7 @@ ARG py_version
 RUN  \
     # Install native bindings required for dependencies.
     apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y \
        # Required by python-snappy
        libsnappy-dev \


### PR DESCRIPTION
Cherry-pick #37841 into 2.72.0 post-release branch.

This is to reduce the number of CVEs of the Python SDK container base images.