### PR TITLE
Fix 'occured' -> 'occurred' typos across Python, Go, and Java SDKs

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/engine/teststream.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/teststream.go
@@ -230,7 +230,7 @@ func (ev tsWatermarkEvent) Execute(em *ElementManager) {
 		ss.updateUpstreamWatermark(ss.inputID, t.watermark)
 		em.changedStages.insert(sID)
 	}
-	// Clear the default hold after the inserts have occured.
+	// Clear the default hold after the inserts have occurred.
 	em.testStreamHandler.UpdateHold(em, t.watermark)
 }
 

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/sources/generator/Generator.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/sources/generator/Generator.java
@@ -56,7 +56,7 @@ public class Generator implements Iterator<TimestampedValue<Event>>, Serializabl
     /** When, in wallclock time, should this event be emitted? */
     public final long wallclockTimestamp;
 
-    /** When, in event time, should this event be considered to have occured? */
+    /** When, in event time, should this event be considered to have occurred? */
     public final long eventTimestamp;
 
     /** The event itself. */

--- a/sdks/python/apache_beam/runners/worker/data_sampler.py
+++ b/sdks/python/apache_beam/runners/worker/data_sampler.py
@@ -81,10 +81,10 @@ class ExceptionMetadata:
   # The repr-ified Exception.
   msg: str
 
-  # The transform where the exception occured.
+  # The transform where the exception occurred.
   transform_id: str
 
-  # The instruction when the exception occured.
+  # The instruction when the exception occurred.
   instruction_id: str
 
 


### PR DESCRIPTION
Trivial spelling fix in three source files.

- `sdks/python/apache_beam/runners/worker/data_sampler.py` — 2 occurrences on dataclass field comments (`transform_id`, `instruction_id`).
- `sdks/go/pkg/beam/runners/prism/internal/engine/teststream.go` — internal code comment.
- `sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/sources/generator/Generator.java` — Javadoc on the `eventTimestamp` field.

No functional changes.