### PR TITLE
Update hbase version to fix netty CVEs.

### DIFF
--- a/sdks/java/io/hbase/build.gradle
+++ b/sdks/java/io/hbase/build.gradle
@@ -34,7 +34,7 @@ test {
   jvmArgs "-Dtest.build.data.basedirectory=build/test-data"
 }
 
-def hbase_version = "2.6.3-hadoop3"
+def hbase_version = "2.6.5-hadoop3"
 
 dependencies {
   implementation library.java.vendored_guava_32_1_2_jre

--- a/sdks/java/io/hbase/src/test/java/org/apache/beam/sdk/io/hbase/HBaseIOTest.java
+++ b/sdks/java/io/hbase/src/test/java/org/apache/beam/sdk/io/hbase/HBaseIOTest.java
@@ -436,7 +436,7 @@ public class HBaseIOTest {
 
     thrown.expect(Pipeline.PipelineExecutionException.class);
     thrown.expectCause(Matchers.instanceOf(IllegalArgumentException.class));
-    thrown.expectMessage("No columns to insert");
+    thrown.expectMessage("No columns to put");
     p.run().waitUntilFinish();
   }
 

--- a/sdks/java/io/iceberg/hive/build.gradle
+++ b/sdks/java/io/iceberg/hive/build.gradle
@@ -26,7 +26,7 @@ description = "Apache Beam :: SDKs :: Java :: IO :: Iceberg :: Hive"
 ext.summary = "Runtime dependencies needed for Hive catalog integration."
 
 def hive_version = "3.1.3"
-def hbase_version = "2.6.3-hadoop3"
+def hbase_version = "2.6.5-hadoop3"
 def hadoop_version = "3.4.1"
 def iceberg_version = "1.6.1"
 def avatica_version = "1.25.0"


### PR DESCRIPTION
Fix a long-standing netty related CVE caused by old version of modules:
- org.apache.hbase.thirdparty:hbase-shaded-netty:4.1.11
- org.apache.hbase:hbase-client:2.6.3-hadoop3

Internal bug: 470988049