### PR TITLE
Fix: Correct portability_worker_id for child process logs in Python SDK harness

### DIFF
--- a/sdks/python/container/boot.go
+++ b/sdks/python/container/boot.go
@@ -318,7 +318,7 @@ for _, workerId := range workerIds {
     go func(workerId string) {
         defer wg.Done()
 
-        workerCtx := grpcx.WriteWorkerID(ctx, workerId)
+        workerCtx := grpcx.WriteWorkerID(context.Background(), workerId)
 
         // Create a separate logger per worker so that each worker initializes
         // its own Fn logging stream with the correct worker_id metadata.
@@ -328,7 +328,7 @@ for _, workerId := range workerIds {
             Endpoint: *loggingEndpoint,
         }
 
-       bufLogger := tools.NewBufferedLogger(workerLogger)
+       bufLogger := tools.NewBufferedLoggerWithFlushInterval(workerCtx, workerLogger, 100*time.Millisecond)
 
         errorCount := 0
         for {

--- a/sdks/python/container/boot.go
+++ b/sdks/python/container/boot.go
@@ -328,11 +328,7 @@ for _, workerId := range workerIds {
             Endpoint: *loggingEndpoint,
         }
 
-        bufLogger := tools.NewBufferedLoggerWithFlushInterval(
-            workerCtx,
-            workerLogger,
-            100*time.Millisecond,
-        )
+       bufLogger := tools.NewBufferedLogger(workerLogger)
 
         errorCount := 0
         for {

--- a/sdks/python/container/boot.go
+++ b/sdks/python/container/boot.go
@@ -314,23 +314,51 @@ func launchSDKProcess() error {
 
 	var wg sync.WaitGroup
 	wg.Add(len(workerIds))
-	for _, workerId := range workerIds {
-		go func(workerId string) {
-			defer wg.Done()
+for _, workerId := range workerIds {
+    go func(workerId string) {
+        defer wg.Done()
 
-			bufLogger := tools.NewBufferedLogger(logger)
-			errorCount := 0
-			for {
-				childPids.mu.Lock()
-				if childPids.canceled {
-					childPids.mu.Unlock()
-					return
-				}
-				logger.Printf(ctx, "Executing Python (worker %v): python %v", workerId, strings.Join(args, " "))
-				cmd := StartCommandEnv(map[string]string{"WORKER_ID": workerId}, os.Stdin, bufLogger, bufLogger, "python", args...)
-				childPids.v = append(childPids.v, cmd.Process.Pid)
-				childPids.mu.Unlock()
+        workerCtx := grpcx.WriteWorkerID(ctx, workerId)
 
+        // Create a separate logger per worker so that each worker initializes
+        // its own Fn logging stream with the correct worker_id metadata.
+        // Shared loggers would reuse the first stream and cause incorrect
+        // portability_worker_id attribution across workers.
+        workerLogger := &tools.Logger{
+            Endpoint: *loggingEndpoint,
+        }
+
+        bufLogger := tools.NewBufferedLoggerWithFlushInterval(
+            workerCtx,
+            workerLogger,
+            100*time.Millisecond,
+        )
+
+        errorCount := 0
+        for {
+            childPids.mu.Lock()
+            if childPids.canceled {
+                childPids.mu.Unlock()
+                return
+            }
+
+            workerLogger.Printf(workerCtx,
+                "Executing Python (worker %v): python %v",
+                workerId,
+                strings.Join(args, " "),
+            )
+
+            cmd := StartCommandEnv(
+                map[string]string{"WORKER_ID": workerId},
+                os.Stdin,
+                bufLogger,
+                bufLogger,
+                "python",
+                args...,
+            )
+
+            childPids.v = append(childPids.v, cmd.Process.Pid)
+            childPids.mu.Unlock()
 				if err := cmd.Wait(); err != nil {
 					// Retry on fatal errors, like OOMs and segfaults, not just
 					// DoFns throwing exceptions.

--- a/sdks/python/container/boot.go
+++ b/sdks/python/container/boot.go
@@ -34,7 +34,7 @@ import (
 	"sync"
 	"syscall"
 	"time"
-
+git 
 	"github.com/apache/beam/sdks/v2/go/container/tools"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/artifact"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime/xlangx/expansionx"
@@ -318,7 +318,7 @@ for _, workerId := range workerIds {
     go func(workerId string) {
         defer wg.Done()
 
-        workerCtx := grpcx.WriteWorkerID(context.Background(), workerId)
+       workerCtx := grpcx.WriteWorkerID(context.WithoutCancel(ctx), workerId)
 
         // Create a separate logger per worker so that each worker initializes
         // its own Fn logging stream with the correct worker_id metadata.

--- a/sdks/python/container/boot.go
+++ b/sdks/python/container/boot.go
@@ -34,7 +34,6 @@ import (
 	"sync"
 	"syscall"
 	"time"
-git 
 	"github.com/apache/beam/sdks/v2/go/container/tools"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/artifact"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime/xlangx/expansionx"


### PR DESCRIPTION
Closes #38214

## Summary

Fix: Correct `portability_worker_id` for child process logs in Python SDK harness.

## Problem

Child process logs are captured via `boot.go` using a shared `tools.Logger`. Since the Fn logging stream is initialized on the first log call, all subsequent logs reuse the same stream, causing incorrect `portability_worker_id` (e.g., `sdk-0-0` instead of `sdk-0-0_sibling_X`).

## Root Cause

A shared logger instance is used across multiple workers. The Fn logging client initializes a single stream with metadata from the first worker, which is then reused for all workers.

## Fix

* Create a separate `tools.Logger` per worker
* Initialize `BufferedLogger` with worker-specific context using `grpcx.WriteWorkerID`
* Ensure each worker establishes its own logging stream with correct metadata

## Validation

* Verified successful build targeting Linux (`GOOS=linux`)
* Ensured each worker initializes an independent logger with worker-specific context
* Prevents reuse of a shared Fn logging stream, ensuring correct `portability_worker_id` attribution for child process logs

## Notes

This change is limited to worker logging initialization and does not modify existing logging behavior for Python SDK logs.
