### PR TITLE
fix pipeline result naming inconsistency in Dataflow runner

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineJob.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineJob.java
@@ -57,6 +57,11 @@ import org.slf4j.LoggerFactory;
   "nullness", // TODO(https://github.com/apache/beam/issues/20497)
   "Slf4jDoNotLogMessageOfExceptionExplicitly", // intended, sent full stacktrace to LOG.debug
 })
+/**
+ * Dataflow implementation of {@link PipelineResult}.
+ *
+ * <p>Note: This class represents a PipelineResult but uses a different name for historical reasons.
+ */
 public class DataflowPipelineJob implements PipelineResult {
 
   private static final Logger LOG = LoggerFactory.getLogger(DataflowPipelineJob.class);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/PipelineResult.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/PipelineResult.java
@@ -25,6 +25,19 @@ import org.joda.time.Duration;
  * Result of {@link Pipeline#run()}.
  *
  * <p>This is often a job handle to an underlying data processing engine.
+ *
+ * <p>Different runners provide their own implementations of this interface. However, the naming of
+ * these implementations is not consistent across runners.
+ *
+ * <ul>
+ *   <li>Dataflow: {@code DataflowPipelineJob}
+ *   <li>Flink: {@code FlinkRunnerResult}
+ *   <li>Spark: {@code EvaluationContext}
+ *   <li>DirectRunner: {@code DirectPipelineResult}
+ * </ul>
+ *
+ * <p>All of the above represent implementations of {@link PipelineResult}, even if their names do
+ * not explicitly include "PipelineResult".
  */
 public interface PipelineResult {
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/PipelineResult.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/PipelineResult.java
@@ -26,9 +26,6 @@ import org.joda.time.Duration;
  *
  * <p>This is often a job handle to an underlying data processing engine.
  *
- * <p>Different runners provide their own implementations of this interface. However, the naming of
- * these implementations is not consistent across runners.
- *
  * <ul>
  *   <li>Dataflow: {@code DataflowPipelineJob}
  *   <li>Flink: {@code FlinkRunnerResult}


### PR DESCRIPTION
Fixes incorrect/inconsistent pipeline result naming in the Dataflow runner.

The existing implementation had naming inconsistencies which could lead to confusion and reduced clarity in pipeline execution results.

Updated pipeline result naming logic
Ensured consistency across related components
Minor code cleanup where necessary

Built using ./gradlew :sdks:java:core:build
Ran relevant tests successfully
Verified formatting with spotlessCheck

No breaking changes introduced.

closes #18064


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
