### PR TITLE
Fix data race in JsonPayloadSerializerProvider.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/io/payloads/JsonPayloadSerializerProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/io/payloads/JsonPayloadSerializerProvider.java
@@ -45,25 +45,32 @@ public class JsonPayloadSerializerProvider implements PayloadSerializerProvider 
 
   private static class JsonPayloadSerializer implements PayloadSerializer {
     private final Schema schema;
-    private transient @Nullable ObjectMapper deserializeMapper;
-    private transient @Nullable ObjectMapper serializeMapper;
+    private transient volatile @Nullable ObjectMapper deserializeMapper;
+    private transient volatile @Nullable ObjectMapper serializeMapper;
 
     public JsonPayloadSerializer(Schema schema) {
       this.schema = schema;
-      this.deserializeMapper = null;
-      this.serializeMapper = null;
     }
 
-    private synchronized ObjectMapper getDeserializeMapper() {
+    private ObjectMapper getDeserializeMapper() {
       if (deserializeMapper == null) {
-        deserializeMapper = RowJsonUtils.newObjectMapperWith(RowJsonDeserializer.forSchema(schema));
+        synchronized (this) {
+          if (deserializeMapper == null) {
+            deserializeMapper =
+                RowJsonUtils.newObjectMapperWith(RowJsonDeserializer.forSchema(schema));
+          }
+        }
       }
       return deserializeMapper;
     }
 
-    private synchronized ObjectMapper getSerializeMapper() {
+    private ObjectMapper getSerializeMapper() {
       if (serializeMapper == null) {
-        serializeMapper = RowJsonUtils.newObjectMapperWith(RowJsonSerializer.forSchema(schema));
+        synchronized (this) {
+          if (serializeMapper == null) {
+            serializeMapper = RowJsonUtils.newObjectMapperWith(RowJsonSerializer.forSchema(schema));
+          }
+        }
       }
       return serializeMapper;
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/io/payloads/JsonPayloadSerializerProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/io/payloads/JsonPayloadSerializerProvider.java
@@ -27,6 +27,8 @@ import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.util.RowJson.RowJsonDeserializer;
 import org.apache.beam.sdk.util.RowJson.RowJsonSerializer;
 import org.apache.beam.sdk.util.RowJsonUtils;
+import org.apache.beam.sdk.values.Row;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 @Internal
 @AutoService(PayloadSerializerProvider.class)
@@ -38,12 +40,42 @@ public class JsonPayloadSerializerProvider implements PayloadSerializerProvider 
 
   @Override
   public PayloadSerializer getSerializer(Schema schema, Map<String, Object> tableParams) {
-    ObjectMapper deserializeMapper =
-        RowJsonUtils.newObjectMapperWith(RowJsonDeserializer.forSchema(schema));
-    ObjectMapper serializeMapper =
-        RowJsonUtils.newObjectMapperWith(RowJsonSerializer.forSchema(schema));
-    return PayloadSerializer.of(
-        row -> RowJsonUtils.rowToJson(serializeMapper, row).getBytes(UTF_8),
-        bytes -> RowJsonUtils.jsonToRow(deserializeMapper, new String(bytes, UTF_8)));
+    return new JsonPayloadSerializer(schema);
+  }
+
+  private static class JsonPayloadSerializer implements PayloadSerializer {
+    private final Schema schema;
+    private transient @Nullable ObjectMapper deserializeMapper;
+    private transient @Nullable ObjectMapper serializeMapper;
+
+    public JsonPayloadSerializer(Schema schema) {
+      this.schema = schema;
+      this.deserializeMapper = null;
+      this.serializeMapper = null;
+    }
+
+    private synchronized ObjectMapper getDeserializeMapper() {
+      if (deserializeMapper == null) {
+        deserializeMapper = RowJsonUtils.newObjectMapperWith(RowJsonDeserializer.forSchema(schema));
+      }
+      return deserializeMapper;
+    }
+
+    private synchronized ObjectMapper getSerializeMapper() {
+      if (serializeMapper == null) {
+        serializeMapper = RowJsonUtils.newObjectMapperWith(RowJsonSerializer.forSchema(schema));
+      }
+      return serializeMapper;
+    }
+
+    @Override
+    public byte[] serialize(Row row) {
+      return RowJsonUtils.rowToJson(getSerializeMapper(), row).getBytes(UTF_8);
+    }
+
+    @Override
+    public Row deserialize(byte[] bytes) {
+      return RowJsonUtils.jsonToRow(getDeserializeMapper(), new String(bytes, UTF_8));
+    }
   }
 }


### PR DESCRIPTION
The anonymous class returned by `getSerializer` captured `ObjectMapper` instances. When these were serialized (e.g., during pipeline translation in `DirectRunner`), a data race occurred in Jackson's `DeserializerCache.writeReplace()` due to concurrent modification of internal caches during serialization.
  
This change introduces a concrete `JsonPayloadSerializer` class that marks the `ObjectMapper` instances as `transient` and initializes them lazily. This avoids serializing the mappers and eliminates the data race.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
