### PR TITLE
[IcebergIO] Support sort order on dynamic table creation

### DIFF
--- a/.github/trigger_files/IO_Iceberg_Integration_Tests.json
+++ b/.github/trigger_files/IO_Iceberg_Integration_Tests.json
@@ -1,4 +1,4 @@
 {
     "comment": "Modify this file in a trivial way to cause this test suite to run.",
-    "modification": 4
+    "modification": 5
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,6 +65,7 @@
 ## I/Os
 
 * Support for X source added (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
+* IcebergIO: support declaring a table's sort order on dynamic table creation via the new `sort_fields` config ([#38269](https://github.com/apache/beam/pull/38269)).
 
 ## New Features / Improvements
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,7 +65,7 @@
 ## I/Os
 
 * Support for X source added (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
-* IcebergIO: support declaring a table's sort order on dynamic table creation via the new `sort_fields` config ([#38269](https://github.com/apache/beam/pull/38269)).
+* IcebergIO: support declaring a table's sort order on dynamic table creation via the new `sort_fields` config ([#38269](https://github.com/apache/beam/issues/38269)).
 
 ## New Features / Improvements
 

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/AddFiles.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/AddFiles.java
@@ -93,9 +93,11 @@ import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
@@ -145,6 +147,7 @@ public class AddFiles extends PTransform<PCollection<String>, PCollectionRowTupl
   private final int manifestFileSize;
   private final @Nullable String locationPrefix;
   private final @Nullable List<String> partitionFields;
+  private final @Nullable List<String> sortFields;
   private final @Nullable Map<String, String> tableProps;
 
   public AddFiles(
@@ -152,12 +155,14 @@ public class AddFiles extends PTransform<PCollection<String>, PCollectionRowTupl
       String tableIdentifier,
       @Nullable String locationPrefix,
       @Nullable List<String> partitionFields,
+      @Nullable List<String> sortFields,
       @Nullable Map<String, String> tableProps,
       @Nullable Integer manifestFileSize,
       @Nullable Duration intervalTrigger) {
     this.catalogConfig = catalogConfig;
     this.tableIdentifier = tableIdentifier;
     this.partitionFields = partitionFields;
+    this.sortFields = sortFields;
     this.tableProps = tableProps;
     this.intervalTrigger = intervalTrigger;
     this.manifestFileSize =
@@ -193,6 +198,7 @@ public class AddFiles extends PTransform<PCollection<String>, PCollectionRowTupl
                         tableIdentifier,
                         locationPrefix,
                         partitionFields,
+                        sortFields,
                         tableProps))
                 .withOutputTags(DATA_FILES, TupleTagList.of(ERRORS)));
     SchemaCoder<SerializableDataFile> sdfCoder;
@@ -267,6 +273,7 @@ public class AddFiles extends PTransform<PCollection<String>, PCollectionRowTupl
     public static final TupleTag<SerializableDataFile> DATA_FILES = new TupleTag<>();
     private final @Nullable String prefix;
     private final @Nullable List<String> partitionFields;
+    private final @Nullable List<String> sortFields;
     private final @Nullable Map<String, String> tableProps;
     private transient @MonotonicNonNull ExecutorService executor;
     private transient @MonotonicNonNull LinkedList<Future<ProcessResult>> activeTasks;
@@ -281,11 +288,13 @@ public class AddFiles extends PTransform<PCollection<String>, PCollectionRowTupl
         String identifier,
         @Nullable String prefix,
         @Nullable List<String> partitionFields,
+        @Nullable List<String> sortFields,
         @Nullable Map<String, String> tableProps) {
       this.catalogConfig = catalogConfig;
       this.identifier = identifier;
       this.prefix = prefix;
       this.partitionFields = partitionFields;
+      this.sortFields = sortFields;
       this.tableProps = tableProps;
     }
 
@@ -522,12 +531,18 @@ public class AddFiles extends PTransform<PCollection<String>, PCollectionRowTupl
         try {
           org.apache.iceberg.Schema schema = getSchema(filePath, format);
           PartitionSpec spec = PartitionUtils.toPartitionSpec(partitionFields, schema);
+          SortOrder sortOrder = SortOrderUtils.toSortOrder(sortFields, schema);
 
-          return tableProps == null
-              ? catalogConfig.catalog().createTable(TableIdentifier.parse(identifier), schema, spec)
-              : catalogConfig
+          Catalog.TableBuilder builder =
+              catalogConfig
                   .catalog()
-                  .createTable(TableIdentifier.parse(identifier), schema, spec, tableProps);
+                  .buildTable(tableId, schema)
+                  .withPartitionSpec(spec)
+                  .withSortOrder(sortOrder);
+          if (tableProps != null) {
+            builder.withProperties(tableProps);
+          }
+          return builder.create();
         } catch (AlreadyExistsException e2) { // if table already exists, just load it
           return catalogConfig.catalog().loadTable(TableIdentifier.parse(identifier));
         }

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/AddFilesSchemaTransformProvider.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/AddFilesSchemaTransformProvider.java
@@ -106,6 +106,15 @@ public class AddFilesSchemaTransformProvider extends TypedSchemaTransformProvide
             + " please visit https://iceberg.apache.org/docs/latest/configuration/#table-properties.")
     public abstract @Nullable Map<String, String> getTableProperties();
 
+    @SchemaFieldDescription(
+        "Fields used to set the table's sort order, applied when the table is created. "
+            + "Each entry has the form `<term> [asc|desc] [nulls first|nulls last]`, where `<term>` "
+            + "is a field name or one of the partition transforms (e.g. `bucket(col, 4)`, `day(ts)`). "
+            + "Direction defaults to ascending; null order defaults to nulls-first for ascending and "
+            + "nulls-last for descending.\n"
+            + "For more information on sort orders, please visit https://iceberg.apache.org/spec/#sort-orders.")
+    public abstract @Nullable List<String> getSortFields();
+
     @SchemaFieldDescription("This option specifies whether and where to output unwritable rows.")
     public abstract @Nullable ErrorHandling getErrorHandling();
 
@@ -126,6 +135,8 @@ public class AddFilesSchemaTransformProvider extends TypedSchemaTransformProvide
       public abstract Builder setPartitionFields(List<String> fields);
 
       public abstract Builder setTableProperties(Map<String, String> props);
+
+      public abstract Builder setSortFields(List<String> sortFields);
 
       public abstract Builder setErrorHandling(ErrorHandling errorHandling);
 
@@ -172,6 +183,7 @@ public class AddFilesSchemaTransformProvider extends TypedSchemaTransformProvide
                       configuration.getTable(),
                       configuration.getLocationPrefix(),
                       configuration.getPartitionFields(),
+                      configuration.getSortFields(),
                       configuration.getTableProperties(),
                       configuration.getManifestFileSize(),
                       frequency != null ? Duration.standardSeconds(frequency) : null));

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergTableCreateConfig.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergTableCreateConfig.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.SortOrder;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.qual.Pure;
 
@@ -41,6 +42,15 @@ public abstract class IcebergTableCreateConfig {
   @Pure
   public abstract @Nullable List<String> getPartitionFields();
 
+  /** Sort order to apply when the table is dynamically created. */
+  @Pure
+  public SortOrder getSortOrder() {
+    return SortOrderUtils.toSortOrder(getSortFields(), getSchema());
+  }
+
+  @Pure
+  public abstract @Nullable List<String> getSortFields();
+
   @Pure
   public abstract @Nullable Map<String, String> getTableProperties();
 
@@ -54,6 +64,8 @@ public abstract class IcebergTableCreateConfig {
     public abstract Builder setSchema(Schema schema);
 
     public abstract Builder setPartitionFields(@Nullable List<String> partitionFields);
+
+    public abstract Builder setSortFields(@Nullable List<String> sortFields);
 
     public abstract Builder setTableProperties(@Nullable Map<String, String> tableProperties);
 

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergTableCreateConfig.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergTableCreateConfig.java
@@ -21,6 +21,7 @@ import com.google.auto.value.AutoValue;
 import java.util.List;
 import java.util.Map;
 import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.annotations.SchemaIgnore;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.SortOrder;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -44,6 +45,7 @@ public abstract class IcebergTableCreateConfig {
 
   /** Sort order to apply when the table is dynamically created. */
   @Pure
+  @SchemaIgnore
   public SortOrder getSortOrder() {
     return SortOrderUtils.toSortOrder(getSortFields(), getSchema());
   }

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergWriteSchemaTransformProvider.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergWriteSchemaTransformProvider.java
@@ -134,6 +134,16 @@ public class IcebergWriteSchemaTransformProvider
             + " please visit https://iceberg.apache.org/docs/latest/configuration/#table-properties.")
     public abstract @Nullable Map<String, String> getTableProperties();
 
+    @SchemaFieldDescription(
+        "Fields used to set the table's sort order, applied when the table is created. "
+            + "Each entry has the form `<term> [asc|desc] [nulls first|nulls last]`, where `<term>` "
+            + "is a field name or one of the partition transforms (e.g. `bucket(col, 4)`, `day(ts)`). "
+            + "Direction defaults to ascending; null order defaults to nulls-first for ascending and "
+            + "nulls-last for descending. Note: this sets the table's declared sort order as metadata; "
+            + "it does not cause Beam to physically sort records before writing.\n"
+            + "For more information on sort orders, please visit https://iceberg.apache.org/spec/#sort-orders.")
+    public abstract @Nullable List<String> getSortFields();
+
     @AutoValue.Builder
     public abstract static class Builder {
       public abstract Builder setTable(String table);
@@ -157,6 +167,8 @@ public class IcebergWriteSchemaTransformProvider
       public abstract Builder setPartitionFields(List<String> partitionFields);
 
       public abstract Builder setTableProperties(Map<String, String> tableProperties);
+
+      public abstract Builder setSortFields(List<String> sortFields);
 
       public abstract Configuration build();
     }
@@ -223,6 +235,7 @@ public class IcebergWriteSchemaTransformProvider
                       FileFormat.PARQUET.toString(),
                       rows.getSchema(),
                       configuration.getPartitionFields(),
+                      configuration.getSortFields(),
                       configuration.getTableProperties(),
                       configuration.getDrop(),
                       configuration.getKeep(),

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/PortableIcebergDestinations.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/PortableIcebergDestinations.java
@@ -34,6 +34,7 @@ class PortableIcebergDestinations implements DynamicDestinations {
   private final String fileFormat;
 
   private final @Nullable List<String> partitionFields;
+  private final @Nullable List<String> sortFields;
   private final @Nullable Map<String, String> tableProperties;
 
   public PortableIcebergDestinations(
@@ -41,12 +42,14 @@ class PortableIcebergDestinations implements DynamicDestinations {
       String fileFormat,
       Schema inputSchema,
       @Nullable List<String> partitionFields,
+      @Nullable List<String> sortFields,
       @Nullable Map<String, String> tableProperties,
       @Nullable List<String> fieldsToDrop,
       @Nullable List<String> fieldsToKeep,
       @Nullable String onlyField) {
     this.interpolator = new RowStringInterpolator(destinationTemplate, inputSchema);
     this.partitionFields = partitionFields;
+    this.sortFields = sortFields;
     this.tableProperties = tableProperties;
     RowFilter rf = new RowFilter(inputSchema);
 
@@ -86,6 +89,7 @@ class PortableIcebergDestinations implements DynamicDestinations {
             IcebergTableCreateConfig.builder()
                 .setSchema(getDataSchema())
                 .setPartitionFields(partitionFields)
+                .setSortFields(sortFields)
                 .setTableProperties(tableProperties)
                 .build())
         .setFileFormat(FileFormat.fromString(fileFormat))

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/RecordWriterManager.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/RecordWriterManager.java
@@ -49,6 +49,7 @@ import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
@@ -329,6 +330,7 @@ class RecordWriterManager implements AutoCloseable {
     @Nullable IcebergTableCreateConfig createConfig = destination.getTableCreateConfig();
     PartitionSpec partitionSpec =
         createConfig != null ? createConfig.getPartitionSpec() : PartitionSpec.unpartitioned();
+    SortOrder sortOrder = createConfig != null ? createConfig.getSortOrder() : SortOrder.unsorted();
     Map<String, String> tableProperties =
         createConfig != null && createConfig.getTableProperties() != null
             ? createConfig.getTableProperties()
@@ -357,13 +359,20 @@ class RecordWriterManager implements AutoCloseable {
       } catch (NoSuchTableException e) { // Otherwise, create the table
         org.apache.iceberg.Schema tableSchema = IcebergUtils.beamSchemaToIcebergSchema(dataSchema);
         try {
-          table = catalog.createTable(identifier, tableSchema, partitionSpec, tableProperties);
+          table =
+              catalog
+                  .buildTable(identifier, tableSchema)
+                  .withPartitionSpec(partitionSpec)
+                  .withSortOrder(sortOrder)
+                  .withProperties(tableProperties)
+                  .create();
           LOG.info(
               "Created Iceberg table '{}' with schema: {}\n"
-                  + ", partition spec: {}, table properties: {}",
+                  + ", partition spec: {}, sort order: {}, table properties: {}",
               identifier,
               tableSchema,
               partitionSpec,
+              sortOrder,
               tableProperties);
         } catch (AlreadyExistsException ignored) {
           // race condition: another worker already created this table

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/SortOrderUtils.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/SortOrderUtils.java
@@ -27,6 +27,20 @@ import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.expressions.Term;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+/**
+ * Parses a list of sort field strings into an Iceberg {@link SortOrder} for use when dynamically
+ * creating a table.
+ *
+ * <p>Each entry has the grammar: {@code <term> [asc|desc] [nulls first|nulls last]}, where {@code
+ * <term>} reuses the partition-transform parser ({@link PartitionUtils#toIcebergTerm}) and accepts
+ * an identity column name or a transform such as {@code bucket(col, N)}, {@code truncate(col, N)},
+ * or {@code year|month|day|hour(col)}.
+ *
+ * <p>Defaults: direction defaults to {@code asc}; null order defaults to {@code nulls first} for
+ * ascending and {@code nulls last} for descending, matching Iceberg's {@link
+ * SortOrder.Builder#asc(Term)} / {@link SortOrder.Builder#desc(Term)} conventions. A {@code null}
+ * or empty input yields {@link SortOrder#unsorted()}.
+ */
 class SortOrderUtils {
   private static final Pattern MODIFIERS =
       Pattern.compile(
@@ -54,6 +68,7 @@ class SortOrderUtils {
   }
 
   private static ParsedSortField parse(String field) {
+    field = field.trim();
     int splitAt = findTopLevelWhitespace(field);
     String termStr = (splitAt < 0 ? field : field.substring(0, splitAt)).trim();
     String rest = (splitAt < 0 ? "" : field.substring(splitAt)).trim();

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/SortOrderUtils.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/SortOrderUtils.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.iceberg;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.expressions.Term;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+class SortOrderUtils {
+  private static final Pattern MODIFIERS =
+      Pattern.compile(
+          "^(?<dir>asc|desc)?\\s*(nulls\\s+(?<nulls>first|last))?\\s*$", Pattern.CASE_INSENSITIVE);
+
+  static SortOrder toSortOrder(
+      @Nullable List<String> fields, org.apache.beam.sdk.schemas.Schema beamSchema) {
+    return toSortOrder(fields, IcebergUtils.beamSchemaToIcebergSchema(beamSchema));
+  }
+
+  static SortOrder toSortOrder(@Nullable List<String> fields, Schema schema) {
+    if (fields == null || fields.isEmpty()) {
+      return SortOrder.unsorted();
+    }
+    SortOrder.Builder builder = SortOrder.builderFor(schema);
+    for (String field : fields) {
+      ParsedSortField parsed = parse(field);
+      if (parsed.ascending) {
+        builder.asc(parsed.term, parsed.nullOrder);
+      } else {
+        builder.desc(parsed.term, parsed.nullOrder);
+      }
+    }
+    return builder.build();
+  }
+
+  private static ParsedSortField parse(String field) {
+    int splitAt = findTopLevelWhitespace(field);
+    String termStr = (splitAt < 0 ? field : field.substring(0, splitAt)).trim();
+    String rest = (splitAt < 0 ? "" : field.substring(splitAt)).trim();
+
+    Term term = PartitionUtils.toIcebergTerm(termStr);
+    boolean ascending = true;
+    @Nullable NullOrder nullOrder = null;
+
+    if (!rest.isEmpty()) {
+      Matcher matcher = MODIFIERS.matcher(rest);
+      if (!matcher.matches()) {
+        throw new IllegalArgumentException(
+            "Could not parse sort modifiers '"
+                + rest
+                + "' in '"
+                + field
+                + "'. Expected: [asc|desc] [nulls first|nulls last].");
+      }
+      String dir = matcher.group("dir");
+      if (dir != null) {
+        ascending = dir.toLowerCase(Locale.ROOT).equals("asc");
+      }
+      String nulls = matcher.group("nulls");
+      if (nulls != null) {
+        nullOrder =
+            nulls.toLowerCase(Locale.ROOT).equals("first")
+                ? NullOrder.NULLS_FIRST
+                : NullOrder.NULLS_LAST;
+      }
+    }
+
+    if (nullOrder == null) {
+      nullOrder = ascending ? NullOrder.NULLS_FIRST : NullOrder.NULLS_LAST;
+    }
+    return new ParsedSortField(term, ascending, nullOrder);
+  }
+
+  private static int findTopLevelWhitespace(String s) {
+    int depth = 0;
+    for (int i = 0; i < s.length(); i++) {
+      char c = s.charAt(i);
+      if (c == '(') {
+        depth++;
+      } else if (c == ')') {
+        depth--;
+      } else if (depth == 0 && Character.isWhitespace(c)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private static class ParsedSortField {
+    final Term term;
+    final boolean ascending;
+    final NullOrder nullOrder;
+
+    ParsedSortField(Term term, boolean ascending, NullOrder nullOrder) {
+      this.term = term;
+      this.ascending = ascending;
+      this.nullOrder = nullOrder;
+    }
+  }
+}

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/AddFilesIT.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/AddFilesIT.java
@@ -455,6 +455,7 @@ public class AddFilesIT {
                     namespace + "." + destTableName,
                     null,
                     PARTITION_FIELDS,
+                    null,
                     TABLE_PROPS,
                     null,
                     null));
@@ -522,6 +523,7 @@ public class AddFilesIT {
                     namespace + "." + destTableName,
                     null,
                     PARTITION_FIELDS,
+                    null,
                     TABLE_PROPS,
                     10,
                     Duration.standardSeconds(10)));

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/AddFilesTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/AddFilesTest.java
@@ -173,6 +173,7 @@ public class AddFilesTest {
                 tableId.toString(),
                 isPartitioned ? root : null,
                 isPartitioned ? partitionFields : null,
+                null,
                 tableProps,
                 null,
                 null));
@@ -269,6 +270,7 @@ public class AddFilesTest {
                 tableId.toString(),
                 null, // no prefix, so determine partition from DF metrics
                 partitionFields,
+                null,
                 tableProps,
                 null,
                 null));
@@ -368,6 +370,7 @@ public class AddFilesTest {
             null,
             null,
             null,
+            null,
             10, // trigger at 10 files
             Duration.standardSeconds(5)));
     pipeline.run().waitUntilFinish();
@@ -399,7 +402,7 @@ public class AddFilesTest {
         pipeline.apply("Create Input", Create.of(txtFile.getAbsolutePath()));
 
     AddFiles addFiles =
-        new AddFiles(catalogConfig, tableId.toString(), null, null, null, null, null);
+        new AddFiles(catalogConfig, tableId.toString(), null, null, null, null, null, null);
     PCollectionRowTuple outputTuple = inputFiles.apply(addFiles);
 
     // Validate the file ended up in the errors PCollection with the correct schema
@@ -429,7 +432,8 @@ public class AddFilesTest {
 
     // Notice locationPrefix is "some/prefix/" but the absolute path doesn't start with it
     AddFiles addFiles =
-        new AddFiles(catalogConfig, tableId.toString(), "some/prefix/", null, null, null, null);
+        new AddFiles(
+            catalogConfig, tableId.toString(), "some/prefix/", null, null, null, null, null);
     PCollectionRowTuple outputTuple = inputFiles.apply(addFiles);
 
     PAssert.that(outputTuple.get("errors"))
@@ -472,7 +476,8 @@ public class AddFilesTest {
     assertEquals(0, (int) transformFunc.apply(10L));
 
     AddFiles addFiles =
-        new AddFiles(catalogConfig, tableId.toString(), null, partitionFields, null, null, null);
+        new AddFiles(
+            catalogConfig, tableId.toString(), null, partitionFields, null, null, null, null);
     PCollection<String> inputFiles = pipeline.apply("Create Input", Create.of(file1));
     PCollectionRowTuple outputTuple = inputFiles.apply(addFiles);
 
@@ -494,7 +499,9 @@ public class AddFilesTest {
     PCollectionRowTuple outputTuple =
         pipeline
             .apply("Create Input", Create.of(file))
-            .apply(new AddFiles(catalogConfig, tableId.toString(), null, null, null, null, null));
+            .apply(
+                new AddFiles(
+                    catalogConfig, tableId.toString(), null, null, null, null, null, null));
 
     PAssert.that(outputTuple.get("errors"))
         .satisfies(

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/RecordWriterManagerTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/RecordWriterManagerTest.java
@@ -57,10 +57,13 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.NullOrder;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SortDirection;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
@@ -158,6 +161,36 @@ public class RecordWriterManagerTest {
     boolean writeSuccess = writerManager.write(dest, row);
     assertTrue(writeSuccess);
     assertTrue(catalog.namespaceExists(newNamespace));
+  }
+
+  @Test
+  public void testCreateTableWithSortOrder() throws IOException {
+    RecordWriterManager writerManager = new RecordWriterManager(catalog, "test_file_name", 1000, 3);
+    TableIdentifier identifier = TableIdentifier.of("default", testName.getMethodName());
+    WindowedValue<IcebergDestination> dest =
+        WindowedValues.valueInGlobalWindow(
+            IcebergDestination.builder()
+                .setFileFormat(FileFormat.PARQUET)
+                .setTableIdentifier(identifier)
+                .setTableCreateConfig(
+                    IcebergTableCreateConfig.builder()
+                        .setSchema(BEAM_SCHEMA)
+                        .setPartitionFields(null)
+                        .setSortFields(java.util.Arrays.asList("id desc", "name asc nulls last"))
+                        .build())
+                .build());
+
+    Row row = Row.withSchema(BEAM_SCHEMA).addValues(1, "aaa", true).build();
+    assertTrue(writerManager.write(dest, row));
+    writerManager.close();
+
+    Table created = catalog.loadTable(identifier);
+    SortOrder order = created.sortOrder();
+    assertEquals(2, order.fields().size());
+    assertEquals(SortDirection.DESC, order.fields().get(0).direction());
+    assertEquals(NullOrder.NULLS_LAST, order.fields().get(0).nullOrder());
+    assertEquals(SortDirection.ASC, order.fields().get(1).direction());
+    assertEquals(NullOrder.NULLS_LAST, order.fields().get(1).nullOrder());
   }
 
   @Test

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/SortOrderUtilsTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/SortOrderUtilsTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.iceberg;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortDirection;
+import org.apache.iceberg.SortField;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.types.Types;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SortOrderUtilsTest {
+  private static final Schema SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.LongType.get()),
+          Types.NestedField.optional(2, "name", Types.StringType.get()),
+          Types.NestedField.optional(3, "ts", Types.TimestampType.withoutZone()));
+
+  @Test
+  public void testNullOrEmptyFieldsYieldsUnsorted() {
+    assertTrue(SortOrderUtils.toSortOrder(null, SCHEMA).isUnsorted());
+    assertTrue(SortOrderUtils.toSortOrder(Collections.emptyList(), SCHEMA).isUnsorted());
+  }
+
+  @Test
+  public void testIdentityDefaultsToAscNullsFirst() {
+    SortOrder order = SortOrderUtils.toSortOrder(Collections.singletonList("id"), SCHEMA);
+    assertEquals(1, order.fields().size());
+    SortField field = order.fields().get(0);
+    assertEquals(SortDirection.ASC, field.direction());
+    assertEquals(NullOrder.NULLS_FIRST, field.nullOrder());
+  }
+
+  @Test
+  public void testDescDefaultsToNullsLast() {
+    SortOrder order = SortOrderUtils.toSortOrder(Collections.singletonList("id desc"), SCHEMA);
+    SortField field = order.fields().get(0);
+    assertEquals(SortDirection.DESC, field.direction());
+    assertEquals(NullOrder.NULLS_LAST, field.nullOrder());
+  }
+
+  @Test
+  public void testExplicitNullOrder() {
+    SortOrder order =
+        SortOrderUtils.toSortOrder(Collections.singletonList("name asc nulls last"), SCHEMA);
+    SortField field = order.fields().get(0);
+    assertEquals(SortDirection.ASC, field.direction());
+    assertEquals(NullOrder.NULLS_LAST, field.nullOrder());
+  }
+
+  @Test
+  public void testTransformTerms() {
+    SortOrder order =
+        SortOrderUtils.toSortOrder(
+            Arrays.asList("bucket(id, 4) desc", "day(ts)", "truncate(name, 3) asc nulls first"),
+            SCHEMA);
+    assertEquals(3, order.fields().size());
+    assertEquals(SortDirection.DESC, order.fields().get(0).direction());
+    assertEquals(SortDirection.ASC, order.fields().get(1).direction());
+    assertEquals(SortDirection.ASC, order.fields().get(2).direction());
+    assertEquals(NullOrder.NULLS_FIRST, order.fields().get(2).nullOrder());
+  }
+
+  @Test
+  public void testCaseInsensitive() {
+    SortOrder order =
+        SortOrderUtils.toSortOrder(Collections.singletonList("id DESC NULLS FIRST"), SCHEMA);
+    SortField field = order.fields().get(0);
+    assertEquals(SortDirection.DESC, field.direction());
+    assertEquals(NullOrder.NULLS_FIRST, field.nullOrder());
+  }
+
+  @Test
+  public void testBadModifierThrows() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SortOrderUtils.toSortOrder(Collections.singletonList("id upward"), SCHEMA));
+  }
+
+  @Test
+  public void testUnknownTermThrows() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SortOrderUtils.toSortOrder(Collections.singletonList("sqrt(id)"), SCHEMA));
+  }
+}

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/SortOrderUtilsTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/SortOrderUtilsTest.java
@@ -81,9 +81,23 @@ public class SortOrderUtilsTest {
             SCHEMA);
     assertEquals(3, order.fields().size());
     assertEquals(SortDirection.DESC, order.fields().get(0).direction());
+    assertEquals("bucket[4]", order.fields().get(0).transform().toString());
     assertEquals(SortDirection.ASC, order.fields().get(1).direction());
+    assertEquals("day", order.fields().get(1).transform().toString());
     assertEquals(SortDirection.ASC, order.fields().get(2).direction());
     assertEquals(NullOrder.NULLS_FIRST, order.fields().get(2).nullOrder());
+    assertEquals("truncate[3]", order.fields().get(2).transform().toString());
+  }
+
+  @Test
+  public void testHandlesExtraWhitespace() {
+    SortOrder order =
+        SortOrderUtils.toSortOrder(Collections.singletonList("  id   desc   "), SCHEMA);
+    assertEquals(1, order.fields().size());
+    SortField field = order.fields().get(0);
+    assertEquals(SortDirection.DESC, field.direction());
+    assertEquals(NullOrder.NULLS_LAST, field.nullOrder());
+    assertEquals("identity", field.transform().toString());
   }
 
   @Test

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/catalog/IcebergCatalogBaseIT.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/catalog/IcebergCatalogBaseIT.java
@@ -79,8 +79,11 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Immuta
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.NullOrder;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SortDirection;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.catalog.Catalog;
@@ -683,6 +686,28 @@ public abstract class IcebergCatalogBaseIT implements Serializable {
             .truncate("str", truncLength)
             .build();
     assertEquals(expectedSpec, table.spec());
+    assertThat(
+        returnedRecords, containsInAnyOrder(inputRows.stream().map(RECORD_FUNC::apply).toArray()));
+  }
+
+  @Test
+  public void testWriteWithSortOrder() throws IOException {
+    Map<String, Object> config = new HashMap<>(managedIcebergConfig(tableId()));
+    config.put(
+        "sort_fields", Arrays.asList("int_field desc", "bucket(modulo_5, 4) asc nulls last"));
+    PCollection<Row> input = pipeline.apply(Create.of(inputRows)).setRowSchema(BEAM_SCHEMA);
+    input.apply(Managed.write(ICEBERG).withConfig(config));
+    pipeline.run().waitUntilFinish();
+
+    Table table = catalog.loadTable(TableIdentifier.parse(tableId()));
+    SortOrder order = table.sortOrder();
+    assertEquals(2, order.fields().size());
+    assertEquals(SortDirection.DESC, order.fields().get(0).direction());
+    assertEquals(NullOrder.NULLS_LAST, order.fields().get(0).nullOrder());
+    assertEquals(SortDirection.ASC, order.fields().get(1).direction());
+    assertEquals(NullOrder.NULLS_LAST, order.fields().get(1).nullOrder());
+
+    List<Record> returnedRecords = readRecords(table);
     assertThat(
         returnedRecords, containsInAnyOrder(inputRows.stream().map(RECORD_FUNC::apply).toArray()));
   }


### PR DESCRIPTION
## Summary
- Adds a `sort_fields` option to `IcebergWriteSchemaTransformProvider` and `AddFilesSchemaTransformProvider`, applied when a table is dynamically created.
- Grammar: `<term> [asc|desc] [nulls first|nulls last]`, where `<term>` reuses the partition-transform parser (identity, bucket, truncate, year/month/day/hour).
- Backward compatible: when `sort_fields` is unset, the created table gets `SortOrder.unsorted()` - identical to the prior `Catalog.createTable(...)` path, which uses the same default internally. See [BaseMetastoreCatalog.TableBuilder#L114](https://github.com/apache/iceberg/blob/844a0abc3b6f7ec3164c4d60b26973eb686a27db/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java#L144).

### Note
- Sort order here is **declarative metadata**, per the [Iceberg spec](https://iceberg.apache.org/spec/#sort-orders). Beam does not physically sort records before writing; downstream compaction jobs or upstream sorting remain the way to produce physically-sorted files.
- Declaring the table's sort order is still valuable: maintenance jobs read `table.sortOrder()` to decide how to cluster rows when rewriting data files.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
