### PR TITLE
[runners-flink] Use index-based version comparison in flink_runner.gradle

### DIFF
--- a/runners/flink/flink_runner.gradle
+++ b/runners/flink/flink_runner.gradle
@@ -32,9 +32,16 @@ def overrides(versions, type, base_path, group='java') {
   ["${base_path}/src/${type}/${group}"] + versions.collect { "${base_path}/${it}/src/${type}/${group}" } + ["./src/${type}/${group}"]
 }
 
-def all_versions = flink_versions.split(",")
-
-def previous_versions = all_versions.findAll { it < flink_major }
+def all_versions = flink_versions.split(",").collect { it.trim() }
+// Determine version order by list position rather than string comparison so two-digit
+// minors (e.g. "1.20") sort correctly relative to "1.18" / "1.19".
+def flink_major_index = all_versions.indexOf(flink_major)
+if (flink_major_index < 0) {
+  throw new GradleException(
+      "flink_major='${flink_major}' is not listed in flink_versions='${flink_versions}' " +
+      "(see root gradle.properties).")
+}
+def previous_versions = flink_major_index > 0 ? all_versions.subList(0, flink_major_index) : []
 
 // Version specific code overrides.
 def main_source_overrides = overrides(previous_versions, "main", base_path)
@@ -106,7 +113,7 @@ def copyTestResourcesOverrides = tasks.register('copyTestResourcesOverrides', Co
   it.duplicatesStrategy DuplicatesStrategy.INCLUDE
 }
 
-def use_override = (flink_major != all_versions.first())
+def use_override = (flink_major_index > 0)
 def sourceBase = "${project.projectDir}/../src"
 
 if (use_override) {

--- a/runners/flink/flink_runner.gradle
+++ b/runners/flink/flink_runner.gradle
@@ -35,13 +35,13 @@ def overrides(versions, type, base_path, group='java') {
 def all_versions = flink_versions.split(",").collect { it.trim() }
 // Determine version order by list position rather than string comparison so two-digit
 // minors (e.g. "1.20") sort correctly relative to "1.18" / "1.19".
-def flink_major_index = all_versions.indexOf(flink_major)
+def flink_major_index = all_versions.indexOf(flink_major?.toString()?.trim())
 if (flink_major_index < 0) {
   throw new GradleException(
       "flink_major='${flink_major}' is not listed in flink_versions='${flink_versions}' " +
       "(see root gradle.properties).")
 }
-def previous_versions = flink_major_index > 0 ? all_versions.subList(0, flink_major_index) : []
+def previous_versions = all_versions.subList(0, flink_major_index)
 
 // Version specific code overrides.
 def main_source_overrides = overrides(previous_versions, "main", base_path)


### PR DESCRIPTION
## Summary
Promised follow-up to @Abacn from PR #38233 review (issue comment 2026-04-17), where the same lex-comparison bug was flagged in `spark_runner.gradle` and asked to be split into a separate PR for the Flink side.

`runners/flink/flink_runner.gradle` resolves `previous_versions` (the list
of older Flink majors whose source-overrides should be merged into the
current build) via lexicographic string comparison against `flink_major`:

```groovy
def previous_versions = all_versions.findAll { it < flink_major }
```

This breaks for the current `flink_versions=1.17,1.18,1.19,1.20,2.0` because
lexicographic ordering disagrees with semantic ordering whenever a two-digit
minor crosses a single-digit boundary.

## Impact today

| `flink_major` | Computed `previous_versions` | Correct |
|---|---|---|
| `1.17` | `[]` | `[]` ✓ |
| `1.18` | `["1.17", "1.20"]` ❌ | `["1.17"]` |
| `1.19` | `["1.17", "1.18", "1.20"]` ❌ | `["1.17", "1.18"]` |
| `1.20` | `[]` ❌ | `["1.17", "1.18", "1.19"]` |
| `2.0`  | `["1.17", "1.18", "1.19", "1.20"]` | same ✓ |

Concretely:

- **1.18 and 1.19 builds erroneously pull in `runners/flink/1.20/src/main/java/.../DoFnOperator.java`** as a "previous" override. If that file relies on Flink 1.20+ APIs, those builds would fail to compile.
- **1.20 builds drop the 1.19 test overrides** (`MemoryStateBackendWrapper`, `StreamSources`). Both classes also exist in the shared base, so 1.20's tests use the shared-base versions today; whether that's correct depends on whether the 1.19 overrides exist precisely because the shared-base versions don't compile against the 1.19+ test API.

## Fix

Mirror the Spark approach landed in #38233 (`runners/spark/spark_runner.gradle`):

- Compute `flink_major_index = all_versions.indexOf(flink_major)` and derive `previous_versions` as `all_versions.subList(0, flink_major_index)`.
- Throw a clear `GradleException` if `flink_major` isn't listed in `flink_versions` (today the buggy path silently produced `[]`).
- Update `use_override` to `(flink_major_index > 0)`, matching the Spark formulation.
- Trim whitespace from each `flink_versions` entry, defensive against `flink_versions=1.17, 1.18, ...` style.