### PR TITLE
Enable connection pooling by default

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryOptions.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryOptions.java
@@ -158,7 +158,7 @@ public interface BigQueryOptions
           + " mode. This is recommended if your write operation is creating 20+ connections. When using multiplexing, consider tuning "
           + "the number of connections created by the connection pool with minConnectionPoolConnections and maxConnectionPoolConnections. "
           + "For more information, see https://cloud.google.com/bigquery/docs/write-api-best-practices#connection_pool_management")
-  @Default.Boolean(false)
+  @Default.Boolean(true)
   Boolean getUseStorageApiConnectionPool();
 
   void setUseStorageApiConnectionPool(Boolean value);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/CreateTableHelpers.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/CreateTableHelpers.java
@@ -32,7 +32,6 @@ import com.google.api.services.bigquery.model.TableConstraints;
 import com.google.api.services.bigquery.model.TableReference;
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.api.services.bigquery.model.TimePartitioning;
-import com.google.common.base.Throwables;
 import io.grpc.StatusRuntimeException;
 import java.util.Collections;
 import java.util.Map;
@@ -50,6 +49,7 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.Vi
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.MoreObjects;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Strings;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Supplier;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Throwables;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.Duration;
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/CreateTableHelpers.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/CreateTableHelpers.java
@@ -32,6 +32,7 @@ import com.google.api.services.bigquery.model.TableConstraints;
 import com.google.api.services.bigquery.model.TableReference;
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.api.services.bigquery.model.TimePartitioning;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.grpc.StatusRuntimeException;
 import java.util.Collections;
 import java.util.Map;
@@ -74,7 +75,14 @@ public class CreateTableHelpers {
       try {
         action.call();
         return;
-      } catch (ApiException | StatusRuntimeException e) {
+      } catch (ApiException | StatusRuntimeException | UncheckedExecutionException e) {
+        // The Storage Write library can wrap errors in UncheckedExecutionException
+        if (e instanceof UncheckedExecutionException) {
+          Throwable cause = e.getCause();
+          if (!(cause instanceof ApiException || cause instanceof StatusRuntimeException)) {
+            throw e;
+          }
+        }
         lastException = e;
         // TODO: Once BigQuery reliably returns a consistent error on table not found, we should
         // only try creating

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/CreateTableHelpers.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/CreateTableHelpers.java
@@ -32,10 +32,11 @@ import com.google.api.services.bigquery.model.TableConstraints;
 import com.google.api.services.bigquery.model.TableReference;
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.api.services.bigquery.model.TimePartitioning;
-import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.google.common.base.Throwables;
 import io.grpc.StatusRuntimeException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
@@ -70,19 +71,23 @@ public class CreateTableHelpers {
   static void createTableWrapper(Callable<Void> action, Callable<Boolean> tryCreateTable)
       throws Exception {
     BackOff backoff = BackOffAdapter.toGcpBackOff(DEFAULT_BACKOFF_FACTORY.backoff());
-    RuntimeException lastException = null;
+    Exception lastException = null;
     do {
       try {
         action.call();
         return;
-      } catch (ApiException | StatusRuntimeException | UncheckedExecutionException e) {
+      } catch (Exception e) {
         // The Storage Write library can wrap errors in UncheckedExecutionException
-        if (e instanceof UncheckedExecutionException) {
-          Throwable cause = e.getCause();
-          if (!(cause instanceof ApiException || cause instanceof StatusRuntimeException)) {
-            throw e;
-          }
+        Optional<Throwable> handledCause =
+            Throwables.getCausalChain(e).stream()
+                .filter(
+                    cause ->
+                        (cause instanceof ApiException || cause instanceof StatusRuntimeException))
+                .findAny();
+        if (!handledCause.isPresent()) {
+          throw e;
         }
+
         lastException = e;
         // TODO: Once BigQuery reliably returns a consistent error on table not found, we should
         // only try creating

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
@@ -824,7 +824,9 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
                 if (status.getCode() == Status.Code.INVALID_ARGUMENT) {
                   String description = status.getDescription();
                   schemaMismatchError =
-                      description != null && description.contains("incompatible fields");
+                      description != null
+                          && (description.contains("incompatible fields")
+                              || description.contains("extra proto fields"));
                 }
               }
               if (schemaMismatchError) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
@@ -164,9 +164,6 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
   public PCollectionTuple expand(PCollection<KV<DestinationT, StorageApiWritePayload>> input) {
     String operationName = input.getName() + "/" + getName();
     BigQueryOptions options = input.getPipeline().getOptions().as(BigQueryOptions.class);
-    org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument(
-        !options.getUseStorageApiConnectionPool(),
-        "useStorageApiConnectionPool only supported " + "when using STORAGE_API_AT_LEAST_ONCE");
     TupleTagList tupleTagList = TupleTagList.of(failedRowsTag);
     if (successfulRowsTag != null) {
       tupleTagList = tupleTagList.and(successfulRowsTag);
@@ -1139,7 +1136,7 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
             writeStreamService,
             useDefaultStream,
             streamAppendClientCount,
-            bigQueryOptions.getUseStorageApiConnectionPool(),
+            useDefaultStream ? bigQueryOptions.getUseStorageApiConnectionPool() : false,
             bigQueryOptions.getStorageWriteApiMaxRequestSize(),
             tryCreateTable,
             useCdc);


### PR DESCRIPTION
This was initially disabled as there were stability issues with connection pools. Several years have now gone by, and connection pooling support is stable.