### PR TITLE
Do not set representsation for pythonsdk_any type when typehint is Any

### DIFF
--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -260,28 +260,32 @@ def schema_field(
 
 def _python_any_schema_pb2(has_repr):
   # A portable schema matches FastPrimitivesCoder encoded values
-  representation = schema_pb2.FieldType(
-      nullable=False,
-      row_type=schema_pb2.RowType(
-          schema=schema_pb2.Schema(
-              fields=[
-                  schema_pb2.Field(
-                      name=_PYTHON_ANY_FIELD_TYPE_BYTE,
-                      type=schema_pb2.FieldType(
-                          atomic_type=schema_pb2.BYTE, nullable=False)),
-                  schema_pb2.Field(
-                      name=_PYTHON_ANY_FIELD_PAYLOAD,
-                      type=schema_pb2.FieldType(
-                          atomic_type=schema_pb2.BYTES, nullable=False))
-              ],
-              options=[
-                  schema_pb2.Option(
-                      name=_SCHEMA_OPTION_STATIC_ENCODING,
-                      type=schema_pb2.FieldType(atomic_type=schema_pb2.BOOLEAN),
-                      value=schema_pb2.FieldValue(
-                          atomic_value=schema_pb2.AtomicTypeValue(
-                              boolean=True)))
-              ]))) if has_repr else None
+  if has_repr:
+    representation = schema_pb2.FieldType(
+        nullable=False,
+        row_type=schema_pb2.RowType(
+            schema=schema_pb2.Schema(
+                fields=[
+                    schema_pb2.Field(
+                        name=_PYTHON_ANY_FIELD_TYPE_BYTE,
+                        type=schema_pb2.FieldType(
+                            atomic_type=schema_pb2.BYTE, nullable=False)),
+                    schema_pb2.Field(
+                        name=_PYTHON_ANY_FIELD_PAYLOAD,
+                        type=schema_pb2.FieldType(
+                            atomic_type=schema_pb2.BYTES, nullable=False))
+                ],
+                options=[
+                    schema_pb2.Option(
+                        name=_SCHEMA_OPTION_STATIC_ENCODING,
+                        type=schema_pb2.FieldType(
+                            atomic_type=schema_pb2.BOOLEAN),
+                        value=schema_pb2.FieldValue(
+                            atomic_value=schema_pb2.AtomicTypeValue(
+                                boolean=True)))
+                ]))) if has_repr else None
+  else:
+    representation = None
 
   return schema_pb2.FieldType(
       logical_type=schema_pb2.LogicalType(

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -258,34 +258,34 @@ def schema_field(
       description=description)
 
 
-def _python_any_schema_pb2():
+def _python_any_schema_pb2(has_repr):
   # A portable schema matches FastPrimitivesCoder encoded values
+  representation = schema_pb2.FieldType(
+      nullable=False,
+      row_type=schema_pb2.RowType(
+          schema=schema_pb2.Schema(
+              fields=[
+                  schema_pb2.Field(
+                      name=_PYTHON_ANY_FIELD_TYPE_BYTE,
+                      type=schema_pb2.FieldType(
+                          atomic_type=schema_pb2.BYTE, nullable=False)),
+                  schema_pb2.Field(
+                      name=_PYTHON_ANY_FIELD_PAYLOAD,
+                      type=schema_pb2.FieldType(
+                          atomic_type=schema_pb2.BYTES, nullable=False))
+              ],
+              options=[
+                  schema_pb2.Option(
+                      name=_SCHEMA_OPTION_STATIC_ENCODING,
+                      type=schema_pb2.FieldType(atomic_type=schema_pb2.BOOLEAN),
+                      value=schema_pb2.FieldValue(
+                          atomic_value=schema_pb2.AtomicTypeValue(
+                              boolean=True)))
+              ]))) if has_repr else None
+
   return schema_pb2.FieldType(
       logical_type=schema_pb2.LogicalType(
-          urn=PYTHON_ANY_URN,
-          representation=schema_pb2.FieldType(
-              nullable=False,
-              row_type=schema_pb2.RowType(
-                  schema=schema_pb2.Schema(
-                      fields=[
-                          schema_pb2.Field(
-                              name=_PYTHON_ANY_FIELD_TYPE_BYTE,
-                              type=schema_pb2.FieldType(
-                                  atomic_type=schema_pb2.BYTE, nullable=False)),
-                          schema_pb2.Field(
-                              name=_PYTHON_ANY_FIELD_PAYLOAD,
-                              type=schema_pb2.FieldType(
-                                  atomic_type=schema_pb2.BYTES, nullable=False))
-                      ],
-                      options=[
-                          schema_pb2.Option(
-                              name=_SCHEMA_OPTION_STATIC_ENCODING,
-                              type=schema_pb2.FieldType(
-                                  atomic_type=schema_pb2.BOOLEAN),
-                              value=schema_pb2.FieldValue(
-                                  atomic_value=schema_pb2.AtomicTypeValue(
-                                      boolean=True)))
-                      ])))),
+          urn=PYTHON_ANY_URN, representation=representation),
       nullable=True)
 
 
@@ -388,14 +388,18 @@ class SchemaTranslation(object):
         return schema_pb2.FieldType(
             array_type=schema_pb2.ArrayType(element_type=element_type))
 
+    elif type_ == Any:
+      return _python_any_schema_pb2(has_repr=False)
+
     try:
       if LogicalType.is_known_logical_type(type_):
         logical_type = type_
       else:
         logical_type = LogicalType.from_typing(type_)
     except ValueError:
-      # Unknown type, just treat it like Any
-      return _python_any_schema_pb2()
+      # Unknown type, use pythonsdk_any with a representation compatible with
+      # FastPrimitiveCoder encoded UNKNOWN type
+      return _python_any_schema_pb2(has_repr=True)
     else:
       argument_type = None
       argument = None

--- a/sdks/python/apache_beam/typehints/schemas_test.py
+++ b/sdks/python/apache_beam/typehints/schemas_test.py
@@ -582,9 +582,26 @@ class SchemaTest(unittest.TestCase):
                 fieldtype_proto, schema_registry=SchemaTypeRegistry()),
             schema_registry=SchemaTypeRegistry()))
 
+  def test_any_maps_to_any(self):
+    # python_any for typing.Any logical type's representation is delibrately set
+    # absent to prevent the usage crossing language boundary, as its encoded
+    # form isn't predictable from foreign SDK.
+    self.assertEqual(
+        typing_to_runner_api(Any),
+        schemas._python_any_schema_pb2(has_repr=False))
+
   def test_unknown_primitive_maps_to_any(self):
     self.assertEqual(
-        typing_to_runner_api(np.uint32), schemas._python_any_schema_pb2())
+        typing_to_runner_api(np.uint32),
+        schemas._python_any_schema_pb2(has_repr=True))
+
+  def test_unknown_user_type_maps_to_any(self):
+    class MyUnknownType:
+      pass
+
+    self.assertEqual(
+        typing_to_runner_api(MyUnknownType),
+        schemas._python_any_schema_pb2(has_repr=True))
 
   def test_unknown_atomic_raise_valueerror(self):
     self.assertRaises(


### PR DESCRIPTION
Follow up of #38206

#38206 added portable representation to pythonsdk_any logical type, making it recognizable by foreign SDK. However there are two cases we get pythonsdk_any in schema.py:

- typehints not covered by all previous cases, including user types or third party types. They'are going to be encoded with FastPrimitveCoder's "UNKNOWN_TYPE" branch, that is a type byte + pickled bytes. The representation set in #38206 is made to be compatible with this encoding form

- true "typing.Any" typehint. In this case, the field may carry Python primitive values, it's encoded form doesn't fit its representation, causing coder errors at runtime

This change then restore the original form of pythonsdk_any logical type's schema pb2 definition that is the representation is absent for the second case.

This is found when revisiting an old StackOverFlow question: https://stackoverflow.com/questions/65903919/local-testing-apache-beam-with-sqltransform-in-python-sdk-i-receive-an-error mentioned in #20738. It is preferred to throw at pipeline expansion time instead of data-corruption-taste coder error at runtime

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
