### PR TITLE
yaml_transform_test - add some debug logs and increase row count

### DIFF
--- a/sdks/python/apache_beam/yaml/yaml_transform_test.py
+++ b/sdks/python/apache_beam/yaml/yaml_transform_test.py
@@ -282,8 +282,8 @@ class YamlTransformE2ETest(unittest.TestCase):
       self.assertEqual(
           len(all_output),
           1,
-          msg=f"Expected 1 shard file, but found {len(all_output)}. \
-        Files & sizes (bytes): {file_and_size}")
+          msg=f"Expected 1 shard file, but found {len(all_output)}. "
+          f"Files & sizes (bytes): {file_and_size}")
       output_shard = all_output[0]
       result = pd.read_json(
           output_shard, orient='records',

--- a/sdks/python/apache_beam/yaml/yaml_transform_test.py
+++ b/sdks/python/apache_beam/yaml/yaml_transform_test.py
@@ -253,17 +253,8 @@ class YamlTransformE2ETest(unittest.TestCase):
       raise unittest.SkipTest('Pandas not available.')
 
     with tempfile.TemporaryDirectory() as tmpdir:
-      data = pd.DataFrame([
-          {
-              'label': '11a', 'rank': 0
-          },
-          {
-              'label': '37a', 'rank': 1
-          },
-          {
-              'label': '389a', 'rank': 2
-          },
-      ])
+      data = pd.DataFrame([{'label': f'{i}a', 'rank': i} for i in range(1024)])
+
       input = os.path.join(tmpdir, 'input.csv')
       output = os.path.join(tmpdir, 'output.json')
       data.to_csv(input, index=False)
@@ -286,9 +277,14 @@ class YamlTransformE2ETest(unittest.TestCase):
                     num_shards: 1
               - type: LogForTesting
             ''' % (repr(input), repr(output)))
-      all_output = list(glob.glob(output + "*"))
-      self.assertEqual(len(all_output), 1)
-      output_shard = list(glob.glob(output + "*"))[0]
+      all_output = list(glob.glob(output + "-*"))
+      file_and_size = {f: os.path.getsize(f) for f in all_output}
+      self.assertEqual(
+          len(all_output),
+          1,
+          msg=f"Expected 1 shard file, but found {len(all_output)}. \
+        Files & sizes (bytes): {file_and_size}")
+      output_shard = all_output[0]
       result = pd.read_json(
           output_shard, orient='records',
           lines=True).sort_values('rank').reindex()


### PR DESCRIPTION
1. Seeing some flakey test for test_csv_to_json, so adding some debug logs when encountered again.
2. Tried increasing input data to 10,000,000 rows to detect any splitting into multiple shards but nothing seen.
3. Tried running 100 times, but didn't catch it.
4. Tried PrismRunner instead of DirectRunner, but nothing caught.
5. Added some debug logs to tell if maybe an empty file is created by chance.
6. There could be a race condition where the system hasn't cleaned up the temporary file yet used during the pipeline and we globbed the output + "\*" pattern, we caught that condition. So changing to "-\*" to eliminate that possibility.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
