### PR TITLE
Fix FHIR search method signature mismatch after google.golang.org/api

### DIFF
--- a/sdks/go/pkg/beam/io/fhirio/common.go
+++ b/sdks/go/pkg/beam/io/fhirio/common.go
@@ -127,12 +127,12 @@ func (c *fhirStoreClientImpl) search(storePath, resourceType string, queries map
 		queryParams = append(queryParams, googleapi.QueryParameter(pageTokenParameterKey, pageToken))
 	}
 
-	// Pass nil as the body because search parameters are passed via queryParams,
+	// Pass an empty reader as the body because search parameters are passed via queryParams,
 	// and the new API expects an io.Reader instead of a specific struct.
 	if resourceType == "" {
-		return c.fhirService().Search(storePath, nil).Do(queryParams...)
+		return c.fhirService().Search(storePath, strings.NewReader("")).Do(queryParams...)
 	}
-	return c.fhirService().SearchType(storePath, resourceType, nil).Do(queryParams...)
+	return c.fhirService().SearchType(storePath, resourceType, strings.NewReader("")).Do(queryParams...)
 }
 
 func (c *fhirStoreClientImpl) deidentify(srcStorePath, dstStorePath string, deidConfig *healthcare.DeidentifyConfig) (operationResults, error) {


### PR DESCRIPTION
This PR fixes a build/test failure in the Go SDK's fhirio package that occurred after updating the google.golang.org/api dependency to v0.276.0 (which was done to support provisioned IOPS and throughput options for Dataflow workers).

In the newer version of the library, the Search and SearchType methods for the FHIR service require an io.Reader for the request body. The previous code was passing nil, which caused failures. This PR updates those call sites to pass an empty reader (strings.NewReader("")) instead of nil

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
