### PR TITLE
Fix deadlock in AsyncWrapper reset_state()

### DIFF
--- a/sdks/python/apache_beam/transforms/async_dofn.py
+++ b/sdks/python/apache_beam/transforms/async_dofn.py
@@ -165,10 +165,11 @@ class AsyncWrapper(beam.DoFn):
       if AsyncWrapper._loop_started is not None:
         AsyncWrapper._loop_started.clear()
 
-      pools_to_shutdown = [
-          pool.acquire(AsyncWrapper.initialize_pool(1))
-          for pool in AsyncWrapper._pool.values()
-      ]
+      pools = list(AsyncWrapper._pool.values())
+
+    pools_to_shutdown = [
+        pool.acquire(AsyncWrapper.initialize_pool(1)) for pool in pools
+    ]
 
     for pool in pools_to_shutdown:
       pool.shutdown(wait=True, cancel_futures=True)

--- a/sdks/python/apache_beam/transforms/async_dofn.py
+++ b/sdks/python/apache_beam/transforms/async_dofn.py
@@ -153,12 +153,13 @@ class AsyncWrapper(beam.DoFn):
 
   @staticmethod
   def reset_state():
+    event_loop_thread_to_join = None
     with AsyncWrapper._lock:
       if AsyncWrapper._event_loop:
         AsyncWrapper._event_loop.call_soon_threadsafe(
             AsyncWrapper._event_loop.stop)
       if AsyncWrapper._event_loop_thread:
-        AsyncWrapper._event_loop_thread.join()
+        event_loop_thread_to_join = AsyncWrapper._event_loop_thread
 
       AsyncWrapper._event_loop = None
       AsyncWrapper._event_loop_thread = None
@@ -167,6 +168,17 @@ class AsyncWrapper(beam.DoFn):
 
       pools = list(AsyncWrapper._pool.values())
 
+    # We must join the asyncio event loop thread outside of the lock block.
+    # If joined inside the lock, the waiting thread holds the lock while blocking,
+    # preventing active coroutines' done callbacks from acquiring the lock on the
+    # event loop thread, resulting in a deadlock.
+    if event_loop_thread_to_join:
+      event_loop_thread_to_join.join()
+
+    # We must acquire and shut down the thread pools outside of the lock block.
+    # If shutdown(wait=True) is called inside the lock, the caller blocks holding
+    # the lock, preventing active worker threads from acquiring the lock to run
+    # their done callbacks, resulting in a deadlock.
     pools_to_shutdown = [
         pool.acquire(AsyncWrapper.initialize_pool(1)) for pool in pools
     ]

--- a/sdks/python/apache_beam/transforms/async_dofn.py
+++ b/sdks/python/apache_beam/transforms/async_dofn.py
@@ -165,9 +165,14 @@ class AsyncWrapper(beam.DoFn):
       if AsyncWrapper._loop_started is not None:
         AsyncWrapper._loop_started.clear()
 
-      for pool in AsyncWrapper._pool.values():
-        pool.acquire(AsyncWrapper.initialize_pool(1)).shutdown(
-            wait=True, cancel_futures=True)
+      pools_to_shutdown = [
+          pool.acquire(AsyncWrapper.initialize_pool(1))
+          for pool in AsyncWrapper._pool.values()
+      ]
+
+    for pool in pools_to_shutdown:
+      pool.shutdown(wait=True, cancel_futures=True)
+
     with AsyncWrapper._lock:
       AsyncWrapper._pool = {}
       AsyncWrapper._processing_elements = {}
@@ -268,7 +273,8 @@ class AsyncWrapper(beam.DoFn):
 
   def decrement_items_in_buffer(self, future):
     with AsyncWrapper._lock:
-      AsyncWrapper._items_in_buffer[self._uuid] -= 1
+      if self._uuid in AsyncWrapper._items_in_buffer:
+        AsyncWrapper._items_in_buffer[self._uuid] -= 1
 
   def schedule_if_room(self, element, ignore_buffer=False, *args, **kwargs):
     """Schedules an item to be processed asynchronously if there is room.

--- a/sdks/python/apache_beam/transforms/async_dofn_test.py
+++ b/sdks/python/apache_beam/transforms/async_dofn_test.py
@@ -489,7 +489,7 @@ class AsyncTest(unittest.TestCase):
       self.assertEqual(bag_states['key' + str(i)].items, [])
 
   @staticmethod
-  def _run_reset_state_deadlock_scenario(use_asyncio):
+  def _run_reset_state_concurrent_teardown(use_asyncio):
     dofn = BasicDofn(sleep_time=0.5)
     async_dofn = async_lib.AsyncWrapper(dofn, use_asyncio=use_asyncio)
     async_dofn.setup()
@@ -500,16 +500,15 @@ class AsyncTest(unittest.TestCase):
     async_dofn.process(('key1', 1), to_process=fake_bag_state, timer=fake_timer)
     time.sleep(0.05)
 
-    # Attempt to call reset_state(). If the fix is NOT applied, this will deadlock
-    # forever because reset_state() holds the lock while waiting for active tasks/threads,
-    # blocking the future's done callback from acquiring the lock.
+    # Verify that calling reset_state() while background tasks are actively running
+    # completes cleanly without causing lock-ordering deadlocks.
     async_lib.AsyncWrapper.reset_state()
 
-  def test_reset_state_hang_reproduction(self):
-    # Run the deadlock scenario in a separate process so that if it hangs,
-    # we can terminate it without causing the main pytest process to hang at exit.
+  def test_reset_state_concurrent_teardown(self):
+    # Verify concurrent teardown safety in a separate process to prevent any potential
+    # regressions from freezing the main pytest process at exit.
     p = multiprocessing.Process(
-        target=AsyncTest._run_reset_state_deadlock_scenario,
+        target=AsyncTest._run_reset_state_concurrent_teardown,
         args=(self.use_asyncio, ))
     p.start()
     p.join(timeout=10.0)

--- a/sdks/python/apache_beam/transforms/async_dofn_test.py
+++ b/sdks/python/apache_beam/transforms/async_dofn_test.py
@@ -518,11 +518,11 @@ class AsyncTest(unittest.TestCase):
       p.terminate()
       p.join()
       self.fail(
-          "reset_state() deadlocked/hung waiting for active threads/tasks to finish")
+          "reset_state() deadlocked/hung waiting for active threads/tasks to finish"
+      )
     else:
       self.assertEqual(p.exitcode, 0)
 
 
 if __name__ == '__main__':
   unittest.main()
-

--- a/sdks/python/apache_beam/transforms/async_dofn_test.py
+++ b/sdks/python/apache_beam/transforms/async_dofn_test.py
@@ -490,30 +490,24 @@ class AsyncTest(unittest.TestCase):
 
   @staticmethod
   def _run_reset_state_deadlock_scenario(use_asyncio):
-    if use_asyncio:
-      return
-
     dofn = BasicDofn(sleep_time=0.5)
-    async_dofn = async_lib.AsyncWrapper(dofn, use_asyncio=False)
+    async_dofn = async_lib.AsyncWrapper(dofn, use_asyncio=use_asyncio)
     async_dofn.setup()
     fake_bag_state = FakeBagState([])
     fake_timer = FakeTimer(0)
 
-    # Start processing an item. This starts a worker thread sleeping for 0.5s.
+    # Start processing an item. This starts a worker thread/coroutine sleeping for 0.5s.
     async_dofn.process(('key1', 1), to_process=fake_bag_state, timer=fake_timer)
     time.sleep(0.05)
 
     # Attempt to call reset_state(). If the fix is NOT applied, this will deadlock
-    # forever because reset_state() holds the lock while calling shutdown(wait=True),
+    # forever because reset_state() holds the lock while waiting for active tasks/threads,
     # blocking the future's done callback from acquiring the lock.
     async_lib.AsyncWrapper.reset_state()
 
   def test_reset_state_hang_reproduction(self):
     # Run the deadlock scenario in a separate process so that if it hangs,
     # we can terminate it without causing the main pytest process to hang at exit.
-    if self.use_asyncio:
-      return
-
     p = multiprocessing.Process(
         target=AsyncTest._run_reset_state_deadlock_scenario,
         args=(self.use_asyncio, ))
@@ -524,7 +518,7 @@ class AsyncTest(unittest.TestCase):
       p.terminate()
       p.join()
       self.fail(
-          "reset_state() deadlocked/hung waiting for active threads to finish")
+          "reset_state() deadlocked/hung waiting for active threads/tasks to finish")
     else:
       self.assertEqual(p.exitcode, 0)
 

--- a/sdks/python/apache_beam/transforms/async_dofn_test.py
+++ b/sdks/python/apache_beam/transforms/async_dofn_test.py
@@ -512,7 +512,7 @@ class AsyncTest(unittest.TestCase):
         target=AsyncTest._run_reset_state_deadlock_scenario,
         args=(self.use_asyncio, ))
     p.start()
-    p.join(timeout=3.0)
+    p.join(timeout=10.0)
 
     if p.is_alive():
       p.terminate()

--- a/sdks/python/apache_beam/transforms/async_dofn_test.py
+++ b/sdks/python/apache_beam/transforms/async_dofn_test.py
@@ -16,6 +16,7 @@
 #
 
 import logging
+import multiprocessing
 import random
 import time
 import unittest
@@ -487,6 +488,46 @@ class AsyncTest(unittest.TestCase):
       self.check_output(results[i], expected_outputs['key' + str(i)])
       self.assertEqual(bag_states['key' + str(i)].items, [])
 
+  @staticmethod
+  def _run_reset_state_deadlock_scenario(use_asyncio):
+    if use_asyncio:
+      return
+
+    dofn = BasicDofn(sleep_time=0.5)
+    async_dofn = async_lib.AsyncWrapper(dofn, use_asyncio=False)
+    async_dofn.setup()
+    fake_bag_state = FakeBagState([])
+    fake_timer = FakeTimer(0)
+
+    # Start processing an item. This starts a worker thread sleeping for 0.5s.
+    async_dofn.process(('key1', 1), to_process=fake_bag_state, timer=fake_timer)
+    time.sleep(0.05)
+
+    # Attempt to call reset_state(). If the fix is NOT applied, this will deadlock
+    # forever because reset_state() holds the lock while calling shutdown(wait=True),
+    # blocking the future's done callback from acquiring the lock.
+    async_lib.AsyncWrapper.reset_state()
+
+  def test_reset_state_hang_reproduction(self):
+    # Run the deadlock scenario in a separate process so that if it hangs,
+    # we can terminate it without causing the main pytest process to hang at exit.
+    if self.use_asyncio:
+      return
+
+    p = multiprocessing.Process(
+        target=AsyncTest._run_reset_state_deadlock_scenario,
+        args=(self.use_asyncio,))
+    p.start()
+    p.join(timeout=3.0)
+
+    if p.is_alive():
+      p.terminate()
+      p.join()
+      self.fail("reset_state() deadlocked/hung waiting for active threads to finish")
+    else:
+      self.assertEqual(p.exitcode, 0)
+
 
 if __name__ == '__main__':
   unittest.main()
+

--- a/sdks/python/apache_beam/transforms/async_dofn_test.py
+++ b/sdks/python/apache_beam/transforms/async_dofn_test.py
@@ -516,14 +516,15 @@ class AsyncTest(unittest.TestCase):
 
     p = multiprocessing.Process(
         target=AsyncTest._run_reset_state_deadlock_scenario,
-        args=(self.use_asyncio,))
+        args=(self.use_asyncio, ))
     p.start()
     p.join(timeout=3.0)
 
     if p.is_alive():
       p.terminate()
       p.join()
-      self.fail("reset_state() deadlocked/hung waiting for active threads to finish")
+      self.fail(
+          "reset_state() deadlocked/hung waiting for active threads to finish")
     else:
       self.assertEqual(p.exitcode, 0)
 


### PR DESCRIPTION
During test execution or pipeline teardown, calling `reset_state` on `AsyncWrapper` intermittently hangs the pipeline indefinitely, leading to test runner timeouts (https://github.com/apache/beam/actions/runs/25590690572/job/75127752557?pr=38425).

The traceback of timeout is shown below (on a different occasion AsyncTest_0.test_duplicates failed too):

```
________________________ AsyncTest_1.test_duplicates __________________________
[gw0] darwin -- Python 3.13.13 /Users/runner/work/beam/beam/sdks/python/target/.tox/py313-macos/bin/python

self = <apache_beam.transforms.async_dofn_test.AsyncTest_1 testMethod=test_duplicates>

    def setUp(self):
      super().setUp()
>     async_lib.AsyncWrapper.reset_state()

apache_beam/transforms/async_dofn_test.py:102: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
target/.tox/py313-macos/lib/python3.13/site-packages/apache_beam/transforms/async_dofn.py:169: in reset_state
    pool.acquire(AsyncWrapper.initialize_pool(1)).shutdown(
/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/concurrent/futures/thread.py:239: in shutdown
    t.join()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <Thread(ThreadPoolExecutor-180_0, stopped 14025928704)>, timeout = None

    def join(self, timeout=None):
        """Wait until the thread terminates.
    
        This blocks the calling thread until the thread whose join() method is
        called terminates -- either normally or through an unhandled exception
        or until the optional timeout occurs.
    
        When the timeout argument is present and not None, it should be a
        floating-point number specifying a timeout for the operation in seconds
        (or fractions thereof). As join() always returns None, you must call
        is_alive() after join() to decide whether a timeout happened -- if the
        thread is still alive, the join() call timed out.
    
        When the timeout argument is not present or None, the operation will
        block until the thread terminates.
    
        A thread can be join()ed many times.
    
        join() raises a RuntimeError if an attempt is made to join the current
        thread as that would cause a deadlock. It is also an error to join() a
        thread before it has been started and attempts to do so raises the same
        exception.
    
        """
        if not self._initialized:
            raise RuntimeError("Thread.__init__() not called")
        if not self._started.is_set():
            raise RuntimeError("cannot join thread before it is started")
        if self is current_thread():
            raise RuntimeError("cannot join current thread")
    
        # the behavior of a negative timeout isn't documented, but
    self._bootstrap_inner()
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 1044, in _bootstrap_inner
    self.run()
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 995, in run
    self._target(*self._args, **self._kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/multiprocessing/managers.py", line 179, in serve_forever
    self.stop_event.wait(1)
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 660, in wait
    signaled = self._cond.wait(timeout)
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 363, in wait
    gotit = waiter.acquire(True, timeout)
```

The deadlock occurs in the following order:
- The main thread executing `reset_state` acquires `AsyncWrapper._lock` and calls `pool.shutdown(wait=True)`. It remains blocked waiting for active worker threads to finish while holding the lock.
- When an active worker thread finishes processing an item, the underlying future completes and tries to invoke its done callbacks on that same worker thread. The registered callback `decrement_items_in_buffer`, however, attempts to acquire `AsyncWrapper._lock` to decrement the buffer count. This leads to a deadlock.

To fix it, we move the shutdown call outside of the lock scope, so while the main thread is waiting for worker threads to complete, it won't hold the lock.

