### PR TITLE
Fix PreCommit Java PVR Prism Loopback workflow

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/MetadataPropagationTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/MetadataPropagationTest.java
@@ -80,6 +80,11 @@ public class MetadataPropagationTest {
     pipeline.run();
   }
 
+  /**
+   * Tests metadata propagation for a parameter. Note: PAssert internally introduces a GroupByKey.
+   * This test works only with DirectRunner and runners that support metadata propagation.
+   * See {@link #testMetadataPropagationAcrossGBK} for more information.
+   */
   @Test
   @Category(NeedsRunner.class)
   public void testMetadataPropagationParameter() {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/MetadataPropagationTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/MetadataPropagationTest.java
@@ -81,7 +81,7 @@ public class MetadataPropagationTest {
   }
 
   @Test
-  @Category({ValidatesRunner.class, NeedsRunner.class})
+  @Category(NeedsRunner.class)
   public void testMetadataPropagationParameter() {
     WindowedValues.WindowedValueCoder.setMetadataSupported();
     PCollection<String> results =

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/MetadataPropagationTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/MetadataPropagationTest.java
@@ -22,7 +22,6 @@ import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.TestStream;
-import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.transforms.windowing.Window;
@@ -82,8 +81,8 @@ public class MetadataPropagationTest {
 
   /**
    * Tests metadata propagation for a parameter. Note: PAssert internally introduces a GroupByKey.
-   * This test works only with DirectRunner and runners that support metadata propagation.
-   * See {@link #testMetadataPropagationAcrossGBK} for more information.
+   * This test works only with DirectRunner and runners that support metadata propagation across
+   * GroupByKey. See {@link #testMetadataPropagationAcrossGBK} for more information.
    */
   @Test
   @Category(NeedsRunner.class)


### PR DESCRIPTION
The [PreCommit Java PVR Prism Loopback workflow]( https://github.com/apache/beam/actions/workflows/beam_PreCommit_Java_PVR_Prism_Loopback.yml) failed recently due to the following error in test `testMetadataPropagationParameter`.

```
[2026-05-10T22:15:34.499261252Z]  ERROR  job failed
G job  : 
    key : job-001
    name: metadatapropagationtest0testmetadatapropagationparameter-runner-0510221530-8b8b2767
E error: 
    0: bundle inst006 stage-006 failed:org.apache.beam.sdk.coders.CoderException: java.io.EOFException: reached end of stream after reading 0 bytes; 8 bytes expected
	at org.apache.beam.sdk.coders.InstantCoder.decode(InstantCoder.java:68)
	at org.apache.beam.sdk.values.ValueInSingleWindow$Coder.decode(ValueInSingleWindow.java:166)
	at org.apache.beam.sdk.values.ValueInSingleWindow$Coder.decode(ValueInSingleWindow.java:101)
	at org.apache.beam.sdk.coders.LengthPrefixCoder.decode(LengthPrefixCoder.java:64)
	at org.apache.beam.sdk.coders.IterableLikeCoder.decode(IterableLikeCoder.java:134)
	at org.apache.beam.sdk.coders.IterableLikeCoder.decode(IterableLikeCoder.java:58)
	at org.apache.beam.sdk.coders.Coder.decode(Coder.java:164)
	at org.apache.beam.sdk.values.WindowedValues$FullWindowedValueCoder.decode(WindowedValues.java:1079)
	at org.apache.beam.sdk.values.WindowedValues$FullWindowedValueCoder.decode(WindowedValues.java:1059)
	at org.apache.beam.sdk.values.WindowedValues$FullWindowedValueCoder.decode(WindowedValues.java:985)
	at org.apache.beam.sdk.fn.data.BeamFnDataInboundObserver.multiplexElements(BeamFnDataInboundObserver.java:232)
	at org.apache.beam.sdk.fn.data.BeamFnDataInboundObserver.awaitCompletion(BeamFnDataInboundObserver.java:186)
	at org.apache.beam.fn.harness.control.ProcessBundleHandler.processBundle(ProcessBundleHandler.java:551)
	at org.apache.beam.fn.harness.control.BeamFnControlClient.delegateOnInstructionRequestType(BeamFnControlClient.java:150)
	at org.apache.beam.fn.harness.control.BeamFnControlClient$InboundObserver.lambda$onNext$0(BeamFnControlClient.java:115)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at org.apache.beam.sdk.util.UnboundedScheduledExecutorService$ScheduledFutureTask.run(UnboundedScheduledExecutorService.java:164)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.io.EOFException: reached end of stream after reading 0 bytes; 8 bytes expected
	at org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.io.ByteStreams.readFully(ByteStreams.java:802)
	at org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.io.ByteStreams.readFully(ByteStreams.java:784)
	at org.apache.beam.sdk.coders.BitConverters.readBigEndianLong(BitConverters.java:32)
	at org.apache.beam.sdk.coders.InstantCoder.decode(InstantCoder.java:64)
	... 20 more
```

According to the comment for `testMetadataPropagationAcrossGBK`, portable runners like Prism do not yet support metadata propagation across `GroupByKey`, enabling metadata encoding causes an EOFException coder mismatch:

https://github.com/apache/beam/blob/a8e7ffab3716459518aeea2e81fe7181c6885179/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/MetadataPropagationTest.java#L107-L110

In `testMetadataPropagationParameter`, even though there is no explicit `GroupByKey` step, `PAssert.that().containsInAnyOrder()` internally introduces a `GroupByKey`. Therefore, we see the said error in this test as well. 

Removing `ValidatesRunner` aligns this test with the other GBK-dependent tests in MetadataPropagationTest.

fixes #36686