### PR TITLE
Fix thread leak for LOOPBACK workers in external worker pool

### DIFF
--- a/sdks/python/apache_beam/runners/portability/prism_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner_test.py
@@ -19,7 +19,10 @@
 import argparse
 import logging
 import os.path
+import queue
 import shlex
+import threading
+import time
 import typing
 import unittest
 import zipfile
@@ -37,8 +40,10 @@ from apache_beam.options.pipeline_options import DebugOptions
 from apache_beam.options.pipeline_options import PortableOptions
 from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.options.pipeline_options import TypeOptions
+from apache_beam.portability.api import beam_fn_api_pb2
 from apache_beam.runners.portability import portable_runner_test
 from apache_beam.runners.portability import prism_runner
+from apache_beam.runners.worker import worker_pool_main
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
 from apache_beam.transforms import trigger
@@ -494,12 +499,6 @@ class PrismRunnerSingletonTest(unittest.TestCase):
     StopWorker via sentinel messages. This prevents background daemon threads from
     accumulating across sequential pipeline executions and leaking resources.
     """
-    import queue
-    import threading
-    import time
-    from apache_beam.portability.api import beam_fn_api_pb2
-    from apache_beam.runners.worker import worker_pool_main
-
     servicer = worker_pool_main.BeamFnExternalWorkerPoolServicer(
         use_process=False, state_cache_size=0, data_buffer_time_limit_ms=0)
 

--- a/sdks/python/apache_beam/runners/portability/prism_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner_test.py
@@ -510,6 +510,14 @@ class PrismRunnerSingletonTest(unittest.TestCase):
       mock_responses.get()
       active_workers.remove(self_worker)
 
+    def wait_for_workers(expected_count, timeout=5.0):
+      start = time.time()
+      while time.time() - start < timeout:
+        if len(active_workers) == expected_count:
+          return
+        time.sleep(0.01)
+      self.assertEqual(len(active_workers), expected_count)
+
     with mock.patch(
         'apache_beam.runners.worker.sdk_worker.SdkHarness') as mock_harness:
       mock_harness.return_value._responses = mock_responses
@@ -520,31 +528,27 @@ class PrismRunnerSingletonTest(unittest.TestCase):
       req1.control_endpoint.url = "localhost:12345"
       servicer.StartWorker(req1, None)
 
-      time.sleep(0.05)
-      self.assertEqual(len(active_workers), 1)
+      wait_for_workers(1)
 
       # Simulate stopping Worker 1 at the end of Pipeline 1
       stop_req1 = beam_fn_api_pb2.StopWorkerRequest(worker_id="worker_1")
       servicer.StopWorker(stop_req1, None)
 
-      time.sleep(0.05)
       # Verify the fix: StopWorker successfully tells the thread harness to shut down,
       # completely resolving the thread leak!
-      self.assertEqual(len(active_workers), 0)
+      wait_for_workers(0)
 
       # Simulate starting Worker 2 for Pipeline 2
       req2 = beam_fn_api_pb2.StartWorkerRequest(worker_id="worker_2")
       req2.control_endpoint.url = "localhost:12345"
       servicer.StartWorker(req2, None)
 
-      time.sleep(0.05)
-      self.assertEqual(len(active_workers), 1)
+      wait_for_workers(1)
 
       # Clean up the second worker
       servicer.StopWorker(
           beam_fn_api_pb2.StopWorkerRequest(worker_id="worker_2"), None)
-      time.sleep(0.05)
-      self.assertEqual(len(active_workers), 0)
+      wait_for_workers(0)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/portability/prism_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner_test.py
@@ -488,6 +488,63 @@ class PrismRunnerSingletonTest(unittest.TestCase):
       else:
         mock_prism_server.assert_called_once()
 
+  def test_loopback_worker_daemon_thread_accumulation(self):
+    """Verifies that in LOOPBACK mode, the external worker pool servicer properly
+    tracks active thread-based SdkHarness workers and cleanly shuts them down in
+    StopWorker via sentinel messages. This prevents background daemon threads from
+    accumulating across sequential pipeline executions and leaking resources.
+    """
+    import queue
+    import threading
+    import time
+    from apache_beam.portability.api import beam_fn_api_pb2
+    from apache_beam.runners.worker import worker_pool_main
+
+    servicer = worker_pool_main.BeamFnExternalWorkerPoolServicer(
+        use_process=False, state_cache_size=0, data_buffer_time_limit_ms=0)
+
+    active_workers = []
+    mock_responses = queue.Queue()
+
+    def mock_run(self_worker):
+      active_workers.append(self_worker)
+      mock_responses.get()
+      active_workers.remove(self_worker)
+
+    with mock.patch('apache_beam.runners.worker.sdk_worker.SdkHarness') as mock_harness:
+      mock_harness.return_value._responses = mock_responses
+      mock_harness.return_value.run = lambda: mock_run(mock_harness)
+
+      # Simulate starting Worker 1 for Pipeline 1
+      req1 = beam_fn_api_pb2.StartWorkerRequest(worker_id="worker_1")
+      req1.control_endpoint.url = "localhost:12345"
+      servicer.StartWorker(req1, None)
+
+      time.sleep(0.05)
+      self.assertEqual(len(active_workers), 1)
+
+      # Simulate stopping Worker 1 at the end of Pipeline 1
+      stop_req1 = beam_fn_api_pb2.StopWorkerRequest(worker_id="worker_1")
+      servicer.StopWorker(stop_req1, None)
+
+      time.sleep(0.05)
+      # Verify the fix: StopWorker successfully tells the thread harness to shut down,
+      # completely resolving the thread leak!
+      self.assertEqual(len(active_workers), 0)
+
+      # Simulate starting Worker 2 for Pipeline 2
+      req2 = beam_fn_api_pb2.StartWorkerRequest(worker_id="worker_2")
+      req2.control_endpoint.url = "localhost:12345"
+      servicer.StartWorker(req2, None)
+
+      time.sleep(0.05)
+      self.assertEqual(len(active_workers), 1)
+
+      # Clean up the second worker
+      servicer.StopWorker(beam_fn_api_pb2.StopWorkerRequest(worker_id="worker_2"), None)
+      time.sleep(0.05)
+      self.assertEqual(len(active_workers), 0)
+
 
 if __name__ == '__main__':
   # Run the tests.

--- a/sdks/python/apache_beam/runners/portability/prism_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner_test.py
@@ -511,7 +511,8 @@ class PrismRunnerSingletonTest(unittest.TestCase):
       mock_responses.get()
       active_workers.remove(self_worker)
 
-    with mock.patch('apache_beam.runners.worker.sdk_worker.SdkHarness') as mock_harness:
+    with mock.patch(
+        'apache_beam.runners.worker.sdk_worker.SdkHarness') as mock_harness:
       mock_harness.return_value._responses = mock_responses
       mock_harness.return_value.run = lambda: mock_run(mock_harness)
 
@@ -541,7 +542,8 @@ class PrismRunnerSingletonTest(unittest.TestCase):
       self.assertEqual(len(active_workers), 1)
 
       # Clean up the second worker
-      servicer.StopWorker(beam_fn_api_pb2.StopWorkerRequest(worker_id="worker_2"), None)
+      servicer.StopWorker(
+          beam_fn_api_pb2.StopWorkerRequest(worker_id="worker_2"), None)
       time.sleep(0.05)
       self.assertEqual(len(active_workers), 0)
 

--- a/sdks/python/apache_beam/runners/worker/worker_pool_main.py
+++ b/sdks/python/apache_beam/runners/worker/worker_pool_main.py
@@ -45,6 +45,7 @@ from apache_beam.portability.api import beam_fn_api_pb2
 from apache_beam.portability.api import beam_fn_api_pb2_grpc
 from apache_beam.runners.worker import sdk_worker
 from apache_beam.utils import thread_pool_executor
+from apache_beam.utils.sentinel import Sentinel
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -196,7 +197,6 @@ class BeamFnExternalWorkerPoolServicer(
         stop_worker_request.worker_id, None)
     if worker_thread_harness:
       _LOGGER.info("Stopping thread worker %s" % stop_worker_request.worker_id)
-      from apache_beam.utils.sentinel import Sentinel
       worker_thread_harness._responses.put(Sentinel.sentinel)
 
     return beam_fn_api_pb2.StopWorkerResponse()

--- a/sdks/python/apache_beam/runners/worker/worker_pool_main.py
+++ b/sdks/python/apache_beam/runners/worker/worker_pool_main.py
@@ -190,6 +190,8 @@ class BeamFnExternalWorkerPoolServicer(
       _LOGGER.info("Stopping worker %s" % stop_worker_request.worker_id)
       kill_process_gracefully(worker_process)
 
+    # applicable for thread mode to ensure thread cleanup by
+    # unblocking the harness request stream.
     worker_thread_harness = self._worker_threads.pop(
         stop_worker_request.worker_id, None)
     if worker_thread_harness:

--- a/sdks/python/apache_beam/runners/worker/worker_pool_main.py
+++ b/sdks/python/apache_beam/runners/worker/worker_pool_main.py
@@ -82,6 +82,7 @@ class BeamFnExternalWorkerPoolServicer(
     self._state_cache_size = state_cache_size
     self._data_buffer_time_limit_ms = data_buffer_time_limit_ms
     self._worker_processes: dict[str, subprocess.Popen] = {}
+    self._worker_threads: dict[str, sdk_worker.SdkHarness] = {}
 
   @classmethod
   def start(
@@ -166,6 +167,7 @@ class BeamFnExternalWorkerPoolServicer(
             worker_id=start_worker_request.worker_id,
             state_cache_size=self._state_cache_size,
             data_buffer_time_limit_ms=self._data_buffer_time_limit_ms)
+        self._worker_threads[start_worker_request.worker_id] = worker
         worker_thread = threading.Thread(
             name='run_worker_%s' % start_worker_request.worker_id,
             target=worker.run)
@@ -187,6 +189,13 @@ class BeamFnExternalWorkerPoolServicer(
     if worker_process:
       _LOGGER.info("Stopping worker %s" % stop_worker_request.worker_id)
       kill_process_gracefully(worker_process)
+
+    worker_thread_harness = self._worker_threads.pop(
+        stop_worker_request.worker_id, None)
+    if worker_thread_harness:
+      _LOGGER.info("Stopping thread worker %s" % stop_worker_request.worker_id)
+      from apache_beam.utils.sentinel import Sentinel
+      worker_thread_harness._responses.put(Sentinel.sentinel)
 
     return beam_fn_api_pb2.StopWorkerResponse()
 


### PR DESCRIPTION
We have been seeing "DEADLINE EXCEEDED" from time to time in our tests since we switched the default python runner to Prism.

Below is an example traceback:

```
target/.tox-py314-cloud/py314-cloud/lib/python3.14/site-packages/apache_beam/pipeline.py:654: in __exit__
    self.result.wait_until_finish()
target/.tox-py314-cloud/py314-cloud/lib/python3.14/site-packages/apache_beam/runners/portability/portable_runner.py:572: in wait_until_finish
    raise self._runtime_exception
target/.tox-py314-cloud/py314-cloud/lib/python3.14/site-packages/apache_beam/runners/portability/portable_runner.py:581: in _observe_state
    for state_response in self._state_stream:
                          ^^^^^^^^^^^^^^^^^^
target/.tox-py314-cloud/py314-cloud/lib/python3.14/site-packages/grpc/_channel.py:538: in __next__
    return self._next()
           ^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <_MultiThreadedRendezvous of RPC that terminated with:
	status = StatusCode.DEADLINE_EXCEEDED
	details = "Deadline Exceeded"
	debug_error_string = "UNKNOWN:Error received from peer  {grpc_status:4, grpc_message:"Deadline Exceeded"}"
>

    def _next(self) -> Any:
        with self._state.condition:
            if self._state.code is None:
                event_handler = _event_handler(
                    self._state, self._response_deserializer
                )
                self._state.due.add(cygrpc.OperationType.receive_message)
                operating = self._call.operate(
                    (cygrpc.ReceiveMessageOperation(_EMPTY_FLAGS),),
                    event_handler,
                )
                if not operating:
                    self._state.due.remove(cygrpc.OperationType.receive_message)
            elif self._state.code is grpc.StatusCode.OK:
                raise StopIteration()
            else:
                raise self
    
            def _response_ready():
                return self._state.response is not None or (
                    cygrpc.OperationType.receive_message not in self._state.due
                    and self._state.code is not None
                )
    
            _common.wait(self._state.condition.wait, _response_ready)
            if self._state.response is not None:
                response = self._state.response
                self._state.response = None
                return response
            if cygrpc.OperationType.receive_message not in self._state.due:
                if self._state.code is grpc.StatusCode.OK:
                    raise StopIteration()
                if self._state.code is not None:
>                   raise self
E                   grpc._channel._MultiThreadedRendezvous: <_MultiThreadedRendezvous of RPC that terminated with:
E                   	status = StatusCode.DEADLINE_EXCEEDED
E                   	details = "Deadline Exceeded"
E                   	debug_error_string = "UNKNOWN:Error received from peer  {grpc_status:4, grpc_message:"Deadline Exceeded"}"
E                   >

target/.tox-py314-cloud/py314-cloud/lib/python3.14/site-packages/grpc/_channel.py:956: _MultiThreadedRendezvous
```

The above traceback suggests that the Python client tries to retrieve state from Prism server, but it is timeout. We suspect the timeout is due to resource starvation from leaking threads and grpc channels of SdkHarness workers.

- When executing portable pipelines in `LOOPBACK` mode (the default environment for `PrismRunner`), the external worker pool launches `SdkHarness` workers inside the Python process as **background daemon threads** (not separate processes). 
Previously, `StopWorker` explicitly skipped terminating thread-based workers under the assumption that they would exit automatically. However, because `PrismRunner` acts as a process-level shared singleton(#36228), its gRPC server remains active across tests and does not immediately close these control/data streams. As a result, background daemon threads and open gRPC channels accumulate sequentially across test runs. 
- When executing large test suites via `pytest`, accumulating dozens or hundreds of these threads creates severe GIL contention, memory pressure, and socket exhaustion, eventually stalling pipeline execution and causing `DEADLINE_EXCEEDED` timeouts.

In this PR, we add code to (1) track active `SdkHarness` worker threads and (2) push `Sentinel.sentinel` directly into its `_responses` queue in `StopWorker()` to unblock the worker's request iterator and shut down all associated thread pools and grpc channel resources.