### PR TITLE
Make SubprocessServer shared cache purging idempotent

### DIFF
--- a/sdks/python/apache_beam/utils/subprocess_server.py
+++ b/sdks/python/apache_beam/utils/subprocess_server.py
@@ -91,7 +91,11 @@ class _SharedCache:
     to_delete = []
     with self._lock:
       if owner not in self._live_owners:
-        raise ValueError(f"{owner} not in {self._live_owners}")
+        _LOGGER.warning(
+            "Subprocess owner %s already purged. If this occurs during atexit "
+            "shutdown, the subprocess was already cleaned up earlier.",
+            owner)
+        return
       self._live_owners.remove(owner)
       for key, entry in list(self._cache.items()):
         if owner in entry.owners:

--- a/sdks/python/apache_beam/utils/subprocess_server_test.py
+++ b/sdks/python/apache_beam/utils/subprocess_server_test.py
@@ -421,10 +421,30 @@ class CacheTest(unittest.TestCase):
     t1.join()
     t2.join()
 
-    # Exactly one thread should raise the expected ValueError because they are cleanly serialized
-    self.assertEqual(len(exceptions), 1)
-    self.assertIsInstance(exceptions[0], ValueError)
-    self.assertNotIsInstance(exceptions[0], KeyError)
+    # Both threads should succeed cleanly without raising an exception under idempotent purging.
+    self.assertEqual(len(exceptions), 0)
+
+  def test_stop_process_after_cache_purged(self):
+    # Reproduce the ValueError when stop_process() (called by atexit)
+    # runs after the cache/owner was already purged during test teardown.
+    cache = subprocess_server._SharedCache(
+        lambda *args: "dummy_process", lambda obj: None)
+
+    class DummySubprocessServer(subprocess_server.SubprocessServer):
+      _cache = cache
+      def __init__(self):
+        super().__init__(lambda channel: None, ["dummy_cmd"], port=12345)
+
+    server = DummySubprocessServer()
+    server.start_process()
+    owner_id = server._owner_id
+
+    # Simulate pipeline context exit or test teardown purging the cache directly
+    cache.purge(owner_id)
+
+    # Calling stop_process() (which happens during atexit) should succeed cleanly
+    # without raising ValueError.
+    server.stop_process()
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/utils/subprocess_server_test.py
+++ b/sdks/python/apache_beam/utils/subprocess_server_test.py
@@ -432,6 +432,7 @@ class CacheTest(unittest.TestCase):
 
     class DummySubprocessServer(subprocess_server.SubprocessServer):
       _cache = cache
+
       def __init__(self):
         super().__init__(lambda channel: None, ["dummy_cmd"], port=12345)
 


### PR DESCRIPTION
Avoid raising ValueError during atexit shutdown when a cached subprocess server was already cleaned up earlier. Right now, such exception is already ignored (from the log below).

Example traceback (https://github.com/apache/beam/actions/runs/25705764624/job/75475412939):
```
Exception ignored in atexit callback: <bound method StopOnExitJobServer.stop of <apache_beam.runners.portability.job_server.StopOnExitJobServer object at 0x7f60831f4da0>>
Traceback (most recent call last):
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312/py312/lib/python3.12/site-packages/apache_beam/runners/portability/job_server.py", line 98, in stop
    self._job_server.stop()
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312/py312/lib/python3.12/site-packages/apache_beam/runners/portability/job_server.py", line 132, in stop
    return self._server.stop()
           ^^^^^^^^^^^^^^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312/py312/lib/python3.12/site-packages/apache_beam/utils/subprocess_server.py", line 254, in stop
    self.stop_process()
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312/py312/lib/python3.12/site-packages/apache_beam/utils/subprocess_server.py", line 259, in stop_process
    self._cache.purge(self._owner_id)
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312/py312/lib/python3.12/site-packages/apache_beam/utils/subprocess_server.py", line 94, in purge
    raise ValueError(f"{owner} not in {self._live_owners}")
ValueError: 267 not in set()
Exception ignored in atexit callback: <bound method StopOnExitJobServer.stop of <apache_beam.runners.portability.job_server.StopOnExitJobServer object at 0x7f603aeb8ef0>>
Traceback (most recent call last):
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312/py312/lib/python3.12/site-packages/apache_beam/runners/portability/job_server.py", line 98, in stop
    self._job_server.stop()
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312/py312/lib/python3.12/site-packages/apache_beam/runners/portability/job_server.py", line 132, in stop
    return self._server.stop()
           ^^^^^^^^^^^^^^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312/py312/lib/python3.12/site-packages/apache_beam/utils/subprocess_server.py", line 254, in stop
    self.stop_process()
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312/py312/lib/python3.12/site-packages/apache_beam/utils/subprocess_server.py", line 259, in stop_process
    self._cache.purge(self._owner_id)
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312/py312/lib/python3.12/site-packages/apache_beam/utils/subprocess_server.py", line 94, in purge
    raise ValueError(f"{owner} not in {self._live_owners}")
ValueError: 2 not in set()
```
