### PR TITLE
Add retry in connecting manager in MultiProcessShared

### DIFF
--- a/sdks/python/apache_beam/utils/multi_process_shared.py
+++ b/sdks/python/apache_beam/utils/multi_process_shared.py
@@ -38,6 +38,8 @@ from typing import TypeVar
 
 import fasteners
 
+from apache_beam.utils import retry
+
 # In some python versions, there is a bug where AutoProxy doesn't handle
 # the kwarg 'manager_owned'. We implement our own backup here to make sure
 # we avoid this problem. More info here:
@@ -391,10 +393,19 @@ class MultiProcessShared(Generic[T]):
               manager = _SingletonRegistrar(
                   address=(host, int(port)), authkey=AUTH_KEY)
               multiprocessing.current_process().authkey = AUTH_KEY
-              try:
+
+              @retry.with_exponential_backoff(
+                  num_retries=5,
+                  initial_delay_secs=0.1,
+                  retry_filter=lambda exn: isinstance(
+                      exn, (ConnectionError, EOFError)))
+              def connect_manager():
                 manager.connect()
+
+              try:
+                connect_manager()
                 self._manager = manager
-              except ConnectionError:
+              except (ConnectionError, EOFError):
                 # The server is no longer good, assume it died.
                 os.unlink(address_file)
 

--- a/sdks/python/apache_beam/utils/multi_process_shared.py
+++ b/sdks/python/apache_beam/utils/multi_process_shared.py
@@ -394,18 +394,20 @@ class MultiProcessShared(Generic[T]):
                   address=(host, int(port)), authkey=AUTH_KEY)
               multiprocessing.current_process().authkey = AUTH_KEY
 
+              retryable_exceptions = (ConnectionError, EOFError)
+
               @retry.with_exponential_backoff(
                   num_retries=5,
                   initial_delay_secs=0.1,
                   retry_filter=lambda exn: isinstance(
-                      exn, (ConnectionError, EOFError)))
+                      exn, retryable_exceptions))
               def connect_manager():
                 manager.connect()
 
               try:
                 connect_manager()
                 self._manager = manager
-              except (ConnectionError, EOFError):
+              except retryable_exceptions:
                 # The server is no longer good, assume it died.
                 os.unlink(address_file)
 

--- a/sdks/python/apache_beam/utils/multi_process_shared_test.py
+++ b/sdks/python/apache_beam/utils/multi_process_shared_test.py
@@ -480,11 +480,10 @@ class MultiProcessSharedSpawnProcessTest(unittest.TestCase):
         raise ConnectionError("Simulated transient connection failure")
       return orig_connect(self_mgr, *args, **kwargs)
 
-    with patch.object(
-        multi_process_shared._SingletonRegistrar,
-        'connect',
-        autospec=True,
-        side_effect=side_effect_connect):
+    with patch.object(multi_process_shared._SingletonRegistrar,
+                      'connect',
+                      autospec=True,
+                      side_effect=side_effect_connect):
       counter2 = shared2.acquire()
 
     self.assertEqual(counter1.increment(), 1)

--- a/sdks/python/apache_beam/utils/multi_process_shared_test.py
+++ b/sdks/python/apache_beam/utils/multi_process_shared_test.py
@@ -22,8 +22,8 @@ import os
 import tempfile
 import threading
 import unittest
-from unittest.mock import patch
 from typing import Any
+from unittest.mock import patch
 
 from apache_beam.utils import multi_process_shared
 

--- a/sdks/python/apache_beam/utils/multi_process_shared_test.py
+++ b/sdks/python/apache_beam/utils/multi_process_shared_test.py
@@ -22,6 +22,7 @@ import os
 import tempfile
 import threading
 import unittest
+from unittest.mock import patch
 from typing import Any
 
 from apache_beam.utils import multi_process_shared
@@ -293,7 +294,8 @@ class MultiProcessSharedSpawnProcessTest(unittest.TestCase):
                 'mix1',
                 'mix2',
                 'test_process_exit',
-                'thundering_herd_test']:
+                'thundering_herd_test',
+                'transient_test']:
       for ext in ['', '.address', '.address.error']:
         try:
           os.remove(os.path.join(tempdir, tag + ext))
@@ -460,6 +462,33 @@ class MultiProcessSharedSpawnProcessTest(unittest.TestCase):
       shared2.unsafe_hard_delete()
     except Exception:
       pass
+
+  def test_transient_connection_error_recovery(self):
+    shared1 = multi_process_shared.MultiProcessShared(
+        Counter, tag='transient_test', always_proxy=True, spawn_process=True)
+    shared2 = multi_process_shared.MultiProcessShared(
+        Counter, tag='transient_test', always_proxy=True, spawn_process=True)
+
+    counter1 = shared1.acquire()
+
+    orig_connect = multi_process_shared._SingletonRegistrar.connect
+    connect_calls = [0]
+
+    def side_effect_connect(self_mgr, *args, **kwargs):
+      connect_calls[0] += 1
+      if connect_calls[0] == 1:
+        raise ConnectionError("Simulated transient connection failure")
+      return orig_connect(self_mgr, *args, **kwargs)
+
+    with patch.object(
+        multi_process_shared._SingletonRegistrar,
+        'connect',
+        autospec=True,
+        side_effect=side_effect_connect):
+      counter2 = shared2.acquire()
+
+    self.assertEqual(counter1.increment(), 1)
+    self.assertEqual(counter2.increment(), 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Got another flaky test below (https://github.com/apache/beam/actions/runs/25705764624/job/75475412939 and https://github.com/apache/beam/actions/runs/25708527415/job/75483693419?pr=38455)

```
=================================== FAILURES ===================================
_ MultiProcessSharedSpawnProcessTest.test_unsafe_hard_delete_autoproxywrapper __
[gw1] linux -- Python 3.12.13 /runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312/py312/bin/python

self = <apache_beam.utils.multi_process_shared_test.MultiProcessSharedSpawnProcessTest testMethod=test_unsafe_hard_delete_autoproxywrapper>

    def test_unsafe_hard_delete_autoproxywrapper(self):
      shared1 = multi_process_shared.MultiProcessShared(
          Counter, tag='to_delete', always_proxy=True, spawn_process=True)
      shared2 = multi_process_shared.MultiProcessShared(
          Counter, tag='to_delete', always_proxy=True, spawn_process=True)
      counter3 = multi_process_shared.MultiProcessShared(
          Counter, tag='to_keep', always_proxy=True,
          spawn_process=True).acquire()
    
      counter1 = shared1.acquire()
      counter2 = shared2.acquire()
      self.assertEqual(counter1.increment(), 1)
>     self.assertEqual(counter2.increment(), 2)
E     AssertionError: 1 != 2

apache_beam/utils/multi_process_shared_test.py:333: AssertionError
----------------------------- Captured stderr call -----------------------------
INFO:root:Process 273400: Proxy serving to_keep at ('127.0.0.1', 44037)
INFO:root:Process 273459: Proxy serving to_delete at ('127.0.0.1', 33487)
INFO:root:Process 273507: Proxy serving to_delete at ('127.0.0.1', 44533)
```

This could happen when it fails to connect to the manager (a possibly remote proxy) at `counter2 = shared2.acquire()` due to some transient network issue. In the proposed fix, we add some retrying during making the connection.