### PR TITLE
Bump urllib3 to patched release in Python container requirements

### DIFF
--- a/sdks/python/container/ml/py310/base_image_requirements.txt
+++ b/sdks/python/container/ml/py310/base_image_requirements.txt
@@ -222,7 +222,7 @@ typing_extensions==4.15.0
 tzdata==2025.3
 tzlocal==5.3.1
 uritemplate==4.2.0
-urllib3==2.6.3
+urllib3==2.7.0
 virtualenv-clone==0.5.7
 websockets==16.0
 wheel==0.46.3

--- a/sdks/python/container/ml/py310/gpu_image_requirements.txt
+++ b/sdks/python/container/ml/py310/gpu_image_requirements.txt
@@ -298,7 +298,7 @@ typing-inspection==0.4.2
 typing_extensions==4.15.0
 tzdata==2025.3
 uritemplate==4.2.0
-urllib3==2.6.3
+urllib3==2.7.0
 uvicorn==0.41.0
 uvloop==0.22.1
 virtualenv-clone==0.5.7

--- a/sdks/python/container/ml/py311/base_image_requirements.txt
+++ b/sdks/python/container/ml/py311/base_image_requirements.txt
@@ -220,7 +220,7 @@ typing_extensions==4.15.0
 tzdata==2025.3
 tzlocal==5.3.1
 uritemplate==4.2.0
-urllib3==2.6.3
+urllib3==2.7.0
 virtualenv-clone==0.5.7
 websockets==16.0
 wheel==0.46.3

--- a/sdks/python/container/ml/py311/gpu_image_requirements.txt
+++ b/sdks/python/container/ml/py311/gpu_image_requirements.txt
@@ -296,7 +296,7 @@ typing-inspection==0.4.2
 typing_extensions==4.15.0
 tzdata==2025.3
 uritemplate==4.2.0
-urllib3==2.6.3
+urllib3==2.7.0
 uvicorn==0.41.0
 uvloop==0.22.1
 virtualenv-clone==0.5.7

--- a/sdks/python/container/ml/py312/base_image_requirements.txt
+++ b/sdks/python/container/ml/py312/base_image_requirements.txt
@@ -216,7 +216,7 @@ typing-inspection==0.4.2
 typing_extensions==4.15.0
 tzdata==2025.3
 uritemplate==4.2.0
-urllib3==2.6.3
+urllib3==2.7.0
 virtualenv-clone==0.5.7
 websockets==16.0
 wheel==0.46.3

--- a/sdks/python/container/ml/py312/gpu_image_requirements.txt
+++ b/sdks/python/container/ml/py312/gpu_image_requirements.txt
@@ -295,7 +295,7 @@ typing-inspection==0.4.2
 typing_extensions==4.15.0
 tzdata==2025.3
 uritemplate==4.2.0
-urllib3==2.6.3
+urllib3==2.7.0
 uvicorn==0.41.0
 uvloop==0.22.1
 virtualenv-clone==0.5.7

--- a/sdks/python/container/ml/py313/base_image_requirements.txt
+++ b/sdks/python/container/ml/py313/base_image_requirements.txt
@@ -215,7 +215,7 @@ typing-inspection==0.4.2
 typing_extensions==4.15.0
 tzdata==2025.3
 uritemplate==4.2.0
-urllib3==2.6.3
+urllib3==2.7.0
 virtualenv-clone==0.5.7
 websockets==16.0
 wheel==0.46.3

--- a/sdks/python/container/py310/base_image_requirements.txt
+++ b/sdks/python/container/py310/base_image_requirements.txt
@@ -193,7 +193,7 @@ typing_extensions==4.15.0
 tzdata==2025.3
 tzlocal==5.3.1
 uritemplate==4.2.0
-urllib3==2.6.3
+urllib3==2.7.0
 virtualenv-clone==0.5.7
 websockets==16.0
 wheel==0.46.3

--- a/sdks/python/container/py311/base_image_requirements.txt
+++ b/sdks/python/container/py311/base_image_requirements.txt
@@ -191,7 +191,7 @@ typing_extensions==4.15.0
 tzdata==2025.3
 tzlocal==5.3.1
 uritemplate==4.2.0
-urllib3==2.6.3
+urllib3==2.7.0
 virtualenv-clone==0.5.7
 websockets==16.0
 wheel==0.46.3

--- a/sdks/python/container/py313/base_image_requirements.txt
+++ b/sdks/python/container/py313/base_image_requirements.txt
@@ -186,7 +186,7 @@ typing-inspection==0.4.2
 typing_extensions==4.15.0
 tzdata==2025.3
 uritemplate==4.2.0
-urllib3==2.6.3
+urllib3==2.7.0
 virtualenv-clone==0.5.7
 websockets==16.0
 wheel==0.46.3

--- a/sdks/python/container/py314/base_image_requirements.txt
+++ b/sdks/python/container/py314/base_image_requirements.txt
@@ -184,7 +184,7 @@ tqdm==4.67.3
 typing-inspection==0.4.2
 typing_extensions==4.15.0
 tzdata==2025.3
-urllib3==2.6.3
+urllib3==2.7.0
 virtualenv-clone==0.5.7
 websockets==16.0
 wheel==0.46.3


### PR DESCRIPTION
## Summary
- Update pinned `urllib3` versions from `2.6.3` to `2.7.0` in Python SDK container requirements for:
  - `sdks/python/container/py310`, `py311`, `py313`, `py314`
  - `sdks/python/container/ml/py310`, `py311`, `py312`, `py313` (including GPU image requirements)

## Why
Dependabot reports high-severity advisories for `urllib3 < 2.7.0` across these container requirement manifests. This change keeps the updates narrowly scoped to the patched urllib3 version.

## Validation
- Verified all targeted requirement files now consistently pin `urllib3==2.7.0`.