### PR TITLE
Add explicit read-only permissions to CI workflows

### DIFF
--- a/.github/workflows/build_runner_image.yml
+++ b/.github/workflows/build_runner_image.yml
@@ -29,6 +29,10 @@ on:
 env:
   docker_registry: us-central1-docker.pkg.dev
   docker_repo: apache-beam-testing/beam-github-actions/beam-arc-runner
+
+permissions:
+  contents: read
+
 jobs:
   build-and-version-runner:
     if: github.repository == 'apache/beam'

--- a/.github/workflows/code_completion_plugin_tests.yml
+++ b/.github/workflows/code_completion_plugin_tests.yml
@@ -40,6 +40,9 @@ env:
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
   GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
   GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
+permissions:
+  contents: read
+
 jobs:
   # Run Gradle Wrapper Validation Action to verify the wrapper's checksum
   # Run verifyPlugin, IntelliJ Plugin Verifier, and test Gradle tasks

--- a/.github/workflows/dask_runner_tests.yml
+++ b/.github/workflows/dask_runner_tests.yml
@@ -33,6 +33,9 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.issue.number || github.event.pull_request.head.label || github.sha || github.head_ref || github.ref }}-${{ github.event.schedule || github.event.comment.id || github.event.sender.login}}'
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   build_python_sdk_source:
@@ -93,4 +96,3 @@ jobs:
         with:
           name: pytest-${{matrix.os}}-${{matrix.params.py_ver}}
           path: sdks/python/pytest**.xml
-

--- a/.github/workflows/go_tests.yml
+++ b/.github/workflows/go_tests.yml
@@ -34,6 +34,9 @@ on:
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.issue.number || github.event.pull_request.head.label || github.sha || github.head_ref || github.ref }}-${{ github.event.schedule || github.event.comment.id || github.event.sender.login}}'
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: [self-hosted, ubuntu-24.04, main]

--- a/.github/workflows/java_tests.yml
+++ b/.github/workflows/java_tests.yml
@@ -38,6 +38,9 @@ env:
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
   GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
   GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
+permissions:
+  contents: read
+
 jobs:
   java_unit_tests:
     name: 'Java Unit Tests'

--- a/.github/workflows/local_env_tests.yml
+++ b/.github/workflows/local_env_tests.yml
@@ -39,6 +39,9 @@ env:
   GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
   GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
 
+permissions:
+  contents: read
+
 jobs:
   run_local_env_install_ubuntu:
     timeout-minutes: 25

--- a/.github/workflows/playground_frontend_test.yml
+++ b/.github/workflows/playground_frontend_test.yml
@@ -36,6 +36,9 @@ env:
   GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
   GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
 
+permissions:
+  contents: read
+
 jobs:
   playground_frontend_test:
     name: Playground Frontend Test

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -36,6 +36,9 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.issue.number || github.event.pull_request.head.label || github.sha || github.head_ref || github.ref }}-${{ github.event.schedule || github.event.comment.id || github.event.sender.login}}'
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   check_gcp_variables:

--- a/.github/workflows/refresh_looker_metrics.yml
+++ b/.github/workflows/refresh_looker_metrics.yml
@@ -27,6 +27,9 @@ env:
   LOOKERSDK_CLIENT_SECRET: ${{ secrets.LOOKERSDK_CLIENT_SECRET }}
   GCS_BUCKET: 'public_looker_explores_us_a3853f40'
 
+permissions:
+  contents: read
+
 jobs:
   refresh_looker_metrics:
     runs-on: [self-hosted, ubuntu-24.04, main]

--- a/.github/workflows/reportGenerator.yml
+++ b/.github/workflows/reportGenerator.yml
@@ -21,6 +21,9 @@ on:
   - cron: "0 10 * * 2"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   assign:
     name: Generate issue report

--- a/.github/workflows/republish_released_docker_containers.yml
+++ b/.github/workflows/republish_released_docker_containers.yml
@@ -35,6 +35,9 @@ env:
   release: "${{ github.event.inputs.RELEASE || '2.73.0' }}"
   rc: "${{ github.event.inputs.RC || '5' }}"
 
+permissions:
+  contents: read
+
 jobs:
 
   build:
@@ -100,4 +103,3 @@ jobs:
           -Pdocker-tag-list=${{ env.release }},${{ github.sha }},$(date +'%Y-%m-%d') \
           --no-daemon \
           --no-parallel
-

--- a/.github/workflows/tour_of_beam_backend.yml
+++ b/.github/workflows/tour_of_beam_backend.yml
@@ -34,6 +34,9 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.issue.number || github.event.pull_request.head.label || github.sha || github.head_ref || github.ref }}-${{ github.event.schedule || github.event.comment.id || github.event.sender.login}}'
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     runs-on: ubuntu-latest
@@ -62,4 +65,3 @@ jobs:
         with:
           version: v1.49.0
           working-directory: learning/tour-of-beam/backend
-

--- a/.github/workflows/tour_of_beam_backend_integration.yml
+++ b/.github/workflows/tour_of_beam_backend_integration.yml
@@ -69,6 +69,9 @@ env:
   GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
 
 
+permissions:
+  contents: read
+
 jobs:
   integration:
     runs-on: ubuntu-22.04

--- a/.github/workflows/tour_of_beam_frontend_test.yml
+++ b/.github/workflows/tour_of_beam_frontend_test.yml
@@ -38,6 +38,9 @@ env:
   GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
   GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
 
+permissions:
+  contents: read
+
 jobs:
   tour_of_beam_test:
     name: Tour of Beam Frontend Test

--- a/.github/workflows/typescript_tests.yml
+++ b/.github/workflows/typescript_tests.yml
@@ -44,6 +44,9 @@ concurrency:
   cancel-in-progress: true
 env:
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+permissions:
+  contents: read
+
 jobs:
   typescript_unit_tests:
     name: 'TypeScript Unit Tests'


### PR DESCRIPTION
## Summary
- Add explicit `permissions` blocks with `contents: read` to 15 workflows that currently rely on default token scopes.
- Scope this PR to read-only workflows (tests, reporting, container build/test/republish orchestration, and Tour of Beam CI jobs).

## Why
These workflows only need repository read access for checkout and CI execution. Explicit permissions harden GitHub Actions token usage and document intent.

## Notes
- Intentionally excludes workflows that likely require write access for release/tag operations:
  - `.github/workflows/build_release_candidate.yml`
  - `.github/workflows/git_tag_released_version.yml`
- Also excludes `.github/workflows/beam_Playground_Precommit.yml` because it uses `pull_request_target` + custom setup logic that should be reviewed separately for least-privilege writes.