### PR TITLE
WriteToJson - force num_shards

### DIFF
--- a/sdks/python/apache_beam/dataframe/io.py
+++ b/sdks/python/apache_beam/dataframe/io.py
@@ -685,10 +685,14 @@ class _WriteToPandas(beam.PTransform):
     else:
       dir, name = io.filesystems.FileSystems.split(self.path)
     num_shards = self.kwargs.pop('num_shards', None)
+    max_writers_per_bundle = self.kwargs.pop('max_writers_per_bundle', None)
     write_to_files_kwargs = {}
     if num_shards is not None:
       write_to_files_kwargs['shards'] = num_shards
-      write_to_files_kwargs['max_writers_per_bundle'] = 0
+      write_to_files_kwargs['max_writers_per_bundle'] = (
+          0 if max_writers_per_bundle is None else max_writers_per_bundle)
+    elif max_writers_per_bundle is not None:
+      write_to_files_kwargs['max_writers_per_bundle'] = max_writers_per_bundle
     return pcoll | fileio.WriteToFiles(
         path=dir,
         file_naming=self.kwargs.pop(

--- a/sdks/python/apache_beam/dataframe/io.py
+++ b/sdks/python/apache_beam/dataframe/io.py
@@ -684,13 +684,18 @@ class _WriteToPandas(beam.PTransform):
       dir, name = self.path, ''
     else:
       dir, name = io.filesystems.FileSystems.split(self.path)
+    num_shards = self.kwargs.pop('num_shards', None)
+    write_to_files_kwargs = {}
+    if num_shards is not None:
+      write_to_files_kwargs['shards'] = num_shards
+      write_to_files_kwargs['max_writers_per_bundle'] = 0
     return pcoll | fileio.WriteToFiles(
         path=dir,
-        shards=self.kwargs.pop('num_shards', None),
         file_naming=self.kwargs.pop(
             'file_naming', fileio.default_file_naming(name)),
         sink=lambda _: _WriteToPandasFileSink(
-            self.writer, self.args, self.kwargs, self.incremental, self.binary))
+            self.writer, self.args, self.kwargs, self.incremental, self.binary),
+        **write_to_files_kwargs)
 
 
 class _WriteToPandasFileSink(fileio.FileSink):

--- a/sdks/python/apache_beam/dataframe/io.py
+++ b/sdks/python/apache_beam/dataframe/io.py
@@ -680,25 +680,25 @@ class _WriteToPandas(beam.PTransform):
     self.binary = binary
 
   def expand(self, pcoll):
-    if 'file_naming' in self.kwargs:
+    kwargs = dict(self.kwargs)
+    if 'file_naming' in kwargs:
       dir, name = self.path, ''
     else:
       dir, name = io.filesystems.FileSystems.split(self.path)
-    num_shards = self.kwargs.pop('num_shards', None)
-    max_writers_per_bundle = self.kwargs.pop('max_writers_per_bundle', None)
+    num_shards = kwargs.pop('num_shards', None)
+    max_writers_per_bundle = kwargs.pop('max_writers_per_bundle', None)
     write_to_files_kwargs = {}
     if num_shards is not None:
       write_to_files_kwargs['shards'] = num_shards
       write_to_files_kwargs['max_writers_per_bundle'] = (
-          0 if max_writers_per_bundle is None else max_writers_per_bundle)
+          max_writers_per_bundle if max_writers_per_bundle is not None else 0)
     elif max_writers_per_bundle is not None:
       write_to_files_kwargs['max_writers_per_bundle'] = max_writers_per_bundle
     return pcoll | fileio.WriteToFiles(
         path=dir,
-        file_naming=self.kwargs.pop(
-            'file_naming', fileio.default_file_naming(name)),
+        file_naming=kwargs.pop('file_naming', fileio.default_file_naming(name)),
         sink=lambda _: _WriteToPandasFileSink(
-            self.writer, self.args, self.kwargs, self.incremental, self.binary),
+            self.writer, self.args, kwargs, self.incremental, self.binary),
         **write_to_files_kwargs)
 
 

--- a/sdks/python/apache_beam/dataframe/io.py
+++ b/sdks/python/apache_beam/dataframe/io.py
@@ -690,13 +690,14 @@ class _WriteToPandas(beam.PTransform):
     write_to_files_kwargs = {}
     if num_shards is not None:
       write_to_files_kwargs['shards'] = num_shards
-      write_to_files_kwargs['max_writers_per_bundle'] = (
-          max_writers_per_bundle if max_writers_per_bundle is not None else 0)
+      write_to_files_kwargs['max_writers_per_bundle'] = 0
     elif max_writers_per_bundle is not None:
       write_to_files_kwargs['max_writers_per_bundle'] = max_writers_per_bundle
+
+    file_naming = kwargs.pop('file_naming', fileio.default_file_naming(name))
     return pcoll | fileio.WriteToFiles(
         path=dir,
-        file_naming=kwargs.pop('file_naming', fileio.default_file_naming(name)),
+        file_naming=file_naming,
         sink=lambda _: _WriteToPandasFileSink(
             self.writer, self.args, kwargs, self.incremental, self.binary),
         **write_to_files_kwargs)


### PR DESCRIPTION
1. Flaky csv_to_json test due to num_shards parameter not being honored because Beam's `WriteToFiles` uses a fast ### "unsharded" writer if fewer than 20 files are open in a worker bundle. If the runner splits the input data into N bundles, the worker will write N separate files, which would completely ignore `num_shards`.
2. We fix by forcing `max_writers_per_bundle` to 0 when `num_shards` is specified. Setting this to 0 immediately bypasses the unsharded path and routes 100% of the records to the sharded pipeline path. This sharded path applies a global `GroupByKey` shuffle, guaranteeing that exactly `num_shards` output files are produced, regardless of how many bundles the runner splits the input into.
3. Additionally, `self.kwargs` used in the function initially was being directly mutated after its first use, which would potentially cause issues further down in the pipeline. We make a local copy to process further.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
