### PR TITLE
[runners-spark] Spark 4 follow-up: Announce in CHANGES.md and address remaining review comments from #38255

### DIFF
--- a/.github/trigger_files/beam_PostCommit_Java_ValidatesRunner_Spark4StructuredStreaming.json
+++ b/.github/trigger_files/beam_PostCommit_Java_ValidatesRunner_Spark4StructuredStreaming.json
@@ -1,3 +1,0 @@
-{
-  "comment": "Modify this file in a trivial way to cause this test suite to run"
-}

--- a/.github/trigger_files/beam_PreCommit_Java_Spark4_Versions.json
+++ b/.github/trigger_files/beam_PreCommit_Java_Spark4_Versions.json
@@ -1,3 +1,0 @@
-{
-  "comment": "Modify this file in a trivial way to cause this test suite to run"
-}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,6 +61,7 @@
 
 * New highly anticipated feature X added to Python SDK ([#X](https://github.com/apache/beam/issues/X)).
 * New highly anticipated feature Y added to Java SDK ([#Y](https://github.com/apache/beam/issues/Y)).
+* Spark 4 runner added to Java SDK ([#38255](https://github.com/apache/beam/pull/38255)).
 
 ## I/Os
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,7 +61,7 @@
 
 * New highly anticipated feature X added to Python SDK ([#X](https://github.com/apache/beam/issues/X)).
 * New highly anticipated feature Y added to Java SDK ([#Y](https://github.com/apache/beam/issues/Y)).
-* Spark 4 runner added to Java SDK ([#38255](https://github.com/apache/beam/pull/38255)).
+* Spark 4 runner added to Java SDK ([#38255](https://github.com/apache/beam/issues/38255)).
 
 ## I/Os
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,7 @@
 ## Highlights
 
 * New highly anticipated feature X added to Python SDK ([#X](https://github.com/apache/beam/issues/X)).
+* New highly anticipated feature Y added to Java SDK ([#Y](https://github.com/apache/beam/issues/Y)).
 
 ## I/Os
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,7 +61,7 @@
 
 * New highly anticipated feature X added to Python SDK ([#X](https://github.com/apache/beam/issues/X)).
 * New highly anticipated feature Y added to Java SDK ([#Y](https://github.com/apache/beam/issues/Y)).
-* Spark 4 runner added to Java SDK ([#38255](https://github.com/apache/beam/issues/38255)).
+* Spark 4 runner support for Java SDK ([#38255](https://github.com/apache/beam/issues/38255)).
 
 ## I/Os
 


### PR DESCRIPTION
Small follow-up to PR #38255 (`[runners-spark] Add Spark 4 runner`) addressing the two review comments left at the approved/merged head SHA that weren't folded in before merge.

## Changes

1. **Restore `CHANGES.md` `feature Y added to Java SDK` placeholder line** — lost to a rebase; reinstated verbatim. Addresses [`r3204237226`](https://github.com/apache/beam/pull/38255#discussion_r3204237226).

2. **Delete two orphaned `.github/trigger_files/*.json`** - addresses [`r3204241059`](https://github.com/apache/beam/pull/38255#discussion_r3204241059):
   - `beam_PreCommit_Java_Spark4_Versions.json` - its workflow YAML was deleted in #38255.
   - `beam_PostCommit_Java_ValidatesRunner_Spark4StructuredStreaming.json` - flagged as "not effective yet"; since the comment was written, #38478 renamed the associated workflow YAML to `beam_PostCommit_Java_ValidatesRunner_Spark4.yml`, so this trigger JSON is doubly orphaned.

The renamed workflow YAML stays in place - per the trigger-files convention, these JSONs are only added when an author wants to manually trigger a specific PostCommit.

## Verification

- Local `:validateChanges` passes

R: @Abacn