### PR TITLE
[Iceberg] pin hadoop to 3.3.6

### DIFF
--- a/.github/trigger_files/IO_Iceberg_Integration_Tests.json
+++ b/.github/trigger_files/IO_Iceberg_Integration_Tests.json
@@ -1,4 +1,4 @@
 {
     "comment": "Modify this file in a trivial way to cause this test suite to run.",
-    "modification": 1
+    "modification": 2
 }

--- a/.github/trigger_files/IO_Iceberg_Integration_Tests_Dataflow.json
+++ b/.github/trigger_files/IO_Iceberg_Integration_Tests_Dataflow.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run.",
-  "modification": 1
+  "modification": 2
 }

--- a/sdks/java/io/expansion-service/build.gradle
+++ b/sdks/java/io/expansion-service/build.gradle
@@ -57,6 +57,16 @@ configurations.runtimeClasspath {
 
   // Pin nimbus-jose-jwt to 9.37.4 to fix CVE-2025-53864 (transitive via hadoop-auth)
   resolutionStrategy.force 'com.nimbusds:nimbus-jose-jwt:9.37.4'
+
+  // [iceberg]
+  // bigdataoss:gcs-connector and parquet:parquet-hadoop have conflicts with global hadoop-common:3.4.2
+  // upgrading gcs-connector to 4.0.0 would be fine, because it uses hadoop-common 3.4.2
+  // but parquet-hadoop is still at 3.3.0
+  // so for now we need to pin hadoop to 3.3.6 until parquet-hadoop releases a version that uses hadoop 3.4.2+
+  resolutionStrategy.force 'org.apache.hadoop:hadoop-common:3.3.6'
+  resolutionStrategy.force 'org.apache.hadoop:hadoop-client:3.3.6'
+  resolutionStrategy.force 'org.apache.hadoop:hadoop-hdfs:3.3.6'
+  resolutionStrategy.force 'org.apache.hadoop:hadoop-hdfs-client:3.3.6'
 }
 
 shadowJar {

--- a/sdks/java/io/iceberg/build.gradle
+++ b/sdks/java/io/iceberg/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     runtimeOnly "org.apache.iceberg:iceberg-azure:$iceberg_version"
     runtimeOnly "org.apache.iceberg:iceberg-azure-bundle:$iceberg_version"
     runtimeOnly library.java.bigdataoss_gcs_connector
+    runtimeOnly library.java.bigdataoss_util_hadoop
     runtimeOnly library.java.hadoop_client
 
     testImplementation project(":sdks:java:managed")

--- a/sdks/java/io/iceberg/build.gradle
+++ b/sdks/java/io/iceberg/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation "org.apache.iceberg:iceberg-parquet:$iceberg_version"
     implementation "org.apache.iceberg:iceberg-orc:$iceberg_version"
     implementation "org.apache.iceberg:iceberg-data:$iceberg_version"
-    implementation library.java.hadoop_common
+    implementation "org.apache.hadoop:hadoop-common:3.3.6"
     // TODO(https://github.com/apache/beam/issues/21156): Determine how to build without this dependency
     provided "org.immutables:value:2.8.8"
     permitUnusedDeclared "org.immutables:value:2.8.8"
@@ -117,6 +117,14 @@ dependencies {
 configurations.all {
   // iceberg-core needs avro:1.12.0
   resolutionStrategy.force 'org.apache.avro:avro:1.12.0'
+  // bigdataoss:gcs-connector and parquet:parquet-hadoop have conflicts with global hadoop-common:3.4.2
+  // upgrading gcs-connector to 4.0.0 would be fine, because it uses hadoop-common 3.4.2
+  // but parquet-hadoop is still at 3.3.0
+  // so for now we need to pin hadoop to 3.3.6 until parquet-hadoop releases a version that uses hadoop 3.4.2+
+  resolutionStrategy.force 'org.apache.hadoop:hadoop-common:3.3.6'
+  resolutionStrategy.force 'org.apache.hadoop:hadoop-client:3.3.6'
+  resolutionStrategy.force 'org.apache.hadoop:hadoop-hdfs:3.3.6'
+  resolutionStrategy.force 'org.apache.hadoop:hadoop-hdfs-client:3.3.6'
 }
 
 hadoopVersions.each {kv ->

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergScanConfig.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergScanConfig.java
@@ -19,7 +19,7 @@ package org.apache.beam.sdk.io.iceberg;
 
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkNotNull;
-import static org.apache.hadoop.util.Sets.newHashSet;
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Sets.newHashSet;
 
 import com.google.auto.value.AutoValue;
 import java.io.Serializable;


### PR DESCRIPTION
We upgraded some shaded bigdataoss libraries in #38419, and they now bring in hadoop 3x libraries. Some of these libraries conflict with existing hadoop-common 3.4.2 as well as parquet-hadoop (1.16.0)

This causes Iceberg HadoopFileIO read operations to fail with the following exceptions:

```
java.lang.NoSuchMethodError: 'void org.apache.hadoop.fs.VectoredReadUtils.validateRangeRequest(org.apache.hadoop.fs.FileRange)'
java.lang.RuntimeException: java.lang.NoSuchMethodError: 'void org.apache.hadoop.fs.VectoredReadUtils.validateRangeRequest(org.apache.hadoop.fs.FileRange)'
	at org.apache.parquet.util.DynMethods$UnboundMethod.invokeChecked(DynMethods.java:67)
	at org.apache.parquet.hadoop.util.wrapped.io.VectorIoBridge.readWrappedRanges(VectorIoBridge.java:244)
	at org.apache.parquet.hadoop.util.wrapped.io.VectorIoBridge.readVectoredRanges(VectorIoBridge.java:201)
	at org.apache.parquet.hadoop.util.H1SeekableInputStream.readVectored(H1SeekableInputStream.java:75)
	at org.apache.parquet.hadoop.ParquetFileReader.readVectored(ParquetFileReader.java:1357)
	at org.apache.parquet.hadoop.ParquetFileReader.readAllPartsVectoredOrNormal(ParquetFileReader.java:1274)
	at org.apache.parquet.hadoop.ParquetFileReader.internalReadRowGroup(ParquetFileReader.java:1185)
	at org.apache.parquet.hadoop.ParquetFileReader.readNextRowGroup(ParquetFileReader.java:1135)
	at org.apache.iceberg.parquet.ParquetReader$FileIterator.advance(ParquetReader.java:161)
	at org.apache.iceberg.parquet.ParquetReader$FileIterator.next(ParquetReader.java:130)
	at org.apache.iceberg.io.FilterIterator.advance(FilterIterator.java:65)
	at org.apache.iceberg.io.FilterIterator.hasNext(FilterIterator.java:49)
	at org.apache.beam.sdk.io.iceberg.ScanTaskReader.advance(ScanTaskReader.java:102)
	at org.apache.beam.sdk.io.iceberg.ScanTaskReader.start(ScanTaskReader.java:84)
```

gcs-connector has a newer version (4.0.0+) that pulls in 3.4.2 and would work fine, but parquet-hadoop is still stuck at 3.3.0, so the only workaround is to pin our hadoop version to 3.3.6 for now.

Fixes #34962
Fixes #34809
Fixes #31931

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
