### PR TITLE
Fix SubprocessServer cache thread-safety and test isolation

### DIFF
--- a/.github/trigger_files/beam_PostCommit_Python_Versions.json
+++ b/.github/trigger_files/beam_PostCommit_Python_Versions.json
@@ -1,0 +1,4 @@
+{
+  "comment": "Modify this file in a trivial way to cause this test suite to run",
+  "revision": 1
+}

--- a/sdks/python/apache_beam/transforms/external_test.py
+++ b/sdks/python/apache_beam/transforms/external_test.py
@@ -799,7 +799,13 @@ class JavaClassLookupPayloadBuilderTest(unittest.TestCase):
 
 class JavaJarExpansionServiceTest(unittest.TestCase):
   def setUp(self):
-    SubprocessServer._cache._live_owners = set()
+    # Temporarily override _live_owners with an empty set for this test,
+    # preventing contamination of the process-wide global cache and avoiding
+    # side effects on other tests.
+    patcher = mock.patch.object(
+        SubprocessServer._cache, '_live_owners', new=set())
+    patcher.start()
+    self.addCleanup(patcher.stop)
 
   def test_classpath(self):
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/sdks/python/apache_beam/utils/subprocess_server.py
+++ b/sdks/python/apache_beam/utils/subprocess_server.py
@@ -78,13 +78,14 @@ class _SharedCache:
     self._counter = 0
 
   def _next_id(self):
-    with self._lock:
-      self._counter += 1
-      return self._counter
+    # Caller must hold self._lock.
+    self._counter += 1
+    return self._counter
 
   def register(self):
-    owner = self._next_id()
-    self._live_owners.add(owner)
+    with self._lock:
+      owner = self._next_id()
+      self._live_owners.add(owner)
     return owner
 
   def purge(self, owner):


### PR DESCRIPTION
I have seen the following intermittent log warnings in some test workflow logs, which seems to be double purge or some problems with server shutdown.

https://github.com/apache/beam/blob/4c4a2c11e29d7b644f30b91789e6989a4d8ff21c/sdks/python/apache_beam/utils/subprocess_server.py#L95-L96

After some manual investigation (AI tooling not helpful here), however, I have revealed it is a global cache state that was being contaminated during tests. 

Specifically, `JavaJarExpansionServiceTest.setUp()` was clearing the global `_live_owners list`. This caused any owners existed in the list to be lost from the registry, leading to the warning message when those owners get purged.

This PR fixes SubprocessServer cache thread safety and test isolation
- Use `mock.patch.object` in `JavaJarExpansionServiceTest.setUp()` to prevent contaminating the global `_live_owners` cache for other tests.
- Make `_SharedCache.register()` thread-safe.