### PR TITLE
ClickHouseIO: Add DateTime64 support for sub-second timestamp precision

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,6 +67,7 @@
 
 * Support for reading from Delta Lake added (Java) ([#38551](https://github.com/apache/beam/issues/38551)).
 * Support for X source added (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
+* ClickHouseIO: support writing `DateTime64(precision[, 'timezone'])` columns with sub-second precision (Java) ([#38466](https://github.com/apache/beam/issues/38466)).
 
 ## New Features / Improvements
 

--- a/sdks/java/io/clickhouse/src/main/java/org/apache/beam/sdk/io/clickhouse/ClickHouseIO.java
+++ b/sdks/java/io/clickhouse/src/main/java/org/apache/beam/sdk/io/clickhouse/ClickHouseIO.java
@@ -38,6 +38,8 @@ import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.schemas.FieldAccessDescriptor;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.logicaltypes.FixedBytes;
+import org.apache.beam.sdk.schemas.logicaltypes.NanosInstant;
+import org.apache.beam.sdk.schemas.logicaltypes.SqlTypes;
 import org.apache.beam.sdk.schemas.transforms.Select;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -137,6 +139,7 @@ import org.slf4j.LoggerFactory;
  * <tr><td>{@link TableSchema.TypeName#UINT64}</td> <td>{@link Schema.TypeName#INT64}</td></tr>
  * <tr><td>{@link TableSchema.TypeName#DATE}</td> <td>{@link Schema.TypeName#DATETIME}</td></tr>
  * <tr><td>{@link TableSchema.TypeName#DATETIME}</td> <td>{@link Schema.TypeName#DATETIME}</td></tr>
+ * <tr><td>{@link TableSchema.TypeName#DATETIME64}</td> <td>{@link Schema.TypeName#DATETIME} (precision &le; 3), {@link SqlTypes#TIMESTAMP} (4&ndash;6), or {@link NanosInstant} (&ge; 7)</td></tr>
  * <tr><td>{@link TableSchema.TypeName#ARRAY}</td> <td>{@link Schema.TypeName#ARRAY}</td></tr>
  * <tr><td>{@link TableSchema.TypeName#ENUM8}</td> <td>{@link Schema.TypeName#STRING}</td></tr>
  * <tr><td>{@link TableSchema.TypeName#ENUM16}</td> <td>{@link Schema.TypeName#STRING}</td></tr>

--- a/sdks/java/io/clickhouse/src/main/java/org/apache/beam/sdk/io/clickhouse/ClickHouseWriter.java
+++ b/sdks/java/io/clickhouse/src/main/java/org/apache/beam/sdk/io/clickhouse/ClickHouseWriter.java
@@ -39,6 +39,39 @@ import org.joda.time.ReadableInstant;
 public class ClickHouseWriter {
   private static final Instant EPOCH_INSTANT = new Instant(0L);
 
+  // 10^0 through 10^9 inclusive — precision is validated in [0, 9] by ColumnType.dateTime64.
+  private static final long[] POW10 = {
+    1L, 10L, 100L, 1_000L, 10_000L, 100_000L, 1_000_000L, 10_000_000L, 100_000_000L, 1_000_000_000L
+  };
+
+  /**
+   * Encodes a timestamp into ClickHouse's {@code DateTime64(precision)} representation: a signed
+   * 64-bit integer counting ticks of size 10<sup>-precision</sup> seconds since the Unix epoch.
+   *
+   * <p>Accepts either a Joda {@link ReadableInstant} (millisecond precision) or a {@link
+   * java.time.Instant} (nanosecond precision). Sub-tick fractions are truncated toward negative
+   * infinity, matching ClickHouse's own encoding for negative timestamps.
+   */
+  static long encodeDateTime64(Object value, int precision) {
+    long epochSecond;
+    int nanoOfSecond;
+    if (value instanceof java.time.Instant) {
+      java.time.Instant inst = (java.time.Instant) value;
+      epochSecond = inst.getEpochSecond();
+      nanoOfSecond = inst.getNano();
+    } else if (value instanceof ReadableInstant) {
+      long millis = ((ReadableInstant) value).getMillis();
+      epochSecond = Math.floorDiv(millis, 1000L);
+      nanoOfSecond = (int) Math.floorMod(millis, 1000L) * 1_000_000;
+    } else {
+      throw new IllegalArgumentException(
+          "DateTime64 requires a Joda ReadableInstant or java.time.Instant, got "
+              + (value == null ? "null" : value.getClass().getName()));
+    }
+    long subSecondTicks = nanoOfSecond / POW10[9 - precision];
+    return Math.addExact(Math.multiplyExact(epochSecond, POW10[precision]), subSecondTicks);
+  }
+
   @SuppressWarnings("unchecked")
   static void writeNullableValue(ClickHouseOutputStream stream, ColumnType columnType, Object value)
       throws IOException {
@@ -136,6 +169,13 @@ public class ClickHouseWriter {
       case DATETIME:
         long epochSeconds = ((ReadableInstant) value).getMillis() / 1000L;
         BinaryStreamUtils.writeUnsignedInt32(stream, epochSeconds);
+        break;
+
+      case DATETIME64:
+        int precision =
+            Preconditions.checkNotNull(
+                columnType.precision(), "DateTime64 column is missing precision");
+        BinaryStreamUtils.writeInt64(stream, encodeDateTime64(value, precision));
         break;
 
       case ARRAY:

--- a/sdks/java/io/clickhouse/src/main/java/org/apache/beam/sdk/io/clickhouse/TableSchema.java
+++ b/sdks/java/io/clickhouse/src/main/java/org/apache/beam/sdk/io/clickhouse/TableSchema.java
@@ -27,6 +27,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.logicaltypes.FixedBytes;
+import org.apache.beam.sdk.schemas.logicaltypes.NanosInstant;
+import org.apache.beam.sdk.schemas.logicaltypes.SqlTypes;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -38,6 +40,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
 public abstract class TableSchema implements Serializable {
+
+  private static final Schema.FieldType NANOS_INSTANT_TYPE =
+      Schema.FieldType.logicalType(new NanosInstant());
 
   public abstract List<Column> columns();
 
@@ -75,6 +80,22 @@ public abstract class TableSchema implements Serializable {
       case DATE:
       case DATETIME:
         return Schema.FieldType.DATETIME;
+
+      case DATETIME64:
+        // Pick the narrowest Beam logical type that still round-trips the requested precision:
+        //   ≤ 3 (milliseconds)         → Joda DATETIME, keeping existing pipelines unchanged.
+        //   4–6 (down to microseconds) → SqlTypes.TIMESTAMP (MicrosInstant) — interoperable
+        //                                with BigQueryIO, Avro and Beam SQL.
+        //   ≥ 7 (sub-microsecond)      → NanosInstant, the only built-in type that preserves
+        //                                full nanosecond precision through Row construction.
+        int p = columnType.precision();
+        if (p <= 3) {
+          return Schema.FieldType.DATETIME;
+        } else if (p <= 6) {
+          return Schema.FieldType.logicalType(SqlTypes.TIMESTAMP);
+        } else {
+          return NANOS_INSTANT_TYPE;
+        }
 
       case STRING:
         return Schema.FieldType.STRING;
@@ -163,6 +184,7 @@ public abstract class TableSchema implements Serializable {
     // Primitive types
     DATE,
     DATETIME,
+    DATETIME64,
     ENUM8,
     ENUM16,
     FIXEDSTRING,
@@ -238,6 +260,9 @@ public abstract class TableSchema implements Serializable {
 
     public abstract @Nullable Map<String, ColumnType> tupleTypes();
 
+    /** Sub-second precision (0–9) of {@code DateTime64}. {@code null} for other types. */
+    public abstract @Nullable Integer precision();
+
     public ColumnType withNullable(boolean nullable) {
       return toBuilder().nullable(nullable).build();
     }
@@ -255,6 +280,26 @@ public abstract class TableSchema implements Serializable {
           .typeName(TypeName.FIXEDSTRING)
           .nullable(false)
           .fixedStringSize(size)
+          .build();
+    }
+
+    /** Default {@code DateTime64} precision in ClickHouse. */
+    public static final int DEFAULT_DATETIME64_PRECISION = 3;
+
+    /** Returns a {@code DateTime64} type with ClickHouse's default precision of 3. */
+    public static ColumnType dateTime64() {
+      return dateTime64(DEFAULT_DATETIME64_PRECISION);
+    }
+
+    public static ColumnType dateTime64(int precision) {
+      if (precision < 0 || precision > 9) {
+        throw new IllegalArgumentException(
+            "DateTime64 precision must be in [0, 9], got " + precision);
+      }
+      return ColumnType.builder()
+          .typeName(TypeName.DATETIME64)
+          .nullable(false)
+          .precision(precision)
           .build();
     }
 
@@ -296,13 +341,17 @@ public abstract class TableSchema implements Serializable {
      *
      * @param str string representation of ClickHouse type
      * @return type of ClickHouse column
+     * @throws IllegalArgumentException if {@code str} is not a valid ClickHouse column type
      */
     public static ColumnType parse(String str) {
       try {
         return new org.apache.beam.sdk.io.clickhouse.impl.parser.ColumnTypeParser(
                 new StringReader(str))
             .parse();
-      } catch (org.apache.beam.sdk.io.clickhouse.impl.parser.ParseException e) {
+      } catch (org.apache.beam.sdk.io.clickhouse.impl.parser.ParseException
+          | org.apache.beam.sdk.io.clickhouse.impl.parser.TokenMgrError
+          | IllegalArgumentException e) {
+        // Funnel lexical, syntactic and validation failures into one error surface.
         throw new IllegalArgumentException("failed to parse", e);
       }
     }
@@ -366,6 +415,8 @@ public abstract class TableSchema implements Serializable {
       public abstract Builder fixedStringSize(Integer size);
 
       public abstract Builder tupleTypes(Map<String, ColumnType> tupleElements);
+
+      public abstract Builder precision(@Nullable Integer precision);
 
       public abstract ColumnType build();
     }

--- a/sdks/java/io/clickhouse/src/main/javacc/ColumnTypeParser.jj
+++ b/sdks/java/io/clickhouse/src/main/javacc/ColumnTypeParser.jj
@@ -79,6 +79,7 @@ TOKEN :
 {
     < ARRAY          : "ARRAY" >
   | < DATE           : "DATE" >
+  | < DATETIME64     : "DATETIME64" >
   | < DATETIME       : "DATETIME" >
   | < ENUM8          : "ENUM8" >
   | < ENUM16         : "ENUM16" >
@@ -206,6 +207,7 @@ private ColumnType primitive() :
 {
     TypeName type;
     String size;
+    ColumnType ct;
 }
 {
     (
@@ -214,8 +216,33 @@ private ColumnType primitive() :
       (<FIXEDSTRING> <LPAREN> ( size = integer() ) <RPAREN>) {
         return ColumnType.fixedString(Integer.valueOf(size));
       }
+    |
+      (ct = dateTime64()) { return ct; }
     )
 
+}
+
+private ColumnType dateTime64() :
+{
+    String precision = null;
+}
+{
+    (
+        <DATETIME64>
+        (
+            <LPAREN> ( precision = integer() )
+            // The timezone is display-only metadata; accept the syntax and ignore the value.
+            ( <COMMA> string() )?
+            <RPAREN>
+        )?
+    )
+    {
+        // Bare DateTime64 defaults to precision 3, matching ClickHouse.
+        if (precision == null) {
+            return ColumnType.dateTime64();
+        }
+        return ColumnType.dateTime64(Integer.parseInt(precision));
+    }
 }
 
 private ColumnType nullable() :

--- a/sdks/java/io/clickhouse/src/test/java/org/apache/beam/sdk/io/clickhouse/ClickHouseIOIT.java
+++ b/sdks/java/io/clickhouse/src/test/java/org/apache/beam/sdk/io/clickhouse/ClickHouseIOIT.java
@@ -32,6 +32,8 @@ import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
 import org.apache.beam.sdk.schemas.logicaltypes.FixedBytes;
+import org.apache.beam.sdk.schemas.logicaltypes.NanosInstant;
+import org.apache.beam.sdk.schemas.logicaltypes.SqlTypes;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.util.ReleaseInfo;
@@ -48,6 +50,18 @@ import org.junit.runners.JUnit4;
 /** Tests for {@link ClickHouseIO}. */
 @RunWith(JUnit4.class)
 public class ClickHouseIOIT extends BaseClickHouseTest {
+
+  private static final long MICROS_PER_SECOND = 1_000_000L;
+  private static final long NANOS_PER_SECOND = 1_000_000_000L;
+
+  // Shared DateTime64 test instant 2026-05-15T12:34:56Z; its .789012345 sub-second component
+  // exercises every precision bucket.
+  private static final long TEST_EPOCH_SECONDS = 1_778_848_496L;
+  // Nano-of-second; the trailing 345 is not micro-aligned.
+  private static final long TEST_NANOS_OF_SECOND = 789_012_345L;
+  // The same sub-second component truncated to whole microseconds.
+  private static final long TEST_MICROS_OF_SECOND = 789_012L;
+  private static final long TEST_MICRO_ALIGNED_NANOS_OF_SECOND = TEST_MICROS_OF_SECOND * 1_000L;
 
   @Rule public TestPipeline pipeline = TestPipeline.create();
 
@@ -478,6 +492,111 @@ public class ClickHouseIOIT extends BaseClickHouseTest {
 
     assertEquals(6L, sum0);
     assertEquals(12L, sum1);
+  }
+
+  @Test
+  public void testDateTime64Millis() throws Exception {
+    Schema schema = Schema.of(Schema.Field.of("ts", FieldType.DATETIME));
+    DateTime ts = new DateTime(2026, 5, 15, 12, 34, 56, 789, DateTimeZone.UTC);
+    Row row = Row.withSchema(schema).addValue(ts).build();
+
+    executeSql("CREATE TABLE test_datetime64_ms (ts DateTime64(3, 'UTC')) ENGINE=Log");
+
+    pipeline.apply(Create.of(row).withRowSchema(schema)).apply(write("test_datetime64_ms"));
+    pipeline.run().waitUntilFinish();
+
+    // toUnixTimestamp64Milli returns the underlying tick count, which is the most stable thing to
+    // assert across CH versions (string formatting may include trailing zeros depending on
+    // version).
+    long ticks = executeQueryAsLong("SELECT toUnixTimestamp64Milli(ts) FROM test_datetime64_ms");
+    assertEquals(ts.getMillis(), ticks);
+  }
+
+  @Test
+  public void testDateTime64Micros() throws Exception {
+    Schema schema = Schema.of(Schema.Field.of("ts", FieldType.logicalType(SqlTypes.TIMESTAMP)));
+    // Micro-aligned nanos, so MicrosInstant accepts the value.
+    java.time.Instant ts =
+        java.time.Instant.ofEpochSecond(TEST_EPOCH_SECONDS, TEST_MICRO_ALIGNED_NANOS_OF_SECOND);
+    Row row = Row.withSchema(schema).addValue(ts).build();
+
+    executeSql("CREATE TABLE test_datetime64_us (ts DateTime64(6)) ENGINE=Log");
+
+    pipeline.apply(Create.of(row).withRowSchema(schema)).apply(write("test_datetime64_us"));
+    pipeline.run().waitUntilFinish();
+
+    long ticks = executeQueryAsLong("SELECT toUnixTimestamp64Micro(ts) FROM test_datetime64_us");
+    assertEquals(TEST_EPOCH_SECONDS * MICROS_PER_SECOND + TEST_MICROS_OF_SECOND, ticks);
+  }
+
+  @Test
+  public void testDateTime64Nanos() throws Exception {
+    // DateTime64(9) must preserve full nanosecond precision. Use NanosInstant directly
+    // because SqlTypes.TIMESTAMP (MicrosInstant) rejects non-micro-aligned nanos like the
+    // trailing 345.
+    Schema schema = Schema.of(Schema.Field.of("ts", FieldType.logicalType(new NanosInstant())));
+    java.time.Instant ts =
+        java.time.Instant.ofEpochSecond(TEST_EPOCH_SECONDS, TEST_NANOS_OF_SECOND);
+    Row row = Row.withSchema(schema).addValue(ts).build();
+
+    executeSql("CREATE TABLE test_datetime64_ns (ts DateTime64(9)) ENGINE=Log");
+
+    pipeline.apply(Create.of(row).withRowSchema(schema)).apply(write("test_datetime64_ns"));
+    pipeline.run().waitUntilFinish();
+
+    long ticks = executeQueryAsLong("SELECT toUnixTimestamp64Nano(ts) FROM test_datetime64_ns");
+    assertEquals(TEST_EPOCH_SECONDS * NANOS_PER_SECOND + TEST_NANOS_OF_SECOND, ticks);
+  }
+
+  @Test
+  public void testNullableDateTime64() throws Exception {
+    Schema schema =
+        Schema.of(Schema.Field.nullable("ts", FieldType.logicalType(SqlTypes.TIMESTAMP)));
+    java.time.Instant ts =
+        java.time.Instant.ofEpochSecond(TEST_EPOCH_SECONDS, TEST_MICRO_ALIGNED_NANOS_OF_SECOND);
+    Row row1 = Row.withSchema(schema).addValue(ts).build();
+    Row row2 = Row.withSchema(schema).addValue(null).build();
+
+    executeSql("CREATE TABLE test_nullable_datetime64 (ts Nullable(DateTime64(6))) ENGINE=Log");
+
+    pipeline
+        .apply(Create.of(row1, row2).withRowSchema(schema))
+        .apply(write("test_nullable_datetime64"));
+    pipeline.run().waitUntilFinish();
+
+    long total = executeQueryAsLong("SELECT COUNT(*) FROM test_nullable_datetime64");
+    long nonNull = executeQueryAsLong("SELECT COUNT(ts) FROM test_nullable_datetime64");
+    assertEquals(2L, total);
+    assertEquals(1L, nonNull);
+  }
+
+  @Test
+  public void testNullableDateTime64Nanos() throws Exception {
+    // Nullable columns take the writeNullableValue path; verify it preserves full nanosecond
+    // precision alongside an actual null.
+    Schema schema =
+        Schema.of(Schema.Field.nullable("ts", FieldType.logicalType(new NanosInstant())));
+    java.time.Instant ts =
+        java.time.Instant.ofEpochSecond(TEST_EPOCH_SECONDS, TEST_NANOS_OF_SECOND);
+    Row row1 = Row.withSchema(schema).addValue(ts).build();
+    Row row2 = Row.withSchema(schema).addValue(null).build();
+
+    executeSql("CREATE TABLE test_nullable_datetime64_ns (ts Nullable(DateTime64(9))) ENGINE=Log");
+
+    pipeline
+        .apply(Create.of(row1, row2).withRowSchema(schema))
+        .apply(write("test_nullable_datetime64_ns"));
+    pipeline.run().waitUntilFinish();
+
+    long total = executeQueryAsLong("SELECT COUNT(*) FROM test_nullable_datetime64_ns");
+    long nonNull = executeQueryAsLong("SELECT COUNT(ts) FROM test_nullable_datetime64_ns");
+    long ticks =
+        executeQueryAsLong(
+            "SELECT toUnixTimestamp64Nano(ts) FROM test_nullable_datetime64_ns"
+                + " WHERE ts IS NOT NULL");
+    assertEquals(2L, total);
+    assertEquals(1L, nonNull);
+    assertEquals(TEST_EPOCH_SECONDS * NANOS_PER_SECOND + TEST_NANOS_OF_SECOND, ticks);
   }
 
   @Test

--- a/sdks/java/io/clickhouse/src/test/java/org/apache/beam/sdk/io/clickhouse/ClickHouseWriterTest.java
+++ b/sdks/java/io/clickhouse/src/test/java/org/apache/beam/sdk/io/clickhouse/ClickHouseWriterTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.clickhouse;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link ClickHouseWriter}. */
+@RunWith(JUnit4.class)
+public class ClickHouseWriterTest {
+
+  private static final long MICROS_PER_SECOND = 1_000_000L;
+  private static final long NANOS_PER_SECOND = 1_000_000_000L;
+
+  // Shared test instant 2026-05-15T12:34:56Z; its .789012345 sub-second component exercises
+  // every precision bucket.
+  private static final long TEST_EPOCH_SECONDS = 1_778_848_496L;
+  // Nano-of-second; the trailing 345 is not micro-aligned.
+  private static final long TEST_NANOS_OF_SECOND = 789_012_345L;
+  // The same sub-second component truncated to whole microseconds.
+  private static final long TEST_MICROS_OF_SECOND = 789_012L;
+  private static final long TEST_MICRO_ALIGNED_NANOS_OF_SECOND = TEST_MICROS_OF_SECOND * 1_000L;
+
+  // Long.MAX_VALUE nanoseconds past the epoch: 2262-04-11T23:47:16.854775807Z, the last
+  // instant representable in DateTime64(9).
+  private static final long MAX_NANOS_EPOCH_SECONDS = 9_223_372_036L;
+  private static final long MAX_NANOS_NANO_OF_SECOND = 854_775_807L;
+
+  @Test
+  public void encodeDateTime64MillisFromJoda() {
+    DateTime jodaTs = new DateTime(2026, 5, 15, 12, 34, 56, 789, DateTimeZone.UTC);
+    long expectedMillis = jodaTs.getMillis();
+    assertEquals(expectedMillis, ClickHouseWriter.encodeDateTime64(jodaTs.toInstant(), 3));
+  }
+
+  @Test
+  public void encodeDateTime64MicrosFromJavaInstant() {
+    java.time.Instant ts =
+        java.time.Instant.ofEpochSecond(TEST_EPOCH_SECONDS, TEST_MICRO_ALIGNED_NANOS_OF_SECOND);
+    long expectedMicros = TEST_EPOCH_SECONDS * MICROS_PER_SECOND + TEST_MICROS_OF_SECOND;
+    assertEquals(expectedMicros, ClickHouseWriter.encodeDateTime64(ts, 6));
+  }
+
+  @Test
+  public void encodeDateTime64NanosFromJavaInstant() {
+    // The non-micro-aligned trailing 345 must survive the encoding.
+    java.time.Instant ts =
+        java.time.Instant.ofEpochSecond(TEST_EPOCH_SECONDS, TEST_NANOS_OF_SECOND);
+    long expectedNanos = TEST_EPOCH_SECONDS * NANOS_PER_SECOND + TEST_NANOS_OF_SECOND;
+    assertEquals(expectedNanos, ClickHouseWriter.encodeDateTime64(ts, 9));
+  }
+
+  @Test
+  public void encodeDateTime64Precision7TruncatesBelow100Nanos() {
+    // Precision 7 means 100 ns ticks: .789012345 becomes 7890123 ticks, dropping the final 45.
+    java.time.Instant ts =
+        java.time.Instant.ofEpochSecond(TEST_EPOCH_SECONDS, TEST_NANOS_OF_SECOND);
+    long expected = TEST_EPOCH_SECONDS * 10_000_000L + 7_890_123L;
+    assertEquals(expected, ClickHouseWriter.encodeDateTime64(ts, 7));
+  }
+
+  @Test
+  public void encodeDateTime64NanosTruncatesSubNanoFromJoda() {
+    // Joda only carries ms precision, so encoding into nanos shifts left by 6 with no loss.
+    DateTime jodaTs = new DateTime(2030, 1, 1, 0, 0, 0, 123, DateTimeZone.UTC);
+    long expected = jodaTs.getMillis() * 1_000_000L;
+    assertEquals(expected, ClickHouseWriter.encodeDateTime64(jodaTs.toInstant(), 9));
+  }
+
+  @Test
+  public void encodeDateTime64HandlesNegativeMillisWithFloorDivision() {
+    // -1ms maps to (-1s, +999ms), encoded at precision 3 should be exactly -1.
+    org.joda.time.Instant jodaTs = new org.joda.time.Instant(-1L);
+    assertEquals(-1L, ClickHouseWriter.encodeDateTime64(jodaTs, 3));
+  }
+
+  @Test
+  public void encodeDateTime64ZeroPrecisionRoundsTowardEpochSeconds() {
+    java.time.Instant ts = java.time.Instant.ofEpochSecond(42L, 999_999_999L);
+    // Precision 0 means whole-second ticks; sub-second component is truncated.
+    assertEquals(42L, ClickHouseWriter.encodeDateTime64(ts, 0));
+  }
+
+  @Test
+  public void encodeDateTime64NanosMaxRepresentableInstant() {
+    java.time.Instant ts =
+        java.time.Instant.ofEpochSecond(MAX_NANOS_EPOCH_SECONDS, MAX_NANOS_NANO_OF_SECOND);
+    assertEquals(Long.MAX_VALUE, ClickHouseWriter.encodeDateTime64(ts, 9));
+  }
+
+  @Test(expected = ArithmeticException.class)
+  public void encodeDateTime64NanosOverflowsPastYear2262() {
+    // Math.multiplyExact must fail loudly instead of silently wrapping around.
+    java.time.Instant ts = java.time.Instant.ofEpochSecond(MAX_NANOS_EPOCH_SECONDS + 1, 0L);
+    ClickHouseWriter.encodeDateTime64(ts, 9);
+  }
+
+  @Test(expected = ArithmeticException.class)
+  public void encodeDateTime64NanosOverflowsOneNanoPastMax() {
+    // One nanosecond past the last representable tick overflows in Math.addExact.
+    java.time.Instant ts =
+        java.time.Instant.ofEpochSecond(MAX_NANOS_EPOCH_SECONDS, MAX_NANOS_NANO_OF_SECOND + 1);
+    ClickHouseWriter.encodeDateTime64(ts, 9);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void encodeDateTime64RejectsUnsupportedValue() {
+    ClickHouseWriter.encodeDateTime64("not-a-timestamp", 3);
+  }
+
+  @Test
+  public void encodeDateTime64RejectsNull() {
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class, () -> ClickHouseWriter.encodeDateTime64(null, 3));
+    assertEquals(
+        "DateTime64 requires a Joda ReadableInstant or java.time.Instant, got null",
+        e.getMessage());
+  }
+}

--- a/sdks/java/io/clickhouse/src/test/java/org/apache/beam/sdk/io/clickhouse/TableSchemaTest.java
+++ b/sdks/java/io/clickhouse/src/test/java/org/apache/beam/sdk/io/clickhouse/TableSchemaTest.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.io.clickhouse;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -37,6 +38,60 @@ public class TableSchemaTest {
   @Test
   public void testParseDateTime() {
     assertEquals(ColumnType.DATETIME, ColumnType.parse("DateTime"));
+  }
+
+  @Test
+  public void testParseDateTime64Millis() {
+    assertEquals(ColumnType.dateTime64(3), ColumnType.parse("DateTime64(3)"));
+  }
+
+  @Test
+  public void testParseDateTime64MicrosWithTimezone() {
+    // The timezone argument is display-only metadata; the parser accepts and ignores it.
+    assertEquals(ColumnType.dateTime64(6), ColumnType.parse("DateTime64(6, 'UTC')"));
+  }
+
+  @Test
+  public void testParseBareDateTime64DefaultsToPrecision3() {
+    assertEquals(ColumnType.dateTime64(3), ColumnType.parse("DateTime64"));
+  }
+
+  @Test
+  public void testParseDateTime64Nanos() {
+    assertEquals(ColumnType.dateTime64(9), ColumnType.parse("DateTime64(9)"));
+  }
+
+  @Test
+  public void testParseNullableDateTime64() {
+    assertEquals(
+        ColumnType.dateTime64(6).withNullable(true), ColumnType.parse("Nullable(DateTime64(6))"));
+  }
+
+  @Test
+  public void testParseArrayOfDateTime64() {
+    assertEquals(
+        ColumnType.array(ColumnType.dateTime64(3)), ColumnType.parse("Array(DateTime64(3))"));
+  }
+
+  @Test
+  public void testParseDateTime64OutOfRangePrecisionFailsToParse() {
+    IllegalArgumentException e =
+        assertThrows(IllegalArgumentException.class, () -> ColumnType.parse("DateTime64(10)"));
+    assertEquals("failed to parse", e.getMessage());
+  }
+
+  @Test
+  public void testParseDateTime64NegativePrecisionFailsToParse() {
+    IllegalArgumentException e =
+        assertThrows(IllegalArgumentException.class, () -> ColumnType.parse("DateTime64(-1)"));
+    assertEquals("failed to parse", e.getMessage());
+  }
+
+  @Test
+  public void testParseDateTime64GarbagePrecisionFailsToParse() {
+    IllegalArgumentException e =
+        assertThrows(IllegalArgumentException.class, () -> ColumnType.parse("DateTime64(abc)"));
+    assertEquals("failed to parse", e.getMessage());
   }
 
   @Test
@@ -196,6 +251,53 @@ public class TableSchemaTest {
             Schema.Field.nullable("f1", Schema.FieldType.INT64));
 
     assertEquals(expected, TableSchema.getEquivalentSchema(tableSchema));
+  }
+
+  @Test
+  public void testEquivalentSchemaDateTime64Millis() {
+    // Precision ≤ 3 keeps the legacy Joda-backed DATETIME so that existing pipelines using
+    // millisecond timestamps continue to work without code changes.
+    TableSchema tableSchema = TableSchema.of(TableSchema.Column.of("ts", ColumnType.dateTime64(3)));
+    Schema expected = Schema.of(Schema.Field.of("ts", Schema.FieldType.DATETIME));
+    assertEquals(expected, TableSchema.getEquivalentSchema(tableSchema));
+  }
+
+  @Test
+  public void testEquivalentSchemaDateTime64Micros() {
+    // Precision 4–6 maps to SqlTypes.TIMESTAMP (MicrosInstant) — interoperable with
+    // BigQueryIO and Beam SQL, sufficient for microsecond ticks.
+    TableSchema tableSchema = TableSchema.of(TableSchema.Column.of("ts", ColumnType.dateTime64(6)));
+    Schema expected =
+        Schema.of(
+            Schema.Field.of(
+                "ts",
+                Schema.FieldType.logicalType(
+                    org.apache.beam.sdk.schemas.logicaltypes.SqlTypes.TIMESTAMP)));
+    assertEquals(expected, TableSchema.getEquivalentSchema(tableSchema));
+  }
+
+  @Test
+  public void testEquivalentSchemaDateTime64Nanos() {
+    // Precision 7–9 needs nanosecond precision; MicrosInstant rejects non-micro-aligned
+    // nanos, so the mapping must use NanosInstant.
+    TableSchema tableSchema = TableSchema.of(TableSchema.Column.of("ts", ColumnType.dateTime64(9)));
+    Schema expected =
+        Schema.of(
+            Schema.Field.of(
+                "ts",
+                Schema.FieldType.logicalType(
+                    new org.apache.beam.sdk.schemas.logicaltypes.NanosInstant())));
+    assertEquals(expected, TableSchema.getEquivalentSchema(tableSchema));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testDateTime64RejectsNegativePrecision() {
+    ColumnType.dateTime64(-1);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testDateTime64RejectsPrecisionAboveNine() {
+    ColumnType.dateTime64(10);
   }
 
   @Test


### PR DESCRIPTION
ClickHouseIO's `TableSchema` and column-type parser only recognized `DateTime` (second precision), so pipelines emitting sub-second timestamps (log/event ingestion, financial data) could not write to ClickHouse tables declared with `DateTime64(precision[, 'timezone'])` columns.

This change adds first-class `DateTime64` support to `ClickHouseIO`:

* **Schema model** — new `TypeName.DATETIME64`; `ColumnType` carries `precision` (0–9, validated), with `ColumnType.dateTime64(precision)` and a no-arg `ColumnType.dateTime64()` factory for ClickHouse's default precision 3. The timezone argument of `DateTime64` is display-only metadata, so it is not stored.
* **Parser** — JavaCC grammar rule for `DateTime64[(<precision>[, '<timezone>'])]`: bare `DateTime64` defaults to precision 3, and the timezone is accepted and ignored. Also reachable through `Nullable(...)` and `Array(...)` via the existing `primitive()` rule. Lexical, syntactic and precision-validation failures all surface as the parser's uniform `failed to parse` error.
* **Beam field-type mapping** — picks the narrowest logical type that round-trips the requested precision:
  * `precision ≤ 3` → Joda `DATETIME` (preserves existing pipelines).
  * `precision 4–6` → `SqlTypes.TIMESTAMP` (`MicrosInstant`).
  * `precision ≥ 7` → `NanosInstant`, the only built-in logical type that preserves full nanosecond precision through a `Row`; `MicrosInstant` rejects non-micro-aligned nanos.
* **Writer** — serializes `DateTime64` as a little-endian `Int64` of `epoch_seconds * 10^precision + sub_second_units`, accepting both Joda `ReadableInstant` and `java.time.Instant`. Uses `Math.floorDiv` / `Math.floorMod` so negative timestamps match ClickHouse's encoding, and `Math.multiplyExact` / `Math.addExact` for overflow safety.

Tests:

* `TableSchemaTest` — parser cases for `DateTime64(3)`, `DateTime64(6, 'UTC')`, `DateTime64(9)`, bare `DateTime64`, `Nullable(DateTime64(...))`, `Array(DateTime64(...))`; schema-mapping tests for the millis, micros and nanos buckets; precision-range validation; uniform `failed to parse` errors for `DateTime64(10)`, `DateTime64(-1)` and `DateTime64(abc)`.
* `ClickHouseWriterTest` — encoder unit tests covering Joda and `java.time.Instant` inputs, precision 0/3/6/7/9, negative timestamps, the precision-7 100 ns truncation path, the largest representable `DateTime64(9)` instant, overflow past year 2262, and null input.
* `ClickHouseIOIT` — round-trip integration tests against the ClickHouse test container for precisions 3/6/9 (the 9-precision case uses non-micro-aligned nanos), plus `Nullable(DateTime64(6))` and `Nullable(DateTime64(9))` each writing a value and a null.

fixes #38466

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: \`addresses #123\`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment \`fixes #<ISSUE NUMBER>\` instead.
 - [x] Update \`CHANGES.md\` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
