### PR TITLE
Remove redundant HTTP->HTTPS redirect in .htaccess

### DIFF
--- a/website/www/site/static/.htaccess
+++ b/website/www/site/static/.htaccess
@@ -1,19 +1,5 @@
 RewriteEngine On
 
-# This is a 301 (permanent) redirect from HTTP to HTTPS.
-
-# The next rule applies conditionally:
-# * the host is "beam.apache.org",
-# * the host comparison is case insensitive (NC),
-# * HTTPS is not used.
-RewriteCond %{HTTP_HOST} ^beam\.apache\.org [NC]
-RewriteCond %{HTTPS} !on
-
-# Rewrite the URL as follows:
-# * Redirect (R) permanently (301) to https://beam.apache.org/,
-# * Stop processing more rules (L).
-RewriteRule ^(.*)$ https://beam.apache.org/$1 [L,R=301]
-
 # Javadocs / pydocs are available only on the published website, published from
 # https://github.com/apache/beam-site/tree/release-docs
 # They were previously hosted within this repository, and published at the URL


### PR DESCRIPTION
## Summary
Removes redundant HTTP->HTTPS redirect rules in `website/www/site/static/.htaccess` that are already handled by Apache TLP infrastructure.

## Changes
- Removed lines 3-15 containing the HTTP->HTTPS RewriteCond and RewriteRule directives

## Test plan
- Verified the remaining redirects and rules are intact
- No functional changes to other redirects or CSP configuration

Fixes #37432