### PR TITLE
Fix pipeline options NPE after Jackson 2.18 bump

### DIFF
--- a/.github/trigger_files/beam_PostCommit_Python_Portable_Flink.json
+++ b/.github/trigger_files/beam_PostCommit_Python_Portable_Flink.json
@@ -1,4 +1,4 @@
 {
   "comment": "Trigger file for PostCommit Python Portable Flink tests",
-  "modification": "2"
+  "modification": "3"
 }

--- a/.github/trigger_files/beam_PostCommit_Python_Portable_Flink.json
+++ b/.github/trigger_files/beam_PostCommit_Python_Portable_Flink.json
@@ -1,3 +1,4 @@
 {
-  "comment": "Trigger file for PostCommit Python Portable Flink tests"
+  "comment": "Trigger file for PostCommit Python Portable Flink tests",
+  "modification": "1"
 }

--- a/.github/trigger_files/beam_PostCommit_Python_Portable_Flink.json
+++ b/.github/trigger_files/beam_PostCommit_Python_Portable_Flink.json
@@ -1,4 +1,4 @@
 {
   "comment": "Trigger file for PostCommit Python Portable Flink tests",
-  "modification": "1"
+  "modification": "2"
 }

--- a/.github/trigger_files/beam_PostCommit_Python_Portable_Flink.json
+++ b/.github/trigger_files/beam_PostCommit_Python_Portable_Flink.json
@@ -1,4 +1,4 @@
 {
   "comment": "Trigger file for PostCommit Python Portable Flink tests",
-  "modification": "3"
+  "modification": "4"
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
@@ -1800,16 +1800,32 @@ public class PipelineOptionsFactory {
     if (node == null || node.isNull() || node.isMissingNode()) {
       return null;
     }
+    if (node.isTextual() && node.asText().isEmpty()) {
+      return null;
+    }
+
+    JavaType targetType = MAPPER.constructType(method.getGenericReturnType());
+
+    // Portable pipeline options from protobuf Struct are usually string-encoded scalars.
+    // convertValue coerces them reliably; TreeTraversingParser + StdDeserializer can NPE on
+    // Jackson 2.18+ (e.g. LongDeserializer._parseLong when parsing string values).
+    if (node.isValueNode()) {
+      return MAPPER.convertValue(node, targetType);
+    }
 
     JsonDeserializer<Object> jsonDeserializer = getDeserializerForMethod(method);
     if (jsonDeserializer == null) {
-      return MAPPER.convertValue(node, MAPPER.constructType(method.getGenericReturnType()));
+      return MAPPER.convertValue(node, targetType);
     }
 
     JsonParser parser = new TreeTraversingParser(node, MAPPER);
     parser.nextToken();
 
-    return jsonDeserializer.deserialize(parser, DESERIALIZATION_CONTEXT.copy());
+    try {
+      return jsonDeserializer.deserialize(parser, DESERIALIZATION_CONTEXT.copy());
+    } catch (RuntimeException e) {
+      return MAPPER.convertValue(node, targetType);
+    }
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
@@ -1800,17 +1800,12 @@ public class PipelineOptionsFactory {
     if (node == null || node.isNull() || node.isMissingNode()) {
       return null;
     }
-    if (node.isTextual() && node.asText().isEmpty()) {
-      return null;
-    }
 
     JavaType targetType = MAPPER.constructType(method.getGenericReturnType());
-
-    // Portable pipeline options from protobuf Struct are usually string-encoded scalars.
-    // convertValue coerces them reliably; TreeTraversingParser + StdDeserializer can NPE on
-    // Jackson 2.18+ (e.g. LongDeserializer._parseLong when parsing string values).
-    if (node.isValueNode()) {
-      return MAPPER.convertValue(node, targetType);
+    if (node.isTextual()
+        && node.asText().isEmpty()
+        && !targetType.isTypeOrSubTypeOf(String.class)) {
+      return null;
     }
 
     JsonDeserializer<Object> jsonDeserializer = getDeserializerForMethod(method);
@@ -1824,6 +1819,8 @@ public class PipelineOptionsFactory {
     try {
       return jsonDeserializer.deserialize(parser, DESERIALIZATION_CONTEXT.copy());
     } catch (RuntimeException e) {
+      // Jackson 2.18+ can NPE in StdDeserializer when coercing string-encoded Struct values
+      // (e.g. LongDeserializer._parseLong); convertValue handles portable pipeline options.
       return MAPPER.convertValue(node, targetType);
     }
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
@@ -1797,14 +1797,18 @@ public class PipelineOptionsFactory {
   }
 
   static Object deserializeNode(JsonNode node, Method method) throws IOException {
-    if (node.isNull()) {
+    if (node == null || node.isNull() || node.isMissingNode()) {
       return null;
+    }
+
+    JsonDeserializer<Object> jsonDeserializer = getDeserializerForMethod(method);
+    if (jsonDeserializer == null) {
+      return MAPPER.convertValue(node, MAPPER.constructType(method.getGenericReturnType()));
     }
 
     JsonParser parser = new TreeTraversingParser(node, MAPPER);
     parser.nextToken();
 
-    JsonDeserializer<Object> jsonDeserializer = getDeserializerForMethod(method);
     return jsonDeserializer.deserialize(parser, DESERIALIZATION_CONTEXT.copy());
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
@@ -434,6 +434,8 @@ class ProxyInvocationHandler implements InvocationHandler, Serializable {
           continue;
         }
 
+        JsonNode jsonNode = jsonOption.getValue();
+
         for (PipelineOptionSpec spec : specs) {
           if (!spec.shouldSerialize()) {
             continue;
@@ -443,7 +445,7 @@ class ProxyInvocationHandler implements InvocationHandler, Serializable {
             continue;
           }
 
-          Object value = getValueFromJson(jsonOption.getKey(), spec.getGetterMethod());
+          Object value = getValueFromJson(jsonNode, spec.getGetterMethod());
           DisplayDataValue resolved = DisplayDataValue.resolve(value);
           builder.add(
               DisplayData.item(jsonOption.getKey(), resolved.getType(), resolved.getValue())
@@ -600,11 +602,13 @@ class ProxyInvocationHandler implements InvocationHandler, Serializable {
    * @return An object matching the return type of the method passed in.
    */
   private Object getValueFromJson(String propertyName, Method method) {
-    JsonNode jsonNode = jsonOptions.get(propertyName);
-    return getValueFromJson(jsonNode, method);
+    return getValueFromJson(jsonOptions.get(propertyName), method);
   }
 
-  private static Object getValueFromJson(JsonNode node, Method method) {
+  private static Object getValueFromJson(@Nullable JsonNode node, Method method) {
+    if (node == null || node.isNull() || node.isMissingNode()) {
+      return null;
+    }
     try {
       return PipelineOptionsFactory.deserializeNode(node, method);
     } catch (IOException e) {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/construction/PipelineOptionsTranslationTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/construction/PipelineOptionsTranslationTest.java
@@ -209,6 +209,24 @@ public class PipelineOptionsTranslationTest {
       PipelineOptions deserialized = PipelineOptionsTranslation.fromProto(serialized);
       PipelineOptionsTranslation.toProto(deserialized);
     }
+
+    @Test
+    public void emptyStringStringOptionSerializesToProto() {
+      PipelineOptionsFactory.register(TestStringOptions.class);
+      Struct serialized =
+          Struct.newBuilder()
+              .putFields("beam:option:name:v1", Value.newBuilder().setStringValue("").build())
+              .build();
+      PipelineOptions deserialized = PipelineOptionsTranslation.fromProto(serialized);
+      PipelineOptionsTranslation.toProto(deserialized);
+    }
+  }
+
+  /** {@link PipelineOptions} with a string option for empty-string struct value tests. */
+  public interface TestStringOptions extends PipelineOptions {
+    String getName();
+
+    void setName(String name);
   }
 
   /** {@link PipelineOptions} with a nullable boxed option for null struct value tests. */

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/construction/PipelineOptionsTranslationTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/construction/PipelineOptionsTranslationTest.java
@@ -160,6 +160,66 @@ public class PipelineOptionsTranslationTest {
 
       assertThat(deserialized, notNullValue());
     }
+
+    @Test
+    public void nullKnownOptionSerializesToProto() {
+      PipelineOptionsFactory.register(TestBoxedOptions.class);
+      Struct serialized =
+          Struct.newBuilder()
+              .putFields(
+                  "beam:option:example:v1",
+                  Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build())
+              .build();
+      PipelineOptions deserialized = PipelineOptionsTranslation.fromProto(serialized);
+      PipelineOptionsTranslation.toProto(deserialized);
+    }
+
+    @Test
+    public void stringEncodedStreamingOptionsRoundTripToProto() {
+      PipelineOptionsFactory.register(TestStreamingLikeOptions.class);
+      Struct serialized =
+          Struct.newBuilder()
+              .putFields(
+                  "beam:option:streaming:v1", Value.newBuilder().setStringValue("true").build())
+              .putFields(
+                  "beam:option:checkpointing_interval:v1",
+                  Value.newBuilder().setStringValue("3000").build())
+              .putFields(
+                  "beam:option:shutdown_sources_after_idle_ms:v1",
+                  Value.newBuilder().setStringValue("60000").build())
+              .putFields(
+                  "beam:option:number_of_execution_retries:v1",
+                  Value.newBuilder().setStringValue("1").build())
+              .build();
+      PipelineOptions deserialized = PipelineOptionsTranslation.fromProto(serialized);
+      PipelineOptionsTranslation.toProto(deserialized);
+    }
+  }
+
+  /** {@link PipelineOptions} with a nullable boxed option for null struct value tests. */
+  public interface TestBoxedOptions extends PipelineOptions {
+    Integer getExample();
+
+    void setExample(Integer example);
+  }
+
+  /** Options with types matching Flink portable Kafka test pipeline settings. */
+  public interface TestStreamingLikeOptions extends PipelineOptions {
+    boolean isStreaming();
+
+    void setStreaming(boolean streaming);
+
+    Long getCheckpointingInterval();
+
+    void setCheckpointingInterval(Long interval);
+
+    Long getShutdownSourcesAfterIdleMs();
+
+    void setShutdownSourcesAfterIdleMs(Long timeoutMs);
+
+    Integer getNumberOfExecutionRetries();
+
+    void setNumberOfExecutionRetries(Integer retries);
   }
 
   /** {@link PipelineOptions} with an unserializable option. */

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/construction/PipelineOptionsTranslationTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/construction/PipelineOptionsTranslationTest.java
@@ -182,6 +182,8 @@ public class PipelineOptionsTranslationTest {
               .putFields(
                   "beam:option:streaming:v1", Value.newBuilder().setStringValue("true").build())
               .putFields(
+                  "beam:option:parallelism:v1", Value.newBuilder().setStringValue("2").build())
+              .putFields(
                   "beam:option:checkpointing_interval:v1",
                   Value.newBuilder().setStringValue("3000").build())
               .putFields(
@@ -190,6 +192,19 @@ public class PipelineOptionsTranslationTest {
               .putFields(
                   "beam:option:number_of_execution_retries:v1",
                   Value.newBuilder().setStringValue("1").build())
+              .build();
+      PipelineOptions deserialized = PipelineOptionsTranslation.fromProto(serialized);
+      PipelineOptionsTranslation.toProto(deserialized);
+    }
+
+    @Test
+    public void emptyStringLongOptionSerializesToProto() {
+      PipelineOptionsFactory.register(TestStreamingLikeOptions.class);
+      Struct serialized =
+          Struct.newBuilder()
+              .putFields(
+                  "beam:option:checkpointing_interval:v1",
+                  Value.newBuilder().setStringValue("").build())
               .build();
       PipelineOptions deserialized = PipelineOptionsTranslation.fromProto(serialized);
       PipelineOptionsTranslation.toProto(deserialized);
@@ -208,6 +223,10 @@ public class PipelineOptionsTranslationTest {
     boolean isStreaming();
 
     void setStreaming(boolean streaming);
+
+    Integer getParallelism();
+
+    void setParallelism(Integer parallelism);
 
     Long getCheckpointingInterval();
 


### PR DESCRIPTION
Fixes: #37275 
Successful run: https://github.com/apache/beam/actions/runs/25999000538/job/76418541036?pr=38524

The workflow was failing on test_expand_kafka_read. The test expects a Kafka error about bad bootstrap servers, but the job died earlier with a gRPC INTERNAL error and no useful message. The problem is not Kafka or Docker. It started after we bumped Jackson to 2.18 so when Flink submits the job, it serializes pipeline options and builds display data. 

That path called deserializeNode() and hit a NullPointerException, so the job never ran and Kafka was never tried and this test hits it because it turns on streaming/commit options and actually runs the pipeline, not only expansion. so the fix makes deserializeNode and getValueFromJson handle null/missing JSON safely and use convertValue when Jackson has no deserializer. and added small tests in PipelineOptionsTranslationTest for null struct values and string encoded streaming options like the Flink test uses.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
