### PR TITLE
Fix interactive environment clean up failure at atexit.

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/cache_manager.py
+++ b/sdks/python/apache_beam/runners/interactive/cache_manager.py
@@ -19,6 +19,7 @@
 
 import base64
 import collections
+import logging
 import os
 import tempfile
 from urllib.parse import quote
@@ -29,8 +30,12 @@ from apache_beam import coders
 from apache_beam.io import filesystems
 from apache_beam.io import textio
 from apache_beam.io import tfrecordio
+from apache_beam.io.gcp import gcsfilesystem
+from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.testing import test_stream
 from apache_beam.transforms import combiners
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class CacheManager(object):
@@ -286,13 +291,14 @@ class FileBasedCacheManager(CacheManager):
     return self._reader_class(self._glob_path(*labels))
 
   def cleanup(self):
-    if self._cache_dir.startswith('gs://'):
-      from apache_beam.io.gcp import gcsfilesystem
-      from apache_beam.options.pipeline_options import PipelineOptions
-      fs = gcsfilesystem.GCSFileSystem(PipelineOptions())
-      fs.delete([self._cache_dir + '/full/'])
-    elif filesystems.FileSystems.exists(self._cache_dir):
-      filesystems.FileSystems.delete([self._cache_dir])
+    try:
+      if self._cache_dir.startswith('gs://'):
+        fs = gcsfilesystem.GCSFileSystem(PipelineOptions())
+        fs.delete([self._cache_dir + '/full/'])
+      elif filesystems.FileSystems.exists(self._cache_dir):
+        filesystems.FileSystems.delete([self._cache_dir])
+    except Exception as e:
+      _LOGGER.warning('Failed to clean up cache directory %s: %s', self._cache_dir, e)
     self._saved_pcoders = {}
 
   def _glob_path(self, *labels):

--- a/sdks/python/apache_beam/runners/interactive/cache_manager.py
+++ b/sdks/python/apache_beam/runners/interactive/cache_manager.py
@@ -30,7 +30,6 @@ from apache_beam import coders
 from apache_beam.io import filesystems
 from apache_beam.io import textio
 from apache_beam.io import tfrecordio
-from apache_beam.io.gcp import gcsfilesystem
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.testing import test_stream
 from apache_beam.transforms import combiners
@@ -293,6 +292,8 @@ class FileBasedCacheManager(CacheManager):
   def cleanup(self):
     try:
       if self._cache_dir.startswith('gs://'):
+        # Import GCP dependencies only when needed.
+        from apache_beam.io.gcp import gcsfilesystem
         fs = gcsfilesystem.GCSFileSystem(PipelineOptions())
         fs.delete([self._cache_dir + '/full/'])
       elif filesystems.FileSystems.exists(self._cache_dir):

--- a/sdks/python/apache_beam/runners/interactive/cache_manager.py
+++ b/sdks/python/apache_beam/runners/interactive/cache_manager.py
@@ -299,7 +299,8 @@ class FileBasedCacheManager(CacheManager):
       elif filesystems.FileSystems.exists(self._cache_dir):
         filesystems.FileSystems.delete([self._cache_dir])
     except Exception as e:
-      _LOGGER.warning('Failed to clean up cache directory %s: %s', self._cache_dir, e)
+      _LOGGER.warning(
+          'Failed to clean up cache directory %s: %s', self._cache_dir, e)
     self._saved_pcoders = {}
 
   def _glob_path(self, *labels):


### PR DESCRIPTION
The exception occurs in test clean up only and is harmless. Changing it to a warning message and make the test log cleaner.

https://github.com/apache/beam/actions/runs/26003104622/job/76429819073

```
Exception in thread run_worker_job-202[job]_ref_Environment_default_environment_1:
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/threading.py", line 1012, in run
    self._target(*self._args, **self._kwargs)
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/apache_beam/runners/worker/sdk_worker.py", line 265, in run
    for work_request in self._control_stub.Control(get_responses()):
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/grpc/_channel.py", line 538, in __next__
    return self._next()
           ^^^^^^^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/grpc/_channel.py", line 956, in _next
    raise self
grpc._channel._MultiThreadedRendezvous: <_MultiThreadedRendezvous of RPC that terminated with:
	status = StatusCode.UNAVAILABLE
	details = "Socket closed"
	debug_error_string = "UNKNOWN:Error received from peer ipv4:127.0.0.1:45545 {grpc_message:"Socket closed", grpc_status:14}"
>
ERROR:apache_beam.runners.worker.data_plane:Failed to read inputs in the data plane.
Traceback (most recent call last):
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/apache_beam/runners/worker/data_plane.py", line 719, in _read_inputs
    for elements in elements_iterator:
                    ^^^^^^^^^^^^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/grpc/_channel.py", line 538, in __next__
    return self._next()
           ^^^^^^^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/grpc/_channel.py", line 956, in _next
    raise self
grpc._channel._MultiThreadedRendezvous: <_MultiThreadedRendezvous of RPC that terminated with:
	status = StatusCode.UNAVAILABLE
	details = "Socket closed"
	debug_error_string = "UNKNOWN:Error received from peer ipv4:127.0.0.1:45545 {grpc_message:"Socket closed", grpc_status:14}"
>
Exception in thread read_grpc_client_inputs:
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/threading.py", line 1012, in run
    self._target(*self._args, **self._kwargs)
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/apache_beam/runners/worker/data_plane.py", line 736, in <lambda>
    target=lambda: self._read_inputs(elements_iterator),
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/apache_beam/runners/worker/data_plane.py", line 719, in _read_inputs
    for elements in elements_iterator:
                    ^^^^^^^^^^^^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/grpc/_channel.py", line 538, in __next__
    return self._next()
           ^^^^^^^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/grpc/_channel.py", line 956, in _next
    raise self
grpc._channel._MultiThreadedRendezvous: <_MultiThreadedRendezvous of RPC that terminated with:
	status = StatusCode.UNAVAILABLE
	details = "Socket closed"
	debug_error_string = "UNKNOWN:Error received from peer ipv4:127.0.0.1:45545 {grpc_message:"Socket closed", grpc_status:14}"
>
Exception ignored in atexit callback: <bound method InteractiveEnvironment.cleanup of <apache_beam.runners.interactive.interactive_environment.InteractiveEnvironment object at 0x787b14391670>>
Traceback (most recent call last):
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/apache_beam/runners/interactive/interactive_environment.py", line 298, in cleanup
    self.cleanup_environment()
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/apache_beam/runners/interactive/interactive_environment.py", line 288, in cleanup_environment
    cache_manager.cleanup()
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/apache_beam/runners/interactive/cache_manager.py", line 293, in cleanup
    fs.delete([self._cache_dir + '/full/'])
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/apache_beam/io/gcp/gcsfilesystem.py", line 357, in delete
    self._gcsIO().delete(path, recursive=True)
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/apache_beam/io/gcp/gcsio.py", line 272, in delete
    f'gs://{bucket_name}/{blob.name}' for blob in blobs_to_delete
                                                  ^^^^^^^^^^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/google/api_core/page_iterator.py", line 208, in _items_iter
    for page in self._page_iter(increment=False):
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/google/api_core/page_iterator.py", line 244, in _page_iter
    page = self._next_page()
           ^^^^^^^^^^^^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/google/api_core/page_iterator.py", line 373, in _next_page
    response = self._get_next_page_response()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/google/api_core/page_iterator.py", line 432, in _get_next_page_response
    return self.api_request(
           ^^^^^^^^^^^^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/google/cloud/storage/_http.py", line 90, in api_request
    return call()
           ^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/google/api_core/retry/retry_unary.py", line 294, in retry_wrapped_func
    return retry_target(
           ^^^^^^^^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/google/api_core/retry/retry_unary.py", line 156, in retry_target
    next_sleep = _retry_error_helper(
                 ^^^^^^^^^^^^^^^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/google/api_core/retry/retry_base.py", line 216, in _retry_error_helper
    raise final_exc from source_exc
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/google/api_core/retry/retry_unary.py", line 147, in retry_target
    result = target()
             ^^^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py312/build/srcs/sdks/python/target/.tox-py312-cloud/py312-cloud/lib/python3.12/site-packages/google/cloud/_http/__init__.py", line 494, in api_request
    raise exceptions.from_http_response(response)
google.api_core.exceptions.Forbidden: 403 GET https://storage.googleapis.com/storage/v1/b/test-bucket/o?projection=noAcl&prefix=132468897523968%2Ffull%2F&prettyPrint=false: beam-github-actions@apache-beam-testing.iam.gserviceaccount.com does not have storage.objects.list access to the Google Cloud Storage bucket. Permission 'storage.objects.list' denied on resource (or it may not exist).
```