### PR TITLE
Fix PipelineOptions deserialization NPE

### DIFF
--- a/.github/trigger_files/beam_PreCommit_Python_PVR_Flink.json
+++ b/.github/trigger_files/beam_PreCommit_Python_PVR_Flink.json
@@ -1,0 +1,4 @@
+{
+    "comment": "Modify this file in a trivial way to cause this test suite to run",
+    "revision": 1
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
@@ -502,13 +502,6 @@ public class PipelineOptionsFactory {
       new ObjectMapper()
           .registerModules(ObjectMapper.findModules(ReflectHelpers.findClassLoader()));
 
-  private static final DefaultDeserializationContext DESERIALIZATION_CONTEXT =
-      new DefaultDeserializationContext.Impl(MAPPER.getDeserializationContext().getFactory())
-          .createInstance(
-              MAPPER.getDeserializationConfig(),
-              new TokenBuffer(MAPPER, false).asParser(),
-              new InjectableValues.Std());
-
   static final DefaultSerializerProvider SERIALIZER_PROVIDER =
       new DefaultSerializerProvider.Impl()
           .createInstance(MAPPER.getSerializationConfig(), MAPPER.getSerializerFactory());
@@ -1733,7 +1726,15 @@ public class PipelineOptionsFactory {
       BeanProperty prop = createBeanProperty(method);
       AnnotatedMember annotatedMethod = prop.getMember();
 
-      DefaultDeserializationContext context = DESERIALIZATION_CONTEXT.copy();
+      // Initialize a new context that is properly associated with a dummy parser.
+      // Using copy() here would leave the context's transient parser field as null,
+      // causing NullPointerExceptions in Jackson 2.14+ when deserializers try to
+      // query the parser for format constraints or coercion validations.
+      JsonParser dummyParser = new TokenBuffer(MAPPER, false).asParser();
+      DefaultDeserializationContext context =
+          ((DefaultDeserializationContext) MAPPER.getDeserializationContext())
+              .createInstance(
+                  MAPPER.getDeserializationConfig(), dummyParser, new InjectableValues.Std());
       Object maybeDeserializerClass =
           context.getAnnotationIntrospector().findDeserializer(annotatedMethod);
 
@@ -1805,7 +1806,14 @@ public class PipelineOptionsFactory {
     parser.nextToken();
 
     JsonDeserializer<Object> jsonDeserializer = getDeserializerForMethod(method);
-    return jsonDeserializer.deserialize(parser, DESERIALIZATION_CONTEXT.copy());
+    // Create a fresh context that is correctly associated with the active parser.
+    // Using copy() here would leave the context's transient parser field as null,
+    // causing NullPointerExceptions in Jackson 2.14+ deserializers during coercion
+    // validations and length checks.
+    DefaultDeserializationContext context =
+        ((DefaultDeserializationContext) MAPPER.getDeserializationContext())
+            .createInstance(MAPPER.getDeserializationConfig(), parser, new InjectableValues.Std());
+    return jsonDeserializer.deserialize(parser, context);
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
@@ -1731,10 +1731,7 @@ public class PipelineOptionsFactory {
       // causing NullPointerExceptions in Jackson 2.14+ when deserializers try to
       // query the parser for format constraints or coercion validations.
       JsonParser dummyParser = new TokenBuffer(MAPPER, false).asParser();
-      DefaultDeserializationContext context =
-          ((DefaultDeserializationContext) MAPPER.getDeserializationContext())
-              .createInstance(
-                  MAPPER.getDeserializationConfig(), dummyParser, new InjectableValues.Std());
+      DefaultDeserializationContext context = createDeserializationContext(dummyParser);
       Object maybeDeserializerClass =
           context.getAnnotationIntrospector().findDeserializer(annotatedMethod);
 
@@ -1755,6 +1752,11 @@ public class PipelineOptionsFactory {
     } catch (JsonMappingException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  private static DefaultDeserializationContext createDeserializationContext(JsonParser parser) {
+    return ((DefaultDeserializationContext) MAPPER.getDeserializationContext())
+        .createInstance(MAPPER.getDeserializationConfig(), parser, new InjectableValues.Std());
   }
 
   private static Optional<JsonSerializer<Object>> computeCustomSerializerForMethod(Method method) {
@@ -1810,9 +1812,7 @@ public class PipelineOptionsFactory {
     // Using copy() here would leave the context's transient parser field as null,
     // causing NullPointerExceptions in Jackson 2.14+ deserializers during coercion
     // validations and length checks.
-    DefaultDeserializationContext context =
-        ((DefaultDeserializationContext) MAPPER.getDeserializationContext())
-            .createInstance(MAPPER.getDeserializationConfig(), parser, new InjectableValues.Std());
+    DefaultDeserializationContext context = createDeserializationContext(parser);
     return jsonDeserializer.deserialize(parser, context);
   }
 


### PR DESCRIPTION
fixes #36326 

The workflow (https://github.com/apache/beam/actions/workflows/beam_PreCommit_Python_PVR_Flink.yml) started to fail after #37969