### PR TITLE
Disable grpc fork support on some test suites.

### DIFF
--- a/sdks/python/apache_beam/runners/portability/portable_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner_test.py
@@ -328,6 +328,22 @@ class PortableRunnerTestWithSubprocessesAndMultiWorkers(
     PortableRunnerTestWithSubprocesses):
   _use_subprocesses = True
 
+  @classmethod
+  def setUpClass(cls):
+    import os
+    cls._old_fork_support = os.environ.get('GRPC_ENABLE_FORK_SUPPORT')
+    os.environ['GRPC_ENABLE_FORK_SUPPORT'] = 'false'
+    super().setUpClass()
+
+  @classmethod
+  def tearDownClass(cls):
+    import os
+    if cls._old_fork_support is None:
+      os.environ.pop('GRPC_ENABLE_FORK_SUPPORT', None)
+    else:
+      os.environ['GRPC_ENABLE_FORK_SUPPORT'] = cls._old_fork_support
+    super().tearDownClass()
+
   def create_options(self):
     options = super() \
       .create_options()

--- a/sdks/python/apache_beam/runners/portability/portable_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner_test.py
@@ -18,6 +18,7 @@
 
 import inspect
 import logging
+import os
 import socket
 import subprocess
 import sys
@@ -328,16 +329,16 @@ class PortableRunnerTestWithSubprocessesAndMultiWorkers(
     PortableRunnerTestWithSubprocesses):
   _use_subprocesses = True
 
+  # TODO(https://github.com/grpc/grpc/issues/37710): Remove once fixed.
   @classmethod
   def setUpClass(cls):
-    import os
     cls._old_fork_support = os.environ.get('GRPC_ENABLE_FORK_SUPPORT')
     os.environ['GRPC_ENABLE_FORK_SUPPORT'] = 'false'
     super().setUpClass()
 
+  # TODO(https://github.com/grpc/grpc/issues/37710): Remove once fixed.
   @classmethod
   def tearDownClass(cls):
-    import os
     if cls._old_fork_support is None:
       os.environ.pop('GRPC_ENABLE_FORK_SUPPORT', None)
     else:

--- a/sdks/python/apache_beam/utils/subprocess_server_test.py
+++ b/sdks/python/apache_beam/utils/subprocess_server_test.py
@@ -37,6 +37,22 @@ from apache_beam.utils import subprocess_server
 
 
 class JavaJarServerTest(unittest.TestCase):
+  @classmethod
+  def setUpClass(cls):
+    import os
+    cls._old_fork_support = os.environ.get('GRPC_ENABLE_FORK_SUPPORT')
+    os.environ['GRPC_ENABLE_FORK_SUPPORT'] = 'false'
+    super().setUpClass()
+
+  @classmethod
+  def tearDownClass(cls):
+    import os
+    if cls._old_fork_support is None:
+      os.environ.pop('GRPC_ENABLE_FORK_SUPPORT', None)
+    else:
+      os.environ['GRPC_ENABLE_FORK_SUPPORT'] = cls._old_fork_support
+    super().tearDownClass()
+
   def test_gradle_jar_release(self):
     self.assertEqual(
         'https://repo.maven.apache.org/maven2/org/apache/beam/'

--- a/sdks/python/apache_beam/utils/subprocess_server_test.py
+++ b/sdks/python/apache_beam/utils/subprocess_server_test.py
@@ -37,16 +37,17 @@ from apache_beam.utils import subprocess_server
 
 
 class JavaJarServerTest(unittest.TestCase):
+
+  # TODO(https://github.com/grpc/grpc/issues/37710): Remove once fixed.
   @classmethod
   def setUpClass(cls):
-    import os
     cls._old_fork_support = os.environ.get('GRPC_ENABLE_FORK_SUPPORT')
     os.environ['GRPC_ENABLE_FORK_SUPPORT'] = 'false'
     super().setUpClass()
 
+  # TODO(https://github.com/grpc/grpc/issues/37710): Remove once fixed.
   @classmethod
   def tearDownClass(cls):
-    import os
     if cls._old_fork_support is None:
       os.environ.pop('GRPC_ENABLE_FORK_SUPPORT', None)
     else:


### PR DESCRIPTION
We are still seeing DEADLINE EXCEEDED errors related to GRPC fork in our github test workflows:
- `JavaJarServerTest`
- `PortableRunnerTestWithSubprocessesAndMultiWorkers`

The issue has been tracked under https://github.com/grpc/grpc/issues/37710.

Example traceback:
```
_____________________ JavaJarServerTest.test_classpath_jar _____________________
[gw3] darwin -- Python 3.13.13 /Users/runner/work/beam/beam/sdks/python/target/.tox/py313-macos/bin/python

self = <apache_beam.utils.subprocess_server_test.JavaJarServerTest testMethod=test_classpath_jar>

      @unittest.skipUnless(shutil.which('javac'), 'missing java jdk')
      def test_classpath_jar(self):
...
>           subprocess.check_call(f'java -jar {composite_jar}'.split())

apache_beam/utils/subprocess_server_test.py:225: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

popenargs = (['java', '-jar', 'beam_temp/composite-jars/b673a40efb1e743323f7a75a292271fa99a90ab0199fe71896bb17eacc17a88d.jar'],)
kwargs = {}, retcode = -6
cmd = ['java', '-jar', 'beam_temp/composite-jars/b673a40efb1e743323f7a75a292271fa99a90ab0199fe71896bb17eacc17a88d.jar']

    def check_call(*popenargs, **kwargs):
        """Run command with arguments.  Wait for command to complete.  If
        the exit code was zero then return, otherwise raise
        CalledProcessError.  The CalledProcessError object will have the
        return code in the returncode attribute.
    
        The arguments are the same as for the call function.  Example:
    
        check_call(["ls", "-l"])
        """
        retcode = call(*popenargs, **kwargs)
        if retcode:
            cmd = kwargs.get("args")
            if cmd is None:
                cmd = popenargs[0]
>           raise CalledProcessError(retcode, cmd)
E           subprocess.CalledProcessError: Command '['java', '-jar', 'beam_temp/composite-jars/b673a40efb1e743323f7a75a292271fa99a90ab0199fe71896bb17eacc17a88d.jar']' died with <Signals.SIGABRT: 6>.

/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/subprocess.py:419: CalledProcessError
----------------------------- Captured stderr call -----------------------------
I0520 04:04:48.181718   13998 fork_posix.cc:71] Other threads are currently calling into gRPC, skipping fork() handlers
I0520 04:04:48.189891  187465 ev_poll_posix.cc:593] FD from fork parent still in poll list: fd(23, generation: 1)
I0520 04:04:48.190076  187465 ev_poll_posix.cc:593] FD from fork parent still in poll list: fd(22, generation: 1)
I0520 04:04:48.190090  187465 ev_poll_posix.cc:593] FD from fork parent still in poll list: fd(35, generation: 1)
```