### PR TITLE
Revert "[Java Portable SDK] Configure JVM so that it exits upon OutOfMemoryError originating in JVM."

### DIFF
--- a/sdks/java/container/boot.go
+++ b/sdks/java/container/boot.go
@@ -195,9 +195,6 @@ func main() {
 		"-XX:+UseParallelGC",
 		"-XX:+AlwaysActAsServerClassMachine",
 		"-XX:-OmitStackTraceInFastThrow",
-		// Crash and restart instead of throwing OutOfMemoryError which may be caught by user or
-		// framework code and leave things in a degraded state.
-        "-XX:+ExitOnOutOfMemoryError",
 	}
 
 	enableGoogleCloudProfiler := strings.Contains(options, enableGoogleCloudProfilerOption)
@@ -227,17 +224,15 @@ func main() {
 		args = append(args, jammAgentArgs)
 	}
 
-    enableHeapDumpsOnOom := false
 	// If heap dumping is enabled, configure the JVM to dump it on oom events.
 	if pipelineOptions, ok := info.GetPipelineOptions().GetFields()["options"]; ok {
 		if heapDumpOption, ok := pipelineOptions.GetStructValue().GetFields()["enableHeapDumps"]; ok {
-			enableHeapDumpsOnOom = heapDumpOption.GetBoolValue()
+			if heapDumpOption.GetBoolValue() {
+				args = append(args, "-XX:+HeapDumpOnOutOfMemoryError",
+					"-Dbeam.fn.heap_dump_dir="+filepath.Join(dir, "heapdumps"),
+					"-XX:HeapDumpPath="+filepath.Join(dir, "heapdumps", "heap_dump.hprof"))
+			}
 		}
-	}
-    if enableHeapDumpsOnOom {
-		args = append(args, "-XX:+HeapDumpOnOutOfMemoryError",
-			"-Dbeam.fn.heap_dump_dir="+filepath.Join(dir, "heapdumps"),
-			"-XX:HeapDumpPath="+filepath.Join(dir, "heapdumps", "heap_dump.hprof"))
 	}
 
 	// Apply meta options


### PR DESCRIPTION
Reverts apache/beam#37764

This breaks Dataflow Vertical worker scaling feature. It is planned to be remerged at a later point once that has been fixed.