### PR TITLE
Fix table row inference benchmark using wrong model path

### DIFF
--- a/sdks/python/apache_beam/testing/benchmarks/inference/table_row_inference_benchmark.py
+++ b/sdks/python/apache_beam/testing/benchmarks/inference/table_row_inference_benchmark.py
@@ -72,34 +72,36 @@ class TableRowInferenceBenchmarkTest(DataflowCostBenchmark):
         metrics_namespace=self.metrics_namespace,
         is_streaming=False,
         pcollection='RunInference/BeamML_RunInference_Postprocess-0.out0')
-    opts = self.pipeline.get_pipeline_options().view_as(
+    self.opts = self.pipeline.get_pipeline_options().view_as(
         TableRowInferenceOptions)
-    mode = opts.mode or 'batch'
+    mode = self.opts.mode or 'batch'
     self.is_streaming = mode == 'streaming'
     if self.is_streaming:
-      self.subscription = opts.input_subscription
+      self.subscription = self.opts.input_subscription
 
   def test(self):
     """Execute the table row inference pipeline for benchmarking."""
-    opts = self.pipeline.get_pipeline_options().view_as(
-        TableRowInferenceOptions)
-    mode = opts.mode or 'batch'
+    mode = self.opts.mode or 'batch'
     extra_opts = {'mode': mode}
 
     if mode == 'streaming':
-      if opts.input_subscription:
-        extra_opts['input_subscription'] = opts.input_subscription
-      extra_opts['window_size_sec'] = opts.window_size_sec or 60
-      extra_opts['trigger_interval_sec'] = opts.trigger_interval_sec or 30
-    elif opts.input_file:
-      extra_opts['input_file'] = opts.input_file
+      if self.opts.input_subscription:
+        extra_opts['input_subscription'] = self.opts.input_subscription
+      extra_opts['window_size_sec'] = (
+          self.opts.window_size_sec if self.opts.window_size_sec is not None
+          else 60)
+      extra_opts['trigger_interval_sec'] = (
+          self.opts.trigger_interval_sec
+          if self.opts.trigger_interval_sec is not None else 30)
+    elif self.opts.input_file:
+      extra_opts['input_file'] = self.opts.input_file
 
-    if opts.output_table:
-      extra_opts['output_table'] = opts.output_table
-    if opts.model_path:
-      extra_opts['model_path'] = opts.model_path
-    if opts.feature_columns:
-      extra_opts['feature_columns'] = opts.feature_columns
+    if self.opts.output_table:
+      extra_opts['output_table'] = self.opts.output_table
+    if self.opts.model_path:
+      extra_opts['model_path'] = self.opts.model_path
+    if self.opts.feature_columns:
+      extra_opts['feature_columns'] = self.opts.feature_columns
 
     self.result = table_row_inference.run(
         self.pipeline.get_full_options_as_args(**extra_opts),

--- a/sdks/python/apache_beam/testing/benchmarks/inference/table_row_inference_benchmark.py
+++ b/sdks/python/apache_beam/testing/benchmarks/inference/table_row_inference_benchmark.py
@@ -72,32 +72,34 @@ class TableRowInferenceBenchmarkTest(DataflowCostBenchmark):
         metrics_namespace=self.metrics_namespace,
         is_streaming=False,
         pcollection='RunInference/BeamML_RunInference_Postprocess-0.out0')
-    self.is_streaming = ((self.pipeline.get_option('mode') or
-                          'batch') == 'streaming')
+    opts = self.pipeline.get_pipeline_options().view_as(
+        TableRowInferenceOptions)
+    mode = opts.mode or 'batch'
+    self.is_streaming = mode == 'streaming'
     if self.is_streaming:
-      self.subscription = self.pipeline.get_option('input_subscription')
+      self.subscription = opts.input_subscription
 
   def test(self):
     """Execute the table row inference pipeline for benchmarking."""
-    extra_opts = {}
-
-    mode = self.pipeline.get_option('mode') or 'batch'
-    extra_opts['mode'] = mode
+    opts = self.pipeline.get_pipeline_options().view_as(
+        TableRowInferenceOptions)
+    mode = opts.mode or 'batch'
+    extra_opts = {'mode': mode}
 
     if mode == 'streaming':
-      extra_opts['input_subscription'] = self.pipeline.get_option(
-          'input_subscription')
-      extra_opts['window_size_sec'] = int(
-          self.pipeline.get_option('window_size_sec') or 60)
-      extra_opts['trigger_interval_sec'] = int(
-          self.pipeline.get_option('trigger_interval_sec') or 30)
-    else:
-      extra_opts['input_file'] = self.pipeline.get_option('input_file')
+      if opts.input_subscription:
+        extra_opts['input_subscription'] = opts.input_subscription
+      extra_opts['window_size_sec'] = opts.window_size_sec or 60
+      extra_opts['trigger_interval_sec'] = opts.trigger_interval_sec or 30
+    elif opts.input_file:
+      extra_opts['input_file'] = opts.input_file
 
-    for opt in ['output_table', 'model_path', 'feature_columns']:
-      val = self.pipeline.get_option(opt)
-      if val:
-        extra_opts[opt] = val
+    if opts.output_table:
+      extra_opts['output_table'] = opts.output_table
+    if opts.model_path:
+      extra_opts['model_path'] = opts.model_path
+    if opts.feature_columns:
+      extra_opts['feature_columns'] = opts.feature_columns
 
     self.result = table_row_inference.run(
         self.pipeline.get_full_options_as_args(**extra_opts),

--- a/sdks/python/apache_beam/testing/benchmarks/inference/table_row_inference_benchmark.py
+++ b/sdks/python/apache_beam/testing/benchmarks/inference/table_row_inference_benchmark.py
@@ -88,8 +88,8 @@ class TableRowInferenceBenchmarkTest(DataflowCostBenchmark):
       if self.opts.input_subscription:
         extra_opts['input_subscription'] = self.opts.input_subscription
       extra_opts['window_size_sec'] = (
-          self.opts.window_size_sec if self.opts.window_size_sec is not None
-          else 60)
+          self.opts.window_size_sec
+          if self.opts.window_size_sec is not None else 60)
       extra_opts['trigger_interval_sec'] = (
           self.opts.trigger_interval_sec
           if self.opts.trigger_interval_sec is not None else 30)

--- a/sdks/python/apache_beam/testing/test_pipeline.py
+++ b/sdks/python/apache_beam/testing/test_pipeline.py
@@ -209,7 +209,9 @@ class TestPipeline(Pipeline):
       None if option is not found in existing option list which is generated
       by parsing value of argument `test-pipeline-options`.
     """
-    parser = argparse.ArgumentParser()
+    # Parse one flag at a time; disable prefix matching so e.g. --mode does
+    # not satisfy --model_path when both appear in options_list.
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     opt_name = opt_name[:2] if opt_name[:2] == '--' else opt_name
     # Option name should start with '--' when it's used for parsing.
     if bool_option:


### PR DESCRIPTION
Fixes:  https://github.com/apache/beam/actions/runs/26142790013/job/76891591709

The table row inference batch benchmark on Dataflow failed because the pipeline tried to load a model from a file named batch instead of the real model.

That happened by mistake: the test read --mode=batch as if it were --model_path. This change fixes how options are read so the correct model path is always used.
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
