### PR TITLE
Fix test hang in subprocess expansion service on port bind failure

### DIFF
--- a/sdks/python/apache_beam/runners/portability/expansion_service_main.py
+++ b/sdks/python/apache_beam/runners/portability/expansion_service_main.py
@@ -55,7 +55,9 @@ def main(argv):
   with fully_qualified_named_transform.FullyQualifiedNamedTransform.with_filter(
       known_args.fully_qualified_name_glob):
 
-    address = '0.0.0.0:{}'.format(known_args.port)
+    # Bind to localhost instead of 0.0.0.0 to ensure compatibility with loopback
+    # connections on dual-stack (IPv4/IPv6) systems.
+    address = 'localhost:{}'.format(known_args.port)
     server = grpc.server(thread_pool_executor.shared_unbounded_instance())
     if known_args.serve_loopback_worker:
       beam_fn_api_pb2_grpc.add_BeamFnExternalWorkerPoolServicer_to_server(
@@ -71,9 +73,14 @@ def main(argv):
         artifact_service.ArtifactRetrievalService(
             artifact_service.BeamFilesystemHandler(None).file_reader),
         server)
-    server.add_insecure_port(address)
+    # Ensure gRPC server successfully binds. If this fails (e.g., due to port collision),
+    # add_insecure_port returns 0. We raise an error to crash the subprocess immediately,
+    # allowing the parent process to detect it and fail fast rather than hanging.
+    bound_port = server.add_insecure_port(address)
+    if not bound_port:
+      raise RuntimeError("Failed to bind expansion service to {}".format(address))
     server.start()
-    _LOGGER.info('Listening for expansion requests at %d', known_args.port)
+    _LOGGER.info('Listening for expansion requests at %d', bound_port)
 
     def cleanup(unused_signum, unused_frame):
       _LOGGER.info('Shutting down expansion service.')

--- a/sdks/python/apache_beam/runners/portability/expansion_service_main.py
+++ b/sdks/python/apache_beam/runners/portability/expansion_service_main.py
@@ -78,7 +78,8 @@ def main(argv):
     # allowing the parent process to detect it and fail fast rather than hanging.
     bound_port = server.add_insecure_port(address)
     if not bound_port:
-      raise RuntimeError("Failed to bind expansion service to {}".format(address))
+      raise RuntimeError(
+          "Failed to bind expansion service to {}".format(address))
     server.start()
     _LOGGER.info('Listening for expansion requests at %d', bound_port)
 

--- a/sdks/python/apache_beam/utils/subprocess_server.py
+++ b/sdks/python/apache_beam/utils/subprocess_server.py
@@ -232,6 +232,7 @@ class SubprocessServer(object):
         self.stop()
         if attempt == max_attempts - 1:
           raise
+        time.sleep(1)
 
   def start_process(self):
     if self._owner_id is not None:

--- a/sdks/python/apache_beam/utils/subprocess_server.py
+++ b/sdks/python/apache_beam/utils/subprocess_server.py
@@ -186,45 +186,52 @@ class SubprocessServer(object):
     self.stop()
 
   def start(self):
-    try:
-      process, endpoint = self.start_process()
-      wait_secs = .1
-      channel_options = [
-          ("grpc.max_receive_message_length", -1),
-          ("grpc.max_send_message_length", -1),
-          # Default: 20000ms (20s), increased to 10 minutes for stability
-          ("grpc.keepalive_timeout_ms", 600_000),
-          # Default: 2, set to 0 to allow unlimited pings without data
-          ("grpc.http2.max_pings_without_data", 0),
-          # Default: False, set to True to allow keepalive pings when no calls
-          ("grpc.keepalive_permit_without_calls", True),
-          # Default: 2, set to 0 to allow unlimited ping strikes
-          ("grpc.http2.max_ping_strikes", 0),
-          # Default: 0 (disabled), enable socket reuse for better handling
-          ("grpc.so_reuseport", 1),
-      ]
-      self._grpc_channel = grpc.insecure_channel(
-          endpoint, options=channel_options)
-      channel_ready = grpc.channel_ready_future(self._grpc_channel)
-      while True:
-        if process is not None and process.poll() is not None:
-          _LOGGER.error("Started job service with %s", process.args)
-          raise RuntimeError(
-              'Service failed to start up with error %s' % process.poll())
-        try:
-          channel_ready.result(timeout=wait_secs)
-          break
-        except (grpc.FutureTimeoutError, grpc.RpcError):
-          wait_secs *= 1.2
-          logging.log(
-              logging.WARNING if wait_secs > 1 else logging.DEBUG,
-              'Waiting for grpc channel to be ready at %s.',
-              endpoint)
-      return self._stub_class(self._grpc_channel)
-    except:  # pylint: disable=bare-except
-      _LOGGER.exception("Error bringing up service")
-      self.stop()
-      raise
+    max_attempts = 3
+    for attempt in range(max_attempts):
+      try:
+        process, endpoint = self.start_process()
+        wait_secs = .1
+        channel_options = [
+            ("grpc.max_receive_message_length", -1),
+            ("grpc.max_send_message_length", -1),
+            # Default: 20000ms (20s), increased to 10 minutes for stability
+            ("grpc.keepalive_timeout_ms", 600_000),
+            # Default: 2, set to 0 to allow unlimited pings without data
+            ("grpc.http2.max_pings_without_data", 0),
+            # Default: False, set to True to allow keepalive pings when no calls
+            ("grpc.keepalive_permit_without_calls", True),
+            # Default: 2, set to 0 to allow unlimited ping strikes
+            ("grpc.http2.max_ping_strikes", 0),
+            # Default: 0 (disabled), enable socket reuse for better handling
+            ("grpc.so_reuseport", 1),
+        ]
+        self._grpc_channel = grpc.insecure_channel(
+            endpoint, options=channel_options)
+        channel_ready = grpc.channel_ready_future(self._grpc_channel)
+        while True:
+          if process is not None and process.poll() is not None:
+            _LOGGER.error("Started job service with %s", process.args)
+            raise RuntimeError(
+                'Service failed to start up with error %s' % process.poll())
+          try:
+            channel_ready.result(timeout=wait_secs)
+            break
+          except (grpc.FutureTimeoutError, grpc.RpcError):
+            wait_secs *= 1.2
+            logging.log(
+                logging.WARNING if wait_secs > 1 else logging.DEBUG,
+                'Waiting for grpc channel to be ready at %s.',
+                endpoint)
+        return self._stub_class(self._grpc_channel)
+      except Exception as e:
+        _LOGGER.warning(
+            "Error bringing up service on attempt %d: %s",
+            attempt + 1,
+            e,
+            exc_info=True)
+        self.stop()
+        if attempt == max_attempts - 1:
+          raise
 
   def start_process(self):
     if self._owner_id is not None:


### PR DESCRIPTION
We are seeing the following test timeout when expansion service is being started.

```
=================================== FAILURES ===================================
______________________ MLTest.test_ml_preprocessing_yaml _______________________

...

/opt/hostedtoolcache/Python/3.14.5/x64/lib/python3.14/threading.py:373: Failed
----------------------------- Captured stdout call -----------------------------
Cloning dev environment from /runner/_work/beam/beam/sdks/python/test-suites/tox/py314/build/srcs/sdks/python/target/.tox-py314/py314
Requirement already satisfied: numpy in ./target/.tox-py314/test-venv-cache-_ujxtw1x/31094b9cfa8383d00947c0b043fad03c1b780a2756271f73ea8e0c51b4845142/lib/python3.14/site-packages (1.26.4)
------------------------------ Captured log call -------------------------------
WARNING  apache_beam.yaml.yaml_provider:yaml_provider.py:1410    WARNING: Apache Beam is installing Python packages from PyPI at runtime.
   This may pose security risks or cause instability due to repository availability.
   Packages: numpy
   Consider pre-staging dependencies or using a private repository mirror.
   For more information, see: https://beam.apache.org/documentation/sdks/python-dependencies/
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
WARNING  root:subprocess_server.py:219 Waiting for grpc channel to be ready at localhost:55955.
ERROR    apache_beam.utils.subprocess_server:subprocess_server.py:225 Error bringing up service
Traceback (most recent call last):
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py314/build/srcs/sdks/python/target/.tox-py314/py314/lib/python3.14/site-packages/apache_beam/utils/subprocess_server.py", line 215, in start
    channel_ready.result(timeout=wait_secs)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py314/build/srcs/sdks/python/target/.tox-py314/py314/lib/python3.14/site-packages/grpc/_utilities.py", line 160, in result
    self._block(timeout)
    ~~~~~~~~~~~^^^^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py314/build/srcs/sdks/python/target/.tox-py314/py314/lib/python3.14/site-packages/grpc/_utilities.py", line 106, in _block
    self._condition.wait(timeout=remaining)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.14.5/x64/lib/python3.14/threading.py", line 373, in wait
    gotit = waiter.acquire(True, timeout)
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py314/build/srcs/sdks/python/target/.tox-py314/py314/lib/python3.14/site-packages/pytest_timeout.py", line 317, in handler
    timeout_sigalrm(item, settings)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py314/build/srcs/sdks/python/target/.tox-py314/py314/lib/python3.14/site-packages/pytest_timeout.py", line 502, in timeout_sigalrm
    pytest.fail(PYTEST_FAILURE_MESSAGE % settings.timeout)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py314/build/srcs/sdks/python/target/.tox-py314/py314/lib/python3.14/site-packages/_pytest/outcomes.py", line 163, in __call__
    raise Failed(msg=reason, pytrace=pytrace)
Failed: Timeout (>600.0s) from pytest-timeout.
```

If the expansion service failed to bind to its port, `add_insecure_port` returned `0` but was ignored. 

https://github.com/apache/beam/blob/290e3721b503faf84bd83bf0b99644ccf9c87491/sdks/python/apache_beam/runners/portability/expansion_service_main.py#L74

The subprocess remained alive, causing the parent to wait indefinitely for the gRPC channel to become ready until pytest timeout.

Additionally, binding to '0.0.0.0' caused connection timeouts on dual-stack hosts when the client connected via 'localhost' (resolving to IPv6 loopback `::1`).

In this PR, we address the above problems by:
- Raising a `RuntimeError` in `expansion_service_main` if `add_insecure_port`
  fails, allowing the parent to instantly detect the crash, and fail fast.
- Adding an automatic retry loop in subprocess server to address port problems. 
- Changing the bind address from '0.0.0.0' to 'localhost'.