### PR TITLE
[Iceberg] Fix manifest bounds being padded with trailing 0x00 bytes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,6 +98,7 @@
 
 * Fixed BigQueryEnrichmentHandler batch mode dropping earlier requests when multiple requests share the same enrichment key (Python) ([#38035](https://github.com/apache/beam/issues/38035)).
 * Added `max_batch_duration_secs` passthrough support in Python Enrichment BigQuery and CloudSQL handlers so batching duration can be forwarded to `BatchElements` ([#38243](https://github.com/apache/beam/issues/38243)).
+* Fixed IcebergIO writing manifest column bounds padded with trailing `0x00` bytes, which broke equality predicate pushdown in some query engines (Java) ([#38580](https://github.com/apache/beam/issues/38580)).
 
 ## Security Fixes
 

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/SerializableDataFile.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/SerializableDataFile.java
@@ -205,9 +205,21 @@ abstract class SerializableDataFile {
     }
     Map<Integer, byte[]> output = new HashMap<>(input.size());
     for (Map.Entry<Integer, ByteBuffer> e : input.entrySet()) {
-      output.put(e.getKey(), e.getValue().array());
+      output.put(e.getKey(), toByteArray(e.getValue()));
     }
     return output;
+  }
+
+  // Copy only [position, limit). ByteBuffer.array() returns the full backing
+  // array, which is sometimes larger than the buffer's content (e.g. trailing
+  // 0x00 bytes). Leaking those into manifest bounds shifts the lower bound
+  // above the real min and breaks equality predicate pushdown in some query
+  // engines.
+  private static byte[] toByteArray(ByteBuffer buf) {
+    ByteBuffer view = buf.duplicate();
+    byte[] bytes = new byte[view.remaining()];
+    view.get(bytes);
+    return bytes;
   }
 
   private static @Nullable Map<Integer, ByteBuffer> toByteBufferMap(

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/SerializableDataFileTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/SerializableDataFileTest.java
@@ -17,13 +17,25 @@
  */
 package org.apache.beam.sdk.io.iceberg;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
 import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.PartitionSpec;
 import org.junit.Test;
 
 /**
@@ -72,5 +84,59 @@ public class SerializableDataFileTest {
               + "\nPlease include the new field(s) in SerializableDataFile's equals() and hashCode() methods, then add them "
               + "to this test class's FIELDS_SET.");
     }
+  }
+
+  /**
+   * Bounds with {@code capacity > limit} must be copied by {@code [position, limit)}, not by {@link
+   * ByteBuffer#array()}. Otherwise trailing 0x00 bytes leak into the manifest bounds and break
+   * equality predicate pushdown in some query engines.
+   */
+  @Test
+  public void testBoundByteBufferIsCopiedByLimitNotBackingArrayLength() {
+    // Reproduce the shape iceberg-parquet produces in the wild: a ByteBuffer
+    // whose backing array is larger than [position, limit), with trailing
+    // 0x00 bytes. iceberg-parquet hits this because the JDK UTF-8 encoder
+    // over-allocates; here we build it explicitly so the test doesn't depend
+    // on encoder internals.
+    int columnId = 3;
+    byte[] expectedLower = "lower_bound_str".getBytes(StandardCharsets.UTF_8);
+    byte[] expectedUpper = "upper_bound_str".getBytes(StandardCharsets.UTF_8);
+
+    ByteBuffer lower = ByteBuffer.allocate(expectedLower.length + 1);
+    lower.put(expectedLower);
+    lower.flip();
+    ByteBuffer upper = ByteBuffer.allocate(expectedUpper.length + 1);
+    upper.put(expectedUpper);
+    upper.flip();
+
+    Map<Integer, ByteBuffer> lowerBounds = new HashMap<>();
+    lowerBounds.put(columnId, lower);
+    Map<Integer, ByteBuffer> upperBounds = new HashMap<>();
+    upperBounds.put(columnId, upper);
+
+    Metrics metrics = new Metrics(1L, null, null, null, null, lowerBounds, upperBounds);
+
+    DataFile dataFile =
+        DataFiles.builder(PartitionSpec.unpartitioned())
+            .withFormat(FileFormat.PARQUET)
+            .withPath("gs://test-bucket/data/test-file.parquet")
+            .withFileSizeInBytes(1024L)
+            .withMetrics(metrics)
+            .build();
+
+    SerializableDataFile serialized = SerializableDataFile.from(dataFile, "");
+
+    byte[] serializedLower = serialized.getLowerBounds().get(columnId);
+    byte[] serializedUpper = serialized.getUpperBounds().get(columnId);
+    assertEquals(
+        "lower bound length must match content, not backing array",
+        expectedLower.length,
+        serializedLower.length);
+    assertEquals(
+        "upper bound length must match content, not backing array",
+        expectedUpper.length,
+        serializedUpper.length);
+    assertArrayEquals(expectedLower, serializedLower);
+    assertArrayEquals(expectedUpper, serializedUpper);
   }
 }

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/SerializableDataFileTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/SerializableDataFileTest.java
@@ -36,6 +36,8 @@ import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Types;
 import org.junit.Test;
 
 /**
@@ -93,21 +95,18 @@ public class SerializableDataFileTest {
    */
   @Test
   public void testBoundByteBufferIsCopiedByLimitNotBackingArrayLength() {
-    // Reproduce the shape iceberg-parquet produces in the wild: a ByteBuffer
-    // whose backing array is larger than [position, limit), with trailing
-    // 0x00 bytes. iceberg-parquet hits this because the JDK UTF-8 encoder
-    // over-allocates; here we build it explicitly so the test doesn't depend
-    // on encoder internals.
+    // Encode bounds the same way iceberg-parquet does in the wild — via
+    // Conversions.toByteBuffer(STRING, value). For UTF-8 strings of 10+
+    // characters the underlying JDK CharsetEncoder over-allocates by ~10%
+    // and flips, producing a ByteBuffer with capacity > limit.
     int columnId = 3;
-    byte[] expectedLower = "lower_bound_str".getBytes(StandardCharsets.UTF_8);
-    byte[] expectedUpper = "upper_bound_str".getBytes(StandardCharsets.UTF_8);
+    String lowerValue = "lower_bound_str";
+    String upperValue = "upper_bound_str";
+    byte[] expectedLower = lowerValue.getBytes(StandardCharsets.UTF_8);
+    byte[] expectedUpper = upperValue.getBytes(StandardCharsets.UTF_8);
 
-    ByteBuffer lower = ByteBuffer.allocate(expectedLower.length + 1);
-    lower.put(expectedLower);
-    lower.flip();
-    ByteBuffer upper = ByteBuffer.allocate(expectedUpper.length + 1);
-    upper.put(expectedUpper);
-    upper.flip();
+    ByteBuffer lower = Conversions.toByteBuffer(Types.StringType.get(), lowerValue);
+    ByteBuffer upper = Conversions.toByteBuffer(Types.StringType.get(), upperValue);
 
     Map<Integer, ByteBuffer> lowerBounds = new HashMap<>();
     lowerBounds.put(columnId, lower);


### PR DESCRIPTION
## Summary

`SerializableDataFile.toByteArrayMap` used `ByteBuffer.array()` to extract bound bytes. `array()` returns the full backing array, ignoring the buffer's `[position, limit)` content window.

Iceberg's [Conversions.toByteBuffer](https://github.com/apache/iceberg/blob/56013b72db456f774efb696e237b58de88c2e94e/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetrics.java#L247-L248) delegates to JDK [CharsetEncoder.encode(CharBuffer)](https://github.com/apache/iceberg/blob/56013b72db456f774efb696e237b58de88c2e94e/api/src/main/java/org/apache/iceberg/types/Conversions.java#L112), which sizes its allocation by `(int)(chars * averageBytesPerChar)`. For UTF-8 the average is 1.1, so a 15-char string lands in a 16-byte buffer with position=0, limit=15, capacity=16. The 16th byte is the zero-initialized tail of the backing array.

Reading via `.array()` leaks that tail into the byte[] form, and on the return trip `ByteBuffer.wrap(byte[])` treats it as content. The manifest ends up with a lower bound that is strictly greater than the real minimum byte-lexicographically. Query engines using Iceberg metadata for predicate pushdown decide `value < lower_bound` for any equality filter on that minimum and prune every file, returning 0 rows.


## Why the bug stays quiet for most queries

All three must hold:

1. **Encoded length 10–N bytes** (N = `truncate(N)` from metrics config, default 16). Below 10, the JDK encoder allocates exact-size buffers; above N, Iceberg trims the string first, so the bound holds a truncated form that a full-value query naturally sorts past.
2. **Value is the file's actual lower bound** on that column. Other values never compare against the padding byte.
3. **Predicate is eligible for bound pruning** (`=`, `IN`, etc.).

## Fix
- Fix by copying the buffer's [position, limit) window. Added a regression test that builds a DataFile with bounds matching that shape, roundtrips through `SerializableDataFile`, and asserts the resulting byte[] match the encoded content rather than the inflated backing array.
- New writes will produce correct bounds. Tables already written by the buggy sink keep broken bounds until their manifests are rewritten

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
