### PR TITLE
Fix flaky MatrixPowerTest.test_basics by reading all generated shards

### DIFF
--- a/sdks/python/apache_beam/examples/matrix_power_test.py
+++ b/sdks/python/apache_beam/examples/matrix_power_test.py
@@ -17,6 +17,7 @@
 
 """Test for the matrix power integration test."""
 
+import glob
 import logging
 import tempfile
 import unittest
@@ -51,9 +52,11 @@ class MatrixPowerTest(unittest.TestCase):
         '--input_matrix=%s --input_vector=%s --exponent=%d --output=%s.result' %
         (matrix_path, vector_path, self.EXPONENT, vector_path)).split())
     # Parse result file and compare.
-    with open(vector_path + '.result-00000-of-00001') as result_file:
-      results = result_file.read()
-      self.assertEqual(sorted(self.EXPECTED_OUTPUT), sorted(results))
+    results = []
+    for path in glob.glob(vector_path + '.result*'):
+      with open(path) as result_file:
+        results.append(result_file.read())
+    self.assertEqual(sorted(self.EXPECTED_OUTPUT), sorted(''.join(results)))
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/examples/matrix_power_test.py
+++ b/sdks/python/apache_beam/examples/matrix_power_test.py
@@ -52,8 +52,12 @@ class MatrixPowerTest(unittest.TestCase):
         '--input_matrix=%s --input_vector=%s --exponent=%d --output=%s.result' %
         (matrix_path, vector_path, self.EXPONENT, vector_path)).split())
     # Parse result file and compare.
+    shard_paths = glob.glob(vector_path + '.result*')
+    self.assertTrue(
+        shard_paths,
+        'No output shards found matching prefix: %s.result' % vector_path)
     results = []
-    for path in glob.glob(vector_path + '.result*'):
+    for path in shard_paths:
       with open(path) as result_file:
         results.append(result_file.read())
     self.assertEqual(sorted(self.EXPECTED_OUTPUT), sorted(''.join(results)))


### PR DESCRIPTION
Flaky test (https://github.com/apache/beam/actions/runs/26220137898/job/77152699556):

```
_________________________ MatrixPowerTest.test_basics __________________________
[gw3] linux -- Python 3.11.15 /runner/_work/beam/beam/sdks/python/test-suites/tox/py311/build/srcs/sdks/python/target/.tox-py311-cloud/py311-cloud/bin/python

self = <apache_beam.examples.matrix_power_test.MatrixPowerTest testMethod=test_basics>

    def test_basics(self):
      matrix_path = self.create_temp_file(self.MATRIX_INPUT)
      vector_path = self.create_temp_file(self.VECTOR_INPUT)
      matrix_power.run((
          '--input_matrix=%s --input_vector=%s --exponent=%d --output=%s.result' %
          (matrix_path, vector_path, self.EXPONENT, vector_path)).split())
      # Parse result file and compare.
>     with open(vector_path + '.result-00000-of-00001') as result_file:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E     FileNotFoundError: [Errno 2] No such file or directory: '/runner/_work/beam/beam/sdks/python/test-suites/tox/py311/build/srcs/sdks/python/target/.tox-py311-cloud/py311-cloud/tmp/tmp2mc8u76w.result-00000-of-00001'

apache_beam/examples/matrix_power_test.py:54: FileNotFoundError
```


The test was previously expecting the output to be written to a single file shard (`.result-00000-of-00001`). Depending on the runner execution details, the output can be split into multiple shards, resulting in a flaky FileNotFoundError.

This PR dynamically finds and reads all generated shards matching the prefix using `glob`, merging their contents before validating against the expected output.


Related to #38484