### PR TITLE
Revert "Bump golangci/golangci-lint-action from 3 to 8"

### DIFF
--- a/.github/workflows/tour_of_beam_backend.yml
+++ b/.github/workflows/tour_of_beam_backend.yml
@@ -58,7 +58,7 @@ jobs:
         run: go test -v ./...
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.49.0
           working-directory: learning/tour-of-beam/backend


### PR DESCRIPTION
Reverts apache/beam#36291

Currently failing:

` Failed to run: Error: invalid version string 'v1.49.0', golangci-lint v1 is not supported by golangci-lint-action >= v7., Error: invalid version string 'v1.49.0', golangci-lint v1 is not supported by golangci-lint-action >= v7.`

breaks the test. More details: #38605