### PR TITLE
Add metrics for Kafka offset commit failures

### DIFF
--- a/sdks/java/io/delta/src/test/java/org/apache/beam/sdk/io/delta/DeltaIOTest.java
+++ b/sdks/java/io/delta/src/test/java/org/apache/beam/sdk/io/delta/DeltaIOTest.java
@@ -37,11 +37,12 @@ public class DeltaIOTest {
     Map<String, String> hadoopConfig = new HashMap<>();
     hadoopConfig.put("fs.defaultFS", "file:///");
 
-    ReadRows readRows = DeltaIO.readRows()
-        .from(tablePath)
-        .withVersion(version)
-        .withTimestamp(timestamp)
-        .withConfig(hadoopConfig);
+    ReadRows readRows =
+        DeltaIO.readRows()
+            .from(tablePath)
+            .withVersion(version)
+            .withTimestamp(timestamp)
+            .withConfig(hadoopConfig);
 
     Assert.assertEquals(tablePath, readRows.getTablePath());
     Assert.assertEquals(Long.valueOf(version), readRows.getVersion());

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaCommitOffset.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaCommitOffset.java
@@ -82,8 +82,7 @@ public class KafkaCommitOffset<K, V>
       consumerFactoryFn = readSourceDescriptors.getConsumerFactoryFn();
     }
 
-    @SuppressWarnings(
-        "Slf4jDoNotLogMessageOfExceptionExplicitly") // for tests checking error message
+    @SuppressWarnings("Slf4jDoNotLogMessageOfExceptionExplicitly")
     @RequiresStableInput
     @ProcessElement
     public void processElement(@Element KV<KafkaSourceDescriptor, Long> element) {
@@ -137,6 +136,7 @@ public class KafkaCommitOffset<K, V>
     private static class OffsetAndTimestamp {
 
       OffsetAndTimestamp(long offset, Instant timestamp) {
+
         this.offset = offset;
         this.timestamp = timestamp;
       }
@@ -167,7 +167,7 @@ public class KafkaCommitOffset<K, V>
 
     @RequiresStableInput
     @ProcessElement
-    @SuppressWarnings("nullness") // startBundle guaranteed to initialize
+    @SuppressWarnings("nullness")
     public void processElement(
         @Element KV<KafkaSourceDescriptor, KafkaRecord<K, V>> element,
         @Timestamp Instant timestamp) {
@@ -182,12 +182,13 @@ public class KafkaCommitOffset<K, V>
             }
 
             v.merge(offset, timestamp);
+
             return v;
           });
     }
 
     @FinishBundle
-    @SuppressWarnings("nullness") // startBundle guaranteed to initialize
+    @SuppressWarnings("nullness")
     public void finishBundle(FinishBundleContext context) {
 
       maxObserved.forEach(
@@ -211,8 +212,6 @@ public class KafkaCommitOffset<K, V>
 
       } else {
 
-        // Reduce the amount of data to combine by calculating a max within the generally dense
-        // bundles of reading from a Kafka partition.
         offsets = input.apply(ParDo.of(new MaxOffsetFn<>()));
       }
 

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaCommitOffset.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaCommitOffset.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.VarLongCoder;
 import org.apache.beam.sdk.coders.VoidCoder;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.schemas.NoSuchSchemaException;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.MapElements;
@@ -62,7 +64,15 @@ public class KafkaCommitOffset<K, V>
 
   static class CommitOffsetDoFn extends DoFn<KV<KafkaSourceDescriptor, Long>, Void> {
     private static final Logger LOG = LoggerFactory.getLogger(CommitOffsetDoFn.class);
+
+    private final Counter commitFailures =
+        Metrics.counter(CommitOffsetDoFn.class, "commit-failures");
+
+    private final Counter retriesExhausted =
+        Metrics.counter(CommitOffsetDoFn.class, "retries-exhausted");
+
     private final Map<String, Object> consumerConfig;
+
     private final SerializableFunction<Map<String, Object>, Consumer<byte[], byte[]>>
         consumerFactoryFn;
 
@@ -76,16 +86,24 @@ public class KafkaCommitOffset<K, V>
     @RequiresStableInput
     @ProcessElement
     public void processElement(@Element KV<KafkaSourceDescriptor, Long> element) {
+
       Map<String, Object> updatedConsumerConfig =
           overrideBootstrapServersConfig(consumerConfig, element.getKey());
+
       try (Consumer<byte[], byte[]> consumer = consumerFactoryFn.apply(updatedConsumerConfig)) {
+
         try {
           consumer.commitSync(
               Collections.singletonMap(
                   element.getKey().getTopicPartition(),
                   new OffsetAndMetadata(element.getValue() + 1)));
+
         } catch (Exception e) {
-          // TODO: consider retrying.
+
+          commitFailures.inc();
+          retriesExhausted.inc();
+
+          // TODO: consider retrying and increment retry-attempt metrics.
           LOG.warn("Getting exception when committing offset: {}", e.getMessage());
         }
       }
@@ -93,23 +111,30 @@ public class KafkaCommitOffset<K, V>
 
     private Map<String, Object> overrideBootstrapServersConfig(
         Map<String, Object> currentConfig, KafkaSourceDescriptor description) {
+
       checkState(
           currentConfig.containsKey(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG)
               || description.getBootStrapServers() != null);
+
       Map<String, Object> config = new HashMap<>(currentConfig);
+
       if (description.getBootStrapServers() != null
           && !description.getBootStrapServers().isEmpty()) {
+
         config.put(
             ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
             String.join(",", description.getBootStrapServers()));
       }
+
       return config;
     }
   }
 
   private static final class MaxOffsetFn<K, V>
       extends DoFn<KV<KafkaSourceDescriptor, KafkaRecord<K, V>>, KV<KafkaSourceDescriptor, Long>> {
+
     private static class OffsetAndTimestamp {
+
       OffsetAndTimestamp(long offset, Instant timestamp) {
         this.offset = offset;
         this.timestamp = timestamp;
@@ -130,6 +155,7 @@ public class KafkaCommitOffset<K, V>
 
     @StartBundle
     public void startBundle() {
+
       if (maxObserved == null) {
         maxObserved = new HashMap<>();
       } else {
@@ -143,13 +169,16 @@ public class KafkaCommitOffset<K, V>
     public void processElement(
         @Element KV<KafkaSourceDescriptor, KafkaRecord<K, V>> element,
         @Timestamp Instant timestamp) {
+
       maxObserved.compute(
           element.getKey(),
           (k, v) -> {
             long offset = element.getValue().getOffset();
+
             if (v == null) {
               return new OffsetAndTimestamp(offset, timestamp);
             }
+
             v.merge(offset, timestamp);
             return v;
           });
@@ -158,6 +187,7 @@ public class KafkaCommitOffset<K, V>
     @FinishBundle
     @SuppressWarnings("nullness") // startBundle guaranteed to initialize
     public void finishBundle(FinishBundleContext context) {
+
       maxObserved.forEach(
           (k, v) -> context.output(KV.of(k, v.offset), v.timestamp, GlobalWindow.INSTANCE));
     }
@@ -165,19 +195,26 @@ public class KafkaCommitOffset<K, V>
 
   @Override
   public PCollection<Void> expand(PCollection<KV<KafkaSourceDescriptor, KafkaRecord<K, V>>> input) {
+
     try {
+
       PCollection<KV<KafkaSourceDescriptor, Long>> offsets;
+
       if (use259implementation) {
+
         offsets =
             input.apply(
                 MapElements.into(new TypeDescriptor<KV<KafkaSourceDescriptor, Long>>() {})
                     .via(element -> KV.of(element.getKey(), element.getValue().getOffset())));
+
       } else {
+
         // Reduce the amount of data to combine by calculating a max within the generally dense
         // bundles of reading
         // from a Kafka partition.
         offsets = input.apply(ParDo.of(new MaxOffsetFn<>()));
       }
+
       return offsets
           .setCoder(
               KvCoder.of(
@@ -190,6 +227,7 @@ public class KafkaCommitOffset<K, V>
           .apply(Max.longsPerKey())
           .apply(ParDo.of(new CommitOffsetDoFn(readSourceDescriptors)))
           .setCoder(VoidCoder.of());
+
     } catch (NoSuchSchemaException e) {
       throw new RuntimeException(e.getMessage());
     }

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaCommitOffset.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaCommitOffset.java
@@ -58,8 +58,7 @@ public class KafkaCommitOffset<K, V>
   private final boolean use259implementation;
 
   KafkaCommitOffset(
-      KafkaIO.ReadSourceDescriptors<K, V> readSourceDescriptors,
-      boolean use259implementation) {
+      KafkaIO.ReadSourceDescriptors<K, V> readSourceDescriptors, boolean use259implementation) {
 
     this.readSourceDescriptors = readSourceDescriptors;
     this.use259implementation = use259implementation;
@@ -112,8 +111,7 @@ public class KafkaCommitOffset<K, V>
     }
 
     private Map<String, Object> overrideBootstrapServersConfig(
-        Map<String, Object> currentConfig,
-        KafkaSourceDescriptor description) {
+        Map<String, Object> currentConfig, KafkaSourceDescriptor description) {
 
       checkState(
           currentConfig.containsKey(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG)
@@ -134,9 +132,7 @@ public class KafkaCommitOffset<K, V>
   }
 
   private static final class MaxOffsetFn<K, V>
-      extends DoFn<
-          KV<KafkaSourceDescriptor, KafkaRecord<K, V>>,
-          KV<KafkaSourceDescriptor, Long>> {
+      extends DoFn<KV<KafkaSourceDescriptor, KafkaRecord<K, V>>, KV<KafkaSourceDescriptor, Long>> {
 
     private static class OffsetAndTimestamp {
 
@@ -157,8 +153,7 @@ public class KafkaCommitOffset<K, V>
       Instant timestamp;
     }
 
-    private transient @MonotonicNonNull
-        Map<KafkaSourceDescriptor, OffsetAndTimestamp> maxObserved;
+    private transient @MonotonicNonNull Map<KafkaSourceDescriptor, OffsetAndTimestamp> maxObserved;
 
     @StartBundle
     public void startBundle() {
@@ -201,8 +196,7 @@ public class KafkaCommitOffset<K, V>
   }
 
   @Override
-  public PCollection<Void> expand(
-      PCollection<KV<KafkaSourceDescriptor, KafkaRecord<K, V>>> input) {
+  public PCollection<Void> expand(PCollection<KV<KafkaSourceDescriptor, KafkaRecord<K, V>>> input) {
 
     try {
 
@@ -212,13 +206,8 @@ public class KafkaCommitOffset<K, V>
 
         offsets =
             input.apply(
-                MapElements.into(
-                        new TypeDescriptor<KV<KafkaSourceDescriptor, Long>>() {})
-                    .via(
-                        element ->
-                            KV.of(
-                                element.getKey(),
-                                element.getValue().getOffset())));
+                MapElements.into(new TypeDescriptor<KV<KafkaSourceDescriptor, Long>>() {})
+                    .via(element -> KV.of(element.getKey(), element.getValue().getOffset())));
 
       } else {
 

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaCommitOffset.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaCommitOffset.java
@@ -53,23 +53,24 @@ import org.slf4j.LoggerFactory;
 public class KafkaCommitOffset<K, V>
     extends PTransform<
         PCollection<KV<KafkaSourceDescriptor, KafkaRecord<K, V>>>, PCollection<Void>> {
+
   private final KafkaIO.ReadSourceDescriptors<K, V> readSourceDescriptors;
   private final boolean use259implementation;
 
   KafkaCommitOffset(
-      KafkaIO.ReadSourceDescriptors<K, V> readSourceDescriptors, boolean use259implementation) {
+      KafkaIO.ReadSourceDescriptors<K, V> readSourceDescriptors,
+      boolean use259implementation) {
+
     this.readSourceDescriptors = readSourceDescriptors;
     this.use259implementation = use259implementation;
   }
 
   static class CommitOffsetDoFn extends DoFn<KV<KafkaSourceDescriptor, Long>, Void> {
+
     private static final Logger LOG = LoggerFactory.getLogger(CommitOffsetDoFn.class);
 
     private final Counter commitFailures =
         Metrics.counter(CommitOffsetDoFn.class, "commit-failures");
-
-    private final Counter retriesExhausted =
-        Metrics.counter(CommitOffsetDoFn.class, "retries-exhausted");
 
     private final Map<String, Object> consumerConfig;
 
@@ -77,6 +78,7 @@ public class KafkaCommitOffset<K, V>
         consumerFactoryFn;
 
     CommitOffsetDoFn(KafkaIO.ReadSourceDescriptors<?, ?> readSourceDescriptors) {
+
       consumerConfig = readSourceDescriptors.getConsumerConfig();
       consumerFactoryFn = readSourceDescriptors.getConsumerFactoryFn();
     }
@@ -93,6 +95,7 @@ public class KafkaCommitOffset<K, V>
       try (Consumer<byte[], byte[]> consumer = consumerFactoryFn.apply(updatedConsumerConfig)) {
 
         try {
+
           consumer.commitSync(
               Collections.singletonMap(
                   element.getKey().getTopicPartition(),
@@ -101,16 +104,16 @@ public class KafkaCommitOffset<K, V>
         } catch (Exception e) {
 
           commitFailures.inc();
-          retriesExhausted.inc();
 
-          // TODO: consider retrying and increment retry-attempt metrics.
+          // TODO: consider retrying.
           LOG.warn("Getting exception when committing offset: {}", e.getMessage());
         }
       }
     }
 
     private Map<String, Object> overrideBootstrapServersConfig(
-        Map<String, Object> currentConfig, KafkaSourceDescriptor description) {
+        Map<String, Object> currentConfig,
+        KafkaSourceDescriptor description) {
 
       checkState(
           currentConfig.containsKey(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG)
@@ -131,7 +134,9 @@ public class KafkaCommitOffset<K, V>
   }
 
   private static final class MaxOffsetFn<K, V>
-      extends DoFn<KV<KafkaSourceDescriptor, KafkaRecord<K, V>>, KV<KafkaSourceDescriptor, Long>> {
+      extends DoFn<
+          KV<KafkaSourceDescriptor, KafkaRecord<K, V>>,
+          KV<KafkaSourceDescriptor, Long>> {
 
     private static class OffsetAndTimestamp {
 
@@ -141,6 +146,7 @@ public class KafkaCommitOffset<K, V>
       }
 
       void merge(long offset, Instant timestamp) {
+
         if (this.offset < offset) {
           this.offset = offset;
           this.timestamp = timestamp;
@@ -151,7 +157,8 @@ public class KafkaCommitOffset<K, V>
       Instant timestamp;
     }
 
-    private transient @MonotonicNonNull Map<KafkaSourceDescriptor, OffsetAndTimestamp> maxObserved;
+    private transient @MonotonicNonNull
+        Map<KafkaSourceDescriptor, OffsetAndTimestamp> maxObserved;
 
     @StartBundle
     public void startBundle() {
@@ -194,7 +201,8 @@ public class KafkaCommitOffset<K, V>
   }
 
   @Override
-  public PCollection<Void> expand(PCollection<KV<KafkaSourceDescriptor, KafkaRecord<K, V>>> input) {
+  public PCollection<Void> expand(
+      PCollection<KV<KafkaSourceDescriptor, KafkaRecord<K, V>>> input) {
 
     try {
 
@@ -204,14 +212,18 @@ public class KafkaCommitOffset<K, V>
 
         offsets =
             input.apply(
-                MapElements.into(new TypeDescriptor<KV<KafkaSourceDescriptor, Long>>() {})
-                    .via(element -> KV.of(element.getKey(), element.getValue().getOffset())));
+                MapElements.into(
+                        new TypeDescriptor<KV<KafkaSourceDescriptor, Long>>() {})
+                    .via(
+                        element ->
+                            KV.of(
+                                element.getKey(),
+                                element.getValue().getOffset())));
 
       } else {
 
         // Reduce the amount of data to combine by calculating a max within the generally dense
-        // bundles of reading
-        // from a Kafka partition.
+        // bundles of reading from a Kafka partition.
         offsets = input.apply(ParDo.of(new MaxOffsetFn<>()));
       }
 
@@ -229,6 +241,7 @@ public class KafkaCommitOffset<K, V>
           .setCoder(VoidCoder.of());
 
     } catch (NoSuchSchemaException e) {
+
       throw new RuntimeException(e.getMessage());
     }
   }


### PR DESCRIPTION
## Summary

Added Beam metrics in `KafkaCommitOffset.CommitOffsetDoFn` to improve visibility into offset commit failures.

### Added metrics
- `commit-failures`
- `retries-exhausted`

These counters help monitor failed offset commits through existing Beam monitoring dashboards.

Retry-attempt metrics can be added once retry logic is implemented.