### PR TITLE
Refactor _SharedCache to handle context vs non-context ownership

### DIFF
--- a/sdks/python/apache_beam/utils/subprocess_server.py
+++ b/sdks/python/apache_beam/utils/subprocess_server.py
@@ -214,7 +214,7 @@ class SubprocessServer(object):
       channel_ready = grpc.channel_ready_future(self._grpc_channel)
       while True:
         if process is not None and process.poll() is not None:
-          _LOGGER.error("Started job service with %s", process.args)
+          _LOGGER.error("Failed to start job service with %s", process.args)
           raise RuntimeError(
               'Service failed to start up with error %s' % process.poll())
         try:
@@ -243,7 +243,7 @@ class SubprocessServer(object):
       port, = pick_port(None)
       cmd = [arg.replace('{{PORT}}', str(port)) for arg in cmd]  # pylint: disable=not-an-iterable
     endpoint = 'localhost:%s' % port
-    _LOGGER.info("Starting service with %s", str(cmd).replace("',", "'"))
+    _LOGGER.warning("Really starting service at %s with cmd: %s", endpoint, cmd)
     process = subprocess.Popen(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
@@ -295,9 +295,11 @@ class SubprocessServer(object):
         self._grpc_channel = None
 
   def _really_stop_process(process_and_endpoint):
-    process, _ = process_and_endpoint  # pylint: disable=unpacking-non-sequence
+    process, endpoint = process_and_endpoint  # pylint: disable=unpacking-non-sequence
     if not process:
       return
+    _LOGGER.warning(
+        "Really destroying service at %s with cmd: %s", endpoint, process.args)
     for _ in range(5):
       if process.poll() is not None:
         break

--- a/sdks/python/apache_beam/utils/subprocess_server.py
+++ b/sdks/python/apache_beam/utils/subprocess_server.py
@@ -72,7 +72,7 @@ class _SharedCache:
   def __init__(self, constructor, destructor):
     self._constructor = constructor
     self._destructor = destructor
-    self._live_owners = set()
+    self._live_owners = {}
     self._cache = {}
     self._lock = threading.Lock()
     self._counter = 0
@@ -82,10 +82,10 @@ class _SharedCache:
     self._counter += 1
     return self._counter
 
-  def register(self):
+  def register(self, is_context=False):
     with self._lock:
       owner = self._next_id()
-      self._live_owners.add(owner)
+      self._live_owners[owner] = is_context
     return owner
 
   def purge(self, owner):
@@ -97,7 +97,7 @@ class _SharedCache:
             "shutdown, the subprocess was already cleaned up earlier.",
             owner)
         return
-      self._live_owners.remove(owner)
+      del self._live_owners[owner]
       for key, entry in list(self._cache.items()):
         if owner in entry.owners:
           entry.owners.remove(owner)
@@ -108,14 +108,22 @@ class _SharedCache:
     for value in to_delete:
       self._destructor(value)
 
-  def get(self, *key):
+  def get(self, *key, owner=None):
     if not self._live_owners:
       raise RuntimeError("At least one owner must be registered.")
     with self._lock:
       if key not in self._cache:
         self._cache[key] = _SharedCacheEntry(self._constructor(*key), set())
-      for owner in self._live_owners:
+      if owner is not None:
+        if owner not in self._live_owners:
+          raise RuntimeError("The requesting owner must be registered.")
         self._cache[key].owners.add(owner)
+        for live_owner, is_context in self._live_owners.items():
+          if is_context:
+            self._cache[key].owners.add(live_owner)
+      else:
+        for live_owner in self._live_owners:
+          self._cache[key].owners.add(live_owner)
       return self._cache[key].obj
 
   def force_remove(self, *key):
@@ -180,7 +188,7 @@ class SubprocessServer(object):
     These subprocesses may be shared with other contexts as well.
     """
     try:
-      unique_id = cls._cache.register()
+      unique_id = cls._cache.register(is_context=True)
       yield
     finally:
       cls._cache.purge(unique_id)
@@ -235,8 +243,9 @@ class SubprocessServer(object):
   def start_process(self):
     if self._owner_id is not None:
       self._cache.purge(self._owner_id)
-    self._owner_id = self._cache.register()
-    return self._cache.get(tuple(self._cmd), self._port, self._logger)
+    self._owner_id = self._cache.register(is_context=False)
+    return self._cache.get(
+        tuple(self._cmd), self._port, self._logger, owner=self._owner_id)
 
   def _really_start_process(cmd, port, logger):
     if not port:

--- a/sdks/python/apache_beam/utils/subprocess_server.py
+++ b/sdks/python/apache_beam/utils/subprocess_server.py
@@ -109,14 +109,15 @@ class _SharedCache:
       self._destructor(value)
 
   def get(self, *key, owner=None):
-    if not self._live_owners:
-      raise RuntimeError("At least one owner must be registered.")
     with self._lock:
+      if not self._live_owners:
+        raise RuntimeError("At least one owner must be registered.")
+      if owner is not None and owner not in self._live_owners:
+        raise RuntimeError("The requesting owner must be registered.")
+
       if key not in self._cache:
         self._cache[key] = _SharedCacheEntry(self._constructor(*key), set())
       if owner is not None:
-        if owner not in self._live_owners:
-          raise RuntimeError("The requesting owner must be registered.")
         self._cache[key].owners.add(owner)
         for live_owner, is_context in self._live_owners.items():
           if is_context:

--- a/sdks/python/apache_beam/utils/subprocess_server_test.py
+++ b/sdks/python/apache_beam/utils/subprocess_server_test.py
@@ -402,16 +402,16 @@ class CacheTest(unittest.TestCase):
       self.assertEqual(len(registered_callbacks), 1)
 
   def test_concurrent_purge_race_condition(self):
-    # Concurrent threads attempting to check memebership and call purge for the same owner.
-    # Here we explicitly define a synchronized set to mimic the behavior of _live_owners.
-    # This set will block two threads on __contains__, allowing us to test the race condition.
+    # Concurrent threads attempting to check membership and call purge for the same owner.
+    # Here we explicitly define a synchronized dict to mimic the behavior of _live_owners.
+    # This dict will block two threads on __contains__, allowing us to test the race condition.
     cache = subprocess_server._SharedCache(lambda x: "obj", lambda x: None)
     owner = cache.register()
 
     barrier = threading.Barrier(2)
     exceptions = []
 
-    class SynchronizedSet(set):
+    class SynchronizedDict(dict):
       def __contains__(self, item):
         res = super().__contains__(item)
         try:
@@ -421,7 +421,7 @@ class CacheTest(unittest.TestCase):
           pass
         return res
 
-    cache._live_owners = SynchronizedSet(cache._live_owners)
+    cache._live_owners = SynchronizedDict(cache._live_owners)
 
     def purge_worker():
       try:
@@ -550,6 +550,53 @@ class CacheTest(unittest.TestCase):
 
     # Clean up the other owner
     cache.purge(other_owner)
+
+  def test_non_context_owners_do_not_share_keys(self):
+    cache = subprocess_server._SharedCache(self.with_prefix, lambda x: None)
+    # owner1 is a non-context owner (e.g., prism)
+    owner1 = cache.register(is_context=False)
+    a = cache.get('a', owner=owner1)
+
+    # owner2 is another non-context owner (e.g., short-lived expansion service)
+    owner2 = cache.register(is_context=False)
+    b = cache.get('b', owner=owner2)
+
+    # Verify that owner1 does not own 'b'
+    self.assertNotIn(owner1, cache._cache[('b', )].owners)
+
+    # Verify that owner2 does not own 'a'
+    self.assertNotIn(owner2, cache._cache[('a', )].owners)
+
+    # Purging owner2 should immediately destroy/remove 'b'
+    cache.purge(owner2)
+    self.assertNotIn(('b', ), cache._cache)
+
+    # 'a' is still alive because owner1 is still registered
+    self.assertIn(('a', ), cache._cache)
+
+    # Purging owner1 should destroy/remove 'a'
+    cache.purge(owner1)
+    self.assertNotIn(('a', ), cache._cache)
+
+  def test_context_owner_owns_all_keys(self):
+    cache = subprocess_server._SharedCache(self.with_prefix, lambda x: None)
+    # owner1 is a non-context owner (e.g., prism)
+    owner1 = cache.register(is_context=False)
+
+    # owner2 is a context owner (e.g., cache_subprocesses)
+    owner2 = cache.register(is_context=True)
+
+    # owner3 is another non-context owner (e.g., short-lived service)
+    owner3 = cache.register(is_context=False)
+
+    # owner3 requests 'b'
+    b = cache.get('b', owner=owner3)
+
+    # owner2 (context) should own 'b'
+    self.assertIn(owner2, cache._cache[('b', )].owners)
+
+    # owner1 (non-context) should NOT own 'b'
+    self.assertNotIn(owner1, cache._cache[('b', )].owners)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently, `_SharedCache` registers all live owners as joint owners of every cached subprocess key. This works fine when all owners are within a unified context (e.g. a test class wrapping multiple runs), but it causes unintended resource sharing/leakage when there are concurrent, independent, non-context owners (such as a long-lived runner).

Here is a resource leak scenario:
1. The Prism runner starts and registers a persistent non-context owner `owner_1`.
1. The pipeline requests an external transform, spinning up a short-lived Java Expansion Service that registers its own owner `owner_2` and requests its startup command key.
1. In the old implementation, `get()` automatically added all currently registered live owners to the cache key's owner set.
https://github.com/apache/beam/blob/361c2c473a8eb6ebddfc3211f78553b521fdfa54/sdks/python/apache_beam/utils/subprocess_server.py#L117-L118
As a result, `owner_1` (the Prism runner) was registered as a joint owner of the short-lived Expansion Service's cache key.
1. When the pipeline finished using the external transform and called purge(`owner_2`), the short-lived Expansion Service subprocess was never terminated because `owner_1` was still registered as an owner (`entry.owners` is not empty).
https://github.com/apache/beam/blob/361c2c473a8eb6ebddfc3211f78553b521fdfa54/sdks/python/apache_beam/utils/subprocess_server.py#L104-L105
1. This resulted in orphaned, zombie Expansion Service processes accumulating in the background, binding up localhost ports and exhausting resources.

This PR refactors `_SharedCache` in `subprocess_server.py` to explicitly distinguish between context owners (e.g., cache_subprocesses which should hold ownership over everything created under its block) and non-context owners (e.g., individual subprocess server instances like PrismRunner or expansion service subprocesses).

Additionally, get() now takes an optional owner arg. Context owners automatically own all created keys, while independent non-context owners only own the keys they explicitly request.

---

For example, we run YAML example test with `pytest apache_beam/yaml/examples/testing/examples_test.py --log-cli-level=INFO -s`.

- Without this PR, we see all expansion service servers created in these 46 tests and prism server being destroyed at the end of pytest execution.
  ```
  Really destroying service at localhost:49623 with cmd: ('/Users/shunping/.apache_beam/cache/prism/bin/prism', '--job_port', '49623', '--log_level', 'info', '--log_kind', 'json', '--serve_http=false')
  WARNING:apache_beam.utils.subprocess_server:Really destroying service at localhost:49745 with cmd: ['/Users/shunping/.apache_beam/cache/venvs/e08b2501f55abf367196f6578e3dbed1fe2a6d9244fc96ad5d82f3d5c621c1cf/bin/python', '-m', 'apache_beam.runners.portability.expansion_service_main', '--port', '49745', '--fully_qualified_name_glob=*', '--pickle_library=cloudpickle', '--requirements_file=/Users/shunping/.apache_beam/cache/venvs/e08b2501f55abf367196f6578e3dbed1fe2a6d9244fc96ad5d82f3d5c621c1cf-requirements.txt', '--serve_loopback_worker']
  WARNING:apache_beam.utils.subprocess_server:Really destroying service at localhost:49855 with cmd: ['/Users/shunping/.apache_beam/cache/venvs/5052f7801853faa5017d022495ad2a30f1ae0a321fa50de56227e75028f0e612/bin/python', '-m', 'apache_beam.runners.portability.expansion_service_main', '--port', '49855', '--fully_qualified_name_glob=*', '--pickle_library=cloudpickle', '--requirements_file=/Users/shunping/.apache_beam/cache/venvs/5052f7801853faa5017d022495ad2a30f1ae0a321fa50de56227e75028f0e612-requirements.txt', '--serve_loopback_worker']
  WARNING:apache_beam.utils.subprocess_server:Really destroying service at localhost:49888 with cmd: ['/Users/shunping/.apache_beam/cache/venvs/aedc40ba446114c3eb019ef9c411c0ab2204da67a2f4c732530c1c6aba7eef31/bin/python', '-m', 'apache_beam.runners.portability.expansion_service_main', '--port', '49888', '--fully_qualified_name_glob=*', '--pickle_library=cloudpickle', '--requirements_file=/Users/shunping/.apache_beam/cache/venvs/aedc40ba446114c3eb019ef9c411c0ab2204da67a2f4c732530c1c6aba7eef31-requirements.txt', '--serve_loopback_worker']
  ```
- With this PR, each expansion service server is destroyed as soon as the corresponding test is over. Prism server is cleaned up before pytest ends.