### PR TITLE
ci: declare workflow-level `contents: read` on go/python/java/typescript test workflows

### DIFF
--- a/.github/workflows/go_tests.yml
+++ b/.github/workflows/go_tests.yml
@@ -34,6 +34,9 @@ on:
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.issue.number || github.event.pull_request.head.label || github.sha || github.head_ref || github.ref }}-${{ github.event.schedule || github.event.comment.id || github.event.sender.login}}'
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: [self-hosted, ubuntu-24.04, main]

--- a/.github/workflows/java_tests.yml
+++ b/.github/workflows/java_tests.yml
@@ -38,6 +38,9 @@ env:
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
   GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
   GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
+permissions:
+  contents: read
+
 jobs:
   java_unit_tests:
     name: 'Java Unit Tests'

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -36,6 +36,9 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.issue.number || github.event.pull_request.head.label || github.sha || github.head_ref || github.ref }}-${{ github.event.schedule || github.event.comment.id || github.event.sender.login}}'
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   check_gcp_variables:

--- a/.github/workflows/typescript_tests.yml
+++ b/.github/workflows/typescript_tests.yml
@@ -44,6 +44,9 @@ concurrency:
   cancel-in-progress: true
 env:
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+permissions:
+  contents: read
+
 jobs:
   typescript_unit_tests:
     name: 'TypeScript Unit Tests'


### PR DESCRIPTION
Four per-language test workflows (`go_tests`, `python_tests`, `java_tests`, `typescript_tests`) just run their language test suites. No GitHub API writes from the workflows themselves.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.