### PR TITLE
Remove blocked setup-gradle action from CI setup

### DIFF
--- a/.github/actions/setup-environment-action/action.yml
+++ b/.github/actions/setup-environment-action/action.yml
@@ -75,11 +75,6 @@ runs:
       with:
         distribution: 'temurin'
         java-version: ${{ inputs.java-version == 'default' && '11' || inputs.java-version }}
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
-      with:
-        cache-disabled: ${{ inputs.disable-cache }}
-        validate-wrappers: false
     - name: Install Go
       if: ${{ inputs.go-version != '' }}
       uses: actions/setup-go@v6


### PR DESCRIPTION
Removes the blocked `setup-gradle` action from the CI setup workflow.

The `gradle/actions/setup-gradle` action is blocked in this repository, which was causing the PreCommit Python Formatter job to fail over 50% of the time.

fixes #38622

## Changes
- Removed the `Setup Gradle` step (lines 78–82) from `.github/actions/setup-environment-action/action.yml`

## Checklist
- [x] Addresses #38622
- [x] No `CHANGES.md` update needed — this is a CI infrastructure fix with no user-facing changes
- [x] Small fix, Apache ICLA not required