### PR TITLE
Enforce binary-only constraints during early requirements cache attempts

### DIFF
--- a/.github/trigger_files/beam_PostCommit_Python.json
+++ b/.github/trigger_files/beam_PostCommit_Python.json
@@ -1,5 +1,5 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run.",
   "pr": "38069",
-  "modification": 41
+  "modification": 42
 }

--- a/sdks/python/apache_beam/runners/portability/stager.py
+++ b/sdks/python/apache_beam/runners/portability/stager.py
@@ -88,6 +88,14 @@ SUBMISSION_ENV_DEPENDENCIES_FILE = 'submission_environment_dependencies.txt'
 # One of the choices for user to use for requirements cache during staging
 SKIP_REQUIREMENTS_CACHE = 'skip'
 
+# Ordered list of manylinux tags from newest (strictest) to oldest (most compatible)
+# used for cross-platform binary dependency downloads.
+_MANYLINUX_PLATFORMS = [
+    'manylinux_2_28_x86_64',
+    'manylinux2014_x86_64',  # equivalent to manylinux_2_17
+    'manylinux2010_x86_64',  # equivalent to manylinux_2_12
+]
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -762,15 +770,13 @@ class Stager(object):
       # Download to a temporary directory first, then copy to cache.
       # This allows us to track exactly which packages are needed for this
       # requirements file.
-      download_dir = tempfile.mkdtemp(dir=temp_directory)
+      download_dir = None
 
       cmd_args = [
           Stager._get_python_executable(),
           '-m',
           'pip',
           'download',
-          '--dest',
-          download_dir,
           '--find-links',
           cache_dir,
           '-r',
@@ -781,23 +787,54 @@ class Stager(object):
       ]
 
       if populate_cache_with_sdists:
-        cmd_args.extend(['--no-binary', ':all:'])
+        download_dir = tempfile.mkdtemp(dir=temp_directory)
+        cmd_args.extend(['--dest', download_dir, '--no-binary', ':all:'])
+        _LOGGER.info('Executing command: %s', cmd_args)
+        processes.check_output(cmd_args, stderr=processes.STDOUT)
       else:
         language_implementation_tag = 'cp'
         abi_suffix = 'm' if sys.version_info < (3, 8) else ''
         abi_tag = 'cp%d%d%s' % (
             sys.version_info[0], sys.version_info[1], abi_suffix)
-        platform_tag = Stager._get_platform_for_default_sdk_container()
-        cmd_args.extend([
-            '--implementation',
-            language_implementation_tag,
-            '--abi',
-            abi_tag,
-            '--platform',
-            platform_tag
-        ])
-      _LOGGER.info('Executing command: %s', cmd_args)
-      processes.check_output(cmd_args, stderr=processes.STDOUT)
+        preferred_platform = Stager._get_platform_for_default_sdk_container()
+
+        # Fallback platform tags in case the preferred modern tag is too strict
+        # for some dependencies on PyPI.
+        try:
+          start_idx = _MANYLINUX_PLATFORMS.index(preferred_platform)
+          platforms = _MANYLINUX_PLATFORMS[start_idx:]
+        except ValueError:
+          platforms = [preferred_platform]
+
+        last_exception = None
+        for platform in platforms:
+          attempt_download_dir = tempfile.mkdtemp(dir=temp_directory)
+          attempt_cmd_args = cmd_args + [
+              '--dest',
+              attempt_download_dir,
+              '--implementation',
+              language_implementation_tag,
+              '--abi',
+              abi_tag,
+              '--platform',
+              platform
+          ]
+          _LOGGER.info('Executing command: %s', attempt_cmd_args)
+          try:
+            processes.check_output(attempt_cmd_args, stderr=processes.STDOUT)
+            download_dir = attempt_download_dir
+            last_exception = None
+            break
+          except Exception as e:
+            _LOGGER.warning(
+                'Pip download failed with platform %s, trying fallback: %s',
+                platform,
+                e)
+            shutil.rmtree(attempt_download_dir)
+            last_exception = e
+
+        if last_exception:
+          raise last_exception
 
       # Get list of downloaded packages and copy them to the cache
       downloaded_packages = set()

--- a/sdks/python/apache_beam/runners/portability/stager.py
+++ b/sdks/python/apache_beam/runners/portability/stager.py
@@ -819,7 +819,9 @@ class Stager(object):
               '--platform',
               platform
           ]
-          # Force binary wheel only if we have more platform fallbacks to try
+          # Force binary wheel only if we have more platform fallbacks to try.
+          # For the last platform, we omit this flag so it can natively fall back
+          # to downloading a source distribution (sdist) if no matching wheel is found.
           if idx < len(platforms) - 1:
             attempt_cmd_args.extend(['--only-binary', ':all:'])
 

--- a/sdks/python/apache_beam/runners/portability/stager.py
+++ b/sdks/python/apache_beam/runners/portability/stager.py
@@ -770,51 +770,7 @@ class Stager(object):
         _LOGGER.info('Executing command: %s', cmd_args)
         processes.check_output(cmd_args, stderr=processes.STDOUT)
       else:
-        language_implementation_tag = 'cp'
-        abi_suffix = 'm' if sys.version_info < (3, 8) else ''
-        abi_tag = 'cp%d%d%s' % (
-            sys.version_info[0], sys.version_info[1], abi_suffix)
-        pip_version = distribution('pip').version
-        platforms = [
-            platform for platform, min_pip_version in _MANYLINUX_PLATFORMS
-            if version.parse(pip_version) >= version.parse(min_pip_version)
-        ]
-
-        last_exception = None
-        for idx, platform in enumerate(platforms):
-          attempt_download_dir = tempfile.mkdtemp(dir=temp_directory)
-          attempt_cmd_args = cmd_args + [
-              '--dest',
-              attempt_download_dir,
-              '--implementation',
-              language_implementation_tag,
-              '--abi',
-              abi_tag,
-              '--platform',
-              platform
-          ]
-          # Force binary wheel only if we have more platform fallbacks to try.
-          # For the last platform, we omit this flag so it can natively fall back
-          # to downloading a source distribution (sdist) if no matching wheel is found.
-          if idx < len(platforms) - 1:
-            attempt_cmd_args.extend(['--only-binary', ':all:'])
-
-          _LOGGER.info('Executing command: %s', attempt_cmd_args)
-          try:
-            processes.check_output(attempt_cmd_args, stderr=processes.STDOUT)
-            download_dir = attempt_download_dir
-            last_exception = None
-            break
-          except Exception as e:
-            _LOGGER.warning(
-                'Pip download failed with platform %s, trying fallback: %s',
-                platform,
-                e)
-            shutil.rmtree(attempt_download_dir)
-            last_exception = e
-
-        if last_exception:
-          raise last_exception
+        download_dir = Stager._download_pypi_packages(cmd_args, temp_directory)
 
       # Get list of downloaded packages and copy them to the cache
       downloaded_packages = set()
@@ -827,6 +783,53 @@ class Stager(object):
           shutil.copy2(src_path, dest_path)
 
       return downloaded_packages
+
+  @staticmethod
+  def _download_pypi_packages(cmd_args, temp_directory):
+    language_implementation_tag = 'cp'
+    abi_suffix = 'm' if sys.version_info < (3, 8) else ''
+    abi_tag = 'cp%d%d%s' % (
+        sys.version_info[0], sys.version_info[1], abi_suffix)
+    pip_version = distribution('pip').version
+    platforms = [
+        platform for platform, min_pip_version in _MANYLINUX_PLATFORMS
+        if version.parse(pip_version) >= version.parse(min_pip_version)
+    ]
+
+    last_exception = None
+    for idx, platform in enumerate(platforms):
+      attempt_download_dir = tempfile.mkdtemp(dir=temp_directory)
+      attempt_cmd_args = cmd_args + [
+          '--dest',
+          attempt_download_dir,
+          '--implementation',
+          language_implementation_tag,
+          '--abi',
+          abi_tag,
+          '--platform',
+          platform
+      ]
+      # Force binary wheel only if we have more platform fallbacks to try.
+      # For the last platform, we omit this flag so it can natively fall back
+      # to downloading a source distribution (sdist) if no matching wheel is found.
+      if idx < len(platforms) - 1:
+        attempt_cmd_args.extend(['--only-binary', ':all:'])
+
+      _LOGGER.info('Executing command: %s', attempt_cmd_args)
+      try:
+        processes.check_output(attempt_cmd_args, stderr=processes.STDOUT)
+        last_exception = None
+        return attempt_download_dir
+      except Exception as e:
+        _LOGGER.warning(
+            'Pip download failed with platform %s, trying fallback: %s',
+            platform,
+            e)
+        shutil.rmtree(attempt_download_dir)
+        last_exception = e
+
+    if last_exception:
+      raise last_exception
 
   @staticmethod
   def _build_setup_package(

--- a/sdks/python/apache_beam/runners/portability/stager.py
+++ b/sdks/python/apache_beam/runners/portability/stager.py
@@ -807,7 +807,7 @@ class Stager(object):
           platforms = [preferred_platform]
 
         last_exception = None
-        for platform in platforms:
+        for idx, platform in enumerate(platforms):
           attempt_download_dir = tempfile.mkdtemp(dir=temp_directory)
           attempt_cmd_args = cmd_args + [
               '--dest',
@@ -819,6 +819,10 @@ class Stager(object):
               '--platform',
               platform
           ]
+          # Force binary wheel only if we have more platform fallbacks to try
+          if idx < len(platforms) - 1:
+            attempt_cmd_args.extend(['--only-binary', ':all:'])
+
           _LOGGER.info('Executing command: %s', attempt_cmd_args)
           try:
             processes.check_output(attempt_cmd_args, stderr=processes.STDOUT)

--- a/sdks/python/apache_beam/runners/portability/stager.py
+++ b/sdks/python/apache_beam/runners/portability/stager.py
@@ -748,29 +748,46 @@ class Stager(object):
       # Download to a temporary directory first, then copy to cache.
       # This allows us to track exactly which packages are needed for this
       # requirements file.
-      download_dir = None
+      download_dir = tempfile.mkdtemp(dir=temp_directory)
 
-      cmd_args = [
-          Stager._get_python_executable(),
-          '-m',
-          'pip',
-          'download',
-          '--find-links',
-          cache_dir,
-          '-r',
-          tmp_requirements_filepath,
-          '--exists-action',
-          'i',
-          '--no-deps'
-      ]
+      # Read packages from the requirements file
+      requirements = []
+      with open(tmp_requirements_filepath, 'r') as f:
+        for line in f:
+          line = line.strip()
+          if line and not line.startswith('#'):
+            requirements.append(line)
 
-      if populate_cache_with_sdists:
-        download_dir = tempfile.mkdtemp(dir=temp_directory)
-        cmd_args.extend(['--dest', download_dir, '--no-binary', ':all:'])
-        _LOGGER.info('Executing command: %s', cmd_args)
-        processes.check_output(cmd_args, stderr=processes.STDOUT)
-      else:
-        download_dir = Stager._download_pypi_packages(cmd_args, temp_directory)
+      for req in requirements:
+        cmd_args = [
+            Stager._get_python_executable(),
+            '-m',
+            'pip',
+            'download',
+            '--find-links',
+            cache_dir,
+            req,
+            '--exists-action',
+            'i',
+            '--no-deps'
+        ]
+
+        if populate_cache_with_sdists:
+          attempt_download_dir = tempfile.mkdtemp(dir=temp_directory)
+          cmd_args.extend(
+              ['--dest', attempt_download_dir, '--no-binary', ':all:'])
+          _LOGGER.info('Executing command: %s', cmd_args)
+          processes.check_output(cmd_args, stderr=processes.STDOUT)
+        else:
+          attempt_download_dir = Stager._download_pypi_packages(
+              cmd_args, temp_directory)
+
+        # Move downloaded packages to our common download directory
+        for pkg_file in os.listdir(attempt_download_dir):
+          src_path = os.path.join(attempt_download_dir, pkg_file)
+          dest_path = os.path.join(download_dir, pkg_file)
+          if not os.path.exists(dest_path):
+            shutil.move(src_path, dest_path)
 
       # Get list of downloaded packages and copy them to the cache
       downloaded_packages = set()

--- a/sdks/python/apache_beam/runners/portability/stager.py
+++ b/sdks/python/apache_beam/runners/portability/stager.py
@@ -89,11 +89,13 @@ SUBMISSION_ENV_DEPENDENCIES_FILE = 'submission_environment_dependencies.txt'
 SKIP_REQUIREMENTS_CACHE = 'skip'
 
 # Ordered list of manylinux tags from newest (strictest) to oldest (most compatible)
-# used for cross-platform binary dependency downloads.
+# paired with the minimum pip version required to support the tag.
+# See https://github.com/pypa/manylinux.
 _MANYLINUX_PLATFORMS = [
-    'manylinux_2_28_x86_64',
-    'manylinux2014_x86_64',  # equivalent to manylinux_2_17
-    'manylinux2010_x86_64',  # equivalent to manylinux_2_12
+    ('manylinux_2_28_x86_64', '20.3'),
+    ('manylinux2014_x86_64', '19.3'),  # equivalent to manylinux_2_17
+    ('manylinux2010_x86_64',
+     '0.0'),  # equivalent to manylinux_2_12, the fallback if pip is too old
 ]
 
 _LOGGER = logging.getLogger(__name__)
@@ -726,30 +728,6 @@ class Stager(object):
       return [], requirements_file
 
   @staticmethod
-  def _get_platform_for_default_sdk_container():
-    """
-    Get the platform for apache beam SDK container based on Pip version.
-
-    Note: pip is still expected to download compatible wheel of a package
-    with platform tag manylinux1 if the package on PyPI doesn't
-    have (manylinux2014) or (manylinux2010) wheels.
-    Reference: https://www.python.org/dev/peps/pep-0599/#id21
-    """
-
-    # TODO(anandinguva): When https://github.com/pypa/pip/issues/10760 is
-    # addressed, download wheel based on glibc version in Beam's Python
-    # Base image
-    pip_version = distribution('pip').version
-    # See more information about manylinux at
-    # https://github.com/pypa/manylinux
-    if version.parse(pip_version) >= version.parse('20.3'):
-      return 'manylinux_2_28_x86_64'
-    elif version.parse(pip_version) >= version.parse('19.3'):
-      return 'manylinux2014_x86_64'
-    else:
-      return 'manylinux2010_x86_64'
-
-  @staticmethod
   @retry.with_exponential_backoff(
       num_retries=4, retry_filter=retry_on_non_zero_exit)
   def _populate_requirements_cache(
@@ -796,15 +774,11 @@ class Stager(object):
         abi_suffix = 'm' if sys.version_info < (3, 8) else ''
         abi_tag = 'cp%d%d%s' % (
             sys.version_info[0], sys.version_info[1], abi_suffix)
-        preferred_platform = Stager._get_platform_for_default_sdk_container()
-
-        # Fallback platform tags in case the preferred modern tag is too strict
-        # for some dependencies on PyPI.
-        try:
-          start_idx = _MANYLINUX_PLATFORMS.index(preferred_platform)
-          platforms = _MANYLINUX_PLATFORMS[start_idx:]
-        except ValueError:
-          platforms = [preferred_platform]
+        pip_version = distribution('pip').version
+        platforms = [
+            platform for platform, min_pip_version in _MANYLINUX_PLATFORMS
+            if version.parse(pip_version) >= version.parse(min_pip_version)
+        ]
 
         last_exception = None
         for idx, platform in enumerate(platforms):


### PR DESCRIPTION
Previously, pip download was executed with preferred platform configurations (e.g., manylinux_2_28_x86_64). However, if no matching binary wheel (.whl) was found, pip would by default fall back to downloading the source distribution (sdist) directly.

We modified the fallback logic here by injecting `--only-binary=:all:` to enforce downloading only binary wheels in the early attempts. For example, for numpy 2.2.6, we first try downloading the `manylinux_2_28_x86_64` wheel. When it fails due to no such wheel, we then try downloading the `manylinux2014_x86_64` wheel. If we could not find any wheels for the platforms on the list, we will fallback to source distribution in the end.

This fixed timeout errors in PreCommit Python 3.10 (for `MLTest.test_ml_preprocessing_yaml` in https://github.com/apache/beam/actions/runs/26420471407/job/77774009271), and PostCommit Python 3.10 (for `VertexAIImageEmbeddingsTest.test_image_embedding_pipeline_from_path` in https://github.com/apache/beam/actions/runs/26424456835/job/77785233507), because rather than staging and building numpy from source, we only need to download the correct version of wheels, which shortens the expansion service startup time during pytest.

Also related to https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/3533