### PR TITLE
[GSoC 2026] Temporary feature-branch CI for Kafka Streams runner

### DIFF
--- a/.github/workflows/beam_KafkaStreamsRunner_FeatureBranch.yml
+++ b/.github/workflows/beam_KafkaStreamsRunner_FeatureBranch.yml
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Temporary, feature-branch-only build for the Kafka Streams runner GSoC work.
+#
+# Beam's standard PreCommit workflows are gated on self-hosted runners and a
+# `branches: ['master', 'release-*']` filter, so they never trigger for PRs
+# targeting the `feat/18479-*` integration branch. This lightweight workflow
+# bypasses that machinery: it runs on a GitHub-hosted runner and simply builds
+# and tests the `runners/kafka-streams` module.
+#
+# REMOVE THIS WORKFLOW when the Kafka Streams runner work merges to master and
+# the standard PreCommit (beam_PreCommit_Java_Kafka_Streams_Runner.yml) takes
+# over.
+
+name: KafkaStreams Runner Feature Branch Build
+
+on:
+  pull_request:
+    branches:
+      - 'feat/18479-*'
+    paths:
+      - 'runners/kafka-streams/**'
+      - '.github/workflows/beam_KafkaStreamsRunner_FeatureBranch.yml'
+  push:
+    branches:
+      - 'feat/18479-*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.number || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Kafka Streams runner build
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '11'
+      - name: Set up Gradle cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-kafka-streams-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-kafka-streams-
+      - name: Build and test Kafka Streams runner
+        run: ./gradlew :runners:kafka-streams:build --no-daemon --stacktrace


### PR DESCRIPTION
Adds a lightweight github-hosted workflow that builds runners/kafka-streams on PRs into feat/18479-*, bypassing the self-hosted + comment-gated standard Beam PreCommit. To be removed when merging to master. 

Refs #18479 
 cc @je-ik