### PR TITLE
[#38708] Add Flink 2.0 to SDK pipeline options validation lists

### DIFF
--- a/.github/actions/setup-default-test-properties/test-properties.json
+++ b/.github/actions/setup-default-test-properties/test-properties.json
@@ -14,7 +14,7 @@
   },
   "JavaTestProperties": {
     "SUPPORTED_VERSIONS": ["8", "11", "17", "21", "25"],
-    "FLINK_VERSIONS": ["1.17", "1.18", "1.19", "1.20"],
+    "FLINK_VERSIONS": ["1.17", "1.18", "1.19", "1.20", "2.0"],
     "SPARK_VERSIONS": ["3"]
   },
   "GoTestProperties": {

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -2021,7 +2021,7 @@ class JobServerOptions(PipelineOptions):
 class FlinkRunnerOptions(PipelineOptions):
 
   # These should stay in sync with gradle.properties.
-  PUBLISHED_FLINK_VERSIONS = ['1.17', '1.18', '1.19', '1.20']
+  PUBLISHED_FLINK_VERSIONS = ['1.17', '1.18', '1.19', '1.20', '2.0']
 
   @classmethod
   def _add_argparse_args(cls, parser):

--- a/sdks/typescript/src/apache_beam/runners/flink.ts
+++ b/sdks/typescript/src/apache_beam/runners/flink.ts
@@ -28,7 +28,7 @@ import { JavaJarService } from "../utils/service";
 const MAGIC_HOST_NAMES = ["[local]", "[auto]"];
 
 // These should stay in sync with gradle.properties.
-const PUBLISHED_FLINK_VERSIONS = ["1.17", "1.18", "1.19", "1.20"];
+const PUBLISHED_FLINK_VERSIONS = ["1.17", "1.18", "1.19", "1.20", "2.0"];
 
 const defaultOptions = {
   flinkMaster: "[local]",


### PR DESCRIPTION
## What does this PR do?

This PR fixes the Flink 2.0 CLI validation mismatch reported in #38708.

Beam 2.72.0 already includes Flink 2.0 runner support and the documentation reflects this, but the SDK option validation lists were not updated accordingly.

As a result, passing:

bash --flink_version 2.0 

failed with:

text invalid choice: '2.0' 

## Changes
- Added 2.0 to PUBLISHED_FLINK_VERSIONS in:
  - sdks/python/apache_beam/options/pipeline_options.py
  - sdks/typescript/src/apache_beam/runners/flink.ts

- Updated default CI Flink version metadata:
  - .github/actions/setup-default-test-properties/test-properties.json

## Verification

Validated locally with:

bash python -c "from apache_beam.options.pipeline_options import PipelineOptions, FlinkRunnerOptions; opts = PipelineOptions(['--runner=FlinkRunner', '--flink_version=2.0']); print(opts.view_as(FlinkRunnerOptions).flink_version)" 

which now parses successfully and returns:

text 2.0 