### PR TITLE
[Prism] Fix race condition in element manager

### DIFF
--- a/.github/trigger_files/beam_PostCommit_Python_Versions.json
+++ b/.github/trigger_files/beam_PostCommit_Python_Versions.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run",
-  "revision": 4
+  "revision": 5
 }

--- a/runners/prism/java/build.gradle
+++ b/runners/prism/java/build.gradle
@@ -185,6 +185,7 @@ def sickbayTests = [
 def createPrismValidatesRunnerTask = { name, environmentType ->
   Task vrTask = tasks.create(name: name, type: Test, group: "Verification") {
     description "PrismRunner Java $environmentType ValidatesRunner suite"
+    outputs.upToDateWhen { false }
     classpath = configurations.validatesRunner
 
     var prismBuildTask = dependsOn(':runners:prism:build')

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
@@ -387,8 +387,11 @@ func (em *ElementManager) Bundles(ctx context.Context, upstreamCancelFn context.
 		em.pendingElements.Wait()
 		slog.Debug("no more pending elements: terminating pipeline")
 		cancelFn(fmt.Errorf("elementManager out of elements, cleaning up"))
-		// Ensure the watermark evaluation goroutine exits.
+		// Ensure the watermark evaluation goroutine exits by locking the mutex
+		// before broadcasting, preventing a lost wake-up signal.
+		em.refreshCond.L.Lock()
 		em.refreshCond.Broadcast()
+		em.refreshCond.L.Unlock()
 	}()
 	// Watermark evaluation goroutine.
 	go func() {
@@ -2496,7 +2499,9 @@ func (em *ElementManager) wakeUpAt(t mtime.Time) {
 		// only create this goroutine if we have real-time clock enabled (also implying the pipeline does not have TestStream).
 		go func(fireAt time.Time) {
 			time.AfterFunc(time.Until(fireAt), func() {
+				em.refreshCond.L.Lock()
 				em.refreshCond.Broadcast()
+				em.refreshCond.L.Unlock()
 			})
 		}(t.ToTime())
 	}


### PR DESCRIPTION
Ensures 'refreshCond.Broadcast()' is fully synchronized with its mutex lock 'refreshCond.L' during pipeline termination and processing-time timer scheduling ('wakeUpAt').
    
This avoids race conditions causing lost wake-up signals and indefinite test hangs.

Without this change, we have seen a rare deadline exceed on random tests. The goroutine dump suggests that it is stuck in the watermark evaluation loop while the pending element goroutine has ended.

```
2026-05-28T13:06:16.6677165Z 1 @ 0x48ddee 0x48f833 0x48f813 0x49e9f3 0xc0fc25 0x495621
2026-05-28T13:06:16.6678046Z #  0x48f812        sync.runtime_notifyListWait+0x192                                                                               /usr/local/go/src/runtime/sema.go:617
2026-05-28T13:06:16.6679030Z #  0x49e9f2        sync.(*Cond).Wait+0x72                                                                                          /usr/local/go/src/sync/cond.go:71
2026-05-28T13:06:16.6680753Z #  0xc0fc24        [github.com/apache/beam/sdks/v2/go/pkg/beam/runners/prism/internal/engine.(*ElementManager).Bundles.func2+0x244](https://www.google.com/url?sa=D&q=http%3A%2F%2Fgithub.com%2Fapache%2Fbeam%2Fsdks%2Fv2%2Fgo%2Fpkg%2Fbeam%2Frunners%2Fprism%2Finternal%2Fengine.(*ElementManager).Bundles.func2%2B0x244)  /runner/_work/beam/beam/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go:426
2026-05-28T13:06:16.6682188Z
```

Example:
https://github.com/apache/beam/actions/runs/26588248130/job/78339963103?pr=38713