### PR TITLE
[Prism] Fix Reshuffle handling to recursively remove sub-transforms

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/handlerunner.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/handlerunner.go
@@ -209,8 +209,8 @@ func (h *runner) handleReshuffle(tid string, t *pipepb.PTransform, comps *pipepb
 		}
 	}
 
-	// And all the sub transforms.
-	toRemove = append(toRemove, t.GetSubtransforms()...)
+	// Also recursively remove all sub-transforms.
+	toRemove = append(toRemove, removeSubTransforms(comps, t.GetSubtransforms())...)
 
 	// Return the new components which is the transforms consumer
 	return prepareResult{

--- a/sdks/go/pkg/beam/runners/prism/internal/handlerunner_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/handlerunner_test.go
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"testing"
+
+	pipepb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/pipeline_v1"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestHandleReshuffle(t *testing.T) {
+	h := &runner{
+		config: RunnerCharacteristic{
+			SDKReshuffle: false,
+		},
+	}
+
+	comps := &pipepb.Components{
+		Transforms: map[string]*pipepb.PTransform{
+			"reshuffle": {
+				UniqueName: "reshuffle",
+				Inputs: map[string]string{
+					"in": "pcol_in",
+				},
+				Outputs: map[string]string{
+					"out": "pcol_out",
+				},
+				Subtransforms: []string{"sub_1"},
+			},
+			"sub_1": {
+				UniqueName:    "sub_1",
+				Subtransforms: []string{"sub_2"},
+			},
+			"sub_2": {
+				UniqueName: "sub_2",
+			},
+			"consumer": {
+				UniqueName: "consumer",
+				Inputs: map[string]string{
+					"in": "pcol_out",
+				},
+			},
+		},
+	}
+
+	got := h.handleReshuffle("reshuffle", comps.GetTransforms()["reshuffle"], comps)
+
+	want := prepareResult{
+		SubbedComps:   nil,
+		RemovedLeaves: []string{"sub_1", "sub_2"},
+		ForcedRoots:   []string{"consumer"},
+	}
+
+	if d := cmp.Diff(want, got, protocmp.Transform()); d != "" {
+		t.Errorf("handleReshuffle() diff (-want, +got):\n%v", d)
+	}
+
+	// Verify that the consumer's input has been remapped to the input of the reshuffle
+	gotInput := comps.GetTransforms()["consumer"].GetInputs()["in"]
+	if gotInput != "pcol_in" {
+		t.Errorf("consumer input got %q, want %q", gotInput, "pcol_in")
+	}
+}


### PR DESCRIPTION
Updates `handleReshuffle` in the Go Prism runner to recursively clean up all nested sub-transforms of a Reshuffle composite transform using `removeSubTransforms`. 

This prevents nested sub-transforms from being processed in subsequent graph optimization stages.

For example, prior to the change, we can see the following stage dump where stage-002, stage-003, stage-004 are from Reshuffle. They have -inf watermark and never have any bundle and stage-002 is connected to a dummy IMPULSE.

```
stage-000 watermark in +inf out +inf upstream +inf from IMPULSE   pending [] byKey map[] inprogressKeys map[] byBundle map[] holds [] holdCounts map[] holdsInBundle map[] pttEvents map[] bundlesToInject []
    sideInputs: [] outputCols: [ref_PCollection_PCollection_23] outputConsumers: [stage-001] sideConsumers: []
stage-001 watermark in +inf out +inf upstream +inf from stage-000 pending [] byKey map[] inprogressKeys map[] byBundle map[] holds [] holdCounts map[] holdsInBundle map[] pttEvents map[] bundlesToInject []
    sideInputs: [] outputCols: [ref_PCollection_PCollection_28] outputConsumers: [stage-008] sideConsumers: []
stage-002 watermark in -inf out -inf upstream -inf from IMPULSE   pending [] byKey map[] inprogressKeys map[] byBundle map[] holds [] holdCounts map[] holdsInBundle map[] pttEvents map[] bundlesToInject []
    sideInputs: [] outputCols: [ref_PCollection_PCollection_4] outputConsumers: [stage-003] sideConsumers: []
stage-003 watermark in -inf out -inf upstream -inf from stage-002 pending [] byKey map[] inprogressKeys map[] byBundle map[] holds [] holdCounts map[] holdsInBundle map[] pttEvents map[] bundlesToInject []
    sideInputs: [] outputCols: [ref_PCollection_PCollection_5] outputConsumers: [stage-004] sideConsumers: []
stage-004 watermark in -inf out -inf upstream -inf from stage-003 pending [] byKey map[] inprogressKeys map[] byBundle map[] holds [] holdCounts map[] holdsInBundle map[] pttEvents map[] bundlesToInject []
    sideInputs: [] outputCols: [] outputConsumers: [] sideConsumers: []
stage-005 watermark in +inf out +inf upstream +inf from IMPULSE   pending [] byKey map[] inprogressKeys map[] byBundle map[] holds [] holdCounts map[] holdsInBundle map[] pttEvents map[] bundlesToInject []
    sideInputs: [] outputCols: [ref_PCollection_PCollection_1] outputConsumers: [stage-006] sideConsumers: []
stage-006 watermark in +inf out +inf upstream +inf from stage-005 pending [] byKey map[] inprogressKeys map[] byBundle map[] holds [] holdCounts map[] holdsInBundle map[] pttEvents map[] bundlesToInject []
    sideInputs: [] outputCols: [ref_PCollection_PCollection_2] outputConsumers: [stage-007] sideConsumers: []
stage-007 watermark in +inf out +inf upstream +inf from stage-006 pending [] byKey map[] inprogressKeys map[] byBundle map[] holds [] holdCounts map[] holdsInBundle map[] pttEvents map[] bundlesToInject []
    sideInputs: [] outputCols: [ref_PCollection_PCollection_15] outputConsumers: [stage-009] sideConsumers: []
stage-008 watermark in +inf out +inf upstream +inf from stage-001 pending [] byKey map[] inprogressKeys map[] byBundle map[] holds [] holdCounts map[] holdsInBundle map[] pttEvents map[] bundlesToInject []
    sideInputs: [] outputCols: [fc_ref_PCollection_PCollection_28_to_ref_PCollection_PCollection_30] outputConsumers: [stage-014] sideConsumers: []
stage-009 watermark in +inf out +inf upstream +inf from stage-007 pending [] byKey map[] inprogressKeys map[] byBundle map[] holds [] holdCounts map[] holdsInBundle map[] pttEvents map[] bundlesToInject []
    sideInputs: [] outputCols: [fc_ref_PCollection_PCollection_15_to_ref_PCollection_PCollection_16] outputConsumers: [stage-010] sideConsumers: []
stage-010 watermark in +inf out +inf upstream +inf from stage-009 pending [] byKey map[] inprogressKeys map[] byBundle map[] holds [] holdCounts map[] holdsInBundle map[] pttEvents map[] bundlesToInject []
    sideInputs: [] outputCols: [ref_PCollection_PCollection_16] outputConsumers: [stage-011] sideConsumers: []
stage-011 watermark in +inf out +inf upstream +inf from stage-010 pending [] byKey map[] inprogressKeys map[] byBundle map[] holds [] holdCounts map[] holdsInBundle map[] pttEvents map[] bundlesToInject []
    sideInputs: [] outputCols: [ref_PCollection_PCollection_17] outputConsumers: [stage-012] sideConsumers: []
stage-012 watermark in +inf out +inf upstream +inf from stage-011 pending [] byKey map[] inprogressKeys map[] byBundle map[] holds [] holdCounts map[] holdsInBundle map[] pttEvents map[] bundlesToInject []
    sideInputs: [] outputCols: [ref_PCollection_PCollection_29] outputConsumers: [stage-013] sideConsumers: []
stage-013 watermark in +inf out +inf upstream +inf from stage-012 pending [] byKey map[] inprogressKeys map[] byBundle map[] holds [] holdCounts map[] holdsInBundle map[] pttEvents map[] bundlesToInject []
    sideInputs: [] outputCols: [fc_ref_PCollection_PCollection_29_to_ref_PCollection_PCollection_30] outputConsumers: [stage-014] sideConsumers: []
stage-014 watermark in +inf out +inf upstream +inf from stage-008 pending [] byKey map[] inprogressKeys map[] byBundle map[] holds [] holdCounts map[] holdsInBundle map[] pttEvents map[] bundlesToInject []
    sideInputs: [] outputCols: [ref_PCollection_PCollection_30] outputConsumers: [stage-015] sideConsumers: []
stage-015 watermark in +inf out +inf upstream +inf from stage-014 pending [] byKey map[] inprogressKeys map[] byBundle map[] holds [] holdCounts map[] holdsInBundle map[] pttEvents map[] bundlesToInject []
    sideInputs: [] outputCols: [ref_PCollection_PCollection_31] outputConsumers: [stage-016] sideConsumers: []
stage-016 watermark in +inf out +inf upstream +inf from stage-015 pending [] byKey map[] inprogressKeys map[] byBundle map[] holds [] holdCounts map[] holdsInBundle map[] pttEvents map[] bundlesToInject []
    sideInputs: [] outputCols: [] outputConsumers: [] sideConsumers: []
)
```