### PR TITLE
Fix flaky TestDataSampler/GetSamplesForPCollectionsTooManySamples

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/datasampler_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasampler_test.go
@@ -104,16 +104,9 @@ func TestDataSampler(t *testing.T) {
 			for _, sample := range test.samples {
 				dataSampler.SendSample(sample.PCollectionID, sample.Element, sample.Timestamp)
 			}
-			var samplesCount = -1
-			var samples map[string][]*DataSample
-			for i := 0; i < 5; i++ {
-				samples = dataSampler.GetSamples(test.pids)
-				if len(samples) == len(test.want) {
-					samplesCount = len(samples)
-					break
-				}
-				time.Sleep(time.Second)
-			}
+			time.Sleep(1 * time.Second)
+			samples := dataSampler.GetSamples(test.pids)
+			samplesCount := len(samples)
 			cancel()
 			if samplesCount != len(test.want) {
 				t.Errorf("got an unexpected number of sampled elements: %v, want: %v", samplesCount, len(test.want))


### PR DESCRIPTION
Since GetSamples is a destructive operation that clears stored samples, polling it in a loop is flaky. If it is called before all asynchronous samples have finished processing, it consumes the early samples and clears them, causing verifySampledElements to fail.

In this PR, we wait for the sampler to finish before reading to ensure all elements are successfully captured.

Failed test:
https://github.com/apache/beam/actions/runs/26611540188/job/78418312179?pr=38713

```
--- FAIL: TestDataSampler (2.04s)
    --- FAIL: TestDataSampler/GetSamplesForPCollectionsTooManySamples (0.01s)
        datasampler_test.go:122: got an unexpected sampled elements: map[pid1:[0x30405c9c2b40]], want: map[pid1:[0x30405c9c29c0 0x30405c9c2a00 0x30405c9c27c0 0x30405c9c2800 0x30405c9c2840 0x30405c9c2880 0x30405c9c28c0 0x30405c9c2900 0x30405c9c2940 0x30405c9c2980]]
beam:coder:iterable:v1-singleChunk
beam:coder:iterable:v1-multiChunk
beam:coder:state_backed_iterable:v1
beam:coder:iterable:v1-singleChunk
beam:coder:iterable:v1-multiChunk
beam:coder:state_backed_iterable:v1
2026/05/29 01:09:19 INFO Unsuccessful split: failed to split DataSource (at index: 0, last index: 0) at fraction 0.0000 with requested splits (2 indices from 0 to 3)
2026/05/29 01:09:19 INFO Unsuccessful split: failed to split DataSource (at index: 0, last index: 9223372036854775807) at fraction 0.0000 with requested splits (1 indices from 0 to 0)
2026/05/29 01:09:19 INFO Unsuccessful split: failed to split DataSource (at index: 5, last index: 9223372036854775807) at fraction 0.0000 with requested splits (1 indices from 0 to 0)
2026/05/29 01:09:19 INFO Unsuccessful split: failed to split DataSource (at index: 5, last index: 0) at fraction 0.0000 with requested splits (1 indices from 0 to 0)
FAIL
```