### PR TITLE
Disable gRPC fork support in PortableRunnerTestWithSubprocesses

### DIFF
--- a/sdks/python/apache_beam/runners/portability/portable_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner_test.py
@@ -295,6 +295,22 @@ class PortableRunnerTestWithExternalEnv(PortableRunnerTest):
 class PortableRunnerTestWithSubprocesses(PortableRunnerTest):
   _use_subprocesses = True
 
+  # TODO(https://github.com/grpc/grpc/issues/37710): Remove once fixed.
+  @classmethod
+  def setUpClass(cls):
+    cls._old_fork_support = os.environ.get('GRPC_ENABLE_FORK_SUPPORT')
+    os.environ['GRPC_ENABLE_FORK_SUPPORT'] = 'false'
+    super().setUpClass()
+
+  # TODO(https://github.com/grpc/grpc/issues/37710): Remove once fixed.
+  @classmethod
+  def tearDownClass(cls):
+    if cls._old_fork_support is None:
+      os.environ.pop('GRPC_ENABLE_FORK_SUPPORT', None)
+    else:
+      os.environ['GRPC_ENABLE_FORK_SUPPORT'] = cls._old_fork_support
+    super().tearDownClass()
+
   def create_options(self):
     options = super().create_options()
     options.view_as(PortableOptions).environment_type = (
@@ -328,22 +344,6 @@ class PortableRunnerTestWithSubprocesses(PortableRunnerTest):
 class PortableRunnerTestWithSubprocessesAndMultiWorkers(
     PortableRunnerTestWithSubprocesses):
   _use_subprocesses = True
-
-  # TODO(https://github.com/grpc/grpc/issues/37710): Remove once fixed.
-  @classmethod
-  def setUpClass(cls):
-    cls._old_fork_support = os.environ.get('GRPC_ENABLE_FORK_SUPPORT')
-    os.environ['GRPC_ENABLE_FORK_SUPPORT'] = 'false'
-    super().setUpClass()
-
-  # TODO(https://github.com/grpc/grpc/issues/37710): Remove once fixed.
-  @classmethod
-  def tearDownClass(cls):
-    if cls._old_fork_support is None:
-      os.environ.pop('GRPC_ENABLE_FORK_SUPPORT', None)
-    else:
-      os.environ['GRPC_ENABLE_FORK_SUPPORT'] = cls._old_fork_support
-    super().tearDownClass()
 
   def create_options(self):
     options = super() \


### PR DESCRIPTION
Applying the fix in #38566 to its parent class.

Redundant setup and teardown in the multi-worker subclass are removed to inherit them cleanly.

Test failure example:
- https://github.com/apache/beam/actions/runs/26552726280/job/78218062486
- https://github.com/apache/beam/actions/runs/26615956510/job/78431613222

```
________ PortableRunnerTestWithSubprocesses.test_custom_merging_window _________
[gw5] darwin -- Python 3.12.10 /Users/runner/work/beam/beam/sdks/python/target/.tox/py312-macos/bin/python

self = <apache_beam.runners.portability.portable_runner_test.PortableRunnerTestWithSubprocesses testMethod=test_custom_merging_window>

    def test_custom_merging_window(self):
>     with self.create_pipeline() as p:
           ^^^^^^^^^^^^^^^^^^^^^^

target/.tox/py312-macos/lib/python3.12/site-packages/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py:1284: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
target/.tox/py312-macos/lib/python3.12/site-packages/apache_beam/pipeline.py:654: in __exit__
    self.result.wait_until_finish()
target/.tox/py312-macos/lib/python3.12/site-packages/apache_beam/runners/portability/portable_runner.py:572: in wait_until_finish
    raise self._runtime_exception
target/.tox/py312-macos/lib/python3.12/site-packages/apache_beam/runners/portability/portable_runner.py:581: in _observe_state
    for state_response in self._state_stream:
                          ^^^^^^^^^^^^^^^^^^
target/.tox/py312-macos/lib/python3.12/site-packages/grpc/_channel.py:538: in __next__
    return self._next()
           ^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <_MultiThreadedRendezvous of RPC that terminated with:
	status = StatusCode.DEADLINE_EXCEEDED
	details = "Stream removed (Deadline Exceeded)"
	debug_error_string = "DEADLINE_EXCEEDED:Stream removed (Deadline Exceeded)"
>

 ...

target/.tox/py312-macos/lib/python3.12/site-packages/grpc/_channel.py:956: _MultiThreadedRendezvous
----------------------------- Captured stderr call -----------------------------
INFO:apache_beam.runners.portability.abstract_job_service:Running job 'job-b448bab8-ee74-4885-804c-2fbb1c2fc353'
INFO:apache_beam.runners.portability.fn_api_runner.worker_handlers:starting control server on port 51713
INFO:apache_beam.runners.portability.fn_api_runner.worker_handlers:starting data server on port 51714
INFO:apache_beam.runners.portability.fn_api_runner.worker_handlers:starting state server on port 51715
INFO:apache_beam.runners.portability.fn_api_runner.worker_handlers:starting logging server on port 51716
I0528 03:33:05.777477  106607 fork_posix.cc:71] Other threads are currently calling into gRPC, skipping fork() handlers
```