### PR TITLE
Handle empty batches in Python worker counters

### DIFF
--- a/sdks/python/apache_beam/runners/worker/opcounters.py
+++ b/sdks/python/apache_beam/runners/worker/opcounters.py
@@ -217,6 +217,8 @@ class OperationCounters(object):
     batch_length = self.producer_batch_converter.get_length(
         windowed_batch.values)
     self.element_counter.update(batch_length)
+    if batch_length == 0:
+      return
 
     mean_element_size = self.producer_batch_converter.estimate_byte_size(
         windowed_batch.values) / batch_length

--- a/sdks/python/apache_beam/runners/worker/opcounters_test.py
+++ b/sdks/python/apache_beam/runners/worker/opcounters_test.py
@@ -194,11 +194,11 @@ class OperationCountersTest(unittest.TestCase):
             element_type=typehints.Any,
             batch_type=typehints.List[typehints.Any]))
 
-    self.verify_counters(opcounts, 0, float('nan'))
+    self.verify_counters(opcounts, 0, math.nan)
 
     opcounts.update_from_batch(GlobalWindows.windowed_batch([]))
 
-    self.verify_counters(opcounts, 0, float('nan'))
+    self.verify_counters(opcounts, 0, math.nan)
 
   def test_should_sample(self):
     # Order of magnitude more buckets than highest constant in code under test.

--- a/sdks/python/apache_beam/runners/worker/opcounters_test.py
+++ b/sdks/python/apache_beam/runners/worker/opcounters_test.py
@@ -184,6 +184,22 @@ class OperationCountersTest(unittest.TestCase):
 
     self.verify_counters(opcounts, 200, size_per_element)
 
+  def test_update_empty_batch(self):
+    opcounts = OperationCounters(
+        CounterFactory(),
+        'some-name',
+        coders.FastPrimitivesCoder(),
+        0,
+        producer_batch_converter=typehints.batch.BatchConverter.from_typehints(
+            element_type=typehints.Any,
+            batch_type=typehints.List[typehints.Any]))
+
+    self.verify_counters(opcounts, 0, float('nan'))
+
+    opcounts.update_from_batch(GlobalWindows.windowed_batch([]))
+
+    self.verify_counters(opcounts, 0, float('nan'))
+
   def test_should_sample(self):
     # Order of magnitude more buckets than highest constant in code under test.
     buckets = [0] * 300


### PR DESCRIPTION
Handles empty batched values in `OperationCounters.update_from_batch` without estimating a per-element byte size when the batch converter reports length zero.

This keeps empty batches from raising `ZeroDivisionError` in the worker counter path. It also leaves the mean byte counter unchanged because there are no elements to average.

Addresses #38742.

### Testing

From `sdks/python`:

- `python -m pytest -q apache_beam/runners/worker/opcounters_test.py::OperationCountersTest::test_update_empty_batch`
- `python -m pytest -q apache_beam/runners/worker/opcounters_test.py`
- `python -m pytest -q apache_beam/typehints/batch_test.py`
- `git diff --check`


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
