### PR TITLE
Fix ensurepip bundled pip upgrade for Python 3.12+

### DIFF
--- a/sdks/python/container/Dockerfile
+++ b/sdks/python/container/Dockerfile
@@ -23,6 +23,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 COPY target/base_image_requirements.txt /tmp/base_image_requirements.txt
+COPY target/license_scripts/upgrade_bundled_pip.py /tmp/upgrade_bundled_pip.py
 COPY target/apache-beam.tar.gz /opt/apache/beam/tars/
 COPY target/launcher/${TARGETOS}_${TARGETARCH}/boot target/LICENSE target/NOTICE target/LICENSE.python /opt/apache/beam/
 
@@ -84,16 +85,20 @@ RUN  \
     # Remove pip cache.
     rm -rf /root/.cache/pip && \
 
-    # Update ensurepip to use most recent versions of setuptools and pip. This avoids some vulnerabilities which won't be fixed on older versions of python.
-    pip install upgrade_ensurepip; \
-    python3 -m upgrade_ensurepip; \
-    # setuptools is not bundled with ensurepip in Python 3.12+
+    # Update ensurepip bundled wheels to patched pip/setuptools (security).
+    # setuptools is not bundled with ensurepip in Python 3.12+; upgrade_ensurepip expects both.
     if [ "${py_version}" = "3.10" ] || [ "${py_version}" = "3.11" ]; then \
-        find /usr/local/lib/python${py_version}/ensurepip/_bundled/setuptools-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/setuptools-*-py3-none-any.whl | tail -n 1)) -delete; \
-    fi; \
-    find /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-*-py3-none-any.whl | tail -n 1)) -delete; \
-    pip uninstall upgrade_ensurepip -y; \
-    python3 -m ensurepip;
+        pip install upgrade_ensurepip && \
+        python3 -m upgrade_ensurepip && \
+        find /usr/local/lib/python${py_version}/ensurepip/_bundled/setuptools-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/setuptools-*-py3-none-any.whl | tail -n 1)) -delete && \
+        find /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-*-py3-none-any.whl | tail -n 1)) -delete && \
+        pip uninstall upgrade_ensurepip -y && \
+        python3 -m ensurepip; \
+    else \
+        python3 /tmp/upgrade_bundled_pip.py && \
+        find /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-*-py3-none-any.whl | tail -n 1)) -delete && \
+        python3 -m ensurepip; \
+    fi
 
 ENTRYPOINT ["/opt/apache/beam/boot"]
 

--- a/sdks/python/container/Dockerfile
+++ b/sdks/python/container/Dockerfile
@@ -86,6 +86,7 @@ RUN  \
     rm -rf /root/.cache/pip && \
 
     # Update ensurepip to use most recent versions of setuptools and pip. This avoids some vulnerabilities which won't be fixed on older versions of python.
+    # upgrade_ensurepip is not maintained for Python 3.12+ (ensurepip no longer bundles setuptools).
     if [ "${py_version}" = "3.10" ] || [ "${py_version}" = "3.11" ]; then \
         pip install upgrade_ensurepip; \
         python3 -m upgrade_ensurepip; \

--- a/sdks/python/container/Dockerfile
+++ b/sdks/python/container/Dockerfile
@@ -85,20 +85,18 @@ RUN  \
     # Remove pip cache.
     rm -rf /root/.cache/pip && \
 
-    # Update ensurepip to use most recent versions of setuptools and pip. This avoids some vulnerabilities which won't be fixed on older versions of python.
-    # Python 3.14: ensurepip bundles pip only; upgrade_ensurepip expects setuptools too (#38305).
-    if [ "${py_version}" = "3.14" ]; then \
-        python3 /tmp/upgrade_bundled_pip.py && \
-        find /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-*-py3-none-any.whl | tail -n 1)) -delete && \
-        python3 -m ensurepip; \
-    else \
+    # Update ensurepip bundled wheels (security). upgrade_ensurepip needs setuptools in
+    # ensurepip; only Python 3.10/3.11 still bundle setuptools (3.12+ is pip-only).
+    if [ "${py_version}" = "3.10" ] || [ "${py_version}" = "3.11" ]; then \
         pip install upgrade_ensurepip && \
         python3 -m upgrade_ensurepip && \
-        if [ "${py_version}" = "3.10" ] || [ "${py_version}" = "3.11" ]; then \
-            find /usr/local/lib/python${py_version}/ensurepip/_bundled/setuptools-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/setuptools-*-py3-none-any.whl | tail -n 1)) -delete; \
-        fi && \
+        find /usr/local/lib/python${py_version}/ensurepip/_bundled/setuptools-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/setuptools-*-py3-none-any.whl | tail -n 1)) -delete && \
         find /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-*-py3-none-any.whl | tail -n 1)) -delete && \
         pip uninstall upgrade_ensurepip -y && \
+        python3 -m ensurepip; \
+    else \
+        python3 /tmp/upgrade_bundled_pip.py && \
+        find /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-*-py3-none-any.whl | tail -n 1)) -delete && \
         python3 -m ensurepip; \
     fi
 

--- a/sdks/python/container/Dockerfile
+++ b/sdks/python/container/Dockerfile
@@ -85,18 +85,20 @@ RUN  \
     # Remove pip cache.
     rm -rf /root/.cache/pip && \
 
-    # Update ensurepip bundled wheels to patched pip/setuptools (security).
-    # setuptools is not bundled with ensurepip in Python 3.12+; upgrade_ensurepip expects both.
-    if [ "${py_version}" = "3.10" ] || [ "${py_version}" = "3.11" ]; then \
-        pip install upgrade_ensurepip && \
-        python3 -m upgrade_ensurepip && \
-        find /usr/local/lib/python${py_version}/ensurepip/_bundled/setuptools-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/setuptools-*-py3-none-any.whl | tail -n 1)) -delete && \
-        find /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-*-py3-none-any.whl | tail -n 1)) -delete && \
-        pip uninstall upgrade_ensurepip -y && \
-        python3 -m ensurepip; \
-    else \
+    # Update ensurepip to use most recent versions of setuptools and pip. This avoids some vulnerabilities which won't be fixed on older versions of python.
+    # Python 3.14: ensurepip bundles pip only; upgrade_ensurepip expects setuptools too (#38305).
+    if [ "${py_version}" = "3.14" ]; then \
         python3 /tmp/upgrade_bundled_pip.py && \
         find /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-*-py3-none-any.whl | tail -n 1)) -delete && \
+        python3 -m ensurepip; \
+    else \
+        pip install upgrade_ensurepip && \
+        python3 -m upgrade_ensurepip && \
+        if [ "${py_version}" = "3.10" ] || [ "${py_version}" = "3.11" ]; then \
+            find /usr/local/lib/python${py_version}/ensurepip/_bundled/setuptools-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/setuptools-*-py3-none-any.whl | tail -n 1)) -delete; \
+        fi && \
+        find /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-*-py3-none-any.whl | tail -n 1)) -delete && \
+        pip uninstall upgrade_ensurepip -y && \
         python3 -m ensurepip; \
     fi
 

--- a/sdks/python/container/Dockerfile
+++ b/sdks/python/container/Dockerfile
@@ -85,20 +85,22 @@ RUN  \
     # Remove pip cache.
     rm -rf /root/.cache/pip && \
 
-    # Update ensurepip bundled wheels (security). upgrade_ensurepip needs setuptools in
-    # ensurepip; only Python 3.10/3.11 still bundle setuptools (3.12+ is pip-only).
+    # Update ensurepip to use most recent versions of setuptools and pip. This avoids some vulnerabilities which won't be fixed on older versions of python.
     if [ "${py_version}" = "3.10" ] || [ "${py_version}" = "3.11" ]; then \
-        pip install upgrade_ensurepip && \
-        python3 -m upgrade_ensurepip && \
-        find /usr/local/lib/python${py_version}/ensurepip/_bundled/setuptools-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/setuptools-*-py3-none-any.whl | tail -n 1)) -delete && \
-        find /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-*-py3-none-any.whl | tail -n 1)) -delete && \
-        pip uninstall upgrade_ensurepip -y && \
-        python3 -m ensurepip; \
+        pip install upgrade_ensurepip; \
+        python3 -m upgrade_ensurepip; \
     else \
-        python3 /tmp/upgrade_bundled_pip.py && \
-        find /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-*-py3-none-any.whl | tail -n 1)) -delete && \
-        python3 -m ensurepip; \
-    fi
+        python3 /tmp/upgrade_bundled_pip.py; \
+    fi; \
+    # setuptools is not bundled with ensurepip in Python 3.12+
+    if [ "${py_version}" = "3.10" ] || [ "${py_version}" = "3.11" ]; then \
+        find /usr/local/lib/python${py_version}/ensurepip/_bundled/setuptools-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/setuptools-*-py3-none-any.whl | tail -n 1)) -delete; \
+    fi; \
+    find /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-*-py3-none-any.whl | tail -n 1)) -delete; \
+    if [ "${py_version}" = "3.10" ] || [ "${py_version}" = "3.11" ]; then \
+        pip uninstall upgrade_ensurepip -y; \
+    fi; \
+    python3 -m ensurepip;
 
 ENTRYPOINT ["/opt/apache/beam/boot"]
 

--- a/sdks/python/container/license_scripts/upgrade_bundled_pip.py
+++ b/sdks/python/container/license_scripts/upgrade_bundled_pip.py
@@ -16,10 +16,10 @@
 #
 
 """
-Upgrade the pip wheel bundled in ensurepip for Python 3.14.
+Upgrade the pip wheel bundled in ensurepip for Python 3.12+.
 
 The script is executed within Docker after the image pip has been upgraded.
-upgrade_ensurepip expects setuptools to be bundled as well, but Python 3.14
+upgrade_ensurepip expects setuptools to be bundled as well, but Python 3.12+
 only ships pip in ensurepip/_bundled.
 """
 

--- a/sdks/python/container/license_scripts/upgrade_bundled_pip.py
+++ b/sdks/python/container/license_scripts/upgrade_bundled_pip.py
@@ -1,0 +1,65 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Upgrade the pip wheel bundled in ensurepip for Python 3.12+.
+
+The script is executed within Docker after the image pip has been upgraded.
+upgrade_ensurepip expects setuptools to be bundled as well, but CPython 3.12+
+only ships pip in ensurepip/_bundled.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import ensurepip
+
+
+def main():
+  ep_path = Path(ensurepip.__file__)
+  wheel_dir = ep_path.parent / '_bundled'
+  pip_version = subprocess.check_output(
+      [sys.executable, '-m', 'pip', '--version'],
+      text=True).split()[1]
+  subprocess.check_call([
+      sys.executable,
+      '-m',
+      'pip',
+      'download',
+      'pip=={}'.format(pip_version),
+      '-d',
+      str(wheel_dir),
+      '--no-deps',
+  ])
+  lines = ep_path.read_text().splitlines()
+  pip_line = None
+  for idx, line in enumerate(lines):
+    if line.startswith('_PIP_VERSION = '):
+      pip_line = idx
+      break
+  if pip_line is None:
+    sys.exit('ensurepip _PIP_VERSION not found')
+  org = ep_path.with_suffix('.py.org')
+  if not org.exists():
+    ep_path.rename(org)
+  lines[pip_line] = '_PIP_VERSION = "{}"'.format(pip_version)
+  ep_path.write_text('\n'.join(lines) + '\n')
+
+
+if __name__ == '__main__':
+  main()

--- a/sdks/python/container/license_scripts/upgrade_bundled_pip.py
+++ b/sdks/python/container/license_scripts/upgrade_bundled_pip.py
@@ -16,10 +16,10 @@
 #
 
 """
-Upgrade the pip wheel bundled in ensurepip for Python 3.12+.
+Upgrade the pip wheel bundled in ensurepip for Python 3.14.
 
 The script is executed within Docker after the image pip has been upgraded.
-upgrade_ensurepip expects setuptools to be bundled as well, but CPython 3.12+
+upgrade_ensurepip expects setuptools to be bundled as well, but Python 3.14
 only ships pip in ensurepip/_bundled.
 """
 


### PR DESCRIPTION
Fixes: #38763 
Republish Released Docker Images workflow is failing on the pushAll job (Python 3.14). python3 -m upgrade_ensurepip crashes because Python 3.12+ no longer bundles setuptools in ensurepip but the Dockerfile still run that tool for all versions

So the fix is keeping upgrade_ensurepip for 3.10/3.11 only and for 3.12+, will run a small license_scripts/upgrade_bundled_pip.py helper to update only the bundled pip wheel, then run the existing pip cleanup and ensurepip.
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
