### PR TITLE
Fix BigQuery Storage Write API stream count for batch writes

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -3401,7 +3401,7 @@ public class BigQueryIO {
      * runner determine the sharding at runtime, set this to zero, or {@link #withAutoSharding()}
      * instead.
      *
-     * <p>For batch pipelines, it inserts a redistribute. To not reshufle and keep the pipeline
+     * <p>For batch pipelines, it inserts a redistribute. To not reshuffle and keep the pipeline
      * parallelism as is, set this to zero.
      */
     public Write<T> withNumStorageWriteApiStreams(int numStorageWriteApiStreams) {
@@ -3834,13 +3834,9 @@ public class BigQueryIO {
           LOG.warn(
               "Setting the triggering frequency is only applicable to an unbounded PCollection.");
         }
-        if (getStorageApiNumStreams(bqOptions) != 0) {
-          LOG.warn(
-              "Setting the number of Storage API streams is only applicable to an unbounded PCollection.");
-        }
       }
 
-      if (method == Method.STORAGE_API_AT_LEAST_ONCE && getStorageApiNumStreams(bqOptions) != 0) {
+      if (method != Method.STORAGE_WRITE_API && getStorageApiNumStreams(bqOptions) != 0) {
         LOG.warn(
             "Setting a number of Storage API streams is only supported when using STORAGE_WRITE_API");
       }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -2483,6 +2483,7 @@ public class BigQueryIO {
         .setSchemaUpdateOptions(Collections.emptySet())
         .setNumFileShards(0)
         .setNumStorageWriteApiStreams(0)
+        .setNumStorageWriteApiStreamsConfigured(false)
         .setMethod(Write.Method.DEFAULT)
         .setExtendedErrorInfo(false)
         .setSkipInvalidRows(false)
@@ -2733,6 +2734,8 @@ public class BigQueryIO {
 
     abstract int getNumStorageWriteApiStreams();
 
+    abstract boolean isNumStorageWriteApiStreamsConfigured();
+
     abstract boolean getPropagateSuccessfulStorageApiWrites();
 
     abstract Predicate<String> getPropagateSuccessfulStorageApiWritesPredicate();
@@ -2849,6 +2852,8 @@ public class BigQueryIO {
       abstract Builder<T> setNumFileShards(int numFileShards);
 
       abstract Builder<T> setNumStorageWriteApiStreams(int numStorageApiStreams);
+
+      abstract Builder<T> setNumStorageWriteApiStreamsConfigured(boolean configured);
 
       abstract Builder<T> setPropagateSuccessfulStorageApiWrites(
           boolean propagateSuccessfulStorageApiWrites);
@@ -3405,7 +3410,10 @@ public class BigQueryIO {
      * parallelism as is, set this to zero.
      */
     public Write<T> withNumStorageWriteApiStreams(int numStorageWriteApiStreams) {
-      return toBuilder().setNumStorageWriteApiStreams(numStorageWriteApiStreams).build();
+      return toBuilder()
+          .setNumStorageWriteApiStreams(numStorageWriteApiStreams)
+          .setNumStorageWriteApiStreamsConfigured(true)
+          .build();
     }
 
     /**
@@ -3736,7 +3744,7 @@ public class BigQueryIO {
     }
 
     private int getStorageApiNumStreams(BigQueryOptions options) {
-      if (getNumStorageWriteApiStreams() != 0) {
+      if (isNumStorageWriteApiStreamsConfigured()) {
         return getNumStorageWriteApiStreams();
       }
       return options.getNumStorageWriteApiStreams();

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTranslation.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTranslation.java
@@ -534,7 +534,9 @@ public class BigQueryIOTranslation {
         fieldValues.put("max_file_size", transform.getMaxFileSize());
       }
       fieldValues.put("num_file_shards", transform.getNumFileShards());
-      fieldValues.put("num_storage_write_api_streams", transform.getNumStorageWriteApiStreams());
+      if (transform.isNumStorageWriteApiStreamsConfigured()) {
+        fieldValues.put("num_storage_write_api_streams", transform.getNumStorageWriteApiStreams());
+      }
       fieldValues.put(
           "propagate_successful_storage_api_writes",
           transform.getPropagateSuccessfulStorageApiWrites());
@@ -749,7 +751,10 @@ public class BigQueryIOTranslation {
         }
         Integer numStorageWriteApiStreams = configRow.getInt32("num_storage_write_api_streams");
         if (numStorageWriteApiStreams != null) {
-          builder = builder.setNumStorageWriteApiStreams(numStorageWriteApiStreams);
+          builder =
+              builder
+                  .setNumStorageWriteApiStreams(numStorageWriteApiStreams)
+                  .setNumStorageWriteApiStreamsConfigured(true);
         }
 
         if (TransformUpgrader.compareVersions(updateCompatibilityBeamVersion, "2.60.0") >= 0) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTranslation.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTranslation.java
@@ -617,7 +617,10 @@ public class BigQueryIOTranslation {
           (updateCompatibilityBeamVersion != null) ? updateCompatibilityBeamVersion : "2.53.0";
 
       try {
-        BigQueryIO.Write.Builder builder = new AutoValue_BigQueryIO_Write.Builder<>();
+        BigQueryIO.Write.Builder builder =
+            new AutoValue_BigQueryIO_Write.Builder<>()
+                .setNumStorageWriteApiStreams(0)
+                .setNumStorageWriteApiStreamsConfigured(false);
 
         String jsonTableRef = configRow.getString("json_table_ref");
         if (jsonTableRef != null) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryOptions.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryOptions.java
@@ -102,7 +102,7 @@ public interface BigQueryOptions
   void setUseStorageWriteApiAtLeastOnce(Boolean value);
 
   @Description(
-      "When writing with a streaming pipeline, the BigQueryIO.Write will default to using this number of Storage Write API streams. ")
+      "When writing with STORAGE_WRITE_API, BigQueryIO.Write will default to using this number of Storage Write API streams. ")
   @Default.Integer(0)
   Integer getNumStorageWriteApiStreams();
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProvider.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProvider.java
@@ -179,11 +179,15 @@ public class BigQueryStorageWriteApiSchemaTransformProvider
       PCollection<Row> inputRows = input.getSinglePCollection();
 
       BigQueryIO.Write<Row> write = createStorageWriteApiTransform(inputRows.getSchema());
+      int numStreams = configuration.getNumStreams() == null ? 0 : configuration.getNumStreams();
+
+      if (numStreams > 0) {
+        write = write.withNumStorageWriteApiStreams(numStreams);
+      }
 
       if (inputRows.isBounded() == IsBounded.UNBOUNDED) {
         Long triggeringFrequency = configuration.getTriggeringFrequencySeconds();
         Boolean autoSharding = configuration.getAutoSharding();
-        int numStreams = configuration.getNumStreams() == null ? 0 : configuration.getNumStreams();
 
         boolean useAtLeastOnceSemantics =
             configuration.getUseAtLeastOnceSemantics() != null
@@ -196,10 +200,8 @@ public class BigQueryStorageWriteApiSchemaTransformProvider
                       ? DEFAULT_TRIGGERING_FREQUENCY
                       : Duration.standardSeconds(triggeringFrequency));
         }
-        // set num streams if specified, otherwise default to autoSharding
-        if (numStreams > 0) {
-          write = write.withNumStorageWriteApiStreams(numStreams);
-        } else if (autoSharding == null || autoSharding) {
+        // Default to autoSharding for unbounded writes when a fixed stream count is not specified.
+        if (numStreams <= 0 && (autoSharding == null || autoSharding)) {
           write = write.withAutoSharding();
         }
       }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProvider.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProvider.java
@@ -179,10 +179,11 @@ public class BigQueryStorageWriteApiSchemaTransformProvider
       PCollection<Row> inputRows = input.getSinglePCollection();
 
       BigQueryIO.Write<Row> write = createStorageWriteApiTransform(inputRows.getSchema());
-      int numStreams = configuration.getNumStreams() == null ? 0 : configuration.getNumStreams();
+      Integer configuredStreams = configuration.getNumStreams();
+      int numStreams = configuredStreams == null ? 0 : configuredStreams;
 
-      if (numStreams > 0) {
-        write = write.withNumStorageWriteApiStreams(numStreams);
+      if (configuredStreams != null) {
+        write = write.withNumStorageWriteApiStreams(configuredStreams);
       }
 
       if (inputRows.isBounded() == IsBounded.UNBOUNDED) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryWriteConfiguration.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryWriteConfiguration.java
@@ -101,6 +101,12 @@ public abstract class BigQueryWriteConfiguration {
 
     Boolean autoSharding = getAutoSharding();
     Integer numStreams = getNumStreams();
+    if (numStreams != null) {
+      checkArgument(
+          numStreams >= 0,
+          invalidConfigMessage + "Number of streams must be non-negative, but was: %s",
+          numStreams);
+    }
     if (autoSharding != null && autoSharding && numStreams != null) {
       checkArgument(
           numStreams == 0,

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryWriteConfiguration.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryWriteConfiguration.java
@@ -152,8 +152,7 @@ public abstract class BigQueryWriteConfiguration {
   public abstract Boolean getAutoSharding();
 
   @SchemaFieldDescription(
-      "Specifies the number of write streams that the Storage API sink will use. "
-          + "This parameter is only applicable when writing unbounded data.")
+      "Specifies the number of write streams that the Storage API sink will use.")
   @Nullable
   public abstract Integer getNumStreams();
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProviderTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProviderTest.java
@@ -122,7 +122,10 @@ public class BigQueryStorageWriteApiSchemaTransformProviderTest {
         Arrays.asList(
             BigQueryWriteConfiguration.builder()
                 .setTable("project:dataset.table")
-                .setCreateDisposition("INVALID_DISPOSITION"));
+                .setCreateDisposition("INVALID_DISPOSITION"),
+            BigQueryWriteConfiguration.builder()
+                .setTable("project:dataset.table")
+                .setNumStreams(-1));
 
     for (BigQueryWriteConfiguration.Builder config : invalidConfigs) {
       assertThrows(

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProviderTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProviderTest.java
@@ -39,6 +39,7 @@ import java.util.stream.Stream;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryOptions;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryUtils;
 import org.apache.beam.sdk.io.gcp.bigquery.providers.BigQueryStorageWriteApiSchemaTransformProvider.BigQueryStorageWriteApiSchemaTransform;
 import org.apache.beam.sdk.io.gcp.testing.FakeBigQueryServices;
@@ -501,6 +502,25 @@ public class BigQueryStorageWriteApiSchemaTransformProviderTest {
         pipelineProto.getComponents().getTransformsMap().values().stream()
             .anyMatch(tr -> tr.getUniqueName().contains("ResdistibuteNumShards"));
     assertTrue(hasFixedNumStreamsRedistribute);
+    p.enableAbandonedNodeEnforcement(false);
+  }
+
+  @Test
+  public void testZeroNumStreamsOverridesPipelineOptionForBoundedStorageApiWrites() {
+    p.getOptions().as(BigQueryOptions.class).setNumStorageWriteApiStreams(3);
+    BigQueryWriteConfiguration config =
+        BigQueryWriteConfiguration.builder()
+            .setTable("project:dataset.bounded_zero_num_streams")
+            .setNumStreams(0)
+            .build();
+
+    runWithConfig(config);
+
+    RunnerApi.Pipeline pipelineProto = PipelineTranslation.toProto(p);
+    boolean hasFixedNumStreamsRedistribute =
+        pipelineProto.getComponents().getTransformsMap().values().stream()
+            .anyMatch(tr -> tr.getUniqueName().contains("ResdistibuteNumShards"));
+    assertTrue(!hasFixedNumStreamsRedistribute);
     p.enableAbandonedNodeEnforcement(false);
   }
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProviderTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProviderTest.java
@@ -484,6 +484,24 @@ public class BigQueryStorageWriteApiSchemaTransformProviderTest {
   }
 
   @Test
+  public void testNumStreamsAppliesToBoundedStorageApiWrites() {
+    BigQueryWriteConfiguration config =
+        BigQueryWriteConfiguration.builder()
+            .setTable("project:dataset.bounded_fixed_num_streams")
+            .setNumStreams(3)
+            .build();
+
+    runWithConfig(config);
+
+    RunnerApi.Pipeline pipelineProto = PipelineTranslation.toProto(p);
+    boolean hasFixedNumStreamsRedistribute =
+        pipelineProto.getComponents().getTransformsMap().values().stream()
+            .anyMatch(tr -> tr.getUniqueName().contains("ResdistibuteNumShards"));
+    assertTrue(hasFixedNumStreamsRedistribute);
+    p.enableAbandonedNodeEnforcement(false);
+  }
+
+  @Test
   public void testManagedChoosesStorageApiForUnboundedWrites() {
     PCollection<Row> batchInput =
         p.apply(TestStream.create(SCHEMA).addElements(ROWS.get(0)).advanceWatermarkToInfinity());

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -2155,8 +2155,7 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
         all of FILE_LOADS, STREAMING_INSERTS, and STORAGE_WRITE_API. Only
         applicable to unbounded input.
       num_storage_api_streams: Specifies the number of write streams that the
-        Storage API sink will use. This parameter is only applicable when
-        writing unbounded data.
+        Storage API sink will use.
       ignore_unknown_columns: Accept rows that contain values that do not match
         the schema. The unknown values are ignored. Default is False,
         which treats unknown values as errors. This option is only valid for

--- a/website/www/site/content/en/documentation/io/built-in/google-bigquery.md
+++ b/website/www/site/content/en/documentation/io/built-in/google-bigquery.md
@@ -835,8 +835,8 @@ TableSchema schema = new TableSchema().setFields(
 {{< code_sample "sdks/python/apache_beam/examples/snippets/snippets.py" model_bigqueryio_write_schema >}}
 {{< /highlight >}}
 
-For streaming pipelines, you need to set two additional parameters: the number
-of streams and the triggering frequency.
+For streaming pipelines, you need to set the triggering frequency. You can also
+set the number of streams for both batch and streaming pipelines.
 
 {{< highlight java >}}
 BigQueryIO.writeTableRows()
@@ -855,7 +855,8 @@ pipeline uses. You can set it explicitly on the transform via
 [`withNumStorageWriteApiStreams`](https://beam.apache.org/releases/javadoc/current/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.Write.html#withNumStorageWriteApiStreams-int-)
 or provide the `numStorageWriteApiStreams` option to the pipeline as defined in
 [`BigQueryOptions`](https://beam.apache.org/releases/javadoc/current/org/apache/beam/sdk/io/gcp/bigquery/BigQueryOptions.html).
-Please note this is only supported for streaming pipelines.
+For batch pipelines, a non-zero stream count inserts a redistribute; set it to
+0 or leave it unspecified to keep the pipeline parallelism as is.
 
 Triggering frequency determines how soon the data is visible for querying in
 BigQuery. You can explicitly set it via
@@ -874,10 +875,10 @@ pipelines.
 
 {{< paragraph class="language-java" wrap="span">}}
 Similar to streaming inserts, `STORAGE_WRITE_API` supports dynamically determining
-the number of parallel streams to write to BigQuery (starting 2.42.0). You can
-explicitly enable this using [`withAutoSharding`](https://beam.apache.org/releases/javadoc/current/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.Write.html#withAutoSharding--).
+the number of parallel streams to write to BigQuery for streaming pipelines
+(starting 2.42.0). You can explicitly enable this using [`withAutoSharding`](https://beam.apache.org/releases/javadoc/current/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.Write.html#withAutoSharding--).
 
-`STORAGE_WRITE_API` defaults to dynamic sharding when
+For streaming writes, `STORAGE_WRITE_API` defaults to dynamic sharding when
 `numStorageWriteApiStreams` is set to 0 or is unspecified.
 
 {{< /paragraph >}}


### PR DESCRIPTION
### What changed

Fixes #38770

This fixes handling of `num_storage_api_streams` / `num_streams` for BigQuery Storage Write API batch writes.

Previously, the Java schema transform only applied `num_streams` inside the unbounded pipeline branch, so bounded batch pipelines using the Storage Write API ignored the configured fixed stream count. This change applies `withNumStorageWriteApiStreams(...)` whenever `num_streams > 0`, while keeping triggering frequency and auto-sharding behavior limited to unbounded pipelines.

### Details

* Applies fixed Storage Write API stream counts to bounded and unbounded schema transform writes.
* Keeps `auto_sharding` as an unbounded-only option.
* Removes outdated documentation that described `num_storage_api_streams` / `num_streams` as streaming-only.
* Updates Java, Python, and website docs to reflect batch support.
* Adds a bounded pipeline translation test that verifies fixed stream counts produce the expected batch redistribute step.

### Validation

* `git diff --check`
* `./gradlew.bat --no-daemon --console=plain :sdks:java:io:google-cloud-platform:spotlessCheck`

### CHANGES.md

Not updated because this is a targeted behavior/documentation fix rather than a broad user-facing feature addition.

---

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
* [ ] Update `CHANGES.md` with noteworthy changes.
* [ ] If this contribution is large, please file an Apache [[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf)](https://www.apache.org/licenses/icla.pdf).

See the [[Contributor Guide](https://beam.apache.org/contribute)](https://beam.apache.org/contribute) for more tips on [[how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier)](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md

## GitHub Actions Tests Status (on master branch)

[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [[CI.md](https://github.com/apache/beam/blob/master/CI.md)](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [[workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md)](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.