### PR TITLE
Fix offlineRepositoryRoot relative to Beam repo root

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/Repositories.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/Repositories.groovy
@@ -31,7 +31,7 @@ class Repositories {
     }
 
     project.repositories {
-      maven { url project.offlineRepositoryRoot }
+      maven { url project.rootProject.file(project.offlineRepositoryRoot) }
 
       // To run gradle in offline mode, one must first invoke
       // 'updateOfflineRepository' to create an offline repo
@@ -86,7 +86,7 @@ class Repositories {
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url "https://repo.spring.io/plugins-release" }
         maven { url "https://packages.confluent.io/maven/" }
-        maven { url project.offlineRepositoryRoot }
+        maven { url project.rootProject.file(project.offlineRepositoryRoot) }
       }
       includeSources = false
       includeJavadocs = false


### PR DESCRIPTION
**Please** add a meaningful description for your change here

There is a default offline-repository-root offline-repository but it's getting resolved relative to per-sub-module, seen from the error when any dependency is missing:

```
> Could not find org.apache.beam:beam-vendor-calcite-1_40_0:0.2-SNAPSHOT.
     Searched in the following locations:
       - file:/tmpfs/src/git/beam-spark/sdks/java/extensions/sql/offline-repository/org/apache/beam/beam-vendor-calcite-1_40_0/0.2-SNAPSHOT/maven-metadata.xml
       - file:/tmpfs/src/git/beam-spark/sdks/java/extensions/sql/offline-repository/org/apache/beam/beam-vendor-calcite-1_40_0/0.2-SNAPSHOT/beam-vendor-calcite-1_40_0-0.2-SNAPSHOT.pom
```

as a result this offline-repo isn't convenient when a dependency is used by more-than-one submodule

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
