### PR TITLE
feat: add configurable bigtable retries

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableConfigTranslator.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableConfigTranslator.java
@@ -234,16 +234,16 @@ class BigtableConfigTranslator {
     // with the old behavior.
     long initialRpcTimeout =
         writeOptions.getAttemptTimeout() != null
-            ? writeOptions.getAttemptTimeout().getMillis()
+            ? writeOptions.getAttemptTimeout().get().getMillis()
             : (fromBigtableOptions != null && fromBigtableOptions.getAttemptTimeout() != null
-                ? fromBigtableOptions.getAttemptTimeout().getMillis()
+                ? fromBigtableOptions.getAttemptTimeout().get().getMillis()
                 : Duration.ofMinutes(6).toMillis());
 
     long totalTimeout =
         writeOptions.getOperationTimeout() != null
-            ? writeOptions.getOperationTimeout().getMillis()
+            ? writeOptions.getOperationTimeout().get().getMillis()
             : (fromBigtableOptions != null && fromBigtableOptions.getOperationTimeout() != null
-                ? fromBigtableOptions.getOperationTimeout().getMillis()
+                ? fromBigtableOptions.getOperationTimeout().get().getMillis()
                 : retrySettings.getTotalTimeout().toMillis());
 
     retrySettings
@@ -334,26 +334,26 @@ class BigtableConfigTranslator {
     // Options set directly on readOptions overrides Options set in BigtableOptions
     long initialRpcTimeout =
         readOptions.getAttemptTimeout() != null
-            ? readOptions.getAttemptTimeout().getMillis()
+            ? readOptions.getAttemptTimeout().get().getMillis()
             : (optionsFromBigtableOptions != null
                     && optionsFromBigtableOptions.getAttemptTimeout() != null
-                ? optionsFromBigtableOptions.getAttemptTimeout().getMillis()
+                ? optionsFromBigtableOptions.getAttemptTimeout().get().getMillis()
                 : retrySettings.getInitialRpcTimeout().toMillis());
 
     long totalTimeout =
         readOptions.getOperationTimeout() != null
-            ? readOptions.getOperationTimeout().getMillis()
+            ? readOptions.getOperationTimeout().get().getMillis()
             : (optionsFromBigtableOptions != null
                     && optionsFromBigtableOptions.getOperationTimeout() != null
-                ? optionsFromBigtableOptions.getOperationTimeout().getMillis()
+                ? optionsFromBigtableOptions.getOperationTimeout().get().getMillis()
                 : retrySettings.getTotalTimeout().toMillis());
 
     long waitTimeout =
         readOptions.getWaitTimeout() != null
-            ? readOptions.getWaitTimeout().getMillis()
+            ? readOptions.getWaitTimeout().get().getMillis()
             : (optionsFromBigtableOptions != null
                     && optionsFromBigtableOptions.getWaitTimeout() != null
-                ? optionsFromBigtableOptions.getWaitTimeout().getMillis()
+                ? optionsFromBigtableOptions.getWaitTimeout().get().getMillis()
                 : settings.stubSettings().readRowsSettings().getWaitTimeout().toMillis());
 
     retrySettings
@@ -464,14 +464,19 @@ class BigtableConfigTranslator {
       BigtableReadOptions readOptions, BigtableOptions options) {
     BigtableReadOptions.Builder builder = readOptions.toBuilder();
     builder.setWaitTimeout(
-        org.joda.time.Duration.millis(options.getRetryOptions().getReadPartialRowTimeoutMillis()));
+        ValueProvider.StaticValueProvider.of(
+            org.joda.time.Duration.millis(
+                options.getRetryOptions().getReadPartialRowTimeoutMillis())));
     if (options.getCallOptionsConfig().getReadStreamRpcAttemptTimeoutMs().isPresent()) {
       builder.setAttemptTimeout(
-          org.joda.time.Duration.millis(
-              options.getCallOptionsConfig().getReadStreamRpcAttemptTimeoutMs().get()));
+          ValueProvider.StaticValueProvider.of(
+              org.joda.time.Duration.millis(
+                  options.getCallOptionsConfig().getReadStreamRpcAttemptTimeoutMs().get())));
     }
     builder.setOperationTimeout(
-        org.joda.time.Duration.millis(options.getCallOptionsConfig().getReadStreamRpcTimeoutMs()));
+        ValueProvider.StaticValueProvider.of(
+            org.joda.time.Duration.millis(
+                options.getCallOptionsConfig().getReadStreamRpcTimeoutMs())));
     return builder.build();
   }
 
@@ -482,14 +487,16 @@ class BigtableConfigTranslator {
     // configure timeouts
     if (options.getCallOptionsConfig().getMutateRpcAttemptTimeoutMs().isPresent()) {
       builder.setAttemptTimeout(
-          org.joda.time.Duration.millis(
-              options.getCallOptionsConfig().getMutateRpcAttemptTimeoutMs().get()));
+          ValueProvider.StaticValueProvider.of(
+              org.joda.time.Duration.millis(
+                  options.getCallOptionsConfig().getMutateRpcAttemptTimeoutMs().get())));
     }
     if (options.getBulkOptions().isEnableBulkMutationThrottling()) {
       builder.setThrottlingTargetMs(options.getBulkOptions().getBulkMutationRpcTargetMs());
     }
     builder.setOperationTimeout(
-        org.joda.time.Duration.millis(options.getCallOptionsConfig().getMutateRpcTimeoutMs()));
+        ValueProvider.StaticValueProvider.of(
+            org.joda.time.Duration.millis(options.getCallOptionsConfig().getMutateRpcTimeoutMs())));
     // configure batch size
     builder.setMaxElementsPerBatch(options.getBulkOptions().getBulkMaxRowKeyCount());
     builder.setMaxBytesPerBatch(options.getBulkOptions().getBulkMaxRequestSize());

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -705,11 +705,35 @@ public class BigtableIO {
      *
      * <p>Does not modify this object.
      */
-    public Read withAttemptTimeout(Duration timeout) {
-      checkArgument(timeout.isLongerThan(Duration.ZERO), "attempt timeout must be positive");
+    public Read withAttemptTimeout(ValueProvider<Duration> timeout) {
       BigtableReadOptions readOptions = getBigtableReadOptions();
       return toBuilder()
           .setBigtableReadOptions(readOptions.toBuilder().setAttemptTimeout(timeout).build())
+          .build();
+    }
+
+    /**
+     * Returns a new {@link BigtableIO.Read} with the attempt timeout. Attempt timeout controls the
+     * timeout for each remote call.
+     *
+     * <p>Does not modify this object.
+     */
+    public Read withAttemptTimeout(Duration timeout) {
+      checkArgument(timeout.isLongerThan(Duration.ZERO), "attempt timeout must be positive");
+      return withAttemptTimeout(StaticValueProvider.of(timeout));
+    }
+
+    /**
+     * Returns a new {@link BigtableIO.Read} with the operation timeout. Operation timeout has
+     * ultimate control over how long the logic should keep trying the remote call until it gives up
+     * completely.
+     *
+     * <p>Does not modify this object.
+     */
+    public Read withOperationTimeout(ValueProvider<Duration> timeout) {
+      BigtableReadOptions readOptions = getBigtableReadOptions();
+      return toBuilder()
+          .setBigtableReadOptions(readOptions.toBuilder().setOperationTimeout(timeout).build())
           .build();
     }
 
@@ -722,10 +746,7 @@ public class BigtableIO {
      */
     public Read withOperationTimeout(Duration timeout) {
       checkArgument(timeout.isLongerThan(Duration.ZERO), "operation timeout must be positive");
-      BigtableReadOptions readOptions = getBigtableReadOptions();
-      return toBuilder()
-          .setBigtableReadOptions(readOptions.toBuilder().setOperationTimeout(timeout).build())
-          .build();
+      return withOperationTimeout(StaticValueProvider.of(timeout));
     }
 
     Read withServiceFactory(BigtableServiceFactory factory) {
@@ -1043,11 +1064,35 @@ public class BigtableIO {
      *
      * <p>Does not modify this object.
      */
-    public Write withAttemptTimeout(Duration timeout) {
-      checkArgument(timeout.isLongerThan(Duration.ZERO), "attempt timeout must be positive");
+    public Write withAttemptTimeout(ValueProvider<Duration> timeout) {
       BigtableWriteOptions options = getBigtableWriteOptions();
       return toBuilder()
           .setBigtableWriteOptions(options.toBuilder().setAttemptTimeout(timeout).build())
+          .build();
+    }
+
+    /**
+     * Returns a new {@link BigtableIO.Write} with the attempt timeout. Attempt timeout controls the
+     * timeout for each remote call.
+     *
+     * <p>Does not modify this object.
+     */
+    public Write withAttemptTimeout(Duration timeout) {
+      checkArgument(timeout.isLongerThan(Duration.ZERO), "attempt timeout must be positive");
+      return withAttemptTimeout(StaticValueProvider.of(timeout));
+    }
+
+    /**
+     * Returns a new {@link BigtableIO.Write} with the operation timeout. Operation timeout has
+     * ultimate control over how long the logic should keep trying the remote call until it gives up
+     * completely.
+     *
+     * <p>Does not modify this object.
+     */
+    public Write withOperationTimeout(ValueProvider<Duration> timeout) {
+      BigtableWriteOptions options = getBigtableWriteOptions();
+      return toBuilder()
+          .setBigtableWriteOptions(options.toBuilder().setOperationTimeout(timeout).build())
           .build();
     }
 
@@ -1060,10 +1105,7 @@ public class BigtableIO {
      */
     public Write withOperationTimeout(Duration timeout) {
       checkArgument(timeout.isLongerThan(Duration.ZERO), "operation timeout must be positive");
-      BigtableWriteOptions options = getBigtableWriteOptions();
-      return toBuilder()
-          .setBigtableWriteOptions(options.toBuilder().setOperationTimeout(timeout).build())
-          .build();
+      return withOperationTimeout(StaticValueProvider.of(timeout));
     }
 
     /**
@@ -2183,7 +2225,7 @@ public class BigtableIO {
 
     abstract @Nullable Duration getBacklogReplicationAdjustment();
 
-    abstract @Nullable Duration getReadChangeStreamTimeout();
+    abstract @Nullable ValueProvider<Duration> getReadChangeStreamTimeout();
 
     abstract @Nullable Boolean getValidateConfig();
 
@@ -2403,8 +2445,21 @@ public class BigtableIO {
      *
      * <p>Does not modify this object.
      */
-    public ReadChangeStream withReadChangeStreamTimeout(Duration timeout) {
+    public ReadChangeStream withReadChangeStreamTimeout(ValueProvider<Duration> timeout) {
       return toBuilder().setReadChangeStreamTimeout(timeout).build();
+    }
+
+    /**
+     * Returns a new {@link BigtableIO.ReadChangeStream} that overrides timeout for ReadChangeStream
+     * remote calls.
+     *
+     * <p>This is useful to override the default of 15s timeout if the checkpoint duration is longer
+     * than 15s.
+     *
+     * <p>Does not modify this object.
+     */
+    public ReadChangeStream withReadChangeStreamTimeout(Duration timeout) {
+      return withReadChangeStreamTimeout(StaticValueProvider.of(timeout));
     }
 
     /**
@@ -2599,7 +2654,7 @@ public class BigtableIO {
 
       abstract ReadChangeStream.Builder setBacklogReplicationAdjustment(Duration adjustment);
 
-      abstract ReadChangeStream.Builder setReadChangeStreamTimeout(Duration timeout);
+      abstract ReadChangeStream.Builder setReadChangeStreamTimeout(ValueProvider<Duration> timeout);
 
       abstract ReadChangeStream.Builder setValidateConfig(boolean validateConfig);
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableReadOptions.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableReadOptions.java
@@ -53,15 +53,15 @@ abstract class BigtableReadOptions implements Serializable {
   abstract @Nullable Integer getMaxBufferElementCount();
 
   /** Returns the attempt timeout of the reads. */
-  abstract @Nullable Duration getAttemptTimeout();
+  abstract @Nullable ValueProvider<Duration> getAttemptTimeout();
 
   /** Returns the operation timeout of the reads. */
-  abstract @Nullable Duration getOperationTimeout();
+  abstract @Nullable ValueProvider<Duration> getOperationTimeout();
 
   /**
    * Watchdog will kill the stream after waiting this much time for the next response from server.
    */
-  abstract @Nullable Duration getWaitTimeout();
+  abstract @Nullable ValueProvider<Duration> getWaitTimeout();
 
   abstract Builder toBuilder();
 
@@ -82,11 +82,23 @@ abstract class BigtableReadOptions implements Serializable {
 
     abstract Builder setKeyRanges(ValueProvider<List<ByteKeyRange>> keyRanges);
 
-    abstract Builder setAttemptTimeout(Duration timeout);
+    abstract Builder setAttemptTimeout(ValueProvider<Duration> timeout);
 
-    abstract Builder setOperationTimeout(Duration timeout);
+    Builder setAttemptTimeout(Duration timeout) {
+      return setAttemptTimeout(ValueProvider.StaticValueProvider.of(timeout));
+    }
 
-    abstract Builder setWaitTimeout(Duration timeout);
+    abstract Builder setOperationTimeout(ValueProvider<Duration> timeout);
+
+    Builder setOperationTimeout(Duration timeout) {
+      return setOperationTimeout(ValueProvider.StaticValueProvider.of(timeout));
+    }
+
+    abstract Builder setWaitTimeout(ValueProvider<Duration> timeout);
+
+    Builder setWaitTimeout(Duration timeout) {
+      return setWaitTimeout(ValueProvider.StaticValueProvider.of(timeout));
+    }
 
     abstract BigtableReadOptions build();
   }
@@ -152,9 +164,12 @@ abstract class BigtableReadOptions implements Serializable {
       }
     }
 
-    if (getAttemptTimeout() != null && getOperationTimeout() != null) {
+    if (getAttemptTimeout() != null
+        && getAttemptTimeout().isAccessible()
+        && getOperationTimeout() != null
+        && getOperationTimeout().isAccessible()) {
       checkArgument(
-          getAttemptTimeout().isShorterThan(getOperationTimeout()),
+          getAttemptTimeout().get().isShorterThan(getOperationTimeout().get()),
           "attempt timeout can't be longer than operation timeout");
     }
   }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
@@ -129,7 +129,7 @@ class BigtableServiceImpl implements BigtableService {
         projectId,
         instanceId,
         writeOptions.getTableId().get(),
-        writeOptions.getCloseWaitTimeout());
+        writeOptions.getCloseWaitTimeout().get());
   }
 
   @VisibleForTesting

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableWriteOptions.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableWriteOptions.java
@@ -37,10 +37,10 @@ abstract class BigtableWriteOptions implements Serializable {
   abstract @Nullable ValueProvider<String> getTableId();
 
   /** Returns the attempt timeout for writes. */
-  abstract @Nullable Duration getAttemptTimeout();
+  abstract @Nullable ValueProvider<Duration> getAttemptTimeout();
 
   /** Returns the operation timeout for writes. */
-  abstract @Nullable Duration getOperationTimeout();
+  abstract @Nullable ValueProvider<Duration> getOperationTimeout();
 
   /** Returns the max number of elements of a batch. */
   abstract @Nullable Long getMaxElementsPerBatch();
@@ -61,7 +61,7 @@ abstract class BigtableWriteOptions implements Serializable {
   abstract @Nullable Boolean getFlowControl();
 
   /** Returns the time to wait when closing the writer. */
-  abstract @Nullable Duration getCloseWaitTimeout();
+  abstract @Nullable ValueProvider<Duration> getCloseWaitTimeout();
 
   abstract Builder toBuilder();
 
@@ -74,9 +74,17 @@ abstract class BigtableWriteOptions implements Serializable {
 
     abstract Builder setTableId(ValueProvider<String> tableId);
 
-    abstract Builder setAttemptTimeout(Duration timeout);
+    abstract Builder setAttemptTimeout(ValueProvider<Duration> timeout);
 
-    abstract Builder setOperationTimeout(Duration timeout);
+    Builder setAttemptTimeout(Duration timeout) {
+      return setAttemptTimeout(ValueProvider.StaticValueProvider.of(timeout));
+    }
+
+    abstract Builder setOperationTimeout(ValueProvider<Duration> timeout);
+
+    Builder setOperationTimeout(Duration timeout) {
+      return setOperationTimeout(ValueProvider.StaticValueProvider.of(timeout));
+    }
 
     abstract Builder setMaxElementsPerBatch(long size);
 
@@ -90,7 +98,11 @@ abstract class BigtableWriteOptions implements Serializable {
 
     abstract Builder setFlowControl(boolean enableFlowControl);
 
-    abstract Builder setCloseWaitTimeout(Duration timeout);
+    abstract Builder setCloseWaitTimeout(ValueProvider<Duration> timeout);
+
+    Builder setCloseWaitTimeout(Duration timeout) {
+      return setCloseWaitTimeout(ValueProvider.StaticValueProvider.of(timeout));
+    }
 
     abstract BigtableWriteOptions build();
   }
@@ -130,9 +142,12 @@ abstract class BigtableWriteOptions implements Serializable {
         getTableId() != null && (!getTableId().isAccessible() || !getTableId().get().isEmpty()),
         "Could not obtain Bigtable table id");
 
-    if (getAttemptTimeout() != null && getOperationTimeout() != null) {
+    if (getAttemptTimeout() != null
+        && getAttemptTimeout().isAccessible()
+        && getOperationTimeout() != null
+        && getOperationTimeout().isAccessible()) {
       checkArgument(
-          getAttemptTimeout().isShorterThan(getOperationTimeout()),
+          getAttemptTimeout().get().isShorterThan(getOperationTimeout().get()),
           "attempt timeout can't be longer than operation timeout");
     }
   }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dao/DaoFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dao/DaoFactory.java
@@ -47,7 +47,7 @@ public class DaoFactory implements Serializable, AutoCloseable {
   private final String metadataTableId;
   private final String changeStreamName;
 
-  private @Nullable Duration readChangeStreamTimeout;
+  private @Nullable ValueProvider<Duration> readChangeStreamTimeout;
 
   public DaoFactory(
       BigtableConfig changeStreamConfig,
@@ -76,7 +76,7 @@ public class DaoFactory implements Serializable, AutoCloseable {
     }
   }
 
-  public void setReadChangeStreamTimeout(@Nullable Duration readChangeStreamTimeout) {
+  public void setReadChangeStreamTimeout(@Nullable ValueProvider<Duration> readChangeStreamTimeout) {
     this.readChangeStreamTimeout = readChangeStreamTimeout;
   }
 
@@ -117,7 +117,7 @@ public class DaoFactory implements Serializable, AutoCloseable {
       checkArgumentNotNull(changeStreamConfig.getAppProfileId());
       if (readChangeStreamTimeout != null) {
         BigtableChangeStreamAccessor.setReadChangeStreamTimeout(
-            org.threeten.bp.Duration.ofMillis(readChangeStreamTimeout.getMillis()));
+            org.threeten.bp.Duration.ofMillis(readChangeStreamTimeout.get().getMillis()));
       }
       BigtableDataClient dataClient =
           BigtableChangeStreamAccessor.getOrCreate(changeStreamConfig).getDataClient();

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dao/DaoFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dao/DaoFactory.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.io.gcp.bigtable.BigtableConfig;
+import org.apache.beam.sdk.options.ValueProvider;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.Duration;
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dao/DaoFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dao/DaoFactory.java
@@ -77,7 +77,8 @@ public class DaoFactory implements Serializable, AutoCloseable {
     }
   }
 
-  public void setReadChangeStreamTimeout(@Nullable ValueProvider<Duration> readChangeStreamTimeout) {
+  public void setReadChangeStreamTimeout(
+      @Nullable ValueProvider<Duration> readChangeStreamTimeout) {
     this.readChangeStreamTimeout = readChangeStreamTimeout;
   }
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableConfigTranslatorTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableConfigTranslatorTest.java
@@ -104,8 +104,8 @@ public class BigtableConfigTranslatorTest {
     assertNotNull(fromBigtableOptions.getAttemptTimeout());
     assertNotNull(fromBigtableOptions.getOperationTimeout());
 
-    assertEquals(org.joda.time.Duration.millis(100), fromBigtableOptions.getAttemptTimeout());
-    assertEquals(org.joda.time.Duration.millis(1000), fromBigtableOptions.getOperationTimeout());
+    assertEquals(org.joda.time.Duration.millis(100), fromBigtableOptions.getAttemptTimeout().get());
+    assertEquals(org.joda.time.Duration.millis(1000), fromBigtableOptions.getOperationTimeout().get());
   }
 
   @Test
@@ -145,8 +145,8 @@ public class BigtableConfigTranslatorTest {
     assertNotNull(fromBigtableOptions.getMaxOutstandingElements());
     assertNotNull(fromBigtableOptions.getMaxOutstandingBytes());
 
-    assertEquals(org.joda.time.Duration.millis(200), fromBigtableOptions.getAttemptTimeout());
-    assertEquals(org.joda.time.Duration.millis(2000), fromBigtableOptions.getOperationTimeout());
+    assertEquals(org.joda.time.Duration.millis(200), fromBigtableOptions.getAttemptTimeout().get());
+    assertEquals(org.joda.time.Duration.millis(2000), fromBigtableOptions.getOperationTimeout().get());
     assertEquals(20, (long) fromBigtableOptions.getMaxBytesPerBatch());
     assertEquals(100, (long) fromBigtableOptions.getMaxElementsPerBatch());
     assertEquals(5 * 100, (long) fromBigtableOptions.getMaxOutstandingElements());

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableConfigTranslatorTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableConfigTranslatorTest.java
@@ -105,7 +105,8 @@ public class BigtableConfigTranslatorTest {
     assertNotNull(fromBigtableOptions.getOperationTimeout());
 
     assertEquals(org.joda.time.Duration.millis(100), fromBigtableOptions.getAttemptTimeout().get());
-    assertEquals(org.joda.time.Duration.millis(1000), fromBigtableOptions.getOperationTimeout().get());
+    assertEquals(
+        org.joda.time.Duration.millis(1000), fromBigtableOptions.getOperationTimeout().get());
   }
 
   @Test
@@ -146,7 +147,8 @@ public class BigtableConfigTranslatorTest {
     assertNotNull(fromBigtableOptions.getMaxOutstandingBytes());
 
     assertEquals(org.joda.time.Duration.millis(200), fromBigtableOptions.getAttemptTimeout().get());
-    assertEquals(org.joda.time.Duration.millis(2000), fromBigtableOptions.getOperationTimeout().get());
+    assertEquals(
+        org.joda.time.Duration.millis(2000), fromBigtableOptions.getOperationTimeout().get());
     assertEquals(20, (long) fromBigtableOptions.getMaxBytesPerBatch());
     assertEquals(100, (long) fromBigtableOptions.getMaxElementsPerBatch());
     assertEquals(5 * 100, (long) fromBigtableOptions.getMaxOutstandingElements());

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
@@ -2151,7 +2151,7 @@ public class BigtableIOTest {
     assertEquals("change-stream-name", readChangeStream.getChangeStreamName());
     assertEquals(startTime, readChangeStream.getStartTime());
     assertEquals(Duration.standardMinutes(1), readChangeStream.getBacklogReplicationAdjustment());
-    assertEquals(Duration.standardMinutes(1), readChangeStream.getReadChangeStreamTimeout());
+    assertEquals(Duration.standardMinutes(1), readChangeStream.getReadChangeStreamTimeout().get());
     assertEquals(false, readChangeStream.getCreateOrUpdateMetadataTable());
     assertEquals(
         BigtableIO.ExistingPipelineOptions.FAIL_IF_EXISTS,


### PR DESCRIPTION
Fixes issue #38848 by adding ValueProvider based configuration for BigtableIO attempt and operation timeouts.