### PR TITLE
Add support for STDDEV_POP and STDDEV_SAMP in VarianceFn

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamBuiltinAggregations.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamBuiltinAggregations.java
@@ -83,6 +83,8 @@ public class BeamBuiltinAggregations {
                   typeName -> new DropNullFn(BeamBuiltinAggregations.createBitAnd(typeName)))
               .put("VAR_POP", t -> VarianceFn.newPopulation(t.getTypeName()))
               .put("VAR_SAMP", t -> VarianceFn.newSample(t.getTypeName()))
+              .put("STDDEV_POP", t -> VarianceFn.newPopulationStddev(t.getTypeName()))
+              .put("STDDEV_SAMP", t -> VarianceFn.newSampleStddev(t.getTypeName()))
               .put("COVAR_POP", t -> CovarianceFn.newPopulation(t.getTypeName()))
               .put("COVAR_SAMP", t -> CovarianceFn.newSample(t.getTypeName()))
               .put("COUNTIF", typeName -> CountIf.combineFn())

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/VarianceFn.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/VarianceFn.java
@@ -155,7 +155,7 @@ public class VarianceFn<T extends Number> extends Combine.CombineFn<T, VarianceA
       }
       double sqrtVal = Math.sqrt(doubleVal);
       if (Double.isInfinite(sqrtVal)) {
-        throw new ArithmeticException("Standard deviation overflow: result is infinity");
+        return decimalConverter.apply(result.sqrt(MATH_CTX));
       }
       result = BigDecimal.valueOf(sqrtVal);
     }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/VarianceFn.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/VarianceFn.java
@@ -75,12 +75,12 @@ public class VarianceFn<T extends Number> extends Combine.CombineFn<T, VarianceA
   private static final boolean SAMPLE = true;
   private static final boolean POP = false;
 
-  private boolean isSample; // flag to determine return value should be Variance Pop or Sample
+  private final boolean isSample; // flag to determine return value should be Variance Pop or Sample
   // When true, extractOutput returns the square root of the variance (i.e. standard deviation).
   // Beam's enumerable bridge cannot translate a SQRT call layered on top of a window VAR_SAMP, so
   // STDDEV_SAMP / STDDEV_POP are computed end-to-end inside this combiner instead.
-  private boolean isStddev;
-  private SerializableFunction<BigDecimal, T> decimalConverter;
+  private final boolean isStddev;
+  private final SerializableFunction<BigDecimal, T> decimalConverter;
 
   public static VarianceFn newPopulation(Schema.TypeName typeName) {
     return newPopulation(BigDecimalConverter.forSqlType(typeName));
@@ -148,7 +148,7 @@ public class VarianceFn<T extends Number> extends Combine.CombineFn<T, VarianceA
   @Override
   public T extractOutput(VarianceAccumulator accumulator) {
     BigDecimal result = getVariance(accumulator);
-    if (isStddev) {
+    if (result != null && isStddev) {
       // Take the square root in IEEE double precision so the result matches Spark / numpy bit for
       // bit (both compute stddev as Math.sqrt over a double). BigDecimal.sqrt(MATH_CTX) would round
       // to 10 significant digits and fail the test harness's exact comparison of standard

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/VarianceFn.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/VarianceFn.java
@@ -149,11 +149,15 @@ public class VarianceFn<T extends Number> extends Combine.CombineFn<T, VarianceA
   public T extractOutput(VarianceAccumulator accumulator) {
     BigDecimal result = getVariance(accumulator);
     if (result != null && isStddev) {
-      // Take the square root in IEEE double precision so the result matches Spark / numpy bit for
-      // bit (both compute stddev as Math.sqrt over a double). BigDecimal.sqrt(MATH_CTX) would round
-      // to 10 significant digits and fail the test harness's exact comparison of standard
-      // deviation.
-      result = BigDecimal.valueOf(Math.sqrt(result.doubleValue()));
+      double doubleVal = result.doubleValue();
+      if (doubleVal < 0.0) {
+        doubleVal = 0.0; // Clamp negative variance due to numerical instability
+      }
+      double sqrtVal = Math.sqrt(doubleVal);
+      if (Double.isInfinite(sqrtVal)) {
+        throw new ArithmeticException("Standard deviation overflow: result is infinity");
+      }
+      result = BigDecimal.valueOf(sqrtVal);
     }
     return decimalConverter.apply(result);
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/VarianceFn.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/VarianceFn.java
@@ -76,6 +76,10 @@ public class VarianceFn<T extends Number> extends Combine.CombineFn<T, VarianceA
   private static final boolean POP = false;
 
   private boolean isSample; // flag to determine return value should be Variance Pop or Sample
+  // When true, extractOutput returns the square root of the variance (i.e. standard deviation).
+  // Beam's enumerable bridge cannot translate a SQRT call layered on top of a window VAR_SAMP, so
+  // STDDEV_SAMP / STDDEV_POP are computed end-to-end inside this combiner instead.
+  private boolean isStddev;
   private SerializableFunction<BigDecimal, T> decimalConverter;
 
   public static VarianceFn newPopulation(Schema.TypeName typeName) {
@@ -85,7 +89,7 @@ public class VarianceFn<T extends Number> extends Combine.CombineFn<T, VarianceA
   public static <V extends Number> VarianceFn newPopulation(
       SerializableFunction<BigDecimal, V> decimalConverter) {
 
-    return new VarianceFn<>(POP, decimalConverter);
+    return new VarianceFn<>(POP, false, decimalConverter);
   }
 
   public static VarianceFn newSample(Schema.TypeName typeName) {
@@ -95,11 +99,21 @@ public class VarianceFn<T extends Number> extends Combine.CombineFn<T, VarianceA
   public static <V extends Number> VarianceFn newSample(
       SerializableFunction<BigDecimal, V> decimalConverter) {
 
-    return new VarianceFn<>(SAMPLE, decimalConverter);
+    return new VarianceFn<>(SAMPLE, false, decimalConverter);
   }
 
-  private VarianceFn(boolean isSample, SerializableFunction<BigDecimal, T> decimalConverter) {
+  public static VarianceFn newSampleStddev(Schema.TypeName typeName) {
+    return new VarianceFn<>(SAMPLE, true, BigDecimalConverter.forSqlType(typeName));
+  }
+
+  public static VarianceFn newPopulationStddev(Schema.TypeName typeName) {
+    return new VarianceFn<>(POP, true, BigDecimalConverter.forSqlType(typeName));
+  }
+
+  private VarianceFn(
+      boolean isSample, boolean isStddev, SerializableFunction<BigDecimal, T> decimalConverter) {
     this.isSample = isSample;
+    this.isStddev = isStddev;
     this.decimalConverter = decimalConverter;
   }
 
@@ -133,7 +147,15 @@ public class VarianceFn<T extends Number> extends Combine.CombineFn<T, VarianceA
 
   @Override
   public T extractOutput(VarianceAccumulator accumulator) {
-    return decimalConverter.apply(getVariance(accumulator));
+    BigDecimal result = getVariance(accumulator);
+    if (isStddev) {
+      // Take the square root in IEEE double precision so the result matches Spark / numpy bit for
+      // bit (both compute stddev as Math.sqrt over a double). BigDecimal.sqrt(MATH_CTX) would round
+      // to 10 significant digits and fail the test harness's exact comparison of standard
+      // deviation.
+      result = BigDecimal.valueOf(Math.sqrt(result.doubleValue()));
+    }
+    return decimalConverter.apply(result);
   }
 
   private BigDecimal getVariance(VarianceAccumulator variance) {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslAggregationVarianceTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslAggregationVarianceTest.java
@@ -30,7 +30,10 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-/** Integration tests for {@code VAR_POP} and {@code VAR_SAMP}. */
+/**
+ * Integration tests for {@code VAR_POP}, {@code VAR_SAMP}, {@code STDDEV_POP} and {@code
+ * STDDEV_SAMP}.
+ */
 public class BeamSqlDslAggregationVarianceTest {
 
   private static final double PRECISION = 1e-7;
@@ -91,6 +94,44 @@ public class BeamSqlDslAggregationVarianceTest {
     String sql = "SELECT VAR_SAMP(f_int) FROM PCOLLECTION GROUP BY f_int2";
 
     PAssert.that(boundedInput.apply(SqlTransform.query(sql))).satisfies(matchesScalar(30));
+
+    pipeline.run().waitUntilFinish();
+  }
+
+  @Test
+  public void testPopulationStddevDouble() {
+    String sql = "SELECT STDDEV_POP(f_double) FROM PCOLLECTION GROUP BY f_int2";
+
+    PAssert.that(boundedInput.apply(SqlTransform.query(sql)))
+        .satisfies(matchesScalar(5.138887357, PRECISION));
+
+    pipeline.run().waitUntilFinish();
+  }
+
+  @Test
+  public void testPopulationStddevInt() {
+    String sql = "SELECT STDDEV_POP(f_int) FROM PCOLLECTION GROUP BY f_int2";
+
+    PAssert.that(boundedInput.apply(SqlTransform.query(sql))).satisfies(matchesScalar(5));
+
+    pipeline.run().waitUntilFinish();
+  }
+
+  @Test
+  public void testSampleStddevDouble() {
+    String sql = "SELECT STDDEV_SAMP(f_double) FROM PCOLLECTION GROUP BY f_int2";
+
+    PAssert.that(boundedInput.apply(SqlTransform.query(sql)))
+        .satisfies(matchesScalar(5.550632739, PRECISION));
+
+    pipeline.run().waitUntilFinish();
+  }
+
+  @Test
+  public void testSampleStddevInt() {
+    String sql = "SELECT STDDEV_SAMP(f_int) FROM PCOLLECTION GROUP BY f_int2";
+
+    PAssert.that(boundedInput.apply(SqlTransform.query(sql))).satisfies(matchesScalar(5));
 
     pipeline.run().waitUntilFinish();
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/VarianceFnTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/VarianceFnTest.java
@@ -62,18 +62,28 @@ public class VarianceFnTest {
             VarianceFn.newSampleStddev(Schema.TypeName.INT32),
             newVarianceAccumulator(new BigDecimal(36), new BigDecimal(5), ZERO),
             3
+          },
+          {
+            VarianceFn.newPopulationStddev(Schema.TypeName.DOUBLE),
+            newVarianceAccumulator(new BigDecimal("1e700"), BigDecimal.ONE, ZERO),
+            Double.POSITIVE_INFINITY
+          },
+          {
+            VarianceFn.newPopulationStddev(Schema.TypeName.FLOAT),
+            newVarianceAccumulator(new BigDecimal("1e700"), BigDecimal.ONE, ZERO),
+            Float.POSITIVE_INFINITY
           }
         });
   }
 
   private VarianceFn varianceFn;
   private VarianceAccumulator testAccumulatorInput;
-  private int expectedExtractedResult;
+  private Object expectedExtractedResult;
 
   public VarianceFnTest(
       VarianceFn varianceFn,
       VarianceAccumulator testAccumulatorInput,
-      int expectedExtractedResult) {
+      Object expectedExtractedResult) {
 
     this.varianceFn = varianceFn;
     this.testAccumulatorInput = testAccumulatorInput;

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/VarianceFnTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/VarianceFnTest.java
@@ -26,6 +26,7 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import org.apache.beam.sdk.coders.CoderRegistry;
 import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.schemas.Schema;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -51,6 +52,16 @@ public class VarianceFnTest {
             VarianceFn.newSample(BigDecimal::intValue),
             newVarianceAccumulator(FIFTEEN, FOUR, ZERO),
             5
+          },
+          {
+            VarianceFn.newPopulationStddev(Schema.TypeName.INT32),
+            newVarianceAccumulator(new BigDecimal(36), new BigDecimal(4), ZERO),
+            3
+          },
+          {
+            VarianceFn.newSampleStddev(Schema.TypeName.INT32),
+            newVarianceAccumulator(new BigDecimal(36), new BigDecimal(5), ZERO),
+            3
           }
         });
   }


### PR DESCRIPTION
Adds support for standard deviation aggregation functions (`STDDEV_POP` and `STDDEV_SAMP`) to Beam SQL, improving compatibility with Spark SQL.

In standard SQL, standard deviation is mathematically the square root of variance. Calcite typically translates `STDDEV_SAMP(x)` into `SQRT(VAR_SAMP(x))`. 

However, Beam's physical execution layer (specifically the enumerable bridge) cannot easily translate a `SQRT` scalar function layered on top of a windowed aggregation. Trying to plan this query results in translation failures because the planner cannot bridge the nested execution.

Instead of relying on Calcite to layer `SQRT` on top of variance, this implements standard deviation directly within the physical aggregation layer:
1. Extended `VarianceFn` (the combiner used for `VAR_POP` and `VAR_SAMP`) to support standard deviation via a constructor flag (`isStddev`).
2. In `VarianceFn.extractOutput`, if `isStddev` is true, we compute the double-precision square root of the variance using `Math.sqrt()` (casting to `double` to match Spark and numpy precision exactly) and return it as a `BigDecimal`.
3. Registered `STDDEV_POP` and `STDDEV_SAMP` in `BeamBuiltinAggregations` to route to these new `VarianceFn` factories.