### PR TITLE
Enhance SQL Sort operator and UDF type resolution infrastructure

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/UdfImpl.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/UdfImpl.java
@@ -70,17 +70,24 @@ class UdfImpl {
   }
 
   /*
-   * Finds a method in a given class by name.
+   * Finds a method in a given class by name. In case of overloaded methods with the same name,
+   * this prioritizes the overload with the maximum number of parameters. This ensures Calcite
+   * can resolve optional/default trailing parameters correctly when binding UDF overloads.
+   *
    * @param clazz class to search method in
    * @param name name of the method to find
-   * @return the first method with matching name or null when no method found
+   * @return the matching method with the highest parameter count or null when no method found
    */
   static @Nullable Method findMethod(Class<?> clazz, String name) {
+    Method bestMethod = null;
     for (Method method : clazz.getMethods()) {
       if (method.getName().equals(name) && !method.isBridge()) {
-        return method;
+        if (bestMethod == null
+            || method.getParameterTypes().length > bestMethod.getParameterTypes().length) {
+          bestMethod = method;
+        }
       }
     }
-    return null;
+    return bestMethod;
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRel.java
@@ -40,6 +40,7 @@ import org.apache.beam.sdk.state.StateSpecs;
 import org.apache.beam.sdk.state.ValueState;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.Flatten;
+import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.Top;
@@ -134,11 +135,11 @@ public class BeamSortRel extends Sort implements BeamRelNode {
     }
 
     if (fetch == null) {
-      throw new UnsupportedOperationException("ORDER BY without a LIMIT is not supported!");
+      count = -1;
+    } else {
+      RexLiteral fetchLiteral = (RexLiteral) fetch;
+      count = ((BigDecimal) fetchLiteral.getValue()).intValue();
     }
-
-    RexLiteral fetchLiteral = (RexLiteral) fetch;
-    count = ((BigDecimal) fetchLiteral.getValue()).intValue();
 
     if (offset != null) {
       RexLiteral offsetLiteral = (RexLiteral) offset;
@@ -207,6 +208,20 @@ public class BeamSortRel extends Sort implements BeamRelNode {
               String.format(
                   "`ORDER BY` is only supported for %s, actual windowing strategy: %s",
                   GlobalWindows.class.getSimpleName(), windowingStrategy));
+        }
+
+        // When no limit is specified (count == -1), we must sort the entire dataset.
+        // To achieve this globally, we key all rows by a single dummy key, group them together
+        // using GroupByKey to ensure they are processed together, and then sort them in-memory
+        // via SortInMemoryFn. Note: This can be memory-intensive for large datasets.
+        if (count == -1) {
+          BeamSqlRowComparator comparator =
+              new BeamSqlRowComparator(fieldIndices, orientation, nullsFirst);
+          return upstream
+              .apply("WithDummyKey", WithKeys.of("DummyKey"))
+              .apply("GroupByKey", GroupByKey.create())
+              .apply("SortInMemory", ParDo.of(new SortInMemoryFn(comparator)))
+              .setRowSchema(CalciteUtils.toSchema(getRowType()));
         }
 
         ReversedBeamSqlRowComparator comparator =
@@ -340,9 +355,16 @@ public class BeamSortRel extends Sort implements BeamRelNode {
         if (isValue1Null && isValue2Null) {
           continue;
         } else if (isValue1Null && !isValue2Null) {
-          fieldRet = -1 * (nullsFirst.get(i) ? -1 : 1);
+          // NULL placement is absolute: NULLS FIRST means the null row always sorts before the
+          // non-null row regardless of ASC/DESC, and NULLS LAST means it always sorts after. Do
+          // NOT apply the ASC/DESC orientation flip here — that flip only governs value-vs-value
+          // ordering (handled below). Mixing the two reversed NULLS LAST under ascending sorts
+          // (and NULLS FIRST under descending sorts), placing nulls on the wrong end.
+          fieldRet = nullsFirst.get(i) ? -1 : 1;
+          return fieldRet;
         } else if (!isValue1Null && isValue2Null) {
-          fieldRet = 1 * (nullsFirst.get(i) ? -1 : 1);
+          fieldRet = nullsFirst.get(i) ? 1 : -1;
+          return fieldRet;
         } else {
           switch (sqlTypeName) {
             case TINYINT:
@@ -351,9 +373,17 @@ public class BeamSortRel extends Sort implements BeamRelNode {
             case BIGINT:
             case FLOAT:
             case DOUBLE:
+            case DECIMAL:
+            case BOOLEAN:
             case VARCHAR:
+            case CHAR:
             case DATE:
+            case TIME:
             case TIMESTAMP:
+              // All of the above map to Java types that implement Comparable (Boolean, BigDecimal,
+              // LocalTime, etc.), so a uniform Comparable comparison yields the correct SQL
+              // ordering
+              // (false < true for BOOLEAN). The base value is extracted via Comparable.class.
               Comparable v1 = row1.getBaseValue(fieldIndex, Comparable.class);
               Comparable v2 = row2.getBaseValue(fieldIndex, Comparable.class);
               fieldRet = v1.compareTo(v2);
@@ -371,6 +401,27 @@ public class BeamSortRel extends Sort implements BeamRelNode {
         }
       }
       return 0;
+    }
+  }
+
+  private static class SortInMemoryFn extends DoFn<KV<String, Iterable<Row>>, Row> {
+    private final BeamSqlRowComparator comparator;
+
+    public SortInMemoryFn(BeamSqlRowComparator comparator) {
+      this.comparator = comparator;
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext ctx) {
+      Iterable<Row> input = ctx.element().getValue();
+      List<Row> list = new ArrayList<>();
+      for (Row r : input) {
+        list.add(r);
+      }
+      list.sort(comparator);
+      for (Row r : list) {
+        ctx.output(r);
+      }
     }
   }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
@@ -27,6 +27,7 @@ import java.util.stream.IntStream;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.Schema.TypeName;
+import org.apache.beam.sdk.schemas.logicaltypes.NanosDuration;
 import org.apache.beam.sdk.schemas.logicaltypes.PassThroughLogicalType;
 import org.apache.beam.sdk.schemas.logicaltypes.SqlTypes;
 import org.apache.beam.sdk.util.Preconditions;
@@ -137,6 +138,7 @@ public class CalciteUtils {
           .put(TIME_WITH_LOCAL_TZ, SqlTypeName.TIME_WITH_LOCAL_TIME_ZONE)
           .put(TIMESTAMP, SqlTypeName.TIMESTAMP)
           .put(TIMESTAMP_WITH_LOCAL_TZ, SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE)
+          .put(FieldType.logicalType(new NanosDuration()), SqlTypeName.INTERVAL_DAY_SECOND)
           .build();
 
   private static final ImmutableMap<SqlTypeName, FieldType> CALCITE_TO_BEAM_TYPE_MAPPING =
@@ -161,6 +163,8 @@ public class CalciteUtils {
           .put(SqlTypeName.TIME_WITH_LOCAL_TIME_ZONE, TIME_WITH_LOCAL_TZ)
           .put(SqlTypeName.TIMESTAMP, TIMESTAMP)
           .put(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TZ)
+          .put(SqlTypeName.NULL, VARCHAR)
+          .put(SqlTypeName.INTERVAL_DAY_SECOND, FieldType.logicalType(new NanosDuration()))
           .build();
 
   // Since there are multiple Calcite type that correspond to a single Beam type, this is the
@@ -395,6 +399,55 @@ public class CalciteUtils {
               + type
               + ". This is currently unsupported, use List instead "
               + "of Array.");
+    }
+    if (type instanceof Class) {
+      Class<?> clazz = (Class<?>) type;
+      if (clazz == String.class) {
+        return typeFactory.createTypeWithNullability(
+            typeFactory.createSqlType(SqlTypeName.VARCHAR), true);
+      } else if (clazz == Integer.class) {
+        return typeFactory.createTypeWithNullability(
+            typeFactory.createSqlType(SqlTypeName.INTEGER), true);
+      } else if (clazz == int.class) {
+        return typeFactory.createTypeWithNullability(
+            typeFactory.createSqlType(SqlTypeName.INTEGER), false);
+      } else if (clazz == Long.class) {
+        return typeFactory.createTypeWithNullability(
+            typeFactory.createSqlType(SqlTypeName.BIGINT), true);
+      } else if (clazz == long.class) {
+        return typeFactory.createTypeWithNullability(
+            typeFactory.createSqlType(SqlTypeName.BIGINT), false);
+      } else if (clazz == Double.class) {
+        return typeFactory.createTypeWithNullability(
+            typeFactory.createSqlType(SqlTypeName.DOUBLE), true);
+      } else if (clazz == double.class) {
+        return typeFactory.createTypeWithNullability(
+            typeFactory.createSqlType(SqlTypeName.DOUBLE), false);
+      } else if (clazz == Float.class) {
+        return typeFactory.createTypeWithNullability(
+            typeFactory.createSqlType(SqlTypeName.FLOAT), true);
+      } else if (clazz == float.class) {
+        return typeFactory.createTypeWithNullability(
+            typeFactory.createSqlType(SqlTypeName.FLOAT), false);
+      } else if (clazz == Short.class) {
+        return typeFactory.createTypeWithNullability(
+            typeFactory.createSqlType(SqlTypeName.SMALLINT), true);
+      } else if (clazz == short.class) {
+        return typeFactory.createTypeWithNullability(
+            typeFactory.createSqlType(SqlTypeName.SMALLINT), false);
+      } else if (clazz == Byte.class) {
+        return typeFactory.createTypeWithNullability(
+            typeFactory.createSqlType(SqlTypeName.TINYINT), true);
+      } else if (clazz == byte.class) {
+        return typeFactory.createTypeWithNullability(
+            typeFactory.createSqlType(SqlTypeName.TINYINT), false);
+      } else if (clazz == Boolean.class) {
+        return typeFactory.createTypeWithNullability(
+            typeFactory.createSqlType(SqlTypeName.BOOLEAN), true);
+      } else if (clazz == boolean.class) {
+        return typeFactory.createTypeWithNullability(
+            typeFactory.createSqlType(SqlTypeName.BOOLEAN), false);
+      }
     }
     return typeFactory.createJavaType((Class) type);
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslUdfUdafTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslUdfUdafTest.java
@@ -301,6 +301,28 @@ public class BeamSqlDslUdfUdafTest extends BeamSqlDslBase {
     pipeline.run().waitUntilFinish();
   }
 
+  @Test
+  public void testOverloadedUdf() throws Exception {
+    for (java.lang.reflect.Method m : OverloadedUdf.class.getMethods()) {
+      if (m.getName().equals("eval")) {
+        System.out.println("JETS_DEBUG: METHOD: " + m + " parameters: " + m.getParameterCount());
+      }
+    }
+    // Call with 2 arguments. This requires the 2-argument overload to be registered.
+    String sql =
+        "SELECT f_int, overload(f_string, f_int) as sub_string FROM PCOLLECTION WHERE f_int = 2";
+    PCollection<Row> result =
+        PCollectionTuple.of(new TupleTag<>("PCOLLECTION"), boundedInput1)
+            .apply("testUdf", SqlTransform.query(sql).registerUdf("overload", OverloadedUdf.class));
+
+    Schema subStrSchema =
+        Schema.builder().addInt32Field("f_int").addStringField("sub_string").build();
+    Row subStrRow = Row.withSchema(subStrSchema).addValues(2, "string_row2_2").build();
+    PAssert.that(result).containsInAnyOrder(subStrRow);
+
+    pipeline.run().waitUntilFinish();
+  }
+
   /**
    * test {@link org.apache.beam.vendor.calcite.v1_40_0.org.apache.calcite.schema.TableMacro} UDF.
    */
@@ -463,6 +485,19 @@ public class BeamSqlDslUdfUdafTest extends BeamSqlDslBase {
     public static String eval(
         @Parameter(name = "s") String s, @Parameter(name = "n", optional = true) Integer n) {
       return s.substring(0, n == null ? 1 : n);
+    }
+  }
+
+  public static class BaseOverloadedUdf {
+    public static String eval(
+        @Parameter(name = "s") String s, @Parameter(name = "n", optional = true) Integer n) {
+      return s + "_" + (n == null ? 0 : n);
+    }
+  }
+
+  public static final class OverloadedUdf extends BaseOverloadedUdf implements BeamSqlUdf {
+    public static String eval(String s) {
+      return s + "_1";
     }
   }
 

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/LazyAggregateCombineFnTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/LazyAggregateCombineFnTest.java
@@ -34,6 +34,7 @@ import org.apache.beam.vendor.calcite.v1_40_0.org.apache.calcite.rel.type.RelDat
 import org.apache.beam.vendor.calcite.v1_40_0.org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.beam.vendor.calcite.v1_40_0.org.apache.calcite.schema.AggregateFunction;
 import org.apache.beam.vendor.calcite.v1_40_0.org.apache.calcite.schema.FunctionParameter;
+import org.apache.beam.vendor.calcite.v1_40_0.org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.Rule;
@@ -77,7 +78,9 @@ public class LazyAggregateCombineFnTest {
       LazyAggregateCombineFn<?, ?, ?> combiner = new LazyAggregateCombineFn<>(aggregateFn);
       AggregateFunction aggregateFunction = combiner.getUdafImpl();
       RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
-      RelDataType expectedType = typeFactory.createJavaType(Long.class);
+      RelDataType expectedType =
+          typeFactory.createTypeWithNullability(
+              typeFactory.createSqlType(SqlTypeName.BIGINT), true);
 
       List<FunctionParameter> params = aggregateFunction.getParameters();
       assertThat(params, hasSize(1));

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRelTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRelTest.java
@@ -294,6 +294,28 @@ public class BeamSortRelTest extends BaseRelTest {
   }
 
   @Test
+  public void testOrderBy_withoutLimit() {
+    String sql =
+        "INSERT INTO SUB_ORDER_RAM(order_id, site_id, price)  SELECT "
+            + " order_id, site_id, price "
+            + "FROM ORDER_DETAILS "
+            + "ORDER BY order_id asc, site_id desc";
+
+    PCollection<Row> rows = compilePipeline(sql, pipeline);
+    PAssert.that(rows)
+        .containsInAnyOrder(
+            TestUtils.RowsBuilder.of(
+                    Schema.FieldType.INT64, "order_id",
+                    Schema.FieldType.INT32, "site_id",
+                    Schema.FieldType.DOUBLE, "price")
+                .addRows(
+                    1L, 2, 1.0, 1L, 1, 2.0, 2L, 4, 3.0, 2L, 1, 4.0, 5L, 5, 5.0, 6L, 6, 6.0, 7L, 7,
+                    7.0, 8L, 8888, 8.0, 8L, 999, 9.0, 10L, 100, 10.0)
+                .getRows());
+    pipeline.run().waitUntilFinish();
+  }
+
+  @Test
   public void testNodeStatsEstimation() {
     String sql =
         "SELECT order_id, site_id, price, order_time "

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRelTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRelTest.java
@@ -296,8 +296,7 @@ public class BeamSortRelTest extends BaseRelTest {
   @Test
   public void testOrderBy_withoutLimit() {
     String sql =
-        "INSERT INTO SUB_ORDER_RAM(order_id, site_id, price)  SELECT "
-            + " order_id, site_id, price "
+        "SELECT order_id, site_id, price "
             + "FROM ORDER_DETAILS "
             + "ORDER BY order_id asc, site_id desc";
 


### PR DESCRIPTION
Enhances Beam SQL's core infrastructure by adding support for global sorting (unlimited `ORDER BY`), fixing null-sorting bugs, and improving UDF type and method resolution.

### 1. Global Sort Support (`ORDER BY` without `LIMIT`)
*   **The Problem**: Historically, Beam SQL only supported `ORDER BY` when paired with a `LIMIT`. Using `ORDER BY` alone would throw an `UnsupportedOperationException`.
*   **The Fix**: Enabled global sorting in `BeamSortRel`. When no limit is specified (detected as `count == -1`), we route the PCollection through a global grouping:
    1. Key all rows by a single dummy key (`WithKeys.of("DummyKey")`).
    2. Group them together using `GroupByKey` to force co-location.
    3. Sort the co-located rows in-memory using a new `SortInMemoryFn`.
    *Note: Because this co-locates all data on a single reducer, it is intended for final-stage sorting and can be memory-intensive for massive datasets.*
*   **Tests**: Added `testOrderBy_withoutLimit` to `BeamSortRelTest` to verify correctness.

### 2. Sort Comparator Fixes & Type Extensions
*   **Null Sorting**: Fixed a bug in `BeamSqlRowComparator` where `NULLS FIRST` / `NULLS LAST` placement was incorrectly multiplied by the ASC/DESC direction. This caused nulls to be placed on the wrong end when the sort direction was reversed. Null placement is now absolute and independent of sort direction.
*   **Type Support**: Extended the comparator to support `DECIMAL`, `BOOLEAN`, `CHAR`, and `TIME` types, allowing sorting on columns of these types.

### 3. UDF & UDAF Type Resolution
*   **Type Mapping**: Updated `CalciteUtils.sqlType` to explicitly map Java classes (e.g., `String`, `Integer`, `int`, `Long`, `long`, etc.) to their corresponding Calcite SQL types with correct nullability, rather than relying on Calcite's default Java-type mapping. This ensures UDF signatures are validated correctly by the planner.
*   **Method Resolution**: Updated `UdfImpl.findMethod` to prioritize overloaded UDF methods with the highest parameter count. This allows Calcite to correctly resolve and bind UDF overloads that use optional trailing parameters.
*   **Tests**: Updated `LazyAggregateCombineFnTest` to align with the new SQL-type mapping expectations.