### PR TITLE
[Python] Add UnboundedSource ValidatesRunner test on portable runners

### DIFF
--- a/.github/trigger_files/beam_PostCommit_Python_ValidatesRunner_Dataflow.json
+++ b/.github/trigger_files/beam_PostCommit_Python_ValidatesRunner_Dataflow.json
@@ -1,4 +1,5 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run",
-  "modification": 5
+  "modification": 5,
+  "https://github.com/apache/beam/pull/38892": "UnboundedSource portable VR test"
 }

--- a/.github/trigger_files/beam_PostCommit_Python_ValidatesRunner_Flink.json
+++ b/.github/trigger_files/beam_PostCommit_Python_ValidatesRunner_Flink.json
@@ -1,5 +1,6 @@
 {
   "https://github.com/apache/beam/pull/32648": "testing addition of Flink 1.19 support",
   "https://github.com/apache/beam/pull/34830": "testing",
-  "trigger-2026-04-04": "portable_runner expand_sdf opt-in"
+  "trigger-2026-04-04": "portable_runner expand_sdf opt-in",
+  "https://github.com/apache/beam/pull/38892": "UnboundedSource portable VR test"
 }

--- a/.github/trigger_files/beam_PostCommit_Python_ValidatesRunner_Spark.json
+++ b/.github/trigger_files/beam_PostCommit_Python_ValidatesRunner_Spark.json
@@ -1,5 +1,6 @@
 {
   "https://github.com/apache/beam/pull/34830": "testing",
   "https://github.com/apache/beam/issues/35429": "testing",
-  "trigger-2026-04-04": "portable_runner expand_sdf opt-in"
+  "trigger-2026-04-04": "portable_runner expand_sdf opt-in",
+  "https://github.com/apache/beam/pull/38892": "UnboundedSource portable VR test"
 }

--- a/sdks/python/apache_beam/io/iobase_test.py
+++ b/sdks/python/apache_beam/io/iobase_test.py
@@ -224,22 +224,22 @@ class UseSdfBoundedSourcesTests(unittest.TestCase):
 class UseSdfUnboundedSourcesTests(unittest.TestCase):
   """Covers the UnboundedSource branch in
   ``iobase.Read.expand()``. Uses ``UnboundedCountingSource`` from
-  ``unbounded_source_test`` as a finite fake source (no network).
+  ``unbounded_source`` as a finite fake source (no network).
   """
   def test_read_end_to_end_unbounded(self):
-    from apache_beam.io.unbounded_source_test import UnboundedCountingSource
+    from apache_beam.io.unbounded_source import UnboundedCountingSource
     with beam.Pipeline() as p:
       out = p | beam.io.Read(UnboundedCountingSource(5))
       assert_that(out, equal_to([0, 1, 2, 3, 4]))
 
   def test_read_unbounded_pcollection_is_unbounded(self):
-    from apache_beam.io.unbounded_source_test import UnboundedCountingSource
+    from apache_beam.io.unbounded_source import UnboundedCountingSource
     p = beam.Pipeline()
     out = p | beam.io.Read(UnboundedCountingSource(3))
     self.assertFalse(out.is_bounded)
 
   def test_read_unbounded_serializes_as_expanded_composite(self):
-    from apache_beam.io.unbounded_source_test import UnboundedCountingSource
+    from apache_beam.io.unbounded_source import UnboundedCountingSource
     p = beam.Pipeline()
     p | 'ReadIt' >> beam.io.Read(UnboundedCountingSource(3))
 

--- a/sdks/python/apache_beam/io/unbounded_source.py
+++ b/sdks/python/apache_beam/io/unbounded_source.py
@@ -93,6 +93,8 @@ from typing import Callable
 from typing import Iterable
 from typing import Optional
 
+from typing_extensions import override
+
 from apache_beam import coders
 from apache_beam.coders.coders import BooleanCoder
 from apache_beam.coders.coders import Coder
@@ -994,3 +996,141 @@ class ReadFromUnboundedSource(PTransform):
 
   def _infer_output_coder(self, input_type=None, input_coder=None):
     return self._source.default_output_coder()
+
+
+# ------------------------------------------------------------------------------
+# Internal in-memory counting source, shared by Beam's own tests and examples.
+# ------------------------------------------------------------------------------
+
+# Realistic event-time base away from the Unix epoch.
+_EVENT_TIME_BASE = Timestamp(1729987200)  # 2024-10-27T00:00:00Z
+
+
+class _CountingCheckpointMark(CheckpointMark):
+  def __init__(self, last_index, finalize_log=None):
+    self.last_index = last_index
+    self._finalize_log = finalize_log
+
+  @override
+  def finalize_checkpoint(self):
+    if self._finalize_log is not None:
+      self._finalize_log.append(self.last_index)
+
+  def __eq__(self, other):
+    return (
+        isinstance(other, _CountingCheckpointMark) and
+        other.last_index == self.last_index)
+
+  def __hash__(self):
+    return hash(self.last_index)
+
+  def __repr__(self):
+    return '_CountingCheckpointMark(last_index=%r)' % (self.last_index, )
+
+
+class _CountingReader(UnboundedReader):
+  def __init__(
+      self, count, start_index, finalize_log=None, modulus=1, residue=0):
+    self._count = count
+    self._next = start_index
+    self._modulus = modulus
+    self._residue = residue
+    self._current = None
+    self._exhausted = False
+    self._finalize_log = finalize_log
+    self.closed = False
+
+  def _read_next(self):
+    while self._next < self._count:
+      index = self._next
+      self._next += 1
+      if index % self._modulus == self._residue:
+        self._current = index
+        return True
+    self._exhausted = True
+    return False
+
+  @override
+  def start(self):
+    return self._read_next()
+
+  @override
+  def advance(self):
+    return self._read_next()
+
+  @override
+  def get_current(self):
+    return self._current
+
+  @override
+  def get_current_timestamp(self):
+    return _EVENT_TIME_BASE + self._current
+
+  @override
+  def get_watermark(self):
+    if self._exhausted:
+      return MAX_TIMESTAMP
+    if self._current is None:
+      return MIN_TIMESTAMP
+    return _EVENT_TIME_BASE + self._current
+
+  @override
+  def get_checkpoint_mark(self):
+    last = self._current if self._current is not None else self._next - 1
+    return _CountingCheckpointMark(last, finalize_log=self._finalize_log)
+
+  @override
+  def close(self):
+    self.closed = True
+
+
+class UnboundedCountingSource(UnboundedSource):
+  """In-memory counting source for Beam's own tests and examples.
+
+  Internal: not part of the public ``UnboundedSource`` API. Emits integers
+  ``0..count-1`` with event time ``_EVENT_TIME_BASE + index``, self-terminates
+  at EOF, resumes from ``last_index + 1``, and optionally splits into
+  independent even/odd sub-sources.
+  """
+  def __init__(
+      self,
+      count,
+      finalize_log=None,
+      is_splittable=False,
+      modulus=1,
+      residue=0):
+    self._count = count
+    self._finalize_log = finalize_log
+    self._is_splittable = is_splittable
+    self._modulus = modulus
+    self._residue = residue
+    self.last_reader = None
+
+  @override
+  def split(self, desired_num_splits, options=None):
+    if not self._is_splittable or desired_num_splits < 2:
+      return [self]
+    # Split into independent even/odd sub-sources (each non-splittable).
+    return [
+        UnboundedCountingSource(
+            self._count,
+            finalize_log=self._finalize_log,
+            modulus=2,
+            residue=residue) for residue in (0, 1)
+    ]
+
+  @override
+  def create_reader(self, options, checkpoint_mark):
+    start_index = (
+        0 if checkpoint_mark is None else checkpoint_mark.last_index + 1)
+    self.last_reader = _CountingReader(
+        self._count,
+        start_index,
+        finalize_log=self._finalize_log,
+        modulus=self._modulus,
+        residue=self._residue)
+    return self.last_reader
+
+  @override
+  def get_checkpoint_mark_coder(self):
+    return coders.PickleCoder()

--- a/sdks/python/apache_beam/io/unbounded_source_test.py
+++ b/sdks/python/apache_beam/io/unbounded_source_test.py
@@ -29,11 +29,15 @@ from typing_extensions import override
 import apache_beam as beam
 from apache_beam import coders
 from apache_beam.io import unbounded_source as _unbounded_source_module
+from apache_beam.io.unbounded_source import _EVENT_TIME_BASE
 from apache_beam.io.unbounded_source import _NO_DATA
 from apache_beam.io.unbounded_source import CheckpointMark
 from apache_beam.io.unbounded_source import ReadFromUnboundedSource
+from apache_beam.io.unbounded_source import UnboundedCountingSource
 from apache_beam.io.unbounded_source import UnboundedReader
 from apache_beam.io.unbounded_source import UnboundedSource
+from apache_beam.io.unbounded_source import _CountingCheckpointMark
+from apache_beam.io.unbounded_source import _CountingReader
 from apache_beam.io.unbounded_source import _FinalizeCheckpointOnce
 from apache_beam.io.unbounded_source import _ReaderCache
 from apache_beam.io.unbounded_source import _ReadFromUnboundedSourceDoFn
@@ -54,138 +58,6 @@ from apache_beam.utils.timestamp import MIN_TIMESTAMP
 from apache_beam.utils.timestamp import Timestamp
 
 # pylint: disable=expression-not-assigned
-
-# Realistic event-time base away from the Unix epoch.
-_EVENT_TIME_BASE = Timestamp(1729987200)  # 2024-10-27T00:00:00Z
-
-# ------------------------------------------------------------------------------
-# In-memory demo source emitting integers 0..count-1 with event time
-# ``_EVENT_TIME_BASE + index``. It self-terminates at EOF, resumes from
-# ``last_index + 1``, and splits into even/odd sub-sources when configured.
-# ------------------------------------------------------------------------------
-
-
-class _CountingCheckpointMark(CheckpointMark):
-  def __init__(self, last_index, finalize_log=None):
-    self.last_index = last_index
-    self._finalize_log = finalize_log
-
-  @override
-  def finalize_checkpoint(self):
-    if self._finalize_log is not None:
-      self._finalize_log.append(self.last_index)
-
-  def __eq__(self, other):
-    return (
-        isinstance(other, _CountingCheckpointMark) and
-        other.last_index == self.last_index)
-
-  def __hash__(self):
-    return hash(self.last_index)
-
-  def __repr__(self):
-    return '_CountingCheckpointMark(last_index=%r)' % (self.last_index, )
-
-
-class _CountingReader(UnboundedReader):
-  def __init__(
-      self, count, start_index, finalize_log=None, modulus=1, residue=0):
-    self._count = count
-    self._next = start_index
-    self._modulus = modulus
-    self._residue = residue
-    self._current = None
-    self._exhausted = False
-    self._finalize_log = finalize_log
-    self.closed = False
-
-  def _read_next(self):
-    while self._next < self._count:
-      index = self._next
-      self._next += 1
-      if index % self._modulus == self._residue:
-        self._current = index
-        return True
-    self._exhausted = True
-    return False
-
-  @override
-  def start(self):
-    return self._read_next()
-
-  @override
-  def advance(self):
-    return self._read_next()
-
-  @override
-  def get_current(self):
-    return self._current
-
-  @override
-  def get_current_timestamp(self):
-    return _EVENT_TIME_BASE + self._current
-
-  @override
-  def get_watermark(self):
-    if self._exhausted:
-      return MAX_TIMESTAMP
-    if self._current is None:
-      return MIN_TIMESTAMP
-    return _EVENT_TIME_BASE + self._current
-
-  @override
-  def get_checkpoint_mark(self):
-    last = self._current if self._current is not None else self._next - 1
-    return _CountingCheckpointMark(last, finalize_log=self._finalize_log)
-
-  @override
-  def close(self):
-    self.closed = True
-
-
-class UnboundedCountingSource(UnboundedSource):
-  def __init__(
-      self,
-      count,
-      finalize_log=None,
-      is_splittable=False,
-      modulus=1,
-      residue=0):
-    self._count = count
-    self._finalize_log = finalize_log
-    self._is_splittable = is_splittable
-    self._modulus = modulus
-    self._residue = residue
-    self.last_reader = None
-
-  @override
-  def split(self, desired_num_splits, options=None):
-    if not self._is_splittable or desired_num_splits < 2:
-      return [self]
-    # Split into independent even/odd sub-sources (each non-splittable).
-    return [
-        UnboundedCountingSource(
-            self._count,
-            finalize_log=self._finalize_log,
-            modulus=2,
-            residue=residue) for residue in (0, 1)
-    ]
-
-  @override
-  def create_reader(self, options, checkpoint_mark):
-    start_index = (
-        0 if checkpoint_mark is None else checkpoint_mark.last_index + 1)
-    self.last_reader = _CountingReader(
-        self._count,
-        start_index,
-        finalize_log=self._finalize_log,
-        modulus=self._modulus,
-        residue=self._residue)
-    return self.last_reader
-
-  @override
-  def get_checkpoint_mark_coder(self):
-    return coders.PickleCoder()
 
 
 class _StringCountingReader(_CountingReader):

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
@@ -46,6 +46,7 @@ import apache_beam as beam
 from apache_beam.coders import coders
 from apache_beam.coders.coders import StrUtf8Coder
 from apache_beam.io import restriction_trackers
+from apache_beam.io.unbounded_source import UnboundedCountingSource
 from apache_beam.io.watermark_estimators import ManualWatermarkEstimator
 from apache_beam.metrics import monitoring_infos
 from apache_beam.metrics.execution import MetricKey
@@ -1170,6 +1171,25 @@ class FnApiRunnerTest(unittest.TestCase):
       actual = (p | beam.Create([10]) | beam.ParDo(SimpleSDF()))
       assert_that(actual, equal_to(range(5)))
 
+  def test_unbounded_source_read(self):
+    """Reads a self-terminating UnboundedSource end to end.
+
+    Exercises the runner-API round trip and the EOF ``MAX_TIMESTAMP`` watermark
+    propagation that lets the downstream window fire.
+    """
+    with self.create_pipeline() as p:
+      out = p | beam.io.Read(UnboundedCountingSource(5))
+      self.assertFalse(out.is_bounded)
+      assert_that(out, equal_to([0, 1, 2, 3, 4]), label='assert_elements')
+      windowed = (
+          out
+          | beam.WindowInto(window.FixedWindows(100))
+          | beam.Map(lambda v: ('all', v))
+          | beam.GroupByKey()
+          | beam.MapTuple(lambda _key, values: sorted(values)))
+      assert_that(
+          windowed, equal_to([[0, 1, 2, 3, 4]]), label='assert_windowed')
+
   def test_group_by_key(self):
     with self.create_pipeline() as p:
       res = (
@@ -2038,6 +2058,9 @@ class FnApiRunnerTestWithMultiWorkers(FnApiRunnerTest):
   def test_sdf_with_watermark_tracking(self):
     raise unittest.SkipTest("This test is for a single worker only.")
 
+  def test_unbounded_source_read(self):
+    raise unittest.SkipTest("This test is for a single worker only.")
+
   def test_sdf_with_dofn_as_watermark_estimator(self):
     raise unittest.SkipTest("This test is for a single worker only.")
 
@@ -2069,6 +2092,9 @@ class FnApiRunnerTestWithGrpcAndMultiWorkers(FnApiRunnerTest):
     raise unittest.SkipTest("This test is for a single worker only.")
 
   def test_sdf_with_watermark_tracking(self):
+    raise unittest.SkipTest("This test is for a single worker only.")
+
+  def test_unbounded_source_read(self):
     raise unittest.SkipTest("This test is for a single worker only.")
 
   def test_sdf_with_dofn_as_watermark_estimator(self):
@@ -2113,6 +2139,9 @@ class FnApiRunnerTestWithBundleRepeatAndMultiWorkers(FnApiRunnerTest):
     raise unittest.SkipTest("This test is for a single worker only.")
 
   def test_sdf_with_watermark_tracking(self):
+    raise unittest.SkipTest("This test is for a single worker only.")
+
+  def test_unbounded_source_read(self):
     raise unittest.SkipTest("This test is for a single worker only.")
 
   def test_sdf_with_dofn_as_watermark_estimator(self):

--- a/sdks/python/apache_beam/runners/portability/spark_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/spark_runner_test.py
@@ -146,6 +146,10 @@ class SparkRunnerTest(portable_runner_test.PortableRunnerTest):
     # Skip until Spark runner supports SDF.
     raise unittest.SkipTest("https://github.com/apache/beam/issues/19468")
 
+  def test_unbounded_source_read(self):
+    # Skip until Spark runner supports SDF.
+    raise unittest.SkipTest("https://github.com/apache/beam/issues/19468")
+
   def test_sdf_with_watermark_tracking(self):
     # Skip until Spark runner supports SDF.
     raise unittest.SkipTest("https://github.com/apache/beam/issues/19468")


### PR DESCRIPTION
**Stacked on #38724**, squashed into a single commit. The new change relative to #38724 is `test_unbounded_source_read` in `sdks/python/apache_beam/runners/portability/portable_runner_test.py`; the rest of the diff is the `UnboundedSource` implementation under review there. Will rebase onto master once #38724 merges. Addresses #19137.

This adds portable ValidatesRunner coverage for the ``UnboundedSource`` SDF wrapper introduced in #38724.

``test_unbounded_source_read`` on ``PortableRunnerTest`` reads a self-terminating ``UnboundedCountingSource(5)`` through a real job service and asserts:

* the output PCollection is unbounded,
* the elements ``[0..4]`` arrive,
* the EOF ``MAX_TIMESTAMP`` watermark propagates so a downstream ``FixedWindows(100)`` + ``GroupByKey`` fires.

This complements the DirectRunner tests in ``apache_beam.io.unbounded_source_test`` by exercising the runner-API round trip and watermark propagation through the portable job service path.

Suites inheriting the test:

* ``PortableRunnerTest`` and its embedded variants (external env, subprocesses, subprocesses + multi-worker, local Docker)
* ``FlinkRunnerTest``, ``FlinkRunnerTestOptimized``, ``FlinkRunnerTestStreaming``
* ``PrismRunnerTest``
* ``SparkRunnerTest`` skips it: portable Spark does not execute SDFs (#19468), matching its existing ``test_sdf*`` skips.

Local verification (Windows, Python 3.11):

* ``pytest apache_beam/runners/portability/portable_runner_test.py -k test_unbounded_source_read`` → 6 passed, 1 skipped (``PortableRunnerOptimized`` is class-level skipped, #19422)
* Flink 1.20 job server (``:runners:flink:1.20:job-server:shadowJar``, ``--environment_type=LOOPBACK``): ``FlinkRunnerTest``, ``FlinkRunnerTestOptimized``, ``FlinkRunnerTestStreaming`` all pass
* Prism (``--environment_type=LOOPBACK``): passes

``CHANGES.md`` is intentionally left untouched; the announcement is deferred until the ValidatesRunner milestones complete, per review on #38724.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.

