### PR TITLE
Fix Dataflow legacy worker abort loop thread death issue

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/MapTaskExecutor.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/MapTaskExecutor.java
@@ -100,9 +100,6 @@ public class MapTaskExecutor implements WorkExecutor {
         } catch (Exception closeExn) {
           exn.addSuppressed(closeExn);
         }
-        if (exn instanceof InterruptedException) {
-          Thread.currentThread().interrupt();
-        }
         throw exn;
       }
     }


### PR DESCRIPTION
Previously, when the service asked the worker to abort, it threw ReadLoopAbortedException, which extends InterruptedException. MapTaskExecutor caught this and, in an attempt to preserve the interrupted status, set the interrupted bit on the thread. However, since this was a logical abort and not a real thread interrupt, setting the interrupted bit caused subsequent operations on the thread (like the backoff sleep in DataflowBatchWorkerHarness) to immediately fail with InterruptedException, leading to all worker threads dying and the harness hanging.

This fix changes the interruption handling in MapTaskExecutor to not set the interrupted bit if it is just rethrowing the InterruptedException. Since we are throwing the exception, we can rely on the caller to set the bit if they swallow it and need to preserve it.

This was introduced in https://github.com/apache/beam/pull/36631