### PR TITLE
[Infra] Add beam_viewer and beam_writer roles for GSoC 2026 participant

### DIFF
--- a/infra/iam/users.yml
+++ b/infra/iam/users.yml
@@ -486,6 +486,12 @@
   - role: roles/cloudfunctions.invoker
   - role: roles/iam.serviceAccountTokenCreator
   - role: roles/storage.objectViewer
+- username: hansmarcus
+  email: hansmarcus14@gmail.com
+  member_type: user
+  permissions:
+  - role: projects/apache-beam-testing/roles/beam_viewer
+  - role: projects/apache-beam-testing/roles/beam_writer
 - username: harrisonlim
   email: harrisonlim@google.com
   member_type: user
@@ -1238,12 +1244,6 @@
   - role: roles/editor
 - username: yalah5084
   email: yalahuangfeng@gmail.com
-  member_type: user
-  permissions:
-  - role: projects/apache-beam-testing/roles/beam_viewer
-  - role: projects/apache-beam-testing/roles/beam_writer
-- username: hansmarcus
-  email: hansmarcus14@gmail.com
   member_type: user
   permissions:
   - role: projects/apache-beam-testing/roles/beam_viewer

--- a/infra/iam/users.yml
+++ b/infra/iam/users.yml
@@ -1242,3 +1242,9 @@
   permissions:
   - role: projects/apache-beam-testing/roles/beam_viewer
   - role: projects/apache-beam-testing/roles/beam_writer
+- username: hansmarcus
+  email: hansmarcus14@gmail.com
+  member_type: user
+  permissions:
+  - role: projects/apache-beam-testing/roles/beam_viewer
+  - role: projects/apache-beam-testing/roles/beam_writer


### PR DESCRIPTION
I am requesting user access (beam_viewer and beam_writer) to the apache-beam-testing project to develop and test the infrastructure monitoring modules for my Google Summer of Code 2026 project.

### Project Details
**Issue:** [GSOC-273](https://issues.apache.org/jira/browse/GSOC-273)
**Project:** Simplify management of Beam infrastructure, access control and permissions via Platform features


### Use Case
I am updating the users.yml file to grant my Google account the necessary permissions to interact with GCP APIs during development. These roles will allow me to test my scripts locally against real infrastructure metadata without modifying or destroying production assets.

### Request Changes
- **File:** `user.yaml`
- **Added_User:**` hansmarcus`
- **Email_user:**`hansmarcus14@gmail.com`
- **Roles:**`beam_viewer`, beam_writer``


### Mentor
[@pabloem](https://github.com/pabloem)
