### PR TITLE
Potential fix for environment variable built from user-controlled sources

### DIFF
--- a/.github/workflows/beam_Publish_Beam_SDK_Snapshots.yml
+++ b/.github/workflows/beam_Publish_Beam_SDK_Snapshots.yml
@@ -88,8 +88,21 @@ jobs:
         # This is needed to run pipelines that use the default environment at HEAD, for example, when a
         # pipeline uses an expansion service built from HEAD.
         run: |
-          BEAM_VERSION_LINE=$(cat gradle.properties | grep "sdk_version")
-          echo "BEAM_VERSION=${BEAM_VERSION_LINE#*sdk_version=}" >> $GITHUB_ENV
+          BEAM_VERSION_LINE=$(grep -m1 '^sdk_version=' gradle.properties || true)
+          if [ -z "$BEAM_VERSION_LINE" ]; then
+            echo "Could not find sdk_version in gradle.properties"
+            exit 1
+          fi
+
+          BEAM_VERSION="${BEAM_VERSION_LINE#sdk_version=}"
+
+          # Prevent environment file injection via CR/LF.
+          if printf '%s' "$BEAM_VERSION" | grep -q $'[\r\n]'; then
+            echo "Invalid sdk_version: contains newline characters"
+            exit 1
+          fi
+
+          printf 'BEAM_VERSION=%s\n' "$BEAM_VERSION" >> "$GITHUB_ENV"
       - name: Set latest tag only on master branch
         if: github.ref == 'refs/heads/master'
         run: echo "LATEST_TAG=,latest" >> $GITHUB_ENV

--- a/.github/workflows/beam_Publish_Beam_SDK_Snapshots.yml
+++ b/.github/workflows/beam_Publish_Beam_SDK_Snapshots.yml
@@ -97,7 +97,7 @@ jobs:
           BEAM_VERSION="${BEAM_VERSION_LINE#sdk_version=}"
 
           # Prevent environment file injection via CR/LF.
-          if printf '%s' "$BEAM_VERSION" | grep -q $'[\r\n]'; then
+          if [[ "$BEAM_VERSION" =~ [$'\r\n'] ]]; then
             echo "Invalid sdk_version: contains newline characters"
             exit 1
           fi


### PR DESCRIPTION
Potential fix for [https://github.com/apache/beam/security/code-scanning/1](https://github.com/apache/beam/security/code-scanning/1)

Use strict parsing + sanitization before writing to `$GITHUB_ENV`:

- Read only the first `sdk_version=` line from `gradle.properties`.
- Extract the value safely.
- Reject values containing CR/LF (prevents env-file line injection).
- Optionally validate expected version format to keep behavior aligned with intended semantics.
- Write using `printf` to avoid shell echo quirks.

Change only `.github/workflows/beam_Publish_Beam_SDK_Snapshots.yml` in the `Find Beam Version` step (lines around 90–92). No import/dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


run - https://github.com/apache/beam/actions/runs/27416123769
rerun - https://github.com/apache/beam/actions/runs/30821283730

