### PR TITLE
SQL Database DDL & Usability Improvements

### DIFF
--- a/sdks/java/extensions/sql/src/main/codegen/includes/parserImpls.ftl
+++ b/sdks/java/extensions/sql/src/main/codegen/includes/parserImpls.ftl
@@ -381,7 +381,7 @@ SqlCreate SqlCreateDatabase(Span s, boolean replace) :
 }
 
 /**
- * USE DATABASE ( catalog_name '.' )? database_name
+ * USE [ DATABASE ] ( catalog_name '.' )? database_name
  */
 SqlCall SqlUseDatabase(Span s, String scope) :
 {
@@ -391,7 +391,7 @@ SqlCall SqlUseDatabase(Span s, String scope) :
     <USE> {
         s.add(this);
     }
-    <DATABASE>
+    [ <DATABASE> ]
     databaseName = CompoundIdentifier()
     {
         return new SqlUseDatabase(

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlDdlNodes.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlDdlNodes.java
@@ -73,6 +73,9 @@ public class SqlDdlNodes {
   }
 
   public static @Nullable CalciteSchema childSchema(CalciteSchema rootSchema, List<String> path) {
+    if (path == null) {
+      return null;
+    }
     @Nullable CalciteSchema schema = rootSchema;
     for (String p : path) {
       if (schema == null) {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlDdlNodes.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlDdlNodes.java
@@ -55,7 +55,7 @@ public class SqlDdlNodes {
   }
 
   /** Returns the schema in which to create an object. */
-  static Pair<CalciteSchema, String> schema(
+  public static Pair<CalciteSchema, String> schema(
       CalcitePrepare.Context context, boolean mutable, SqlIdentifier id) {
     CalciteSchema rootSchema = mutable ? context.getMutableRootSchema() : context.getRootSchema();
     @Nullable CalciteSchema schema = null;
@@ -72,7 +72,7 @@ public class SqlDdlNodes {
     return Pair.of(checkStateNotNull(schema, "Got null sub-schema for path '%s'", path), name(id));
   }
 
-  private static @Nullable CalciteSchema childSchema(CalciteSchema rootSchema, List<String> path) {
+  public static @Nullable CalciteSchema childSchema(CalciteSchema rootSchema, List<String> path) {
     @Nullable CalciteSchema schema = rootSchema;
     for (String p : path) {
       if (schema == null) {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/catalog/InMemoryCatalog.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/catalog/InMemoryCatalog.java
@@ -18,7 +18,6 @@
 package org.apache.beam.sdk.extensions.sql.meta.catalog;
 
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
-import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -111,12 +110,16 @@ public class InMemoryCatalog implements Catalog {
 
   @Override
   public boolean dropDatabase(String database, boolean cascade) {
-    checkState(!cascade, "%s does not support CASCADE.", getClass().getSimpleName());
+    MetaStore metaStore = metaStores.get(database);
+    if (!cascade && metaStore != null && !metaStore.getTables().isEmpty()) {
+      throw new IllegalStateException("Database '" + database + "' is not empty.");
+    }
 
     boolean removed = databases.remove(database);
     if (database.equals(currentDatabase)) {
       currentDatabase = null;
     }
+    metaStores.remove(database);
     return removed;
   }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/catalog/InMemoryCatalog.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/catalog/InMemoryCatalog.java
@@ -110,20 +110,20 @@ public class InMemoryCatalog implements Catalog {
 
   @Override
   public boolean dropDatabase(String database, boolean cascade) {
-    if (!databases.contains(database)) {
-      return false;
-    }
     MetaStore metaStore = metaStores.get(database);
     if (!cascade && metaStore != null && !metaStore.getTables().isEmpty()) {
       throw new IllegalStateException("Database '" + database + "' is not empty.");
     }
 
     boolean removed = databases.remove(database);
+    if (!removed) {
+      return false;
+    }
     if (database.equals(currentDatabase)) {
       currentDatabase = null;
     }
     metaStores.remove(database);
-    return removed;
+    return true;
   }
 
   @Override

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/catalog/InMemoryCatalog.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/catalog/InMemoryCatalog.java
@@ -110,6 +110,9 @@ public class InMemoryCatalog implements Catalog {
 
   @Override
   public boolean dropDatabase(String database, boolean cascade) {
+    if (!databases.contains(database)) {
+      return false;
+    }
     MetaStore metaStore = metaStores.get(database);
     if (!cascade && metaStore != null && !metaStore.getTables().isEmpty()) {
       throw new IllegalStateException("Database '" + database + "' is not empty.");

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlCliDatabaseTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlCliDatabaseTest.java
@@ -160,7 +160,7 @@ public class BeamSqlCliDatabaseTest {
     catalogManager.registerTableProvider(testTableProvider);
     cli.execute("CREATE EXTERNAL TABLE person(id int, name varchar, age int) TYPE 'test'");
 
-    thrown.expect(RuntimeException.class);
+    thrown.expect(CalciteContextException.class);
     thrown.expectMessage("Database 'db_1' is not empty.");
     cli.execute("DROP DATABASE db_1");
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlCliDatabaseTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlCliDatabaseTest.java
@@ -84,6 +84,15 @@ public class BeamSqlCliDatabaseTest {
   }
 
   @Test
+  public void testUseDatabaseWithoutDatabaseKeyword() {
+    assertEquals(DEFAULT, catalogManager.currentCatalog().currentDatabase());
+    cli.execute("CREATE DATABASE my_database");
+    assertEquals(DEFAULT, catalogManager.currentCatalog().currentDatabase());
+    cli.execute("USE my_database");
+    assertEquals("my_database", catalogManager.currentCatalog().currentDatabase());
+  }
+
+  @Test
   public void testUseDatabase_doesNotExist() {
     assertEquals(DEFAULT, catalogManager.currentCatalog().currentDatabase());
     thrown.expect(CalciteContextException.class);
@@ -124,6 +133,33 @@ public class BeamSqlCliDatabaseTest {
     thrown.expect(CalciteContextException.class);
     thrown.expectMessage("Database 'my_database' does not exist.");
     cli.execute("DROP DATABASE my_database");
+  }
+
+  @Test
+  public void testDropDatabase_notEmpty_restrict() {
+    cli.execute("CREATE DATABASE db_1");
+    cli.execute("USE db_1");
+
+    TestTableProvider testTableProvider = new TestTableProvider();
+    catalogManager.registerTableProvider(testTableProvider);
+    cli.execute("CREATE EXTERNAL TABLE person(id int, name varchar, age int) TYPE 'test'");
+
+    thrown.expect(RuntimeException.class);
+    thrown.expectMessage("Database 'db_1' is not empty.");
+    cli.execute("DROP DATABASE db_1");
+  }
+
+  @Test
+  public void testDropDatabase_notEmpty_cascade() {
+    cli.execute("CREATE DATABASE db_1");
+    cli.execute("USE db_1");
+
+    TestTableProvider testTableProvider = new TestTableProvider();
+    catalogManager.registerTableProvider(testTableProvider);
+    cli.execute("CREATE EXTERNAL TABLE person(id int, name varchar, age int) TYPE 'test'");
+
+    cli.execute("DROP DATABASE db_1 CASCADE");
+    assertFalse(catalogManager.currentCatalog().databaseExists("db_1"));
   }
 
   @Test

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlCliDatabaseTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlCliDatabaseTest.java
@@ -136,6 +136,22 @@ public class BeamSqlCliDatabaseTest {
   }
 
   @Test
+  public void testDropDatabase_ifExists_nonexistent() {
+    assertFalse(catalogManager.currentCatalog().databaseExists("my_database"));
+    // Should not throw exception
+    cli.execute("DROP DATABASE IF EXISTS my_database");
+    assertFalse(catalogManager.currentCatalog().databaseExists("my_database"));
+  }
+
+  @Test
+  public void testDropDatabase_ifExists_exists() {
+    cli.execute("CREATE DATABASE my_database");
+    assertTrue(catalogManager.currentCatalog().databaseExists("my_database"));
+    cli.execute("DROP DATABASE IF EXISTS my_database");
+    assertFalse(catalogManager.currentCatalog().databaseExists("my_database"));
+  }
+
+  @Test
   public void testDropDatabase_notEmpty_restrict() {
     cli.execute("CREATE DATABASE db_1");
     cli.execute("USE db_1");


### PR DESCRIPTION
## Description

This PR is split from #38866. It introduces comprehensive support for database DDL (Data Definition Language) and usability improvements in the Beam SQL CLI and `InMemoryCatalog`.

### Key Changes

*   **Database DDL Support**:
    *   Introduces `CREATE DATABASE` and `DROP DATABASE` statements.
    *   Supports `CASCADE` and `RESTRICT` options for `DROP DATABASE`:
        *   `DROP DATABASE <db> RESTRICT` (default) will fail if the database is not empty, preventing accidental data loss.
        *   `DROP DATABASE <db> CASCADE` will automatically drop all tables within that database before dropping the database itself.
*   **Usability Improvements**:
    *   Supports the industry-standard `USE <database_name>` shortcut in the CLI, removing the mandatory requirement of the `DATABASE` keyword (i.e. you no longer have to type `USE DATABASE <db>`).
*   **Cross-Database Table Management**:
    *   Allows fully qualified table names in DDL and DML (e.g., `CREATE EXTERNAL TABLE db_1.my_table ...` or `INSERT INTO db_1.my_table ...`), allowing you to manage and write to tables in non-active databases.
*   **Testing**:
    *   Adds a new comprehensive integration test suite `BeamSqlCliDatabaseTest.java` verifying all DDL and database management features in the CLI.