### PR TITLE
Revert "Upgrade expansion jar to java17"

### DIFF
--- a/.github/actions/setup-environment-action/action.yml
+++ b/.github/actions/setup-environment-action/action.yml
@@ -74,7 +74,7 @@ runs:
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: ${{ inputs.java-version == 'default' && ((contains(github.job, 'Xlang') || contains(github.job, 'XVR') || contains(github.job, 'PreCommit_Java')) && '17' || '11') || inputs.java-version }}
+        java-version: ${{ inputs.java-version == 'default' && '11' || inputs.java-version }}
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       with:

--- a/.github/workflows/beam_PreCommit_Xlang_Generated_Transforms.yml
+++ b/.github/workflows/beam_PreCommit_Xlang_Generated_Transforms.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment-action
         with:
-          java-version: '17'
+          java-version: default
           python-version: ${{ matrix.python_version }}
       - name: Set PY_VER_CLEAN
         id: set_py_ver_clean

--- a/sdks/java/expansion-service/container/Dockerfile
+++ b/sdks/java/expansion-service/container/Dockerfile
@@ -16,7 +16,7 @@
 # limitations under the License.
 ###############################################################################
 
-FROM eclipse-temurin:17
+FROM eclipse-temurin:11
 LABEL Author "Apache Beam <dev@beam.apache.org>"
 ARG TARGETOS
 ARG TARGETARCH

--- a/sdks/java/io/expansion-service/build.gradle
+++ b/sdks/java/io/expansion-service/build.gradle
@@ -25,8 +25,8 @@ applyJavaNature(
   exportJavadoc: false,
   validateShadowJar: false,
   shadowClosure: {},
-  // iceberg requires Java11+ and delta lake requires Java17+
-  requireJavaVersion: JavaVersion.VERSION_17
+  // iceberg requires Java11+
+  requireJavaVersion: JavaVersion.VERSION_11
 )
 
 // We don't want to use the latest version for the entire beam sdk since beam Java users can override it themselves.


### PR DESCRIPTION
Reverts apache/beam#38931

Fix `InaccessibleObjectException` seen in presubmit tests

When rolling forward, do not change the default in setup-environment action but use `java_version: 17 11` in individual tests, like what we did in https://github.com/apache/beam/pull/35232/changes#diff-4eb1051f5356e9447cc88403c921bc6b329d5f34a3ca02325b253515bce9dec4