### PR TITLE
[Python] Optimize BigQuery copy jobs in file loads using multi-source copy

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -491,6 +491,7 @@ class TriggerCopyJobs(beam.DoFn):
   """
 
   TRIGGER_DELETE_TEMP_TABLES = 'TriggerDeleteTempTables'
+  # https://docs.cloud.google.com/bigquery/quotas#copy_jobs
   MAX_SOURCES_PER_COPY_JOB = 1200
 
   def __init__(
@@ -549,10 +550,7 @@ class TriggerCopyJobs(beam.DoFn):
             'project', str, '') or self.project
       copy_from_references.append(copy_from_reference)
 
-    full_table_ref = '%s:%s.%s' % (
-        copy_to_reference.projectId,
-        copy_to_reference.datasetId,
-        copy_to_reference.tableId)
+    full_table_ref = bigquery_tools.get_hashable_destination(copy_to_reference)
 
     is_first_time = full_table_ref not in self._observed_tables
     if is_first_time:
@@ -573,11 +571,7 @@ class TriggerCopyJobs(beam.DoFn):
 
     copy_job_name_base = '%s_%s' % (
         job_name_prefix,
-        _bq_uuid(
-            '%s:%s.%s' % (
-                copy_to_reference.projectId,
-                copy_to_reference.datasetId,
-                copy_to_reference.tableId)))
+        _bq_uuid(bigquery_tools.get_hashable_destination(copy_to_reference)))
 
     project_id = (
         copy_to_reference.projectId

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -491,6 +491,7 @@ class TriggerCopyJobs(beam.DoFn):
   """
 
   TRIGGER_DELETE_TEMP_TABLES = 'TriggerDeleteTempTables'
+  MAX_SOURCES_PER_COPY_JOB = 1200
 
   def __init__(
       self,
@@ -528,97 +529,97 @@ class TriggerCopyJobs(beam.DoFn):
       self, element_list, job_name_prefix=None, unused_schema_mod_jobs=None):
     if isinstance(element_list, tuple):
       # Allow this for streaming update compatibility while fixing BEAM-24535.
-      self.process_one(element_list, job_name_prefix)
-    else:
-      for element in element_list:
-        self.process_one(element, job_name_prefix)
+      element_list = [element_list]
 
-  def process_one(self, element, job_name_prefix):
-    destination, job_reference = element
+    if not element_list:
+      return
 
-    copy_to_reference = bigquery_tools.parse_table_reference(destination)
+    first_destination = element_list[0][0]
+    copy_to_reference = bigquery_tools.parse_table_reference(first_destination)
     if copy_to_reference.projectId is None:
       copy_to_reference.projectId = vp.RuntimeValueProvider.get_value(
           'project', str, '') or self.project
 
-    copy_from_reference = bigquery_tools.parse_table_reference(destination)
-    copy_from_reference.tableId = job_reference.jobId
-    if copy_from_reference.projectId is None:
-      copy_from_reference.projectId = vp.RuntimeValueProvider.get_value(
-          'project', str, '') or self.project
+    copy_from_references = []
+    for destination, job_reference in element_list:
+      copy_from_reference = bigquery_tools.parse_table_reference(destination)
+      copy_from_reference.tableId = job_reference.jobId
+      if copy_from_reference.projectId is None:
+        copy_from_reference.projectId = vp.RuntimeValueProvider.get_value(
+            'project', str, '') or self.project
+      copy_from_references.append(copy_from_reference)
 
-    _LOGGER.info(
-        "Triggering copy job from %s to %s",
-        copy_from_reference,
-        copy_to_reference)
-
-    wait_for_job, write_disposition = (
-      self._determine_write_disposition(copy_to_reference))
-
-    if not self.bq_io_metadata:
-      self.bq_io_metadata = create_bigquery_io_metadata(self._step_name)
-
-    project_id = (
-        copy_to_reference.projectId
-        if self.load_job_project_id is None else self.load_job_project_id)
-    copy_job_name = '%s_%s' % (
-        job_name_prefix,
-        _bq_uuid(
-            '%s:%s.%s' % (
-                copy_from_reference.projectId,
-                copy_from_reference.datasetId,
-                copy_from_reference.tableId)))
-    job_reference = self.bq_wrapper._insert_copy_job(
-        project_id,
-        copy_job_name,
-        copy_from_reference,
-        copy_to_reference,
-        create_disposition=self.create_disposition,
-        write_disposition=write_disposition,
-        job_labels=self.bq_io_metadata.add_additional_bq_job_labels())
-
-    if wait_for_job:
-      self.bq_wrapper.wait_for_bq_job(job_reference, sleep_duration_sec=10)
-    self.pending_jobs.append(
-        GlobalWindows.windowed_value((destination, job_reference)))
-
-  def _determine_write_disposition(self, copy_to_reference) -> tuple[bool, str]:
-    """
-    Determines the write disposition for a BigQuery copy job,
-     based on destination.
-
-    When the write_disposition for a job is WRITE_TRUNCATE, multiple copy jobs
-    to the same destination can interfere with each other, truncate data, and
-    write to the BigQuery table repeatedly. To prevent this, the first copy job
-    runs with the user's specified write_disposition, but subsequent jobs must
-    always use WRITE_APPEND. This ensures that subsequent copy jobs do not
-    clear out data appended by previous jobs.
-
-    Args:
-        copy_to_reference: The reference to the destination table.
-
-    Returns:
-        A tuple containing a boolean indicating whether to wait for the job to
-        complete and the write disposition to use for the job.
-    """
     full_table_ref = '%s:%s.%s' % (
         copy_to_reference.projectId,
         copy_to_reference.datasetId,
         copy_to_reference.tableId)
-    if full_table_ref not in self._observed_tables:
-      write_disposition = self.write_disposition
-      wait_for_job = (
-          self.write_disposition != BigQueryDisposition.WRITE_APPEND)
+
+    is_first_time = full_table_ref not in self._observed_tables
+    if is_first_time:
       self._observed_tables.add(full_table_ref)
-      Lineage.sinks().add(
-          'bigquery',
-          copy_to_reference.projectId,
-          copy_to_reference.datasetId,
-          copy_to_reference.tableId)
-    else:
-      wait_for_job = False
-      write_disposition = 'WRITE_APPEND'
-    return wait_for_job, write_disposition
+      if self.bq_io_metadata:
+        Lineage.sinks().add(
+            'bigquery',
+            copy_to_reference.projectId,
+            copy_to_reference.datasetId,
+            copy_to_reference.tableId)
+
+    # Split into chunks of MAX_SOURCES_PER_COPY_JOB
+    chunks = [
+        copy_from_references[i:i + self.MAX_SOURCES_PER_COPY_JOB]
+        for i in range(
+            0, len(copy_from_references), self.MAX_SOURCES_PER_COPY_JOB)
+    ]
+
+    copy_job_name_base = '%s_%s' % (
+        job_name_prefix,
+        _bq_uuid(
+            '%s:%s.%s' % (
+                copy_to_reference.projectId,
+                copy_to_reference.datasetId,
+                copy_to_reference.tableId)))
+
+    project_id = (
+        copy_to_reference.projectId
+        if self.load_job_project_id is None else self.load_job_project_id)
+
+    for i, chunk in enumerate(chunks):
+      if i == 0 and is_first_time:
+        write_disposition = self.write_disposition
+        # Wait inline only if we have multiple chunks and write disposition is WRITE_TRUNCATE or WRITE_EMPTY.
+        # This ensures the first chunk initializes the table, and subsequent chunks (WRITE_APPEND) append to it.
+        wait_for_job = (
+            self.write_disposition in ('WRITE_TRUNCATE', 'WRITE_EMPTY') and
+            len(chunks) > 1)
+      else:
+        write_disposition = 'WRITE_APPEND'
+        wait_for_job = False
+
+      chunk_job_name = copy_job_name_base
+      if len(chunks) > 1:
+        chunk_job_name = f"{copy_job_name_base}_{i}"
+
+      _LOGGER.info(
+          "Triggering copy job %s from %s to %s (write_disposition: %s)",
+          chunk_job_name, [str(r) for r in chunk],
+          copy_to_reference,
+          write_disposition)
+
+      job_reference = self.bq_wrapper._insert_copy_job(
+          project_id,
+          chunk_job_name,
+          chunk,
+          copy_to_reference,
+          create_disposition=self.create_disposition,
+          write_disposition=write_disposition,
+          job_labels=self.bq_io_metadata.add_additional_bq_job_labels()
+          if self.bq_io_metadata else None)
+
+      if wait_for_job:
+        self.bq_wrapper.wait_for_bq_job(job_reference, sleep_duration_sec=10)
+
+      self.pending_jobs.append(
+          GlobalWindows.windowed_value((first_destination, job_reference)))
 
   def finish_bundle(self):
     for windowed_value in self.pending_jobs:
@@ -745,7 +746,7 @@ class TriggerLoadJobs(beam.DoFn):
         else:
           try:
             schema = bigquery_tools.table_schema_to_dict(
-                bigquery_tools.BigQueryWrapper().get_table(
+                self.bq_wrapper.get_table(
                     project_id=table_reference.projectId,
                     dataset_id=table_reference.datasetId,
                     table_id=table_reference.tableId).schema)
@@ -856,7 +857,8 @@ class PartitionFiles(beam.DoFn):
       if latest_partition.can_accept(file_size):
         latest_partition.add(file_path, file_size)
       else:
-        partitions.append(latest_partition.files)
+        if latest_partition.files:
+          partitions.append(latest_partition.files)
         latest_partition = PartitionFiles.Partition(
             self.max_partition_size, self.max_files_per_partition)
         latest_partition.add(file_path, file_size)
@@ -1182,12 +1184,13 @@ class BigQueryBatchFileLoads(beam.PTransform):
       # the truncation happens only once. See
       # https://github.com/apache/beam/issues/24535.
       finished_temp_tables_load_job_ids_list_pc = (
-          finished_temp_tables_load_job_ids_pc | beam.MapTuple(
+          finished_temp_tables_load_job_ids_pc
+          | beam.MapTuple(
               lambda destination, job_reference: (
-                  bigquery_tools.parse_table_reference(destination).tableId,
+                  bigquery_tools.get_hashable_destination(destination),
                   (destination, job_reference)))
           | beam.GroupByKey()
-          | beam.MapTuple(lambda tableId, batch: list(batch)))
+          | beam.MapTuple(lambda dest, batch: list(batch)))
     else:
       # Loads can happen in parallel.
       finished_temp_tables_load_job_ids_list_pc = (

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -607,7 +607,7 @@ class TriggerCopyJobs(beam.DoFn):
         copy_to_reference.tableId)
     if full_table_ref not in self._observed_tables:
       write_disposition = self.write_disposition
-      wait_for_job = True
+      wait_for_job = (self.write_disposition != 'WRITE_APPEND')
       self._observed_tables.add(full_table_ref)
       Lineage.sinks().add(
           'bigquery',

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -607,7 +607,7 @@ class TriggerCopyJobs(beam.DoFn):
         copy_to_reference.tableId)
     if full_table_ref not in self._observed_tables:
       write_disposition = self.write_disposition
-      wait_for_job = (self.write_disposition != 'WRITE_APPEND')
+      wait_for_job = (self.write_disposition != BigQueryDisposition.WRITE_APPEND)
       self._observed_tables.add(full_table_ref)
       Lineage.sinks().add(
           'bigquery',

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -607,7 +607,8 @@ class TriggerCopyJobs(beam.DoFn):
         copy_to_reference.tableId)
     if full_table_ref not in self._observed_tables:
       write_disposition = self.write_disposition
-      wait_for_job = (self.write_disposition != BigQueryDisposition.WRITE_APPEND)
+      wait_for_job = (
+          self.write_disposition != BigQueryDisposition.WRITE_APPEND)
       self._observed_tables.add(full_table_ref)
       Lineage.sinks().add(
           'bigquery',

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
@@ -924,11 +924,11 @@ class TestBigQueryFileLoads(_TestCaseWithTempDirCleanUp):
               write_disposition=BigQueryDisposition.WRITE_TRUNCATE))
 
     from apache_beam.io.gcp.internal.clients.bigquery import TableReference
-    mock_insert_copy_job.assert_has_calls(
-        [
-            call(
-                'project1',
-                mock.ANY,
+    mock_insert_copy_job.assert_has_calls([
+        call(
+            'project1',
+            mock.ANY,
+            [
                 TableReference(
                     datasetId='dataset1',
                     projectId='project1',
@@ -936,57 +936,168 @@ class TestBigQueryFileLoads(_TestCaseWithTempDirCleanUp):
                 TableReference(
                     datasetId='dataset1',
                     projectId='project1',
-                    tableId='table1'),
-                create_disposition=None,
-                write_disposition='WRITE_TRUNCATE',
-                job_labels={'step_name': 'bigquerybatchfileloads'}),
-            call(
-                'project1',
-                mock.ANY,
-                TableReference(
-                    datasetId='dataset1',
-                    projectId='project1',
                     tableId='job_name1'),
-                TableReference(
-                    datasetId='dataset1',
-                    projectId='project1',
-                    tableId='table1'),
-                create_disposition=None,
-                write_disposition='WRITE_APPEND',
-                job_labels={'step_name': 'bigquerybatchfileloads'}),
-            call(
-                'project1',
-                mock.ANY,
+            ],
+            TableReference(
+                datasetId='dataset1', projectId='project1', tableId='table1'),
+            create_disposition=None,
+            write_disposition='WRITE_TRUNCATE',
+            job_labels={'step_name': 'bigquerybatchfileloads'}),
+        call(
+            'project1',
+            mock.ANY,
+            [
                 TableReference(
                     datasetId='dataset2',
                     projectId='project1',
                     tableId='job_name1'),
-                TableReference(
-                    datasetId='dataset2',
-                    projectId='project1',
-                    tableId='table1'),
-                create_disposition=None,
-                # Previously this was `WRITE_APPEND`.
-                write_disposition='WRITE_TRUNCATE',
-                job_labels={'step_name': 'bigquerybatchfileloads'}),
-            call(
-                'project1',
-                mock.ANY,
+            ],
+            TableReference(
+                datasetId='dataset2', projectId='project1', tableId='table1'),
+            create_disposition=None,
+            write_disposition='WRITE_TRUNCATE',
+            job_labels={'step_name': 'bigquerybatchfileloads'}),
+        call(
+            'project1',
+            mock.ANY,
+            [
                 TableReference(
                     datasetId='dataset3',
                     projectId='project1',
                     tableId='job_name1'),
-                TableReference(
-                    datasetId='dataset3',
-                    projectId='project1',
-                    tableId='table1'),
-                create_disposition=None,
-                # Previously this was `WRITE_APPEND`.
-                write_disposition='WRITE_TRUNCATE',
-                job_labels={'step_name': 'bigquerybatchfileloads'}),
-        ],
-        any_order=True)
-    self.assertEqual(4, mock_insert_copy_job.call_count)
+            ],
+            TableReference(
+                datasetId='dataset3', projectId='project1', tableId='table1'),
+            create_disposition=None,
+            write_disposition='WRITE_TRUNCATE',
+            job_labels={'step_name': 'bigquerybatchfileloads'}),
+    ],
+                                          any_order=True)
+    self.assertEqual(3, mock_insert_copy_job.call_count)
+
+  @mock.patch(
+      'apache_beam.io.gcp.bigquery_tools.BigQueryWrapper.wait_for_bq_job')
+  @mock.patch(
+      'apache_beam.io.gcp.bigquery_tools.BigQueryWrapper._insert_copy_job')
+  def test_copy_jobs_splitting(
+      self, mock_insert_copy_job, mock_wait_for_bq_job):
+    destination = 'project1:dataset1.table1'
+
+    from apache_beam.io.gcp.bigquery_file_loads import TriggerCopyJobs
+    original_max_sources = TriggerCopyJobs.MAX_SOURCES_PER_COPY_JOB
+    TriggerCopyJobs.MAX_SOURCES_PER_COPY_JOB = 2
+
+    try:
+      job_reference = bigquery_api.JobReference()
+      job_reference.projectId = 'project1'
+      job_reference.jobId = 'job_name1'
+      result_job = mock.Mock()
+      result_job.jobReference = job_reference
+
+      mock_job = mock.Mock()
+      mock_job.status.state = 'DONE'
+      mock_job.status.errorResult = None
+      mock_job.jobReference = job_reference
+
+      bq_client = mock.Mock()
+      bq_client.jobs.Get.return_value = mock_job
+      bq_client.jobs.Insert.return_value = result_job
+      bq_client.tables.Delete.return_value = None
+      mock_insert_copy_job.return_value = job_reference
+      temp_dir = self._new_tempdir()
+
+      with TestPipeline('FnApiRunner') as p:
+        _ = (
+            p
+            | beam.Create([
+                {
+                    'name': 'a'
+                },
+                {
+                    'name': 'b'
+                },
+                {
+                    'name': 'c'
+                },
+                {
+                    'name': 'd'
+                },
+                {
+                    'name': 'e'
+                },
+            ],
+                          reshuffle=False)
+            | bqfl.BigQueryBatchFileLoads(
+                destination,
+                custom_gcs_temp_location=temp_dir,
+                test_client=bq_client,
+                validate=False,
+                temp_file_format=bigquery_tools.FileFormat.JSON,
+                max_file_size=10,
+                max_partition_size=10,
+                max_files_per_partition=1,
+                write_disposition=BigQueryDisposition.WRITE_TRUNCATE))
+
+      self.assertEqual(3, mock_insert_copy_job.call_count)
+
+      from apache_beam.io.gcp.internal.clients.bigquery import TableReference
+      expected_calls = [
+          call(
+              'project1',
+              mock.ANY,
+              [
+                  TableReference(
+                      datasetId='dataset1',
+                      projectId='project1',
+                      tableId='job_name1'),
+                  TableReference(
+                      datasetId='dataset1',
+                      projectId='project1',
+                      tableId='job_name1'),
+              ],
+              TableReference(
+                  datasetId='dataset1', projectId='project1', tableId='table1'),
+              create_disposition=None,
+              write_disposition='WRITE_TRUNCATE',
+              job_labels=mock.ANY),
+          call(
+              'project1',
+              mock.ANY,
+              [
+                  TableReference(
+                      datasetId='dataset1',
+                      projectId='project1',
+                      tableId='job_name1'),
+                  TableReference(
+                      datasetId='dataset1',
+                      projectId='project1',
+                      tableId='job_name1'),
+              ],
+              TableReference(
+                  datasetId='dataset1', projectId='project1', tableId='table1'),
+              create_disposition=None,
+              write_disposition='WRITE_APPEND',
+              job_labels=mock.ANY),
+          call(
+              'project1',
+              mock.ANY,
+              [
+                  TableReference(
+                      datasetId='dataset1',
+                      projectId='project1',
+                      tableId='job_name1'),
+              ],
+              TableReference(
+                  datasetId='dataset1', projectId='project1', tableId='table1'),
+              create_disposition=None,
+              write_disposition='WRITE_APPEND',
+              job_labels=mock.ANY),
+      ]
+      mock_insert_copy_job.assert_has_calls(expected_calls, any_order=True)
+      self.assertEqual(9, mock_wait_for_bq_job.call_count)
+
+    finally:
+      TriggerCopyJobs.MAX_SOURCES_PER_COPY_JOB = original_max_sources
 
   @parameterized.expand([
       param(is_streaming=False, with_auto_sharding=False, compat_version=None),

--- a/sdks/python/apache_beam/io/gcp/bigquery_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_tools.py
@@ -506,16 +506,22 @@ class BigQueryWrapper(object):
     reference = bigquery.JobReference()
     reference.jobId = job_id
     reference.projectId = project_id
+
+    copy_config = bigquery.JobConfigurationTableCopy(
+        destinationTable=to_table_reference,
+        createDisposition=create_disposition,
+        writeDisposition=write_disposition,
+    )
+    if isinstance(from_table_reference, list):
+      copy_config.sourceTables = from_table_reference
+    else:
+      copy_config.sourceTable = from_table_reference
+
     request = bigquery.BigqueryJobsInsertRequest(
         projectId=project_id,
         job=bigquery.Job(
             configuration=bigquery.JobConfiguration(
-                copy=bigquery.JobConfigurationTableCopy(
-                    destinationTable=to_table_reference,
-                    sourceTable=from_table_reference,
-                    createDisposition=create_disposition,
-                    writeDisposition=write_disposition,
-                ),
+                copy=copy_config,
                 labels=_build_job_labels(job_labels),
             ),
             jobReference=reference,


### PR DESCRIPTION
Fixes: https://github.com/apache/beam/issues/38982

 #### Description

This PR optimizes BigQuery copy jobs in the Python SDK's file loads path by utilizing BigQuery's multi-source copy feature. Instead of triggering a separate copy job for each temporary table, we now group 
them and trigger a single copy job with up to 1,200 sources (BigQuery limit).

#### Key Changes

  • Multi-source Copy Support: Updated  `BigQueryWrapper._insert_copy_job`  to accept a list of source tables and construct the API request with  sourceTables  when multiple sources are provided.              
  • Batch Copying: Re-implemented  `TriggerCopyJobs`  to process temporary tables in batch per destination, splitting them into chunks of 1,200 and using multi-source copy.
  • Truncate/Empty Handling: Implemented inline wait for the first chunk copy job when using  `WRITE_TRUNCATE`  or  `WRITE_EMPTY`  with multiple chunks. This ensures the destination table is correctly           
  initialized (truncated/verified empty) before subsequent chunks append data to it.
  • Grouping Key Fix: Fixed a bug in  `_load_data`  where tables with the same name in different datasets would be incorrectly grouped together because the grouping key was only  `tableId `. It now uses the full
  `hashable_destination` .
  • Test Cleanups & Additions:
      • Added  `test_copy_jobs_splitting`  to verify the splitting logic and inline wait logic.
      • Updated existing tests to match the new behavior (fewer copy jobs).
      • Fixed credential warnings in  `TriggerLoadJobs`  during testing by using the correct mocked client wrapper.
      • Fixed  `PartitionFiles`  to avoid generating empty partitions.



------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
