### PR TITLE
Sanitize logging in FanOutStreamingEngineWorkerHarness

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/FanOutStreamingEngineWorkerHarness.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/FanOutStreamingEngineWorkerHarness.java
@@ -303,10 +303,13 @@ public final class FanOutStreamingEngineWorkerHarness implements StreamingWorker
     }
 
     LOG.info(
-        "Consuming new endpoints: {}. previous metadata version: {}, current metadata version: {}, previous endpoint type: {}, current endpoint type: {}",
-        newWindmillEndpoints,
+        "Consuming new endpoints. previous metadata version: {}, current metadata version: {}, "
+            + "windmill endpoint count: {}, global data endpoint count: {}, "
+            + "previous endpoint type: {}, current endpoint type: {}",
         activeMetadataVersion,
         newWindmillEndpoints.version(),
+        newWindmillEndpoints.windmillEndpoints().size(),
+        newWindmillEndpoints.globalDataEndpoints().size(),
         activeMetadataType,
         newWindmillEndpoints.type());
     closeStreamsNotIn(newWindmillEndpoints).join();


### PR DESCRIPTION
Log endpoints count instead of endpoints in FanOutStreamingEngineWorkerHarness.
