### PR TITLE
Improve WithKeys coder inference context

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithKeys.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithKeys.java
@@ -110,27 +110,32 @@ public class WithKeys<K, V> extends PTransform<PCollection<V>, PCollection<KV<K,
 
   @Override
   public PCollection<KV<K, V>> expand(PCollection<V> in) {
+    TypeDescriptor<V> inputType = in.getTypeDescriptor();
+    TypeDescriptor<KV<K, V>> outputType = getOutputTypeDescriptor(inputType);
     PCollection<KV<K, V>> result =
         in.apply(
             "AddKeys",
-            MapElements.via(
-                new SimpleFunction<V, KV<K, V>>() {
-                  @Override
-                  public KV<K, V> apply(V element) {
-                    return KV.of(fn.apply(element), element);
-                  }
-                }));
+            outputType == null
+                ? MapElements.via(
+                    new SimpleFunction<V, KV<K, V>>() {
+                      @Override
+                      public KV<K, V> apply(V element) {
+                        return KV.of(fn.apply(element), element);
+                      }
+                    })
+                : MapElements.into(outputType)
+                    .via(
+                        (SerializableFunction<V, KV<K, V>>)
+                            element -> KV.of(fn.apply(element), element)));
 
     try {
-      Coder<K> keyCoder;
       CoderRegistry coderRegistry = in.getPipeline().getCoderRegistry();
-      if (keyType == null) {
-        keyCoder = coderRegistry.getOutputCoder(fn, in.getCoder());
+      if (outputType == null) {
+        Coder<K> keyCoder = coderRegistry.getOutputCoder(fn, in.getCoder());
+        result.setCoder(KvCoder.of(keyCoder, in.getCoder()));
       } else {
-        keyCoder = coderRegistry.getCoder(keyType);
+        result.setCoder(coderRegistry.getCoder(outputType, checkNotNull(inputType), in.getCoder()));
       }
-      // TODO: Remove when we can set the coder inference context.
-      result.setCoder(KvCoder.of(keyCoder, in.getCoder()));
     } catch (CannotProvideCoderException exc) {
       if (keyType != null) {
         try {
@@ -150,5 +155,13 @@ public class WithKeys<K, V> extends PTransform<PCollection<V>, PCollection<KV<K,
     }
 
     return result;
+  }
+
+  private @Nullable TypeDescriptor<KV<K, V>> getOutputTypeDescriptor(
+      @Nullable TypeDescriptor<V> inputType) {
+    if (keyType == null || inputType == null) {
+      return null;
+    }
+    return TypeDescriptors.kvs(keyType, inputType);
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithKeys.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithKeys.java
@@ -110,6 +110,7 @@ public class WithKeys<K, V> extends PTransform<PCollection<V>, PCollection<KV<K,
 
   @Override
   public PCollection<KV<K, V>> expand(PCollection<V> in) {
+    SerializableFunction<V, K> localFn = fn;
     TypeDescriptor<V> inputType = in.getTypeDescriptor();
     TypeDescriptor<KV<K, V>> outputType = getOutputTypeDescriptor(inputType);
     PCollection<KV<K, V>> result =
@@ -120,13 +121,13 @@ public class WithKeys<K, V> extends PTransform<PCollection<V>, PCollection<KV<K,
                     new SimpleFunction<V, KV<K, V>>() {
                       @Override
                       public KV<K, V> apply(V element) {
-                        return KV.of(fn.apply(element), element);
+                        return KV.of(localFn.apply(element), element);
                       }
                     })
                 : MapElements.into(outputType)
                     .via(
                         (SerializableFunction<V, KV<K, V>>)
-                            element -> KV.of(fn.apply(element), element)));
+                            element -> KV.of(localFn.apply(element), element)));
 
     try {
       CoderRegistry coderRegistry = in.getPipeline().getCoderRegistry();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/WithKeysTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/WithKeysTest.java
@@ -173,6 +173,21 @@ public class WithKeysTest {
   }
 
   @Test
+  public void withKeyTypeShouldSetOutputTypeDescriptorFromInputType() {
+    PCollection<String> values =
+        p.apply(Create.of("1234", "3210").withType(TypeDescriptors.strings()));
+
+    PCollection<KV<Integer, String>> kvs =
+        values.apply(
+            WithKeys.of((SerializableFunction<String, Integer>) Integer::valueOf)
+                .withKeyType(TypeDescriptors.integers()));
+
+    assertEquals(
+        TypeDescriptors.kvs(TypeDescriptors.integers(), TypeDescriptors.strings()),
+        kvs.getTypeDescriptor());
+  }
+
+  @Test
   @Category(NeedsRunner.class)
   public void withLambdaAndNoTypeDescriptorShouldThrow() {
 


### PR DESCRIPTION
Fixes #18571

This updates WithKeys to build the output KV type descriptor from the explicit key type and the input PCollection type when both are available. That lets coder inference use the actual input coder context instead of only inferring the key coder independently.

The existing fallback behavior, including schema coder fallback, is preserved.

Tested:
./gradlew :sdks:java:core:test --tests org.apache.beam.sdk.transforms.WithKeysTest --no-daemon