### PR TITLE
Update pandas version upper bound to support python 3.14

### DIFF
--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -5050,11 +5050,19 @@ class _DeferredStringMethods(frame_base.DeferredBase):
       cat.split(sep=kwargs.get('sep', '|')) for cat in dtype.categories
     ]
 
+    # Find the name pandas uses for the NaN column in get_dummies().
+    # Older pandas versions (<2.3.0) use 'nan', whereas newer versions
+    # use 'NaN'. We dynamically detect it by running a minimal local operation.
+    dummy_nan_col = pd.Series(
+        ['a', None], dtype='category').str.get_dummies().columns.difference(
+            ['a'])[0]
+
     # Adding the nan category because there could be the case that
     # the data includes NaNs, which is not valid to be casted as a Category,
     # but nevertheless would be broadcasted as a column in get_dummies()
     columns = sorted(set().union(*split_cats))
-    columns = columns + ['nan'] if 'nan' not in columns else columns
+    if dummy_nan_col not in columns:
+      columns = columns + [dummy_nan_col]
 
     proxy = pd.DataFrame(columns=columns).astype(int)
 

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -63,6 +63,10 @@ __all__ = [
 # Get major, minor version
 PD_VERSION = tuple(map(int, pd.__version__.split('.')[0:2]))
 
+# Find the name pandas uses for the NaN column in get_dummies().
+# Older pandas versions (<2.3.0) use 'nan', whereas newer versions (>=2.3.0) use 'NaN'.
+_DUMMY_NAN_COLUMN = 'NaN' if PD_VERSION >= (2, 3) else 'nan'
+
 
 def populate_not_implemented(pd_type):
   def wrapper(deferred_type):
@@ -5050,19 +5054,12 @@ class _DeferredStringMethods(frame_base.DeferredBase):
       cat.split(sep=kwargs.get('sep', '|')) for cat in dtype.categories
     ]
 
-    # Find the name pandas uses for the NaN column in get_dummies().
-    # Older pandas versions (<2.3.0) use 'nan', whereas newer versions
-    # use 'NaN'. We dynamically detect it by running a minimal local operation.
-    dummy_nan_col = pd.Series(
-        ['a', None], dtype='category').str.get_dummies().columns.difference(
-            ['a'])[0]
-
     # Adding the nan category because there could be the case that
     # the data includes NaNs, which is not valid to be casted as a Category,
     # but nevertheless would be broadcasted as a column in get_dummies()
     columns = sorted(set().union(*split_cats))
-    if dummy_nan_col not in columns:
-      columns = columns + [dummy_nan_col]
+    if _DUMMY_NAN_COLUMN not in columns:
+      columns = columns + [_DUMMY_NAN_COLUMN]
 
     proxy = pd.DataFrame(columns=columns).astype(int)
 

--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -37,6 +37,8 @@ from apache_beam.runners.interactive.testing.mock_env import isolated_env
 
 # Get major, minor version
 PD_VERSION = tuple(map(int, pd.__version__.split('.')[0:2]))
+# Get major, minor, patch version
+PD_FULL_VERSION = tuple(int(x) for x in re.findall(r'\d+', pd.__version__)[0:3])
 
 GROUPBY_DF = pd.DataFrame({
     'group': ['a' if i % 5 == 0 or i % 3 == 0 else 'b' for i in range(100)],
@@ -1437,7 +1439,7 @@ class DeferredFrameTest(_AbstractFrameTest):
     self._run_test(lambda s: s.unstack(level=0), s)
 
   @unittest.skipIf(
-      sys.version_info >= (3, 12) and PD_VERSION < (2, 3),
+      sys.version_info >= (3, 12) and PD_FULL_VERSION < (2, 3, 4),
       'https://github.com/pandas-dev/pandas/issues/58604')
   def test_unstack_pandas_example3(self):
     index = self._unstack_get_categorical_index()

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -162,7 +162,7 @@ else:
 # https://github.com/pandas-dev/pandas/issues/45725
 # must update the below "docs" and "test" for extras_require
 dataframe_dependency = [
-    'pandas>=1.4.3,!=1.5.0,!=1.5.1,<2.3',
+    'pandas>=1.4.3,!=1.5.0,!=1.5.1,<2.4',
 ]
 
 milvus_dependency = ['pymilvus>=2.5.10,<3.0.0']
@@ -485,7 +485,7 @@ if __name__ == '__main__':
               'docstring-parser>=0.15,<1.0',
               'docutils>=0.18.1',
               'markdown',
-              'pandas<2.3.0',
+              'pandas<2.4.0',
               'openai',
               'virtualenv-clone>=0.5,<1.0',
           ],
@@ -496,7 +496,7 @@ if __name__ == '__main__':
               'jinja2>=3.0,<3.2',
               'joblib>=1.0.1',
               'mock>=1.0.1,<6.0.0',
-              'pandas<2.3.0',
+              'pandas<2.4.0',
               'parameterized>=0.7.1,<0.10.0',
               'pydot>=1.2.0,<2',
               'pyhamcrest>=1.9,!=1.10.0,<3.0.0',


### PR DESCRIPTION
Bump pandas version to 2.3.x to fix segfault on dataframe tests that run on python 3.14.

Stacktrace of segfault from failed tests: https://github.com/apache/beam/actions/runs/27927544557/job/82678205191
```
Current thread 0x00000002066c22c0 (most recent call first):
  File "/Users/runner/work/beam/beam/sdks/python/target/.tox/py314-macos/lib/python3.14/site-packages/pandas/core/arrays/datetimes.py", line 439 in _generate_range
  File "/Users/runner/work/beam/beam/sdks/python/target/.tox/py314-macos/lib/python3.14/site-packages/pandas/core/indexes/datetimes.py", line 1008 in date_range
  File "/Users/runner/work/beam/beam/sdks/python/apache_beam/dataframe/frames_test.py", line 796 in test_loc
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/unittest/case.py", line 615 in _callTestMethod
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/unittest/case.py", line 669 in run
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/unittest/case.py", line 725 in __call__
```


This failure occurs when running the tests with pandas 2.2.3, whereas pandas 2.3.3 is the first version to introduce support for Python 3.14 (https://github.com/pandas-dev/pandas/releases/tag/v2.3.3).

Also see https://github.com/apache/beam/issues/38691#issuecomment-4640425686

---

Notice that a few tests failed (https://github.com/apache/beam/actions/runs/27951859585/job/82710533408?pr=39056) due to a change in pandas 2.3.0+, where null/missing values returned
by `Series.str.get_dummies()` are changed from `'nan'` to `'NaN'`.
- 2.2.x: https://github.com/pandas-dev/pandas/blob/2.2.x/pandas/core/arrays/categorical.py#L2699
- 2.3.x: https://github.com/pandas-dev/pandas/blob/2.3.x/pandas/core/arrays/categorical.py#L2738

In this PR, we also applied a fix in the code so the tests pass on pandas before and after 2.3.0.

Also related to #31238.