### PR TITLE
Fix playground precommit test failure

### DIFF
--- a/.github/workflows/beam_Playground_Precommit.yml
+++ b/.github/workflows/beam_Playground_Precommit.yml
@@ -45,7 +45,7 @@ jobs:
     env:
       DATASTORE_EMULATOR_VERSION: '423.0.0'
       PYTHON_VERSION: '3.10'
-      JAVA_VERSION: '11'
+      JAVA_VERSION: '17'
     steps:
       - uses: actions/checkout@v6
       - name: Setup repository

--- a/playground/backend/internal/setup_tools/life_cycle/life_cycle_setuper.go
+++ b/playground/backend/internal/setup_tools/life_cycle/life_cycle_setuper.go
@@ -196,9 +196,9 @@ func updateJavaLogConfigFile(paths fs_tool.LifeCyclePaths) error {
 func prepareSbtFiles(lc *fs_tool.LifeCycle, pipelineFolder string, workingDir string) (*fs_tool.LifeCycle, error) {
 	cmd := exec.Command(bashCmd, filepath.Join(workingDir, scioProject))
 	cmd.Dir = pipelineFolder
-	output, err := cmd.CombinedOutput()
+	_, err := cmd.Output()
 	if err != nil {
-		return lc, fmt.Errorf("%w: %s", err, string(output))
+		return lc, err
 	}
 
 	sourceFileFolder := filepath.Join(pipelineFolder, scioProjectPath)

--- a/playground/backend/internal/setup_tools/life_cycle/life_cycle_setuper.go
+++ b/playground/backend/internal/setup_tools/life_cycle/life_cycle_setuper.go
@@ -196,9 +196,9 @@ func updateJavaLogConfigFile(paths fs_tool.LifeCyclePaths) error {
 func prepareSbtFiles(lc *fs_tool.LifeCycle, pipelineFolder string, workingDir string) (*fs_tool.LifeCycle, error) {
 	cmd := exec.Command(bashCmd, filepath.Join(workingDir, scioProject))
 	cmd.Dir = pipelineFolder
-	_, err := cmd.Output()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return lc, err
+		return lc, fmt.Errorf("%w: %s", err, string(output))
 	}
 
 	sourceFileFolder := filepath.Join(pipelineFolder, scioProjectPath)

--- a/playground/backend/internal/setup_tools/life_cycle/life_cycle_setuper_test.go
+++ b/playground/backend/internal/setup_tools/life_cycle/life_cycle_setuper_test.go
@@ -16,12 +16,13 @@
 package life_cycle
 
 import (
-	"beam.apache.org/playground/backend/internal/emulators"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"beam.apache.org/playground/backend/internal/emulators"
 
 	"github.com/google/uuid"
 


### PR DESCRIPTION
We are getting the following error when running playground precommit test (https://github.com/apache/beam/actions/runs/27978705305/job/82802995457?pr=39062).

```
Error:  life_cycle_setuper_test.go:344: Setup() error = error during create necessary files for the Scio sdk: exit status 1: [error] sbt 2.x requires JDK 17 or above, but you have JDK 11
            /runner/_work/beam/beam/playground/backend/internal/setup_tools/life_cycle/workingDir/new_scio_project.sh: line 23: scio/build.sbt: No such file or directory
            /runner/_work/beam/beam/playground/backend/internal/setup_tools/life_cycle/workingDir/new_scio_project.sh: line 24: scio/build.sbt: No such file or directory
            /runner/_work/beam/beam/playground/backend/internal/setup_tools/life_cycle/workingDir/new_scio_project.sh: line 25: scio/build.sbt: No such file or directory
            , wantErr false
```

This is due to the recent release of sbt 2.x (https://www.scala-sbt.org/download/), which requires JDK 17.