### PR TITLE
Enable playground tests triggered on cron schedule

### DIFF
--- a/.github/workflows/beam_Playground_Precommit.yml
+++ b/.github/workflows/beam_Playground_Precommit.yml
@@ -34,6 +34,7 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'pull_request_target' ||
+      (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Playground PreCommit'
     name: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
     runs-on: [self-hosted, ubuntu-24.04, main]


### PR DESCRIPTION
The cron schedule for the workflow (https://github.com/apache/beam/actions/workflows/beam_Playground_Precommit.yml) was added in #37518, but the runs have always been skipped since then.

<img width="2574" height="824" alt="image" src="https://github.com/user-attachments/assets/05bfdaf6-bafc-4f9c-bcfa-072952da9ebc" />


