### PR TITLE
Enable precommit yaml xlang test on code merge

### DIFF
--- a/.github/workflows/beam_PreCommit_Yaml_Xlang_Direct.yml
+++ b/.github/workflows/beam_PreCommit_Yaml_Xlang_Direct.yml
@@ -65,6 +65,7 @@ env:
 jobs:
   beam_PreCommit_Yaml_Xlang_Direct:
     if: |
+      github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'pull_request_target' ||
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||


### PR DESCRIPTION
Currently, the **Precommit Yaml Xlang Direct** workflow only runs on PR updates or scheduled cron jobs, and is skipped when a PR is merged into the `master` branch.

<img width="2610" height="210" alt="image" src="https://github.com/user-attachments/assets/4b9fc7cf-5077-477b-a44d-5ab1443498d8" />

To align with other pre-commit tests and to help pinpoint the culprit PR in the event of a test failure, we should enable it on merge/push events, just like the following workflows:
- [`beam_PreCommit_Python.yml`](https://github.com/apache/beam/blob/d031bddfdc90d567c085a26f5425245302cf2106/.github/workflows/beam_PreCommit_Python.yml#L88)
- [`beam_PreCommit_Python_ML.yml`](https://github.com/apache/beam/blob/d031bddfdc90d567c085a26f5425245302cf2106/.github/workflows/beam_PreCommit_Python_ML.yml#L84)
- [`beam_PreCommit_Go.yml`](https://github.com/apache/beam/blob/d031bddfdc90d567c085a26f5425245302cf2106/.github/workflows/beam_PreCommit_Go.yml#L68)



