### PR TITLE
Fix bundle finalizer callbacks for SDF

### DIFF
--- a/.github/trigger_files/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming.json
+++ b/.github/trigger_files/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run!",
-  "modification":  1,
+  "modification":  2,
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -1186,6 +1186,10 @@ public final class StreamingDataflowWorker {
   }
 
   private void onCompleteCommit(CompleteCommit completeCommit) {
+    if (completeCommit.status() == Windmill.CommitStatus.OK
+        && !completeCommit.finalizeIds().isEmpty()) {
+      streamingWorkScheduler.queueAppliedFinalizeIds(completeCommit.finalizeIds());
+    }
     if (completeCommit.status() != Windmill.CommitStatus.OK) {
       readerCache.invalidateReader(
           WindmillComputationKey.create(

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/commits/CompleteCommit.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/commits/CompleteCommit.java
@@ -24,6 +24,7 @@ import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.CommitStatus;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.stub.StreamObserver;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 
 /**
  * A {@link Commit} is marked as complete when it has been attempted to be committed back to
@@ -38,19 +39,24 @@ import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.stub.StreamObserver;
 public abstract class CompleteCommit {
 
   public static CompleteCommit create(Commit commit, CommitStatus commitStatus) {
-    return new AutoValue_CompleteCommit(
+    return create(
         commit.computationId(),
         ShardedKey.create(commit.request().getKey(), commit.request().getShardingKey()),
         WorkId.builder()
             .setWorkToken(commit.request().getWorkToken())
             .setCacheToken(commit.request().getCacheToken())
             .build(),
-        commitStatus);
+        commitStatus,
+        ImmutableList.copyOf(commit.request().getFinalizeIdsList()));
   }
 
   public static CompleteCommit create(
-      String computationId, ShardedKey shardedKey, WorkId workId, CommitStatus status) {
-    return new AutoValue_CompleteCommit(computationId, shardedKey, workId, status);
+      String computationId,
+      ShardedKey shardedKey,
+      WorkId workId,
+      CommitStatus status,
+      ImmutableList<Long> finalizeIds) {
+    return new AutoValue_CompleteCommit(computationId, shardedKey, workId, status, finalizeIds);
   }
 
   public static CompleteCommit forFailedWork(Commit commit) {
@@ -64,4 +70,6 @@ public abstract class CompleteCommit {
   public abstract WorkId workId();
 
   public abstract CommitStatus status();
+
+  public abstract ImmutableList<Long> finalizeIds();
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/commits/StreamingApplianceWorkCommitter.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/commits/StreamingApplianceWorkCommitter.java
@@ -32,6 +32,7 @@ import org.apache.beam.runners.dataflow.worker.streaming.WorkId;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.CommitWorkRequest;
 import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -155,7 +156,8 @@ public final class StreamingApplianceWorkCommitter implements WorkCommitter {
                     .setCacheToken(workRequest.getCacheToken())
                     .setWorkToken(workRequest.getWorkToken())
                     .build(),
-                Windmill.CommitStatus.OK));
+                Windmill.CommitStatus.OK,
+                ImmutableList.copyOf(workRequest.getFinalizeIdsList())));
       }
     }
   }


### PR DESCRIPTION
Fixes: #38710
Successful run: https://github.com/apache/beam/actions/runs/28039649218/job/83002285984?pr=39075

These tests were failing:
SplittableDoFnTest.testBundleFinalizationOccursOnBoundedSplittableDoFn SplittableDoFnTest.testBundleFinalizationOccursOnUnboundedSplittableDoFn 
as they often timed out after 900 seconds with the job still in RUNNING

The tests use a Splittable DoFn that registers a BundleFinalizer callback and keeps checkpointing with resume() until that callback runs. If the callback never runs, the DoFn never outputs, the pipeline never finishes, and the test hits the timeout. The problem was in the Dataflow legacy streaming worker. Bundle-finalizer callbacks were only run when Windmill sent the finalize IDs back on a later work item (via source_state.finalize_ids or applied_finalize_ids in GetWorkResponse). Windmill documents that this is best effort, the commit can succeed but the IDs may never come back.

For Splittable DoFns with many resume() checkpoints, each step does a new commit and waits for the callback on the next work item and on real Dataflow those IDs often dont come back, so callbacks never run and the job hangs.

This got worse after bundle finalizer support was added for the streaming legacy worker: 
#37723 Added bundle finalizer support to the non portable Dataflow worker and streaming ValidatesRunner tests were first excluded because they were still failing. 
#37954 moved applied_finalize_ids handling and reenabled UsesBundleFinalizer tests for legacy streaming ValidatesRunner and hat helped some cases, but SDF tests could still hang on real Dataflow when finalize IDs were not echoed back. 

#38287 in my previous PR I tried to stabilize SplittableDoFnTest on the test side (thread safety, timeouts) but that did not fix the worker behavior.

So when Windmill acknowledges a successful commit (CommitStatus.OK), we now run bundle finalizer callbacks right away, using the finalize_ids from that commit then a successful commit ACK means the state was persisted and it is same idea as applied_finalize_ids, but without relying on a later best effort GetWork.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
