### PR TITLE
[ReduceFnRunner] Fix Prefetches

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/ReduceFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/ReduceFnRunner.java
@@ -1056,7 +1056,8 @@ public class ReduceFnRunner<K, InputT, OutputT, W extends BoundedWindow> {
     paneInfoTracker.prefetchPaneInfo(directContext);
     watermarkHold.prefetchExtract(renamedContext);
     nonEmptyPanes.isEmpty(renamedContext.state()).readLater();
-    reduceFn.prefetchOnTrigger(directContext.state());
+    directContext.state().access(METADATA_TAG).readLater();
+    reduceFn.prefetchOnTrigger(renamedContext.state());
   }
 
   /**


### PR DESCRIPTION
1. Add a prefetch for CombinedMetadata
2. Prefetch ReduceFn using renamedContext instead of directContext. This improves prefetching on merging windows
