### PR TITLE
[mqtt] Fix streaming xlang IT failing the Messaging PostCommit

### DIFF
--- a/.github/trigger_files/beam_PostCommit_Python_Xlang_Messaging_Direct.json
+++ b/.github/trigger_files/beam_PostCommit_Python_Xlang_Messaging_Direct.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run",
-  "modification": 1
+  "modification": 2
 }

--- a/.github/trigger_files/beam_PostCommit_Python_Xlang_Messaging_Direct.json
+++ b/.github/trigger_files/beam_PostCommit_Python_Xlang_Messaging_Direct.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run",
-  "modification": 2
+  "modification": 3
 }

--- a/sdks/python/apache_beam/io/external/xlang_mqttio_it_test.py
+++ b/sdks/python/apache_beam/io/external/xlang_mqttio_it_test.py
@@ -222,10 +222,11 @@ class CrossLanguageMqttIOTest(unittest.TestCase):
     # Prism delegation for pipelines containing external (cross-language)
     # transforms (see runners/direct/direct_runner.py) and falls back to the
     # BundleBasedDirectRunner, which cannot execute an unbounded read.
-    p = TestPipeline(blocking=False)
-    standard_options = p.get_pipeline_options().view_as(StandardOptions)
-    standard_options.streaming = True
-    standard_options.runner = 'PrismRunner'
+    # The runner is instantiated during TestPipeline construction, so it must be
+    # passed to the constructor; the remaining harness-provided options are
+    # preserved and only amended (streaming + LOOPBACK environment) afterwards.
+    p = TestPipeline(runner='PrismRunner', blocking=False)
+    p.get_pipeline_options().view_as(StandardOptions).streaming = True
     p.get_pipeline_options().view_as(
         PortableOptions).environment_type = 'LOOPBACK'
     p.not_use_test_runner_api = True

--- a/sdks/python/apache_beam/io/external/xlang_mqttio_it_test.py
+++ b/sdks/python/apache_beam/io/external/xlang_mqttio_it_test.py
@@ -33,7 +33,7 @@ import unittest
 import pytest
 
 import apache_beam as beam
-from apache_beam.options.pipeline_options import PipelineOptions
+from apache_beam.options.pipeline_options import PortableOptions
 from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.typehints.row_type import RowTypeConstraint
@@ -214,12 +214,20 @@ class CrossLanguageMqttIOTest(unittest.TestCase):
     publisher.start()
     subscriber.start()
 
-    options = PipelineOptions([
-        '--runner=PrismRunner',
-        '--environment_type=LOOPBACK',
-        '--streaming',
-    ])
-    p = TestPipeline(options=options)
+    # MqttIO read is unbounded, so this pipeline runs in streaming mode and
+    # never terminates on its own. Amend the harness-provided pipeline options
+    # rather than discarding them: enable streaming, run non-blocking so the
+    # observe-then-cancel logic below can execute, and target the Prism portable
+    # runner. The latter is required because SwitchingDirectRunner disables its
+    # Prism delegation for pipelines containing external (cross-language)
+    # transforms (see runners/direct/direct_runner.py) and falls back to the
+    # BundleBasedDirectRunner, which cannot execute an unbounded read.
+    p = TestPipeline(blocking=False)
+    standard_options = p.get_pipeline_options().view_as(StandardOptions)
+    standard_options.streaming = True
+    standard_options.runner = 'PrismRunner'
+    p.get_pipeline_options().view_as(
+        PortableOptions).environment_type = 'LOOPBACK'
     p.not_use_test_runner_api = True
     _ = (
         p


### PR DESCRIPTION
Follow-up to #38966. The first `beam_PostCommit_Python_Xlang_Messaging_Direct` runs (the scheduled master run and a trigger-only retrigger in #39086) **failed deterministically** on `CrossLanguageMqttIOTest::test_xlang_mqtt_read_write_streaming` in both py310 and py314.

### Root cause
1. The unbounded read/write pipeline was launched with a **blocking** `p.run()` (`TestPipeline` defaults to `blocking=True`, so `run()` calls `wait_until_finish`). For a never-terminating streaming pipeline this makes the observe-then-cancel logic after `p.run()` dead code, so the job runs unattended until it dies. In CI it died with the worker data plane reporting `Stream removed (Socket closed)` and the state stream `DEADLINE_EXCEEDED`.
2. The test constructed a fresh `PipelineOptions([...])`, discarding the harness-provided test pipeline options, the point @Abacn raised in review (#38966).

### Fix
- **Amend** the harness `TestPipeline` options instead of discarding them: enable streaming and run **non-blocking**, so the subscriber can collect the relayed records and the pipeline is cancelled cleanly.
- **Target the Prism portable runner via the constructor** (`TestPipeline(runner='PrismRunner', ...)`). The runner is instantiated during `TestPipeline`/`Pipeline` construction, so it must be passed to the constructor — setting `StandardOptions.runner` afterwards is a no-op (thanks @gemini-code-assist for catching this). The remaining harness options are still preserved and only amended (streaming + LOOPBACK environment).
- Prism is required here because `SwitchingDirectRunner` disables its Prism delegation for pipelines containing external (cross-language) transforms (`runners/direct/direct_runner.py`) and falls back to `BundleBasedDirectRunner`, which cannot execute an unbounded read. (Re: @Abacn's note that the direct runner now defaults to Prism, that delegation is skipped for xlang pipelines.)

### Validation
- Verified locally end to end: the streaming read/write IT passes on Prism against the messaging expansion-service shadow jar + a mosquitto testcontainer.
- The trigger-file bump runs the PostCommit against this PR (checked out as the PR merge ref) for CI confirmation.

R: @Abacn