### PR TITLE
Disable flaky SDF finalization tests

### DIFF
--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -486,6 +486,9 @@ def validatesRunnerStreamingConfig = [
     'org.apache.beam.sdk.transforms.ParDoLifecycleTest.testTeardownCalledAfterExceptionInSetupStateful',
     'org.apache.beam.sdk.transforms.ParDoLifecycleTest.testTeardownCalledAfterExceptionInStartBundle',
     'org.apache.beam.sdk.transforms.ParDoLifecycleTest.testTeardownCalledAfterExceptionInStartBundleStateful',
+    // Bundle finalizer tests are flaky https://github.com/apache/beam/issues/38710
+    'org.apache.beam.sdk.transforms.SplittableDoFnTest.testBundleFinalizationOccursOnBoundedSplittableDoFn',
+    'org.apache.beam.sdk.transforms.SplittableDoFnTest.testBundleFinalizationOccursOnUnboundedSplittableDoFn',
   ]
 ]
 


### PR DESCRIPTION
@acrites enabled these tests in https://github.com/apache/beam/pull/37723. These tests are flaky, disabling it for now. I'm not sure if the SDF support in non-portable runner is complete. 

@acrites could you take a look when you are back?

R: @Abacn 
cc: @scwhittle 

https://github.com/apache/beam/issues/38710