### PR TITLE
Avoid RequestResponseIO throttler access when throttler is absent

### DIFF
--- a/sdks/python/apache_beam/io/requestresponse.py
+++ b/sdks/python/apache_beam/io/requestresponse.py
@@ -375,7 +375,8 @@ class _CallDoFn(beam.DoFn):
       response = self._repeater.repeat(
           self._caller, request, self._timeout, self._metrics_collector)
       self._metrics_collector.responses.inc(1)
-      self._throttler.throttler.successful_request(req_time * MSEC_TO_SEC)
+      if self._throttler:
+        self._throttler.throttler.successful_request(req_time * MSEC_TO_SEC)
       yield response
     except Exception as e:
       raise e


### PR DESCRIPTION
## Description
- Guard the post-call success throttler metric callback in `_CallDoFn` with the same `_throttler` presence check used for pre-call throttling.
- Prevent crashes when `RequestResponseIO` is used with no throttler / non-default throttling path.
- This addresses the reported `AttributeError: 'NoneType' object has no attribute 'throttler'` on successful calls.

## Testing
Not run (no test execution requested).
