### PR TITLE
Fix OpenSearch username/password env fallback in examples

### DIFF
--- a/examples/notebooks/beam-ml/rag_usecase/opensearch_connector.py
+++ b/examples/notebooks/beam-ml/rag_usecase/opensearch_connector.py
@@ -88,8 +88,8 @@ class InsertDocInOpenSearch(PTransform):
         """
         self.host = host
         self.port = port
-        self.username = username | os.getenv("OPENSEARCH_USERNAME")
-        self.password = password | os.getenv("OPENSEARCH_PASSWORD")
+        self.username = username or os.getenv("OPENSEARCH_USERNAME")
+        self.password = password or os.getenv("OPENSEARCH_PASSWORD")
         self._batch_size = batch_size
 
         if not self.username or not self.password:
@@ -247,8 +247,8 @@ class InsertEmbeddingInOpenSearch(PTransform):
         """
         self.host = host
         self.port = port
-        self.username = username | os.getenv("OPENSEARCH_USERNAME")
-        self.password = password | os.getenv("OPENSEARCH_PASSWORD")
+        self.username = username or os.getenv("OPENSEARCH_USERNAME")
+        self.password = password or os.getenv("OPENSEARCH_PASSWORD")
         self.batch_size = batch_size
         self.embedded_columns = embedded_columns
 

--- a/examples/notebooks/beam-ml/rag_usecase/opensearch_enrichment.py
+++ b/examples/notebooks/beam-ml/rag_usecase/opensearch_enrichment.py
@@ -77,8 +77,8 @@ class OpenSearchEnrichmentHandler(EnrichmentSourceHandler[beam.Row, beam.Row]):
         """
         self.opensearch_host = opensearch_host
         self.opensearch_port = opensearch_port
-        self.username = username | os.getenv("OPENSEARCH_USERNAME")
-        self.password = password | os.getenv("OPENSEARCH_PASSWORD")
+        self.username = username or os.getenv("OPENSEARCH_USERNAME")
+        self.password = password or os.getenv("OPENSEARCH_PASSWORD")
         self.index_name = index_name
         self.vector_field = vector_field
         self.k = k


### PR DESCRIPTION
## Description
- Fix OpenSearch notebook examples that used bitwise OR for credential fallback.
- Replaces `username | os.getenv(...)` and `password | os.getenv(...)` with `or` so fallback to environment variables works correctly.
- Prevents `TypeError` when `username`/`password` are strings or `None` in:
  - `examples/notebooks/beam-ml/rag_usecase/opensearch_connector.py`
  - `examples/notebooks/beam-ml/rag_usecase/opensearch_enrichment.py`

## Testing
Not run (not requested).
