### PR TITLE
Fix typos in ExecutorServiceParallelExecutor.java

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutor.java
@@ -355,10 +355,10 @@ final class ExecutorServiceParallelExecutor
             new IllegalStateException(
                 "Error"
                     + (errors.size() == 1 ? "" : "s")
-                    + " occurred during pipeline execution:\\n"
+                    + " occurred during executor shutdown:\n"
                     + errors.stream()
                         .map(e -> e.getMessage() == null ? e.getClass().getName() : e.getMessage())
-                        .collect(Collectors.joining("\\n- ", "- ", "")));
+                        .collect(Collectors.joining("\n- ", "- ", "")));
         visibleUpdates.failed(exception);
       }
     } finally {


### PR DESCRIPTION
Follow-up with #39096

Same fix has been applied to 2.75 release branch: #39115 