### PR TITLE
Avoid output inside try-catch in Java IO

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -2109,7 +2109,8 @@ public class BigQueryIO {
       boolean hasCurrent = false;
       try {
         if (reader.start()) {
-          current = java.util.Objects.requireNonNull(reader.getCurrent(), "Reader returned null element");
+          current =
+              java.util.Objects.requireNonNull(reader.getCurrent(), "Reader returned null element");
           hasCurrent = true;
         } else {
           return;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -2109,7 +2109,7 @@ public class BigQueryIO {
       boolean hasCurrent = false;
       try {
         if (reader.start()) {
-          current = reader.getCurrent();
+          current = java.util.Objects.requireNonNull(reader.getCurrent(), "Reader returned null element");
           hasCurrent = true;
         } else {
           return;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -2106,9 +2106,11 @@ public class BigQueryIO {
       BoundedSource.BoundedReader<T> reader = streamSource.createReader(options);
 
       T current = null;
+      boolean hasCurrent = false;
       try {
         if (reader.start()) {
           current = reader.getCurrent();
+          hasCurrent = true;
         } else {
           return;
         }
@@ -2121,15 +2123,17 @@ public class BigQueryIO {
             (Exception) e.getCause(),
             "Unable to parse record reading from BigQuery");
       }
-      if (current != null) {
+      if (hasCurrent) {
         outputReceiver.get(rowTag).output(current);
       }
 
       while (true) {
         current = null;
+        hasCurrent = false;
         try {
           if (reader.advance()) {
             current = reader.getCurrent();
+            hasCurrent = true;
           } else {
             return;
           }
@@ -2142,7 +2146,7 @@ public class BigQueryIO {
               (Exception) e.getCause(),
               "Unable to parse record reading from BigQuery");
         }
-        if (current != null) {
+        if (hasCurrent) {
           outputReceiver.get(rowTag).output(current);
         }
       }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -2105,9 +2105,10 @@ public class BigQueryIO {
       // the same order.
       BoundedSource.BoundedReader<T> reader = streamSource.createReader(options);
 
+      T current = null;
       try {
         if (reader.start()) {
-          outputReceiver.get(rowTag).output(reader.getCurrent());
+          current = reader.getCurrent();
         } else {
           return;
         }
@@ -2120,11 +2121,15 @@ public class BigQueryIO {
             (Exception) e.getCause(),
             "Unable to parse record reading from BigQuery");
       }
+      if (current != null) {
+        outputReceiver.get(rowTag).output(current);
+      }
 
       while (true) {
+        current = null;
         try {
           if (reader.advance()) {
-            outputReceiver.get(rowTag).output(reader.getCurrent());
+            current = reader.getCurrent();
           } else {
             return;
           }
@@ -2136,6 +2141,9 @@ public class BigQueryIO {
               AvroCoder.of(record.getSchema()),
               (Exception) e.getCause(),
               "Unable to parse record reading from BigQuery");
+        }
+        if (current != null) {
+          outputReceiver.get(rowTag).output(current);
         }
       }
     }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/healthcare/FhirIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/healthcare/FhirIO.java
@@ -604,7 +604,7 @@ public class FhirIO {
           String resourceId = context.element();
           String resource = null;
           try {
-            resource = fetchResource(this.client, resourceId);
+            resource = java.util.Objects.requireNonNull(fetchResource(this.client, resourceId));
           } catch (Exception e) {
             READ_RESOURCE_ERRORS.inc();
             LOG.warn(

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/healthcare/FhirIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/healthcare/FhirIO.java
@@ -602,8 +602,9 @@ public class FhirIO {
         @ProcessElement
         public void processElement(ProcessContext context) {
           String resourceId = context.element();
+          String resource = null;
           try {
-            context.output(fetchResource(this.client, resourceId));
+            resource = fetchResource(this.client, resourceId);
           } catch (Exception e) {
             READ_RESOURCE_ERRORS.inc();
             LOG.warn(
@@ -611,6 +612,9 @@ public class FhirIO {
                 resourceId,
                 e);
             context.output(FhirIO.Read.DEAD_LETTER, HealthcareIOError.of(resourceId, e));
+          }
+          if (resource != null) {
+            context.output(resource);
           }
         }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/healthcare/HL7v2IO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/healthcare/HL7v2IO.java
@@ -367,7 +367,7 @@ public class HL7v2IO {
           String msgId = context.element();
           HL7v2Message message = null;
           try {
-            message = client.fetchMessage(msgId);
+            message = java.util.Objects.requireNonNull(client.fetchMessage(msgId));
           } catch (Exception e) {
             context.output(HL7v2IO.Read.DEAD_LETTER, HealthcareIOError.of(msgId, e));
           }
@@ -494,7 +494,9 @@ public class HL7v2IO {
           HL7v2ReadResponse response = null;
           try {
             response =
-                HL7v2ReadResponse.of(context.element().getMetadata(), client.fetchMessage(msgId));
+                java.util.Objects.requireNonNull(
+                    HL7v2ReadResponse.of(
+                        context.element().getMetadata(), client.fetchMessage(msgId)));
           } catch (Exception e) {
             HealthcareIOError<HL7v2ReadParameter> error =
                 HealthcareIOError.of(context.element(), e);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/healthcare/HL7v2IO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/healthcare/HL7v2IO.java
@@ -365,10 +365,14 @@ public class HL7v2IO {
         @ProcessElement
         public void processElement(ProcessContext context) {
           String msgId = context.element();
+          HL7v2Message message = null;
           try {
-            context.output(client.fetchMessage(msgId));
+            message = client.fetchMessage(msgId);
           } catch (Exception e) {
             context.output(HL7v2IO.Read.DEAD_LETTER, HealthcareIOError.of(msgId, e));
+          }
+          if (message != null) {
+            context.output(message);
           }
         }
       }
@@ -487,14 +491,17 @@ public class HL7v2IO {
         @ProcessElement
         public void processElement(ProcessContext context) {
           String msgId = context.element().getHl7v2MessageId();
+          HL7v2ReadResponse response = null;
           try {
-            HL7v2ReadResponse response =
+            response =
                 HL7v2ReadResponse.of(context.element().getMetadata(), client.fetchMessage(msgId));
-            context.output(response);
           } catch (Exception e) {
             HealthcareIOError<HL7v2ReadParameter> error =
                 HealthcareIOError.of(context.element(), e);
             context.output(HL7v2IO.HL7v2Read.DEAD_LETTER, error);
+          }
+          if (response != null) {
+            context.output(response);
           }
         }
       }


### PR DESCRIPTION
Fixes #39101

This separates successful Beam output emission from try/catch blocks that handle local read/fetch/parse failures. This prevents errors from downstream fused transforms from being accidentally caught and reported as source-side failures.

Changes:

* Move HL7v2 successful outputs outside the fetch try/catch blocks.
* Move FHIR successful output outside the fetch try/catch block.
* Move BigQuery row output outside the ParseException try/catch while preserving existing bad record routing.
* Leave already-safe patterns unchanged.

Tests:

* git diff --check
* ./gradlew :sdks:java:io:google-cloud-platform:compileJava --no-daemon --console=plain

Targeted tests attempted:

* ./gradlew :sdks:java:io:google-cloud-platform:test --tests org.apache.beam.sdk.io.gcp.healthcare.HL7v2IOTest --no-daemon --console=plain

  * Failed locally due to Google DefaultCredentialsProvider IOException.
* ./gradlew :sdks:java:io:google-cloud-platform:test --tests org.apache.beam.sdk.io.gcp.healthcare.FhirIOTest --no-daemon --console=plain

  * Failed locally due to Google DefaultCredentialsProvider IOException and one local assertion failure.
* ./gradlew :sdks:java:io:google-cloud-platform:test --tests org.apache.beam.sdk.io.gcp.bigquery.BigQueryIOReadTest --no-daemon --console=plain

  * 31/33 passed; 2 failed locally with Windows FileSystemException.
