### PR TITLE
Fix flaky GcsIOIntegrationTest and handle GCS bucket creation race conditions

### DIFF
--- a/.github/trigger_files/beam_PostCommit_Python.json
+++ b/.github/trigger_files/beam_PostCommit_Python.json
@@ -1,5 +1,5 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run.",
   "pr": "37345",
-  "modification": 52
+  "modification": 53
 }

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -147,10 +147,7 @@ def get_or_create_default_gcs_bucket(options):
     try:
       return gcs.create_bucket(bucket_name, project, location=region)
     except Conflict:
-      try:
-        bucket = gcs.get_bucket(bucket_name)
-      except Exception:
-        raise
+      bucket = gcs.get_bucket(bucket_name)
       if bucket:
         _validate_bucket_project(
             bucket,

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -35,6 +35,7 @@ import time
 from typing import Optional
 from typing import Union
 
+from google.api_core.exceptions import Conflict
 from google.api_core.exceptions import RetryError
 from google.cloud import storage
 from google.cloud.exceptions import NotFound
@@ -143,7 +144,20 @@ def get_or_create_default_gcs_bucket(options):
         'Creating default GCS bucket for project %s: gs://%s',
         project,
         bucket_name)
-    return gcs.create_bucket(bucket_name, project, location=region)
+    try:
+      return gcs.create_bucket(bucket_name, project, location=region)
+    except Conflict:
+      try:
+        bucket = gcs.get_bucket(bucket_name)
+      except Exception:
+        raise
+      if bucket:
+        _validate_bucket_project(
+            bucket,
+            project,
+            credentials=getattr(gcs.client, '_credentials', None))
+        return bucket
+      raise
 
 
 def create_storage_client(pipeline_options, use_credentials=True):

--- a/sdks/python/apache_beam/io/gcp/gcsio_integration_test.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio_integration_test.py
@@ -33,6 +33,7 @@ import time
 import unittest
 import uuid
 import zlib
+from hashlib import blake2b
 
 import mock
 import pytest
@@ -206,9 +207,6 @@ class GcsIOIntegrationTest(unittest.TestCase):
     # overwrite kms option here, because get_or_create_default_gcs_bucket()
     # requires this option unset.
     google_cloud_options.dataflow_kms_key = None
-
-    from hashlib import blake2b
-    import uuid
 
     # Add a unique uuid and the parameterized test options to the bucket name
     # to avoid collisions when multiple parameterized instances run in parallel

--- a/sdks/python/apache_beam/io/gcp/gcsio_integration_test.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio_integration_test.py
@@ -207,19 +207,20 @@ class GcsIOIntegrationTest(unittest.TestCase):
     # requires this option unset.
     google_cloud_options.dataflow_kms_key = None
 
-    import random
     from hashlib import blake2b
+    import uuid
 
-    # Add a random number to avoid collision if multiple test instances
-    # are run at the same time. To avoid too many dangling buckets if bucket
-    # removal fails, we limit the max number of possible bucket names in this
-    # test to 1000.
-    overridden_bucket_name = 'gcsio-it-%d-%s-%s-%d' % (
-        random.randint(0, 999),
+    # Add a unique uuid and the parameterized test options to the bucket name
+    # to avoid collisions when multiple parameterized instances run in parallel
+    # or concurrent CI jobs run at the same time.
+    overridden_bucket_name = 'gcsio-it-%s-%s-%s-%d-%s-%s' % (
+        uuid.uuid4().hex[:8],
         google_cloud_options.region,
         blake2b(google_cloud_options.project.encode('utf8'),
                 digest_size=4).hexdigest(),
-        int(time.time()))
+        int(time.time()),
+        str(self.no_gcsio_throttling_counter).lower(),
+        str(self.enable_gcsio_blob_generation).lower())
 
     mock_default_gcs_bucket_name.return_value = overridden_bucket_name
 

--- a/sdks/python/apache_beam/io/gcp/gcsio_integration_test.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio_integration_test.py
@@ -212,13 +212,13 @@ class GcsIOIntegrationTest(unittest.TestCase):
     # to avoid collisions when multiple parameterized instances run in parallel
     # or concurrent CI jobs run at the same time.
     overridden_bucket_name = 'gcsio-it-%s-%s-%s-%d-%s-%s' % (
-        uuid.uuid4().hex[:8],
+        uuid.uuid4().hex[:6],
         google_cloud_options.region,
         blake2b(google_cloud_options.project.encode('utf8'),
-                digest_size=4).hexdigest(),
+                digest_size=2).hexdigest(),
         int(time.time()),
-        str(self.no_gcsio_throttling_counter).lower(),
-        str(self.enable_gcsio_blob_generation).lower())
+        '1' if self.no_gcsio_throttling_counter else '0',
+        '1' if self.enable_gcsio_blob_generation else '0')
 
     mock_default_gcs_bucket_name.return_value = overridden_bucket_name
 

--- a/sdks/python/apache_beam/io/gcp/gcsio_test.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio_test.py
@@ -487,6 +487,46 @@ class TestGCSIO(unittest.TestCase):
     self.assertEqual(bucket, mock_bucket)
     mock_crm_class.assert_not_called()
 
+  @mock.patch('google.cloud.resourcemanager_v3.ProjectsClient')
+  @mock.patch('apache_beam.io.gcp.gcsio.GcsIO')
+  def test_get_or_create_default_gcs_bucket_conflict(
+      self, mock_gcsio_class, mock_crm_class):
+    mock_gcsio = mock_gcsio_class.return_value
+    mock_bucket = mock.Mock()
+    mock_bucket.project_number = 123456789
+    mock_gcsio.get_bucket.side_effect = [None, mock_bucket]
+
+    from google.api_core.exceptions import Conflict
+    mock_gcsio.create_bucket.side_effect = Conflict("Already owned by you")
+
+    mock_crm_client = mock_crm_class.return_value
+    mock_project_info = mock.Mock()
+    mock_project_info.name = 'projects/123456789'
+    mock_crm_client.get_project.return_value = mock_project_info
+
+    options = SampleOptions(DEFAULT_GCP_PROJECT, 'us-central1')
+    bucket = gcsio.get_or_create_default_gcs_bucket(options)
+
+    self.assertEqual(bucket, mock_bucket)
+    self.assertEqual(mock_gcsio.get_bucket.call_count, 2)
+    mock_gcsio.create_bucket.assert_called_once()
+
+  @mock.patch('google.cloud.resourcemanager_v3.ProjectsClient')
+  @mock.patch('apache_beam.io.gcp.gcsio.GcsIO')
+  def test_get_or_create_default_gcs_bucket_conflict_reraise(
+      self, mock_gcsio_class, mock_crm_class):
+    mock_gcsio = mock_gcsio_class.return_value
+    mock_gcsio.get_bucket.side_effect = [None, None]
+
+    from google.api_core.exceptions import Conflict
+    mock_gcsio.create_bucket.side_effect = Conflict("Bucket name unavailable")
+
+    options = SampleOptions(DEFAULT_GCP_PROJECT, 'us-central1')
+    with self.assertRaises(Conflict):
+      gcsio.get_or_create_default_gcs_bucket(options)
+
+    self.assertEqual(mock_gcsio.get_bucket.call_count, 2)
+
   def test_exists(self):
     file_name = 'gs://gcsio-test/dummy_file'
     file_size = 1234


### PR DESCRIPTION
A flaky test example:
https://github.com/apache/beam/actions/runs/28256309850/job/83720139509

```
______________ GcsIOIntegrationTest_1.test_create_default_bucket _______________
[gw2] linux -- Python 3.11.15 /runner/_work/beam/beam/build/gradleenv/2050596099/bin/python3

self = <apache_beam.io.gcp.gcsio_integration_test.GcsIOIntegrationTest_1 testMethod=test_create_default_bucket>
mock_default_gcs_bucket_name = <MagicMock name='default_gcs_bucket_name' id='134725042979024'>

...
    
>     bucket = gcsio.get_or_create_default_gcs_bucket(google_cloud_options)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

apache_beam/io/gcp/gcsio_integration_test.py:237: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
apache_beam/io/gcp/gcsio.py:146: in get_or_create_default_gcs_bucket
    return gcs.create_bucket(bucket_name, project, location=region)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
apache_beam/io/gcp/gcsio.py:245: in create_bucket
    bucket = self.client.create_bucket(
../../build/gradleenv/2050596099/lib/python3.11/site-packages/google/cloud/storage/client.py:1211: in create_bucket
    api_response = self._post_resource(
../../build/gradleenv/2050596099/lib/python3.11/site-packages/google/cloud/storage/client.py:790: in _post_resource
    return self._connection.api_request(
../../build/gradleenv/2050596099/lib/python3.11/site-packages/google/cloud/storage/_http.py:123: in api_request
    return call()
           ^^^^^^
../../build/gradleenv/2050596099/lib/python3.11/site-packages/google/api_core/retry/retry_unary.py:294: in retry_wrapped_func
    return retry_target(
../../build/gradleenv/2050596099/lib/python3.11/site-packages/google/api_core/retry/retry_unary.py:156: in retry_target
    next_sleep = _retry_error_helper(
../../build/gradleenv/2050596099/lib/python3.11/site-packages/google/api_core/retry/retry_base.py:216: in _retry_error_helper
    raise final_exc from source_exc
../../build/gradleenv/2050596099/lib/python3.11/site-packages/google/api_core/retry/retry_unary.py:147: in retry_target
            path=path,
            query_params=query_params,
            api_base_url=api_base_url,
            api_version=api_version,
        )
    
        # Making the executive decision that any dictionary
        # data will be sent properly as JSON.
        if data and isinstance(data, dict):
            data = json.dumps(data)
            content_type = "application/json"
    
        response = self._make_request(
            method=method,
            url=url,
            data=data,
            content_type=content_type,
            headers=headers,
            target_object=_target_object,
            timeout=timeout,
            extra_api_info=extra_api_info,
        )
    
        if not 200 <= response.status_code < 300:
>           raise exceptions.from_http_response(response)
E           google.api_core.exceptions.Conflict: 409 POST https://storage.googleapis.com/storage/v1/b?project=apache-beam-testing&prettyPrint=false: Your previous request to create the named bucket succeeded and you already own it.

../../build/gradleenv/2050596099/lib/python3.11/site-packages/google/cloud/_http/__init__.py:494: Conflict
```

In this PR, we made the following changes:
* Modify get_or_create_default_gcs_bucket in gcsio.py to catch Conflict (409) exceptions, resolving to the existing bucket on concurrent creation requests.
* Add unit tests for default bucket creation conflict handling in gcsio_test.py.
* Modify test_create_default_bucket in gcsio_integration_test.py to generate unique bucket names with a UUID prefix and test parameters to eliminate parallel test thread collisions.