### PR TITLE
Implement GroupByKey translation for Kafka Streams runner (#18479)

### DIFF
--- a/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/GroupByKeyProcessor.java
+++ b/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/GroupByKeyProcessor.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.kafka.streams.translation;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.ListCoder;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.WindowedValue;
+import org.apache.beam.sdk.values.WindowedValues;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.KeyValueStore;
+
+/** Processor for GroupByKey. */
+class GroupByKeyProcessor
+    implements Processor<
+        byte[],
+        KStreamsPayload<KV<Object, Object>>,
+        byte[],
+        KStreamsPayload<KV<Object, Iterable<Object>>>> {
+
+  private final String stateStoreName;
+  private final String transformId;
+  private final Coder<List<WindowedValue<KV<Object, Object>>>> listCoder;
+
+  private ProcessorContext<byte[], KStreamsPayload<KV<Object, Iterable<Object>>>> context;
+  private KeyValueStore<byte[], byte[]> stateStore;
+
+  GroupByKeyProcessor(
+      String stateStoreName,
+      String transformId,
+      Coder<WindowedValue<KV<Object, Object>>> inputCoder) {
+    this.stateStoreName = stateStoreName;
+    this.transformId = transformId;
+    this.listCoder = ListCoder.of(inputCoder);
+  }
+
+  @Override
+  public void init(
+      ProcessorContext<byte[], KStreamsPayload<KV<Object, Iterable<Object>>>> context) {
+    this.context = context;
+    this.stateStore = context.getStateStore(stateStoreName);
+  }
+
+  @Override
+  public void process(Record<byte[], KStreamsPayload<KV<Object, Object>>> record) {
+    KStreamsPayload<KV<Object, Object>> payload = record.value();
+
+    if (payload.isData()) {
+      byte[] keyBytes = record.key();
+      byte[] existingBytes = stateStore.get(keyBytes);
+      List<WindowedValue<KV<Object, Object>>> list;
+      if (existingBytes == null) {
+        list = new ArrayList<>();
+      } else {
+        try {
+          list = listCoder.decode(new ByteArrayInputStream(existingBytes));
+        } catch (IOException e) {
+          throw new RuntimeException("Failed to decode buffered GroupByKey state", e);
+        }
+      }
+      list.add(payload.getData());
+      ByteArrayOutputStream os = new ByteArrayOutputStream();
+      try {
+        listCoder.encode(list, os);
+      } catch (IOException e) {
+        throw new RuntimeException("Failed to encode buffered GroupByKey state", e);
+      }
+      stateStore.put(keyBytes, os.toByteArray());
+    } else {
+      WatermarkPayload watermark = payload.asWatermark();
+      if (watermark.getWatermarkMillis() == BoundedWindow.TIMESTAMP_MAX_VALUE.getMillis()) {
+        try (KeyValueIterator<byte[], byte[]> iterator = stateStore.all()) {
+          while (iterator.hasNext()) {
+            org.apache.kafka.streams.KeyValue<byte[], byte[]> kv = iterator.next();
+            List<WindowedValue<KV<Object, Object>>> buffered;
+            try {
+              buffered = listCoder.decode(new ByteArrayInputStream(kv.value));
+            } catch (IOException e) {
+              throw new RuntimeException("Failed to decode buffered GroupByKey state on emit", e);
+            }
+            if (!buffered.isEmpty()) {
+              List<Object> values = new ArrayList<>();
+              for (WindowedValue<KV<Object, Object>> wv : buffered) {
+                values.add(wv.getValue().getValue());
+              }
+              Object key = buffered.get(0).getValue().getKey();
+              WindowedValue<KV<Object, Iterable<Object>>> outWv =
+                  WindowedValues.valueInGlobalWindow(KV.of(key, values));
+              context.forward(
+                  new Record<>(kv.key, KStreamsPayload.data(outWv), record.timestamp()));
+            }
+          }
+        }
+        // Since we fired everything for the global window, we can optionally clear the store here.
+        // But the pipeline is finishing.
+
+        // Forward the watermark downstream
+        context.forward(
+            new Record<>(
+                record.key(),
+                KStreamsPayload.watermark(
+                    watermark.getWatermarkMillis(),
+                    watermark.getSourcePartition(),
+                    watermark.getTotalSourcePartitions()),
+                record.timestamp()));
+      }
+    }
+  }
+}

--- a/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/GroupByKeyProcessor.java
+++ b/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/GroupByKeyProcessor.java
@@ -44,7 +44,7 @@ class GroupByKeyProcessor
 
   private final String stateStoreName;
   private final String transformId;
-  private final Coder<List<WindowedValue<KV<Object, Object>>>> listCoder;
+  private final Coder<WindowedValue<KV<Object, Object>>> inputCoder;
 
   private ProcessorContext<byte[], KStreamsPayload<KV<Object, Iterable<Object>>>> context;
   private KeyValueStore<byte[], byte[]> stateStore;
@@ -55,7 +55,7 @@ class GroupByKeyProcessor
       Coder<WindowedValue<KV<Object, Object>>> inputCoder) {
     this.stateStoreName = stateStoreName;
     this.transformId = transformId;
-    this.listCoder = ListCoder.of(inputCoder);
+    this.inputCoder = inputCoder;
   }
 
   @Override

--- a/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/GroupByKeyTranslator.java
+++ b/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/GroupByKeyTranslator.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.kafka.streams.translation;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.util.WindowedValue.WindowedValueCoder;
+import org.apache.beam.sdk.util.construction.RehydratedComponents;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.WindowedValue;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.state.Stores;
+
+/** Translates the {@code beam:transform:group_by_key:v1} URN. */
+class GroupByKeyTranslator implements PTransformTranslator {
+
+  static final String REPARTITION_TOPIC_SUFFIX = "-repartition";
+  static final String SINK_SUFFIX = "-sink";
+  static final String SOURCE_SUFFIX = "-source";
+  static final String EXTRACTOR_SUFFIX = "-extractor";
+  static final String STATE_STORE_SUFFIX = "-state";
+
+  @Override
+  public void translate(
+      String transformId, RunnerApi.Pipeline pipeline, KafkaStreamsTranslationContext context) {
+    RunnerApi.PTransform transform = pipeline.getComponents().getTransformsOrThrow(transformId);
+    String inputPCollectionId = Iterables.getOnlyElement(transform.getInputsMap().values());
+    String outputPCollectionId = Iterables.getOnlyElement(transform.getOutputsMap().values());
+    String parentProcessor = context.getProcessorNameForPCollection(inputPCollectionId);
+
+    RehydratedComponents components = RehydratedComponents.forComponents(pipeline.getComponents());
+    RunnerApi.PCollection inputPColl =
+        pipeline.getComponents().getPcollectionsOrThrow(inputPCollectionId);
+
+    Coder<?> inputCoder;
+    try {
+      inputCoder = components.getCoder(inputPColl.getCoderId());
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Failed to rehydrate coder for " + inputPCollectionId, e);
+    }
+
+    // Input coder should be WindowedValueCoder<KV<K, V>>
+    @SuppressWarnings("unchecked")
+    Coder<WindowedValue<KV<Object, Object>>> typedInputCoder =
+        (Coder<WindowedValue<KV<Object, Object>>>) inputCoder;
+
+    // We extract the KeyCoder to serialize the Kafka key
+    @SuppressWarnings("unchecked")
+    WindowedValueCoder<KV<Object, Object>> wvCoder =
+        (WindowedValueCoder<KV<Object, Object>>) inputCoder;
+    @SuppressWarnings("unchecked")
+    KvCoder<Object, Object> kvCoder = (KvCoder<Object, Object>) wvCoder.getValueCoder();
+    Coder<Object> keyCoder = kvCoder.getKeyCoder();
+
+    KStreamsPayloadSerde<KV<Object, Object>> payloadSerde =
+        new KStreamsPayloadSerde<>(typedInputCoder);
+
+    Topology topology = context.getTopology();
+    String repartitionTopic = transformId + REPARTITION_TOPIC_SUFFIX;
+    String extractorNode = transformId + EXTRACTOR_SUFFIX;
+    String sinkNode = transformId + SINK_SUFFIX;
+    String sourceNode = transformId + SOURCE_SUFFIX;
+    String stateStoreName = transformId + STATE_STORE_SUFFIX;
+
+    // 1. Extractor processor: parses KStreamsPayload, extracts the key and forwards with proper
+    // Kafka key
+    topology.addProcessor(
+        extractorNode, () -> new KeyExtractorProcessor(keyCoder), parentProcessor);
+
+    // 2. Sink node: routes KStreamsPayload to the internal repartition topic
+    topology.addSink(
+        sinkNode,
+        repartitionTopic,
+        Serdes.ByteArray().serializer(),
+        payloadSerde.serializer(),
+        extractorNode);
+
+    // 3. Source node: reads from internal repartition topic
+    topology.addSource(
+        sourceNode,
+        Serdes.ByteArray().deserializer(),
+        payloadSerde.deserializer(),
+        repartitionTopic);
+
+    // 4. GroupByKey processor: Buffers values and emits grouped elements
+    topology.addProcessor(
+        transformId,
+        () -> new GroupByKeyProcessor(stateStoreName, transformId, typedInputCoder),
+        sourceNode);
+
+    // 5. State Store: Buffers elements per key
+    topology.addStateStore(
+        Stores.keyValueStoreBuilder(
+            Stores.persistentKeyValueStore(stateStoreName), Serdes.ByteArray(), Serdes.ByteArray()),
+        transformId);
+
+    context.registerPCollectionProducer(outputPCollectionId, transformId);
+  }
+
+  /**
+   * Processor that extracts the Beam key from the data payload and assigns it as the Kafka record
+   * key.
+   */
+  private static class KeyExtractorProcessor
+      implements Processor<
+          byte[],
+          KStreamsPayload<KV<Object, Object>>,
+          byte[],
+          KStreamsPayload<KV<Object, Object>>> {
+
+    private final Coder<Object> keyCoder;
+    private ProcessorContext<byte[], KStreamsPayload<KV<Object, Object>>> context;
+
+    KeyExtractorProcessor(Coder<Object> keyCoder) {
+      this.keyCoder = keyCoder;
+    }
+
+    @Override
+    public void init(ProcessorContext<byte[], KStreamsPayload<KV<Object, Object>>> context) {
+      this.context = context;
+    }
+
+    @Override
+    public void process(Record<byte[], KStreamsPayload<KV<Object, Object>>> record) {
+      KStreamsPayload<KV<Object, Object>> payload = record.value();
+      if (payload.isData()) {
+        try {
+          Object key = payload.getData().getValue().getKey();
+          ByteArrayOutputStream os = new ByteArrayOutputStream();
+          keyCoder.encode(key, os);
+          context.forward(record.withKey(os.toByteArray()));
+        } catch (IOException e) {
+          throw new RuntimeException("Failed to serialize Beam key for repartitioning", e);
+        }
+      } else {
+        // Watermark payload doesn't have a key, just forward with existing key
+        context.forward(record);
+      }
+    }
+  }
+}

--- a/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/KafkaStreamsPipelineTranslator.java
+++ b/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/KafkaStreamsPipelineTranslator.java
@@ -51,6 +51,7 @@ public class KafkaStreamsPipelineTranslator {
         ImmutableMap.<String, PTransformTranslator>builder()
             .put(PTransformTranslation.IMPULSE_TRANSFORM_URN, new ImpulseTranslator())
             .put(PTransformTranslation.REDISTRIBUTE_ARBITRARILY_URN, new RedistributeTranslator())
+            .put(PTransformTranslation.GROUP_BY_KEY_URN, new GroupByKeyTranslator())
             .put(ExecutableStage.URN, new ExecutableStageTranslator())
             .build());
   }
@@ -134,7 +135,9 @@ public class KafkaStreamsPipelineTranslator {
   @AutoService(NativeTransforms.IsNativeTransform.class)
   public static class IsKafkaStreamsNativeTransform implements NativeTransforms.IsNativeTransform {
     private static final Set<String> URNS =
-        ImmutableSet.of(PTransformTranslation.REDISTRIBUTE_ARBITRARILY_URN);
+        ImmutableSet.of(
+            PTransformTranslation.REDISTRIBUTE_ARBITRARILY_URN,
+            PTransformTranslation.GROUP_BY_KEY_URN);
 
     @Override
     public boolean test(RunnerApi.PTransform pTransform) {

--- a/runners/kafka-streams/src/test/java/org/apache/beam/runners/kafka/streams/translation/GroupByKeyTranslatorTest.java
+++ b/runners/kafka-streams/src/test/java/org/apache/beam/runners/kafka/streams/translation/GroupByKeyTranslatorTest.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.kafka.streams.translation;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.GroupByKey;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.util.construction.PipelineTranslation;
+import org.apache.beam.sdk.util.construction.RehydratedComponents;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.WindowedValue;
+import org.apache.beam.sdk.values.WindowedValues;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+import org.apache.kafka.streams.processor.api.Record;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.Test;
+
+/** Tests for {@link GroupByKeyTranslator}. */
+public class GroupByKeyTranslatorTest {
+
+  @Test
+  public void groupByKeyBuffersAndFiresAtTerminalWatermark() throws Exception {
+    KafkaStreamsTranslationContext context = KafkaStreamsPipelineTranslatorTest.newContext();
+
+    Pipeline sdkPipeline = Pipeline.create(PipelineOptionsFactory.create());
+    sdkPipeline
+        .apply("create", Create.empty(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+        .apply("gbk", GroupByKey.create());
+
+    RunnerApi.Pipeline pipeline = PipelineTranslation.toProto(sdkPipeline);
+    String gbkTransformId = null;
+    for (String id : pipeline.getComponents().getTransformsMap().keySet()) {
+      if (pipeline
+          .getComponents()
+          .getTransformsOrThrow(id)
+          .getSpec()
+          .getUrn()
+          .equals("beam:transform:group_by_key:v1")) {
+        gbkTransformId = id;
+      }
+    }
+
+    RunnerApi.PTransform gbkTransform =
+        pipeline.getComponents().getTransformsOrThrow(gbkTransformId);
+    String inputPCollId = Iterables.getOnlyElement(gbkTransform.getInputsMap().values());
+    context.registerPCollectionProducer(inputPCollId, "mock-parent");
+
+    RehydratedComponents components = RehydratedComponents.forComponents(pipeline.getComponents());
+    Coder<?> rawInputCoder =
+        components.getCoder(
+            pipeline.getComponents().getPcollectionsOrThrow(inputPCollId).getCoderId());
+    @SuppressWarnings("unchecked")
+    Coder<WindowedValue<KV<String, String>>> inputCoder =
+        (Coder<WindowedValue<KV<String, String>>>) rawInputCoder;
+    KStreamsPayloadSerde<KV<String, String>> payloadSerde = new KStreamsPayloadSerde<>(inputCoder);
+
+    Topology topology = context.getTopology();
+    topology.addSource(
+        "mock-source",
+        Serdes.ByteArray().deserializer(),
+        payloadSerde.deserializer(),
+        "mock-topic");
+    // Just a pass-through to satisfy the parent reference
+    topology.addProcessor("mock-parent", PassThroughProcessor::new, "mock-source");
+
+    new GroupByKeyTranslator().translate(gbkTransformId, pipeline, context);
+
+    CapturingProcessor capture = new CapturingProcessor();
+    topology.addProcessor("capture", capture, gbkTransformId);
+
+    try (TopologyTestDriver driver = new TopologyTestDriver(topology, baseProps())) {
+      TestInputTopic<byte[], KStreamsPayload<KV<String, String>>> inputTopic =
+          driver.createInputTopic(
+              "mock-topic", Serdes.ByteArray().serializer(), payloadSerde.serializer());
+
+      // Send elements
+      inputTopic.pipeInput(
+          new byte[0], KStreamsPayload.data(WindowedValues.valueInGlobalWindow(KV.of("k1", "v1"))));
+      inputTopic.pipeInput(
+          new byte[0], KStreamsPayload.data(WindowedValues.valueInGlobalWindow(KV.of("k1", "v2"))));
+      inputTopic.pipeInput(
+          new byte[0], KStreamsPayload.data(WindowedValues.valueInGlobalWindow(KV.of("k2", "v3"))));
+
+      // No output yet
+      assertThat(capture.received.size(), is(0));
+
+      // Send terminal watermark
+      inputTopic.pipeInput(
+          new byte[0],
+          KStreamsPayload.watermark(BoundedWindow.TIMESTAMP_MAX_VALUE.getMillis(), 0, 1));
+    }
+
+    // Now it should have fired. It fires 1 for each key, plus the watermark
+    assertThat(
+        capture.received.size(),
+        is(3)); // 2 data + 1 watermark (wait, maybe order is deterministic?)
+
+    int dataCount = 0;
+    int watermarkCount = 0;
+    for (KStreamsPayload<?> payload : capture.received) {
+      if (payload.isData()) {
+        dataCount++;
+        KV<?, ?> kv = (KV<?, ?>) payload.getData().getValue();
+        Iterable<?> iter = (Iterable<?>) kv.getValue();
+        if ("k1".equals(kv.getKey())) {
+          assertThat(Iterables.size(iter), is(2));
+        } else if ("k2".equals(kv.getKey())) {
+          assertThat(Iterables.size(iter), is(1));
+        }
+      } else {
+        watermarkCount++;
+        assertThat(
+            payload.asWatermark().getWatermarkMillis(),
+            is(BoundedWindow.TIMESTAMP_MAX_VALUE.getMillis()));
+      }
+    }
+    assertThat(dataCount, is(2));
+    assertThat(watermarkCount, is(1));
+  }
+
+  private static Properties baseProps() {
+    Properties props = new Properties();
+    props.put(StreamsConfig.APPLICATION_ID_CONFIG, "ks-gbk-test");
+    props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    props.put(
+        StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.ByteArray().getClass().getName());
+    props.put(
+        StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.ByteArray().getClass().getName());
+    return props;
+  }
+
+  private static class PassThroughProcessor implements Processor<Object, Object, Object, Object> {
+    private ProcessorContext<Object, Object> context;
+
+    @Override
+    public void init(ProcessorContext<Object, Object> context) {
+      this.context = context;
+    }
+
+    @Override
+    public void process(Record<Object, Object> record) {
+      context.forward(record);
+    }
+  }
+
+  private static class CapturingProcessor
+      implements ProcessorSupplier<byte[], KStreamsPayload<?>, byte[], KStreamsPayload<?>> {
+    final List<KStreamsPayload<?>> received = Collections.synchronizedList(new ArrayList<>());
+
+    @Override
+    public Processor<byte[], KStreamsPayload<?>, byte[], KStreamsPayload<?>> get() {
+      return new Processor<byte[], KStreamsPayload<?>, byte[], KStreamsPayload<?>>() {
+        @Override
+        public void init(@Nullable ProcessorContext<byte[], KStreamsPayload<?>> context) {}
+
+        @Override
+        public void process(Record<byte[], KStreamsPayload<?>> record) {
+          received.add(record.value());
+        }
+      };
+    }
+  }
+}


### PR DESCRIPTION
- Registered GroupByKey in KafkaStreamsPipelineTranslator.
- Created GroupByKeyTranslator to repartition via internal topic and route into the GroupByKeyProcessor.
- Added GroupByKeyProcessor using Kafka Streams state stores to buffer the global window KV elements.
- Added GroupByKeyTranslatorTest to verify execution via TopologyTestDriver.

**Please** add a meaningful description for your change here

Fixes #39135 

Description:
Implement PTransformTranslator.
Translate the beam:transform:group_by_key:v1 primitive.
Set up a repartitioning step using Kafka Streams by setting the record key to the extracted Beam GroupByKey key.
Route the data through an internal repartition topic using KStreamsPayloadSerde from #39051.
Attach a key-value state store (via Stores.keyValueStoreBuilder) to buffer the elements.
Implement a Kafka Streams Processor.
Buffer incoming WindowedValue<KV<K, V>> elements per key into the state store.
Listen for watermark advancements (using the runner's watermark management).
When the watermark reaches TIMESTAMP_MAX (the end of GlobalWindow), retrieve all buffered values for each key and emit KV<K, Iterable<V>> downstream.
Clear the state store for emitted keys.
Register GroupByKeyTranslator for beam:transform:group_by_key:v1 (known URNs) alongside other primitives like Redistribute.
Set up a TopologyTestDriver E2E test.
Pipeline structure: Impulse -> produce mock KVs -> GroupByKey -> assert grouped output matches the expected iterables.
Verify that elements are only emitted when the watermark reaches the end of the global window.
Wire in the first @ValidatesRunner test on the GroupByKey category for the global window.





------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
