### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/IO_Iceberg_Integration_Tests.yml
+++ b/.github/workflows/IO_Iceberg_Integration_Tests.yml
@@ -63,7 +63,7 @@ jobs:
         job_name: ["IO_Iceberg_Integration_Tests"]
         job_phrase: ["Run IcebergIO Integration Test"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/IO_Iceberg_Integration_Tests_Dataflow.yml
+++ b/.github/workflows/IO_Iceberg_Integration_Tests_Dataflow.yml
@@ -63,7 +63,7 @@ jobs:
         job_name: ["IO_Iceberg_Integration_Tests_Dataflow"]
         job_phrase: ["Run IcebergIO Integration Tests on Dataflow"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/IO_Iceberg_Managed_Integration_Tests_Dataflow.yml
+++ b/.github/workflows/IO_Iceberg_Managed_Integration_Tests_Dataflow.yml
@@ -63,7 +63,7 @@ jobs:
         job_name: ["IO_Iceberg_Managed_Integration_Tests_Dataflow"]
         job_phrase: ["Run IcebergIO Managed Integration Tests on Dataflow"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/IO_Iceberg_Performance_Tests.yml
+++ b/.github/workflows/IO_Iceberg_Performance_Tests.yml
@@ -63,7 +63,7 @@ jobs:
         job_name: ["IO_Iceberg_Performance_Tests"]
         job_phrase: ["Run IcebergIO Performance Test"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/IO_Iceberg_Unit_Tests.yml
+++ b/.github/workflows/IO_Iceberg_Unit_Tests.yml
@@ -82,7 +82,7 @@ jobs:
       github.event.comment.body == 'Run IcebergIO Unit Tests'
     runs-on: [self-hosted, ubuntu-24.04, main]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -100,13 +100,13 @@ jobs:
             -PdisableCheckStyle=true \
             --info
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'
@@ -114,13 +114,13 @@ jobs:
           files: '**/build/test-results/**/*.xml'
           large_files: true
       - name: Archive SpotBugs Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: SpotBugs Results
           path: '**/build/reports/spotbugs/*.html'
       - name: Publish SpotBugs Results
-        uses: jwgmeligmeyling/spotbugs-github-action@v1.2
+        uses: jwgmeligmeyling/spotbugs-github-action@b8e2c3523acb34c87f14e18cbcd2d87db8c8584e # v1.2
         if: always()
         with:
           name: Publish SpotBugs

--- a/.github/workflows/assign_milestone.yml
+++ b/.github/workflows/assign_milestone.yml
@@ -31,11 +31,11 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 2
 
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const fs = require('fs')

--- a/.github/workflows/beam_CancelStaleDataflowJobs.yml
+++ b/.github/workflows/beam_CancelStaleDataflowJobs.yml
@@ -62,7 +62,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.comment.body == 'Run Cancel Stale Dataflow Jobs'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -77,4 +77,3 @@ jobs:
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:
           gradle-command: :beam-test-tools:cancelStaleDataflowJobs
-

--- a/.github/workflows/beam_CleanUpDataprocResources.yml
+++ b/.github/workflows/beam_CleanUpDataprocResources.yml
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 100
     name: "beam_CleanUpDataprocResources"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Delete leaked resources for all the jobs that generates flink clusters
         run: |
           cd ${{ github.workspace }}/.test-infra/dataproc; ./cleanup.sh -xe

--- a/.github/workflows/beam_CleanUpGCPResources.yml
+++ b/.github/workflows/beam_CleanUpGCPResources.yml
@@ -62,7 +62,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.comment.body == 'Run Clean GCP Resources'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_CleanUpPrebuiltSDKImages.yml
+++ b/.github/workflows/beam_CleanUpPrebuiltSDKImages.yml
@@ -62,7 +62,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.comment.body == 'Run Clean Prebuilt Images'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_CloudML_Benchmarks_Dataflow.yml
+++ b/.github/workflows/beam_CloudML_Benchmarks_Dataflow.yml
@@ -63,7 +63,7 @@ jobs:
         job_name: ["beam_CloudML_Benchmarks_Dataflow"]
         job_phrase: ["Run TFT Criteo Benchmarks"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_IODatastoresCredentialsRotation.yml
+++ b/.github/workflows/beam_IODatastoresCredentialsRotation.yml
@@ -59,7 +59,7 @@ jobs:
         job_name: ["beam_IODatastoresCredentialsRotation"]
         job_phrase: ["N/A"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -83,7 +83,7 @@ jobs:
           date=$(date -u +"%Y-%m-%d")
           echo "date=$date" >> $GITHUB_ENV
 #      - name: Send email
-#        uses: dawidd6/action-send-mail@v3
+#        uses: dawidd6/action-send-mail@4226df7daafa6fc901a43789c49bf7ab309066e7 # v3
 #        if: failure()
 #        with:
 #          server_address: smtp.gmail.com

--- a/.github/workflows/beam_Inference_Python_Benchmarks_Dataflow.yml
+++ b/.github/workflows/beam_Inference_Python_Benchmarks_Dataflow.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_Inference_Python_Benchmarks_Dataflow"]
         job_phrase: ["Run Inference Benchmarks"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_Infrastructure_AuditUnmanagedKeys.yml
+++ b/.github/workflows/beam_Infrastructure_AuditUnmanagedKeys.yml
@@ -41,13 +41,13 @@ jobs:
     runs-on: [self-hosted, ubuntu-24.04, main]
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
     - name: Setup gcloud
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
       with:
         python-version: '3.13'
 
@@ -63,7 +63,3 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_REPOSITORY: ${{ github.repository }}
       run: python account_keys.py --action announce
-
-
-
-

--- a/.github/workflows/beam_Infrastructure_PolicyEnforcer.yml
+++ b/.github/workflows/beam_Infrastructure_PolicyEnforcer.yml
@@ -42,10 +42,10 @@ jobs:
     runs-on: [self-hosted, ubuntu-24.04, main]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.13'
           

--- a/.github/workflows/beam_Infrastructure_SecurityLogging.yml
+++ b/.github/workflows/beam_Infrastructure_SecurityLogging.yml
@@ -44,10 +44,10 @@ jobs:
     runs-on: [self-hosted, ubuntu-24.04, main]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.13'
 

--- a/.github/workflows/beam_Infrastructure_ServiceAccountKeys.yml
+++ b/.github/workflows/beam_Infrastructure_ServiceAccountKeys.yml
@@ -48,12 +48,12 @@ jobs:
     runs-on: [self-hosted, ubuntu-24.04, main]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.13'
 

--- a/.github/workflows/beam_Infrastructure_UsersPermissions.yml
+++ b/.github/workflows/beam_Infrastructure_UsersPermissions.yml
@@ -45,13 +45,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event.pull_request.merged == true && github.base_ref || github.event.pull_request.head.sha }}
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_version: 1.12.2
       - name: Initialize Terraform

--- a/.github/workflows/beam_Java_JMH.yml
+++ b/.github/workflows/beam_Java_JMH.yml
@@ -62,7 +62,7 @@ jobs:
     timeout-minutes: 900
     name: "beam_Java_JMH"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup environment
         uses: ./.github/actions/setup-environment-action
       - name: run the Java JMH micro-benchmark harness suite

--- a/.github/workflows/beam_Java_LoadTests_Combine_Smoke.yml
+++ b/.github/workflows/beam_Java_LoadTests_Combine_Smoke.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_Java_LoadTests_Combine_Smoke"]
         job_phrase: ["Run Java Load Tests Combine Smoke"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Go_CoGBK_Dataflow_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Go_CoGBK_Dataflow_Batch.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Go_CoGBK_Dataflow_Batch"]
         job_phrase: ["Run Load Tests Go CoGBK Dataflow Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Go_CoGBK_Flink_batch.yml
+++ b/.github/workflows/beam_LoadTests_Go_CoGBK_Flink_batch.yml
@@ -72,7 +72,7 @@ jobs:
         job_name: ["beam_LoadTests_Go_CoGBK_Flink_Batch"]
         job_phrase: ["Run Load Tests Go CoGBK Flink Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Go_Combine_Dataflow_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Go_Combine_Dataflow_Batch.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Go_Combine_Dataflow_Batch"]
         job_phrase: ["Run Load Tests Go Combine Dataflow Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Go_Combine_Flink_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Go_Combine_Flink_Batch.yml
@@ -72,7 +72,7 @@ jobs:
         job_name: ["beam_LoadTests_Go_Combine_Flink_Batch"]
         job_phrase: ["Run Load Tests Go Combine Flink Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Go_GBK_Dataflow_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Go_GBK_Dataflow_Batch.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Go_GBK_Dataflow_Batch"]
         job_phrase: ["Run Load Tests Go GBK Dataflow Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Go_GBK_Flink_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Go_GBK_Flink_Batch.yml
@@ -72,7 +72,7 @@ jobs:
         job_name: ["beam_LoadTests_Go_GBK_Flink_Batch"]
         job_phrase: ["Run Load Tests Go GBK Flink Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Go_ParDo_Dataflow_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Go_ParDo_Dataflow_Batch.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Go_ParDo_Dataflow_Batch"]
         job_phrase: ["Run Load Tests Go ParDo Dataflow Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Go_ParDo_Flink_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Go_ParDo_Flink_Batch.yml
@@ -72,7 +72,7 @@ jobs:
         job_name: ["beam_LoadTests_Go_ParDo_Flink_Batch"]
         job_phrase: ["Run Load Tests Go ParDo Flink Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Go_SideInput_Dataflow_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Go_SideInput_Dataflow_Batch.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Go_SideInput_Dataflow_Batch"]
         job_phrase: ["Run Load Tests Go SideInput Dataflow Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Go_SideInput_Flink_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Go_SideInput_Flink_Batch.yml
@@ -72,7 +72,7 @@ jobs:
         job_name: ["beam_LoadTests_Go_SideInput_Flink_Batch"]
         job_phrase: ["Run Load Tests Go SideInput Flink Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Java_CoGBK_Dataflow_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Java_CoGBK_Dataflow_Batch.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Java_CoGBK_Dataflow_Batch"]
         job_phrase: ["Run Load Tests Java CoGBK Dataflow Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Java_CoGBK_Dataflow_Streaming.yml
+++ b/.github/workflows/beam_LoadTests_Java_CoGBK_Dataflow_Streaming.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Java_CoGBK_Dataflow_Streaming"]
         job_phrase: ["Run Load Tests Java CoGBK Dataflow Streaming"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -115,13 +115,13 @@ jobs:
             -Prunner=:runners:google-cloud-dataflow-java \
             '-PloadTest.args=${{ env.beam_LoadTests_Java_CoGBK_Dataflow_Streaming_test_arguments_4 }}' \
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           files: '**/build/test-results/**/*.xml'

--- a/.github/workflows/beam_LoadTests_Java_CoGBK_Dataflow_V2_Batch_JavaVersions.yml
+++ b/.github/workflows/beam_LoadTests_Java_CoGBK_Dataflow_V2_Batch_JavaVersions.yml
@@ -66,7 +66,7 @@ jobs:
         job_phrase_2: ["CoGBK Dataflow V2 Batch"]
         java_version: ['11','17']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Java_CoGBK_Dataflow_V2_Streaming_JavaVersions.yml
+++ b/.github/workflows/beam_LoadTests_Java_CoGBK_Dataflow_V2_Streaming_JavaVersions.yml
@@ -66,7 +66,7 @@ jobs:
         job_phrase_2: ["CoGBK Dataflow V2 Streaming"]
         java_version: ['11','17']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Java_CoGBK_SparkStructuredStreaming_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Java_CoGBK_SparkStructuredStreaming_Batch.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Java_CoGBK_SparkStructuredStreaming_Batch"]
         job_phrase: ["Run Load Tests Java CoGBK SparkStructuredStreaming Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Java_Combine_Dataflow_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Java_Combine_Dataflow_Batch.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Java_Combine_Dataflow_Batch"]
         job_phrase: ["Run Load Tests Java Combine Dataflow Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Java_Combine_Dataflow_Streaming.yml
+++ b/.github/workflows/beam_LoadTests_Java_Combine_Dataflow_Streaming.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Java_Combine_Dataflow_Streaming"]
         job_phrase: ["Run Load Tests Java Combine Dataflow Streaming"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Java_Combine_SparkStructuredStreaming_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Java_Combine_SparkStructuredStreaming_Batch.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Java_Combine_SparkStructuredStreaming_Batch"]
         job_phrase: ["Run Load Tests Java Combine SparkStructuredStreaming Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Java_GBK_Dataflow_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Java_GBK_Dataflow_Batch.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Java_GBK_Dataflow_Batch"]
         job_phrase: ["Run Load Tests Java GBK Dataflow Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Java_GBK_Dataflow_Streaming.yml
+++ b/.github/workflows/beam_LoadTests_Java_GBK_Dataflow_Streaming.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Java_GBK_Dataflow_Streaming"]
         job_phrase: ["Run Load Tests Java GBK Dataflow Streaming"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Java_GBK_Dataflow_V2_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Java_GBK_Dataflow_V2_Batch.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Java_GBK_Dataflow_V2_Batch"]
         job_phrase: ["Run Load Tests GBK Dataflow V2 Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Java_GBK_Dataflow_V2_Batch_Java17.yml
+++ b/.github/workflows/beam_LoadTests_Java_GBK_Dataflow_V2_Batch_Java17.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Java_GBK_Dataflow_V2_Batch_Java17"]
         job_phrase: ["Run Load Tests Java 17 GBK Dataflow V2 Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Java_GBK_Dataflow_V2_Streaming.yml
+++ b/.github/workflows/beam_LoadTests_Java_GBK_Dataflow_V2_Streaming.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Java_GBK_Dataflow_V2_Streaming"]
         job_phrase: ["Run Load Tests GBK Dataflow V2 Streaming"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Java_GBK_Dataflow_V2_Streaming_Java17.yml
+++ b/.github/workflows/beam_LoadTests_Java_GBK_Dataflow_V2_Streaming_Java17.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Java_GBK_Dataflow_V2_Streaming_Java17"]
         job_phrase: ["Run Load Tests Java 17 GBK Dataflow V2 Streaming"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Java_GBK_Smoke.yml
+++ b/.github/workflows/beam_LoadTests_Java_GBK_Smoke.yml
@@ -59,7 +59,7 @@ jobs:
         job_name: ["beam_LoadTests_Java_GBK_Smoke"]
         job_phrase: ["Run Java Load Tests GBK Smoke"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Java_GBK_SparkStructuredStreaming_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Java_GBK_SparkStructuredStreaming_Batch.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Java_GBK_SparkStructuredStreaming_Batch"]
         job_phrase: ["Run Load Tests Java GBK SparkStructuredStreaming Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Java_ParDo_Dataflow_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Java_ParDo_Dataflow_Batch.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Java_ParDo_Dataflow_Batch"]
         job_phrase: ["Run Load Tests Java ParDo Dataflow Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Java_ParDo_Dataflow_Streaming.yml
+++ b/.github/workflows/beam_LoadTests_Java_ParDo_Dataflow_Streaming.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Java_ParDo_Dataflow_Streaming"]
         job_phrase: ["Run Load Tests Java ParDo Dataflow Streaming"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Java_ParDo_Dataflow_V2_Batch_JavaVersions.yml
+++ b/.github/workflows/beam_LoadTests_Java_ParDo_Dataflow_V2_Batch_JavaVersions.yml
@@ -66,7 +66,7 @@ jobs:
         job_phrase_2: ["ParDo Dataflow V2 Batch"]
         java_version: ['11','17']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Java_ParDo_Dataflow_V2_Streaming_JavaVersions.yml
+++ b/.github/workflows/beam_LoadTests_Java_ParDo_Dataflow_V2_Streaming_JavaVersions.yml
@@ -66,7 +66,7 @@ jobs:
         job_phrase_2: ["ParDo Dataflow V2 Streaming"]
         java_version: ['11','17']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Java_ParDo_SparkStructuredStreaming_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Java_ParDo_SparkStructuredStreaming_Batch.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Java_ParDo_SparkStructuredStreaming_Batch"]
         job_phrase: ["Run Load Tests Java ParDo SparkStructuredStreaming Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Java_PubsubIO.yml
+++ b/.github/workflows/beam_LoadTests_Java_PubsubIO.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Java_PubsubIO"]
         job_phrase: ["Run Load Tests Java PubsubIO"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Python_CoGBK_Dataflow_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Python_CoGBK_Dataflow_Batch.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Python_CoGBK_Dataflow_Batch"]
         job_phrase: ["Run Load Tests Python CoGBK Dataflow Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Python_CoGBK_Dataflow_Streaming.yml
+++ b/.github/workflows/beam_LoadTests_Python_CoGBK_Dataflow_Streaming.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Python_CoGBK_Dataflow_Streaming"]
         job_phrase: ["Run Load Tests Python CoGBK Dataflow Streaming"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Python_CoGBK_Flink_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Python_CoGBK_Flink_Batch.yml
@@ -72,7 +72,7 @@ jobs:
         job_name: ["beam_LoadTests_Python_CoGBK_Flink_Batch"]
         job_phrase: ["Run Load Tests Python CoGBK Flink Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Python_Combine_Dataflow_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Python_Combine_Dataflow_Batch.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Python_Combine_Dataflow_Batch"]
         job_phrase: ["Run Load Tests Python Combine Dataflow Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Python_Combine_Dataflow_Streaming.yml
+++ b/.github/workflows/beam_LoadTests_Python_Combine_Dataflow_Streaming.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Python_Combine_Dataflow_Streaming"]
         job_phrase: ["Run Load Tests Python Combine Dataflow Streaming"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Python_Combine_Flink_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Python_Combine_Flink_Batch.yml
@@ -72,7 +72,7 @@ jobs:
         job_name: ["beam_LoadTests_Python_Combine_Flink_Batch"]
         job_phrase: ["Run Load Tests Python Combine Flink Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Python_Combine_Flink_Streaming.yml
+++ b/.github/workflows/beam_LoadTests_Python_Combine_Flink_Streaming.yml
@@ -72,7 +72,7 @@ jobs:
         job_name: ["beam_LoadTests_Python_Combine_Flink_Streaming"]
         job_phrase: ["Run Load Tests Python Combine Flink Streaming"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Python_FnApiRunner_Microbenchmark.yml
+++ b/.github/workflows/beam_LoadTests_Python_FnApiRunner_Microbenchmark.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Python_FnApiRunner_Microbenchmark"]
         job_phrase: ["Run Python Load Tests FnApiRunner Microbenchmark"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Python_GBK_Dataflow_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Python_GBK_Dataflow_Batch.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Python_GBK_Dataflow_Batch"]
         job_phrase: ["Run Load Tests Python GBK Dataflow Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Python_GBK_Dataflow_Streaming.yml
+++ b/.github/workflows/beam_LoadTests_Python_GBK_Dataflow_Streaming.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Python_GBK_Dataflow_Streaming"]
         job_phrase: ["Run Load Tests Python GBK Dataflow Streaming"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Python_GBK_Flink_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Python_GBK_Flink_Batch.yml
@@ -72,7 +72,7 @@ jobs:
         job_name: ["beam_LoadTests_Python_GBK_Flink_Batch"]
         job_phrase: ["Run Load Tests Python GBK Flink Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Python_GBK_reiterate_Dataflow_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Python_GBK_reiterate_Dataflow_Batch.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Python_GBK_reiterate_Dataflow_Batch"]
         job_phrase: ["Run Load Tests Python GBK reiterate Dataflow Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Python_GBK_reiterate_Dataflow_Streaming.yml
+++ b/.github/workflows/beam_LoadTests_Python_GBK_reiterate_Dataflow_Streaming.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Python_GBK_reiterate_Dataflow_Streaming"]
         job_phrase: ["Run Load Tests Python GBK reiterate Dataflow Streaming"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Python_ParDo_Dataflow_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Python_ParDo_Dataflow_Batch.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Python_ParDo_Dataflow_Batch"]
         job_phrase: ["Run Load Tests Python ParDo Dataflow Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Python_ParDo_Dataflow_Streaming.yml
+++ b/.github/workflows/beam_LoadTests_Python_ParDo_Dataflow_Streaming.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Python_ParDo_Dataflow_Streaming"]
         job_phrase: ["Run Python Load Tests ParDo Dataflow Streaming"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Python_ParDo_Flink_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Python_ParDo_Flink_Batch.yml
@@ -72,7 +72,7 @@ jobs:
         job_name: ["beam_LoadTests_Python_ParDo_Flink_Batch"]
         job_phrase: ["Run Load Tests Python ParDo Flink Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Python_ParDo_Flink_Streaming.yml
+++ b/.github/workflows/beam_LoadTests_Python_ParDo_Flink_Streaming.yml
@@ -72,7 +72,7 @@ jobs:
         job_name: ["beam_LoadTests_Python_ParDo_Flink_Streaming"]
         job_phrase: ["Run Load Tests Python ParDo Flink Streaming"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Python_SideInput_Dataflow_Batch.yml
+++ b/.github/workflows/beam_LoadTests_Python_SideInput_Dataflow_Batch.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_LoadTests_Python_SideInput_Dataflow_Batch"]
         job_phrase: ["Run Load Tests Python SideInput Dataflow Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_LoadTests_Python_Smoke.yml
+++ b/.github/workflows/beam_LoadTests_Python_Smoke.yml
@@ -59,7 +59,7 @@ jobs:
         job_name: ["beam_LoadTests_Python_Smoke"]
         job_phrase: ["Run Python Load Tests Smoke"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_MetricsCredentialsRotation.yml
+++ b/.github/workflows/beam_MetricsCredentialsRotation.yml
@@ -59,7 +59,7 @@ jobs:
         job_name: ["beam_MetricsCredentialsRotation"]
         job_phrase: ["N/A"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -83,7 +83,7 @@ jobs:
           date=$(date -u +"%Y-%m-%d")
           echo "date=$date" >> $GITHUB_ENV
 #      - name: Send email
-#        uses: dawidd6/action-send-mail@v3
+#        uses: dawidd6/action-send-mail@4226df7daafa6fc901a43789c49bf7ab309066e7 # v3
 #        if: failure()
 #        with:
 #          server_address: smtp.gmail.com

--- a/.github/workflows/beam_Metrics_Report.yml
+++ b/.github/workflows/beam_Metrics_Report.yml
@@ -61,7 +61,7 @@ jobs:
       )
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup environment
         uses: ./.github/actions/setup-environment-action
         with:
@@ -75,7 +75,7 @@ jobs:
           INFLUXDB_USER: ${{ secrets.INFLUXDB_USER }}
           INFLUXDB_USER_PASSWORD: ${{ secrets.INFLUXDB_USER_PASSWORD }}
       - name: Archive Report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: Metrics Report
           path: "${{ github.workspace }}/.test-infra/jenkins/metrics_report/beam-metrics_report.html"
@@ -84,7 +84,7 @@ jobs:
           date=$(date -u +"%Y-%m-%d")
           echo "date=$date" >> $GITHUB_ENV
 #      - name: Send mail
-#        uses: dawidd6/action-send-mail@v6
+#        uses: dawidd6/action-send-mail@6d98ae34d733f9a723a9e04e94f2f24ba05e1402 # v6
 #        with:
 #          server_address: smtp.gmail.com
 #          server_port: 465

--- a/.github/workflows/beam_PerformanceTests_AvroIOIT.yml
+++ b/.github/workflows/beam_PerformanceTests_AvroIOIT.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_AvroIOIT"]
         job_phrase: ["Run Java AvroIO Performance Test"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_AvroIOIT_HDFS.yml
+++ b/.github/workflows/beam_PerformanceTests_AvroIOIT_HDFS.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_AvroIOIT_HDFS"]
         job_phrase: ["Run Java AvroIO Performance Test HDFS"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_BigQueryIO_Batch_Java_Avro.yml
+++ b/.github/workflows/beam_PerformanceTests_BigQueryIO_Batch_Java_Avro.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_BigQueryIO_Batch_Java_Avro"]
         job_phrase: ["Run BigQueryIO Batch Performance Test Java Avro"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -91,13 +91,13 @@ jobs:
             -DintegrationTestRunner=dataflow \
             -DintegrationTestPipelineOptions='[${{ env.beam_PerformanceTests_BigQueryIO_Batch_Java_Avro_test_arguments_1 }}]' \
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PerformanceTests_BigQueryIO_Batch_Java_Json.yml
+++ b/.github/workflows/beam_PerformanceTests_BigQueryIO_Batch_Java_Json.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_BigQueryIO_Batch_Java_Json"]
         job_phrase: ["Run BigQueryIO Batch Performance Test Java Json"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -91,13 +91,13 @@ jobs:
             -DintegrationTestRunner=dataflow \
             -DintegrationTestPipelineOptions='[${{ env.beam_PerformanceTests_BigQueryIO_Batch_Java_Json_test_arguments_1 }}]' \
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PerformanceTests_BigQueryIO_Streaming_Java.yml
+++ b/.github/workflows/beam_PerformanceTests_BigQueryIO_Streaming_Java.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_BigQueryIO_Streaming_Java"]
         job_phrase: ["Run BigQueryIO Streaming Performance Test Java"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -91,13 +91,13 @@ jobs:
             -DintegrationTestRunner=dataflow \
             -DintegrationTestPipelineOptions='[${{ env.beam_PerformanceTests_BigQueryIO_Streaming_Java_test_arguments_1 }}]' \
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PerformanceTests_BiqQueryIO_Read_Python.yml
+++ b/.github/workflows/beam_PerformanceTests_BiqQueryIO_Read_Python.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_BiqQueryIO_Read_Python"]
         job_phrase: ["Run BigQueryIO Read Performance Test Python"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_BiqQueryIO_Write_Python_Batch.yml
+++ b/.github/workflows/beam_PerformanceTests_BiqQueryIO_Write_Python_Batch.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_BiqQueryIO_Write_Python_Batch"]
         job_phrase: ["Run BigQueryIO Write Performance Test Python"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_Cdap.yml
+++ b/.github/workflows/beam_PerformanceTests_Cdap.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_Cdap"]
         job_phrase: ["Run Java CdapIO Performance Test"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_Compressed_TextIOIT.yml
+++ b/.github/workflows/beam_PerformanceTests_Compressed_TextIOIT.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_Compressed_TextIOIT"]
         job_phrase: ["Run Java CompressedTextIO Performance Test"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_Compressed_TextIOIT_HDFS.yml
+++ b/.github/workflows/beam_PerformanceTests_Compressed_TextIOIT_HDFS.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_Compressed_TextIOIT_HDFS"]
         job_phrase: ["Run Java CompressedTextIO Performance Test HDFS"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_HadoopFormat.yml
+++ b/.github/workflows/beam_PerformanceTests_HadoopFormat.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_HadoopFormat"]
         job_phrase: ["Run Java HadoopFormatIO Performance Test"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_JDBC.yml
+++ b/.github/workflows/beam_PerformanceTests_JDBC.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_JDBC"]
         job_phrase: ["Run Java JdbcIO Performance Test"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_Kafka_IO.yml
+++ b/.github/workflows/beam_PerformanceTests_Kafka_IO.yml
@@ -64,7 +64,7 @@ jobs:
     env:
       KAFKA_SERVICE_PORT: 32400
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_ManyFiles_TextIOIT.yml
+++ b/.github/workflows/beam_PerformanceTests_ManyFiles_TextIOIT.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_ManyFiles_TextIOIT"]
         job_phrase: ["Run Java ManyFilesTextIO Performance Test"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_ManyFiles_TextIOIT_HDFS.yml
+++ b/.github/workflows/beam_PerformanceTests_ManyFiles_TextIOIT_HDFS.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_ManyFiles_TextIOIT_HDFS"]
         job_phrase: ["Run Java ManyFilesTextIO Performance Test HDFS"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_MongoDBIO_IT.yml
+++ b/.github/workflows/beam_PerformanceTests_MongoDBIO_IT.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_MongoDBIO_IT"]
         job_phrase: ["Run Java MongoDBIO Performance Test"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_ParquetIOIT.yml
+++ b/.github/workflows/beam_PerformanceTests_ParquetIOIT.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_ParquetIOIT"]
         job_phrase: ["Run Java ParquetIO Performance Test"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_ParquetIOIT_HDFS.yml
+++ b/.github/workflows/beam_PerformanceTests_ParquetIOIT_HDFS.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_ParquetIOIT_HDFS"]
         job_phrase: ["Run Java ParquetIO Performance Test HDFS"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_PubsubIOIT_Python_Streaming.yml
+++ b/.github/workflows/beam_PerformanceTests_PubsubIOIT_Python_Streaming.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_PubsubIOIT_Python_Streaming"]
         job_phrase: ["Run PubsubIO Performance Test Python"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_SQLBigQueryIO_Batch_Java.yml
+++ b/.github/workflows/beam_PerformanceTests_SQLBigQueryIO_Batch_Java.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_SQLBigQueryIO_Batch_Java"]
         job_phrase: ["Run SQLBigQueryIO Batch Performance Test Java"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -90,13 +90,13 @@ jobs:
             -DintegrationTestRunner=dataflow  \
             '-DintegrationTestPipelineOptions=[${{env.beam_PerformanceTests_SQLBigQueryIO_Batch_Java_test_arguments_1}}]' \
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PerformanceTests_SingleStoreIO.yml
+++ b/.github/workflows/beam_PerformanceTests_SingleStoreIO.yml
@@ -65,7 +65,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.comment.body == 'Run Java SingleStoreIO Performance Test'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_SpannerIO_Read_2GB_Python.yml
+++ b/.github/workflows/beam_PerformanceTests_SpannerIO_Read_2GB_Python.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_SpannerIO_Read_2GB_Python"]
         job_phrase: ["Run SpannerIO Read 2GB Performance Test Python"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_SpannerIO_Write_2GB_Python_Batch.yml
+++ b/.github/workflows/beam_PerformanceTests_SpannerIO_Write_2GB_Python_Batch.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_SpannerIO_Write_2GB_Python_Batch"]
         job_phrase: ["Run SpannerIO Write 2GB Performance Test Python Batch"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_SparkReceiver_IO.yml
+++ b/.github/workflows/beam_PerformanceTests_SparkReceiver_IO.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_SparkReceiver_IO"]
         job_phrase: ["Run Java SparkReceiverIO Performance Test"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_TFRecordIOIT.yml
+++ b/.github/workflows/beam_PerformanceTests_TFRecordIOIT.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_TFRecordIOIT"]
         job_phrase: ["Run Java TFRecordIO Performance Test"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_TFRecordIOIT_HDFS.yml
+++ b/.github/workflows/beam_PerformanceTests_TFRecordIOIT_HDFS.yml
@@ -64,7 +64,7 @@ jobs:
         job_name: ["beam_PerformanceTests_TFRecordIOIT_HDFS"]
         job_phrase: ["Run Java TFRecordIO Performance Test HDFS"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_TextIOIT.yml
+++ b/.github/workflows/beam_PerformanceTests_TextIOIT.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_TextIOIT"]
         job_phrase: ["Run Java TextIO Performance Test"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_TextIOIT_HDFS.yml
+++ b/.github/workflows/beam_PerformanceTests_TextIOIT_HDFS.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_TextIOIT_HDFS"]
         job_phrase: ["Run Java TextIO Performance Test HDFS"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_TextIOIT_Python.yml
+++ b/.github/workflows/beam_PerformanceTests_TextIOIT_Python.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_TextIOIT_Python"]
         job_phrase: ["Run Python TextIO Performance Test"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_WordCountIT_PythonVersions.yml
+++ b/.github/workflows/beam_PerformanceTests_WordCountIT_PythonVersions.yml
@@ -66,7 +66,7 @@ jobs:
         job_phrase_2: [WordCountIT Performance Test]
         python_version: ['3.10']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -104,13 +104,13 @@ jobs:
             -Ptest=apache_beam/examples/wordcount_it_test.py::WordCountIT::test_wordcount_it \
             "-Ptest-pipeline-options=${{ env.beam_PerformanceTests_WordCountIT_PythonVersions_test_arguments_1 }}"
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PerformanceTests_XmlIOIT.yml
+++ b/.github/workflows/beam_PerformanceTests_XmlIOIT.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_XmlIOIT"]
         job_phrase: ["Run Java XmlIO Performance Test"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_XmlIOIT_HDFS.yml
+++ b/.github/workflows/beam_PerformanceTests_XmlIOIT_HDFS.yml
@@ -62,7 +62,7 @@ jobs:
         job_name: ["beam_PerformanceTests_XmlIOIT_HDFS"]
         job_phrase: ["Run Java XmlIO Performance Test HDFS"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PerformanceTests_xlang_KafkaIO_Python.yml
+++ b/.github/workflows/beam_PerformanceTests_xlang_KafkaIO_Python.yml
@@ -63,7 +63,7 @@ jobs:
         job_name: ["beam_PerfTests_xlang_KafkaIO_Python"]
         job_phrase: ["Run Python xlang KafkaIO Performance Test"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_Playground_CI_Nightly.yml
+++ b/.github/workflows/beam_Playground_CI_Nightly.yml
@@ -61,7 +61,7 @@ jobs:
         sdk: ["python", "java", "go"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup environment
         uses: ./.github/actions/setup-environment-action
         with:

--- a/.github/workflows/beam_Playground_Precommit.yml
+++ b/.github/workflows/beam_Playground_Precommit.yml
@@ -48,7 +48,7 @@ jobs:
       PYTHON_VERSION: '3.10'
       JAVA_VERSION: '17'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PostCommit_Go.yml
+++ b/.github/workflows/beam_PostCommit_Go.yml
@@ -63,7 +63,7 @@ jobs:
         job_name: ["beam_PostCommit_Go"]
         job_phrase: ["Run Go PostCommit"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PostCommit_Go_Dataflow_ARM.yml
+++ b/.github/workflows/beam_PostCommit_Go_Dataflow_ARM.yml
@@ -65,7 +65,7 @@ jobs:
         job_name: ["beam_PostCommit_Go_Dataflow_ARM"]
         job_phrase: ["Run Go PostCommit Dataflow ARM"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PostCommit_Go_VR_Flink.yml
+++ b/.github/workflows/beam_PostCommit_Go_VR_Flink.yml
@@ -63,7 +63,7 @@ jobs:
         job_name: ["beam_PostCommit_Go_VR_Flink"]
         job_phrase: ["Run Go Flink ValidatesRunner"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PostCommit_Go_VR_Spark.yml
+++ b/.github/workflows/beam_PostCommit_Go_VR_Spark.yml
@@ -63,7 +63,7 @@ jobs:
         job_name: ["beam_PostCommit_Go_VR_Spark"]
         job_phrase: ["Run Go Spark ValidatesRunner"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PostCommit_Java.yml
+++ b/.github/workflows/beam_PostCommit_Java.yml
@@ -65,7 +65,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Java PostCommit'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -79,13 +79,13 @@ jobs:
         with:
           gradle-command: :javaPostCommit
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_Avro_Versions.yml
+++ b/.github/workflows/beam_PostCommit_Java_Avro_Versions.yml
@@ -65,7 +65,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Java Avro Versions PostCommit'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -79,13 +79,13 @@ jobs:
         with:
             gradle-command: :javaAvroVersionsTest
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_BigQueryEarlyRollout.yml
+++ b/.github/workflows/beam_PostCommit_Java_BigQueryEarlyRollout.yml
@@ -65,7 +65,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Java BigQueryEarlyRollout PostCommit'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -84,7 +84,7 @@ jobs:
           date=$(date -u +"%Y-%m-%d")
           echo "date=$date" >> $GITHUB_ENV
 #      - name: Send email
-#        uses: dawidd6/action-send-mail@v3
+#        uses: dawidd6/action-send-mail@4226df7daafa6fc901a43789c49bf7ab309066e7 # v3
 #        if: failure()
 #        with:
 #          server_address: smtp.gmail.com
@@ -98,13 +98,13 @@ jobs:
 #          body: |
 #            PostCommit Java BigQueryEarlyRollout failed on ${{ env.date }}. This test monitors BigQuery rollouts impacting Beam and should be escalated immediately if a real issue is encountered to pause further rollouts. For further details refer to the following links:\n * Failing job: https://github.com/apache/beam/actions/workflows/beam_PostCommit_Java_BigQueryEarlyRollout.yml \n * Job configuration: https://github.com/apache/beam/blob/master/.github/workflows/beam_PostCommit_Java_BigQueryEarlyRollout.yml
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_DataflowV1.yml
+++ b/.github/workflows/beam_PostCommit_Java_DataflowV1.yml
@@ -65,7 +65,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run PostCommit_Java_Dataflow'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -81,13 +81,13 @@ jobs:
         with:
           gradle-command: :runners:google-cloud-dataflow-java:postCommit
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_DataflowV2.yml
+++ b/.github/workflows/beam_PostCommit_Java_DataflowV2.yml
@@ -65,7 +65,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run PostCommit_Java_DataflowV2'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -79,13 +79,13 @@ jobs:
         with:
           gradle-command: :runners:google-cloud-dataflow-java:postCommitRunnerV2
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_Examples_Dataflow.yml
+++ b/.github/workflows/beam_PostCommit_Java_Examples_Dataflow.yml
@@ -65,7 +65,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Java Examples on Dataflow'
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
     - name: Setup repository
       uses: ./.github/actions/setup-action
       with:
@@ -80,13 +80,13 @@ jobs:
         gradle-command: :runners:google-cloud-dataflow-java:examples:javaPostCommit
         max-workers: 12
     - name: Archive JUnit Test Results
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: ${{ !success() }}
       with:
         name: JUnit Test Results
         path: "**/build/reports/tests/"
     - name: Publish JUnit Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v2
+      uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
       if: always()
       with:
         files: '**/build/test-results/**/*.xml'

--- a/.github/workflows/beam_PostCommit_Java_Examples_Dataflow_ARM.yml
+++ b/.github/workflows/beam_PostCommit_Java_Examples_Dataflow_ARM.yml
@@ -70,7 +70,7 @@ jobs:
       github.event_name == 'pull_request_target' ||
       startswith(github.event.comment.body, 'Run Java_Examples_Dataflow_ARM PostCommit')
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -107,13 +107,13 @@ jobs:
                 -PdisableCheckStyle=true \
                 -PskipCheckerFramework \
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_Examples_Dataflow_Java.yml
+++ b/.github/workflows/beam_PostCommit_Java_Examples_Dataflow_Java.yml
@@ -67,7 +67,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       startswith(github.event.comment.body, 'Run Java examples on Dataflow Java')
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -86,13 +86,13 @@ jobs:
           gradle-command: :runners:google-cloud-dataflow-java:examples:java${{ matrix.java_version }}PostCommit
           max-workers: 12
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_Examples_Dataflow_V2.yml
+++ b/.github/workflows/beam_PostCommit_Java_Examples_Dataflow_V2.yml
@@ -65,7 +65,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Java Examples on Dataflow Runner V2'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -103,13 +103,13 @@ jobs:
               -Pjava17Home=$JAVA_HOME_17_X64 \
               -PdockerTag=${{ env.DOCKER_TAG }} \
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_Examples_Dataflow_V2_Java.yml
+++ b/.github/workflows/beam_PostCommit_Java_Examples_Dataflow_V2_Java.yml
@@ -69,7 +69,7 @@ jobs:
       (contains(github.event.comment.body, 'Run Java') &&
          contains(github.event.comment.body, 'Examples on Dataflow Runner V2'))
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -93,13 +93,13 @@ jobs:
             -PtestJavaVersion=${{ matrix.java_version }} \
             -Pjava${{ matrix.java_version }}Home=$JAVA_HOME_${{ matrix.java_version }}_X64 \
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_Examples_Direct.yml
+++ b/.github/workflows/beam_PostCommit_Java_Examples_Direct.yml
@@ -65,7 +65,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Java Examples_Direct'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -81,13 +81,13 @@ jobs:
         with:
           gradle-command: :runners:direct:examplesIntegrationTest
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_Examples_Flink.yml
+++ b/.github/workflows/beam_PostCommit_Java_Examples_Flink.yml
@@ -65,7 +65,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Java Examples_Flink'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -82,13 +82,13 @@ jobs:
         with:
           gradle-command: :runners:flink:2.2:examplesIntegrationTest
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_Examples_Spark.yml
+++ b/.github/workflows/beam_PostCommit_Java_Examples_Spark.yml
@@ -65,7 +65,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Java Examples_Spark'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -81,13 +81,13 @@ jobs:
         with:
           gradle-command: :runners:spark:3:examplesIntegrationTest
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_Hadoop_Versions.yml
+++ b/.github/workflows/beam_PostCommit_Java_Hadoop_Versions.yml
@@ -63,7 +63,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run PostCommit_Java_Hadoop_Versions'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -77,13 +77,13 @@ jobs:
         with:
           gradle-command: :javaHadoopVersionsTest
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_IO_Performance_Tests.yml
+++ b/.github/workflows/beam_PostCommit_Java_IO_Performance_Tests.yml
@@ -66,7 +66,7 @@ jobs:
         job_phrase: ["Run Java PostCommit IO Performance Tests"]
         test_case: ["GCSPerformanceTest", "BigTablePerformanceTest", "BigQueryStorageApiStreamingPerformanceTest"]
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
     - name: Setup repository
       uses: ./.github/actions/setup-action
       with:
@@ -80,7 +80,7 @@ jobs:
         echo "BEAM_VERSION=${BEAM_VERSION}" >> $GITHUB_ENV
     - name: Checkout release branch
       if: github.event_name == 'schedule' #This has scheduled runs run against the latest release
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         ref: ${{ env.BEAM_VERSION }}
         repository: apache/beam
@@ -105,13 +105,13 @@ jobs:
         exportDataset: performance_tests
         exportTable: io_performance_metrics_test
     - name: Archive JUnit Test Results
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: ${{ !success() }}
       with:
         name: JUnit Test Results
         path: "**/build/reports/tests/"
     - name: Publish JUnit Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v2
+      uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
       if: always()
       with:
         commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_InfluxDbIO_IT.yml
+++ b/.github/workflows/beam_PostCommit_Java_InfluxDbIO_IT.yml
@@ -65,7 +65,7 @@ jobs:
       github.event_name == 'pull_request_target' ||
       github.event.comment.body == 'Run Java InfluxDbIO_IT'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PostCommit_Java_Jpms_Dataflow.yml
+++ b/.github/workflows/beam_PostCommit_Java_Jpms_Dataflow.yml
@@ -63,7 +63,7 @@ jobs:
         job_name: ["beam_PostCommit_Java_Jpms_Dataflow"]
         job_phrase: ["Run Jpms Dataflow PostCommit"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -80,13 +80,13 @@ jobs:
           gradle-command: :sdks:java:testing:jpms-tests:dataflowRunnerIntegrationTest
           arguments: -Dorg.gradle.java.home=$JAVA_HOME_11_X64
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_Jpms_Dataflow_Versions.yml
+++ b/.github/workflows/beam_PostCommit_Java_Jpms_Dataflow_Versions.yml
@@ -64,7 +64,7 @@ jobs:
         job_phrase: ["Run Jpms Dataflow Versions PostCommit"]
         java_version: ["17", "21", "25"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -86,13 +86,13 @@ jobs:
             -PtestJavaVersion=${{ matrix.java_version }}
             -Pjava${{ matrix.java_version }}Home=$JAVA_HOME_${{ matrix.java_version }}_X64
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_Jpms_Direct.yml
+++ b/.github/workflows/beam_PostCommit_Java_Jpms_Direct.yml
@@ -63,7 +63,7 @@ jobs:
         job_name: ["beam_PostCommit_Java_Jpms_Direct"]
         job_phrase: ["Run Jpms Direct PostCommit"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -79,13 +79,13 @@ jobs:
         with:
           gradle-command: :sdks:java:testing:jpms-tests:directRunnerIntegrationTest
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_Jpms_Direct_Versions.yml
+++ b/.github/workflows/beam_PostCommit_Java_Jpms_Direct_Versions.yml
@@ -64,7 +64,7 @@ jobs:
         job_phrase: ["Run Jpms Direct Versions PostCommit"]
         java_version: ["17", "21", "25"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -86,13 +86,13 @@ jobs:
             -PtestJavaVersion=${{ matrix.java_version }}
             -Pjava${{ matrix.java_version }}Home=$JAVA_HOME_${{ matrix.java_version }}_X64
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_Jpms_Flink_Java11.yml
+++ b/.github/workflows/beam_PostCommit_Java_Jpms_Flink_Java11.yml
@@ -63,7 +63,7 @@ jobs:
         job_name: ["beam_PostCommit_Java_Jpms_Flink_Java11"]
         job_phrase: ["Run Jpms Flink Java 11 PostCommit"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -80,13 +80,13 @@ jobs:
           gradle-command: :sdks:java:testing:jpms-tests:flinkRunnerIntegrationTest
           arguments: -Dorg.gradle.java.home=$JAVA_HOME_11_X64
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_Jpms_Spark_Java11.yml
+++ b/.github/workflows/beam_PostCommit_Java_Jpms_Spark_Java11.yml
@@ -63,7 +63,7 @@ jobs:
         job_name: ["beam_PostCommit_Java_Jpms_Spark_Java11"]
         job_phrase: ["Run Jpms Spark Java 11 PostCommit"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -80,13 +80,13 @@ jobs:
           gradle-command: :sdks:java:testing:jpms-tests:sparkRunnerIntegrationTest
           arguments: -Dorg.gradle.java.home=$JAVA_HOME_11_X64
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_Nexmark_Dataflow.yml
+++ b/.github/workflows/beam_PostCommit_Java_Nexmark_Dataflow.yml
@@ -93,7 +93,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Dataflow Runner Nexmark Tests'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PostCommit_Java_Nexmark_Dataflow_V2.yml
+++ b/.github/workflows/beam_PostCommit_Java_Nexmark_Dataflow_V2.yml
@@ -93,7 +93,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Dataflow Runner V2 Nexmark Tests'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PostCommit_Java_Nexmark_Dataflow_V2_Java.yml
+++ b/.github/workflows/beam_PostCommit_Java_Nexmark_Dataflow_V2_Java.yml
@@ -95,7 +95,7 @@ jobs:
       (contains(github.event.comment.body, 'Run Dataflow Runner V2 Java') &&
          contains(github.event.comment.body, 'Nexmark Tests'))
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PostCommit_Java_Nexmark_Direct.yml
+++ b/.github/workflows/beam_PostCommit_Java_Nexmark_Direct.yml
@@ -88,7 +88,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Direct Runner Nexmark Tests'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PostCommit_Java_Nexmark_Flink.yml
+++ b/.github/workflows/beam_PostCommit_Java_Nexmark_Flink.yml
@@ -87,7 +87,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Flink Runner Nexmark Tests'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PostCommit_Java_Nexmark_Spark.yml
+++ b/.github/workflows/beam_PostCommit_Java_Nexmark_Spark.yml
@@ -87,7 +87,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Spark Runner Nexmark Tests'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PostCommit_Java_PVR_Flink_Batch.yml
+++ b/.github/workflows/beam_PostCommit_Java_PVR_Flink_Batch.yml
@@ -79,7 +79,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.comment.body == 'Run Java_PVR_Flink_Batch PostCommit'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -103,7 +103,7 @@ jobs:
         env:
           CLOUDSDK_CONFIG: ${{ env.KUBELET_GCLOUD_CONFIG_PATH }}
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results

--- a/.github/workflows/beam_PostCommit_Java_PVR_Flink_Streaming.yml
+++ b/.github/workflows/beam_PostCommit_Java_PVR_Flink_Streaming.yml
@@ -67,7 +67,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Java Flink PortableValidatesRunner Streaming'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -81,13 +81,13 @@ jobs:
         with:
             gradle-command: runners:flink:${{ matrix.flink_version }}:job-server:validatesPortableRunnerStreaming
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_PVR_Spark3_Streaming.yml
+++ b/.github/workflows/beam_PostCommit_Java_PVR_Spark3_Streaming.yml
@@ -65,7 +65,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Java Spark v3 PortableValidatesRunner Streaming'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -79,13 +79,13 @@ jobs:
         with:
             gradle-command: :runners:spark:3:job-server:validatesPortableRunnerStreaming
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_PVR_Spark4_Batch.yml
+++ b/.github/workflows/beam_PostCommit_Java_PVR_Spark4_Batch.yml
@@ -64,7 +64,7 @@ jobs:
       github.event_name == 'pull_request_target' ||
       (github.event_name == 'schedule' && github.repository == 'apache/beam')
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -84,13 +84,13 @@ jobs:
               :runners:spark:4:job-server:validatesPortableRunnerBatch \
               :runners:spark:4:job-server:validatesPortableRunnerDocker \
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           large_files: true
@@ -98,7 +98,7 @@ jobs:
           comment_mode: ${{ github.event_name == 'issue_comment'  && 'always' || 'off' }}
           files: '**/build/test-results/**/*.xml'
       - name: Archive SpotBugs Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: SpotBugs Results
           path: "**/build/reports/spotbugs/*.html"

--- a/.github/workflows/beam_PostCommit_Java_PVR_Spark4_Streaming.yml
+++ b/.github/workflows/beam_PostCommit_Java_PVR_Spark4_Streaming.yml
@@ -65,7 +65,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Java Spark v4 PortableValidatesRunner Streaming'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -81,13 +81,13 @@ jobs:
         with:
             gradle-command: :runners:spark:4:job-server:validatesPortableRunnerStreaming
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_PVR_Spark_Batch.yml
+++ b/.github/workflows/beam_PostCommit_Java_PVR_Spark_Batch.yml
@@ -64,7 +64,7 @@ jobs:
       github.event_name == 'pull_request_target' ||
       (github.event_name == 'schedule' && github.repository == 'apache/beam')
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -82,13 +82,13 @@ jobs:
               :runners:spark:3:job-server:validatesPortableRunnerBatch \
               :runners:spark:3:job-server:validatesPortableRunnerDocker \
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           large_files: true
@@ -96,7 +96,7 @@ jobs:
           comment_mode: ${{ github.event_name == 'issue_comment'  && 'always' || 'off' }}
           files: '**/build/test-results/**/*.xml'
       - name: Archive SpotBugs Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: SpotBugs Results
           path: "**/build/reports/spotbugs/*.html"

--- a/.github/workflows/beam_PostCommit_Java_SingleStoreIO_IT.yml
+++ b/.github/workflows/beam_PostCommit_Java_SingleStoreIO_IT.yml
@@ -67,7 +67,7 @@ jobs:
       github.event_name == 'pull_request_target' ||
       github.event.comment.body == 'Run Java SingleStoreIO_IT'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PostCommit_Java_Tpcds_Dataflow.yml
+++ b/.github/workflows/beam_PostCommit_Java_Tpcds_Dataflow.yml
@@ -90,7 +90,7 @@ jobs:
         job_name: ["beam_PostCommit_Java_Tpcds_Dataflow"]
         job_phrase: ["Run Dataflow Runner Tpcds Tests"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PostCommit_Java_Tpcds_Flink.yml
+++ b/.github/workflows/beam_PostCommit_Java_Tpcds_Flink.yml
@@ -87,7 +87,7 @@ jobs:
         job_name: ["beam_PostCommit_Java_Tpcds_Flink"]
         job_phrase: ["Run Flink Runner Tpcds Tests"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PostCommit_Java_Tpcds_Spark.yml
+++ b/.github/workflows/beam_PostCommit_Java_Tpcds_Spark.yml
@@ -86,7 +86,7 @@ jobs:
         job_phrase: ["Run Spark Runner Tpcds Tests"]
         runner: [SparkRunner, SparkStructuredStreamingRunner]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Dataflow.yml
+++ b/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Dataflow.yml
@@ -65,7 +65,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Dataflow ValidatesRunner'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -82,13 +82,13 @@ jobs:
           gradle-command: :runners:google-cloud-dataflow-java:validatesRunner
           max-workers: 12
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Dataflow_JavaVersions.yml
+++ b/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Dataflow_JavaVersions.yml
@@ -67,7 +67,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       startswith(github.event.comment.body, 'Run Dataflow ValidatesRunner Java')
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -89,13 +89,13 @@ jobs:
             -Pjava${{ matrix.java_version }}Home=$JAVA_HOME_${{ matrix.java_version }}_X64 \
           max-workers: 12
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming.yml
+++ b/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming.yml
@@ -65,7 +65,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Dataflow Streaming ValidatesRunner'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -82,13 +82,13 @@ jobs:
           gradle-command: :runners:google-cloud-dataflow-java:validatesRunnerStreaming
           max-workers: 12
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming_Engine.yml
+++ b/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming_Engine.yml
@@ -64,7 +64,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Dataflow Streaming Engine ValidatesRunner'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -81,13 +81,13 @@ jobs:
           gradle-command: :runners:google-cloud-dataflow-java:validatesRunnerStreamingEngine
           max-workers: 12
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming_TagEncodingV2.yml
+++ b/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming_TagEncodingV2.yml
@@ -65,7 +65,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Java Dataflow Streaming TagEncodingV2 ValidatesRunner'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -82,13 +82,13 @@ jobs:
           gradle-command: :runners:google-cloud-dataflow-java:validatesRunnerStreamingTagEncodingV2
           max-workers: 12
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Dataflow_V2.yml
+++ b/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Dataflow_V2.yml
@@ -65,7 +65,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Java Dataflow V2 ValidatesRunner'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -82,13 +82,13 @@ jobs:
           gradle-command: :runners:google-cloud-dataflow-java:validatesRunnerV2
           max-workers: 12
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Dataflow_V2_Streaming.yml
+++ b/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Dataflow_V2_Streaming.yml
@@ -65,7 +65,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Java Dataflow V2 ValidatesRunner Streaming'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -89,13 +89,13 @@ jobs:
           gradle-command: :runners:google-cloud-dataflow-java:validatesRunnerV2Streaming
           max-workers: 12
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Direct.yml
+++ b/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Direct.yml
@@ -65,7 +65,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Direct ValidatesRunner'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -79,13 +79,13 @@ jobs:
       - name: run validatesRunner script
         run: ./gradlew :runners:direct-java:validatesRunner
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Direct_JavaVersions.yml
+++ b/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Direct_JavaVersions.yml
@@ -67,7 +67,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       startswith(github.event.comment.body, 'Run Direct ValidatesRunner Java')
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -88,13 +88,13 @@ jobs:
             -PtestJavaVersion=${{ matrix.java_version }} \
             -Pjava${{ matrix.java_version }}Home=$JAVA_HOME_${{ matrix.java_version }}_X64 \
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Flink.yml
+++ b/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Flink.yml
@@ -65,7 +65,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Flink ValidatesRunner'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -82,13 +82,13 @@ jobs:
         with:
           gradle-command: :runners:flink:${{ matrix.flink_version }}:validatesRunner
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           large_files: true

--- a/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Spark.yml
+++ b/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Spark.yml
@@ -63,7 +63,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Spark ValidatesRunner'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -79,13 +79,13 @@ jobs:
         with:
           gradle-command: :runners:spark:3:validatesRunner
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Spark4.yml
+++ b/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Spark4.yml
@@ -63,7 +63,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Spark4 ValidatesRunner'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -80,13 +80,13 @@ jobs:
           gradle-command: :runners:spark:4:validatesRunner
           arguments: -PdisableSpotlessCheck=true
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming.yml
+++ b/.github/workflows/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming.yml
@@ -63,7 +63,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Spark StructuredStreaming ValidatesRunner'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -79,13 +79,13 @@ jobs:
         with:
           gradle-command: :runners:spark:3:validatesStructuredStreamingRunnerBatch
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Twister2.yml
+++ b/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Twister2.yml
@@ -63,7 +63,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Twister2 ValidatesRunner'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -79,13 +79,13 @@ jobs:
         with:
           gradle-command: :runners:twister2:validatesRunner
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Java_ValidatesRunner_ULR.yml
+++ b/.github/workflows/beam_PostCommit_Java_ValidatesRunner_ULR.yml
@@ -63,7 +63,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run ULR Loopback ValidatesRunner'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -78,13 +78,13 @@ jobs:
       - name: run ulrLoopbackValidatesRunner script
         run: ./gradlew :runners:portability:java:ulrLoopbackValidatesRunner
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Javadoc.yml
+++ b/.github/workflows/beam_PostCommit_Javadoc.yml
@@ -65,7 +65,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Javadoc PostCommit'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -82,12 +82,12 @@ jobs:
           gradle-command: :sdks:java:javadoc:aggregateJavadoc
           arguments: -PdisableSpotlessCheck=true
       - name: Add canonical link into javadocs
-        uses: cicirello/javadoc-cleanup@v1
+        uses: cicirello/javadoc-cleanup@eb6cbe89ca0d73aa57f8b1c381a82706311144ad # v1
         with:
           path-to-root: sdks/java/javadoc/build/docs/javadoc
           base-url-path: https://beam.apache.org/releases/javadoc/current/
       - name: Upload Javadoc Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: Javadoc Results
           path: '**/sdks/java/javadoc/build/docs/javadoc/**'

--- a/.github/workflows/beam_PostCommit_PortableJar_Flink.yml
+++ b/.github/workflows/beam_PostCommit_PortableJar_Flink.yml
@@ -63,7 +63,7 @@ jobs:
         job_name: ["beam_PostCommit_PortableJar_Flink"]
         job_phrase: ["Run PortableJar_Flink PostCommit"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -83,13 +83,13 @@ jobs:
           arguments: |
             -PpythonVersion=3.10 \
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_PortableJar_Spark.yml
+++ b/.github/workflows/beam_PostCommit_PortableJar_Spark.yml
@@ -63,7 +63,7 @@ jobs:
         job_name: ["beam_PostCommit_PortableJar_Spark"]
         job_phrase: ["Run PortableJar_Spark PostCommit"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -83,13 +83,13 @@ jobs:
           arguments: |
             -PpythonVersion=3.10 \
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Python.yml
+++ b/.github/workflows/beam_PostCommit_Python.yml
@@ -69,7 +69,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       startswith(github.event.comment.body, 'Run Python PostCommit 3.')
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -105,13 +105,13 @@ jobs:
         env:
           CLOUDSDK_CONFIG: ${{ env.KUBELET_GCLOUD_CONFIG_PATH}}
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python ${{ matrix.python_version }} Test Results (${{ join(matrix.os, ', ') }})
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Python_Arm.yml
+++ b/.github/workflows/beam_PostCommit_Python_Arm.yml
@@ -66,9 +66,9 @@ jobs:
       github.event_name == 'pull_request_target' ||
       (github.event_name == 'schedule' && github.repository == 'apache/beam')
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -119,13 +119,13 @@ jobs:
           MULTIARCH_TAG: ${{ steps.set_tag.outputs.TAG }}
           USER: github-actions
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python ${{ matrix.python_version }} Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Python_Dependency.yml
+++ b/.github/workflows/beam_PostCommit_Python_Dependency.yml
@@ -67,7 +67,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       startsWith(github.event.comment.body, 'Run Python PostCommit Dependency')
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -93,13 +93,13 @@ jobs:
             -PuseWheelDistribution \
             -PpythonVersion=${{ matrix.python_version }}
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Python_Examples_Dataflow.yml
+++ b/.github/workflows/beam_PostCommit_Python_Examples_Dataflow.yml
@@ -63,7 +63,7 @@ jobs:
         job_name: ["beam_PostCommit_Python_Examples_Dataflow"]
         job_phrase: ["Run Python Examples_Dataflow"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -83,13 +83,13 @@ jobs:
             -PuseWheelDistribution \
             -PpythonVersion=3.14 \
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Python_Examples_Direct.yml
+++ b/.github/workflows/beam_PostCommit_Python_Examples_Direct.yml
@@ -65,7 +65,7 @@ jobs:
         job_phrase: ["Run Python Examples_Direct"]
         python_version: ['3.10','3.11','3.12', '3.13','3.14']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -90,13 +90,13 @@ jobs:
           arguments: |
             -PpythonVersion=${{ matrix.python_version }} \
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Python_Examples_Flink.yml
+++ b/.github/workflows/beam_PostCommit_Python_Examples_Flink.yml
@@ -65,7 +65,7 @@ jobs:
         job_phrase: ["Run Python Examples_Flink"]
         python_version: ['3.10', '3.14']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -90,13 +90,13 @@ jobs:
           arguments: |
             -PpythonVersion=${{ matrix.python_version }} \
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Python_Examples_Spark.yml
+++ b/.github/workflows/beam_PostCommit_Python_Examples_Spark.yml
@@ -65,7 +65,7 @@ jobs:
         job_phrase: ["Run Python Examples_Spark"]
         python_version: ['3.10', '3.14']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -90,13 +90,13 @@ jobs:
           arguments: |
             -PpythonVersion=${{ matrix.python_version }} \
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Python_MongoDBIO_IT.yml
+++ b/.github/workflows/beam_PostCommit_Python_MongoDBIO_IT.yml
@@ -63,7 +63,7 @@ jobs:
         job_name: ["beam_PostCommit_Python_MongoDBIO_IT"]
         job_phrase: ["Run Python MongoDBIO_IT"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -82,13 +82,13 @@ jobs:
           arguments: |
             -PpythonVersion=3.14 \
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Python_Nexmark_Direct.yml
+++ b/.github/workflows/beam_PostCommit_Python_Nexmark_Direct.yml
@@ -108,7 +108,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run Python Direct Runner Nexmark Tests'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PostCommit_Python_Portable_Flink.yml
+++ b/.github/workflows/beam_PostCommit_Python_Portable_Flink.yml
@@ -67,7 +67,7 @@ jobs:
         # Run modes not covered by PreCommit_Python_PVR_Flink (i.e. other than 'LOOPBACK')
         environment_type: ['DOCKER']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -88,13 +88,13 @@ jobs:
           arguments: |
             -PpythonVersion=3.10 \
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results ${{ matrix.environment_type }}
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Python_ValidatesContainer_Dataflow.yml
+++ b/.github/workflows/beam_PostCommit_Python_ValidatesContainer_Dataflow.yml
@@ -67,7 +67,7 @@ jobs:
         job_phrase: ["Run Python Dataflow ValidatesContainer"]
         python_version: ['3.10','3.11','3.12','3.13','3.14']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -117,13 +117,13 @@ jobs:
           arguments: |
             -PpythonVersion=${{ matrix.python_version }}
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results ${{ matrix.python_version }}
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Python_ValidatesContainer_Dataflow_With_RC.yml
+++ b/.github/workflows/beam_PostCommit_Python_ValidatesContainer_Dataflow_With_RC.yml
@@ -65,7 +65,7 @@ jobs:
         job_phrase: ["Run Python RC Dataflow ValidatesContainer"]
         python_version: ['3.10','3.11','3.12','3.13','3.14']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -113,13 +113,13 @@ jobs:
             -PtestRCDependencies=true \
             -PpythonVersion=${{ matrix.python_version }}
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Python_ValidatesRunner_Dataflow.yml
+++ b/.github/workflows/beam_PostCommit_Python_ValidatesRunner_Dataflow.yml
@@ -65,7 +65,7 @@ jobs:
         job_phrase: ["Run Python Dataflow ValidatesRunner"]
         python_version: ['3.10', '3.14']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -98,13 +98,13 @@ jobs:
             -PuseWheelDistribution \
             -PpythonVersion=${{ matrix.python_version }} \
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Python_ValidatesRunner_Flink.yml
+++ b/.github/workflows/beam_PostCommit_Python_ValidatesRunner_Flink.yml
@@ -65,7 +65,7 @@ jobs:
         job_phrase: ["Run Python Flink ValidatesRunner"]
         python_version: ['3.10', '3.14']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -92,13 +92,13 @@ jobs:
           arguments: |
             -PpythonVersion=${{ matrix.python_version }} \
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Python_ValidatesRunner_Spark.yml
+++ b/.github/workflows/beam_PostCommit_Python_ValidatesRunner_Spark.yml
@@ -65,7 +65,7 @@ jobs:
         job_phrase: ["Run Python Spark ValidatesRunner"]
         python_version: ['3.10', '3.14']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -90,13 +90,13 @@ jobs:
           arguments: |
             -PpythonVersion=${{ matrix.python_version }} \
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Python_Versions.yml
+++ b/.github/workflows/beam_PostCommit_Python_Versions.yml
@@ -88,7 +88,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -134,13 +134,13 @@ jobs:
             -PpythonVersion=${{ matrix.python_version }} \
             -Pposargs="--ignore=apache_beam/ml/" \
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python ${{ matrix.python_version }} Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Python_Xlang_Gcp_Dataflow.yml
+++ b/.github/workflows/beam_PostCommit_Python_Xlang_Gcp_Dataflow.yml
@@ -64,7 +64,7 @@ jobs:
         job_name: ["beam_PostCommit_Python_Xlang_Gcp_Dataflow"]
         job_phrase: ["Run Python_Xlang_Gcp_Dataflow PostCommit"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -89,13 +89,13 @@ jobs:
             -PuseWheelDistribution \
             -Pjava17Home=$JAVA_HOME_17_X64 \
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Python_Xlang_Gcp_Direct.yml
+++ b/.github/workflows/beam_PostCommit_Python_Xlang_Gcp_Direct.yml
@@ -64,7 +64,7 @@ jobs:
         job_name: ["beam_PostCommit_Python_Xlang_Gcp_Direct"]
         job_phrase: ["Run Python_Xlang_Gcp_Direct PostCommit"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -91,13 +91,13 @@ jobs:
           arguments: |
             -Pjava17Home=$JAVA_HOME_17_X64
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Python_Xlang_IO_Dataflow.yml
+++ b/.github/workflows/beam_PostCommit_Python_Xlang_IO_Dataflow.yml
@@ -63,7 +63,7 @@ jobs:
         job_name: ["beam_PostCommit_Python_Xlang_IO_Dataflow"]
         job_phrase: ["Run Python_Xlang_IO_Dataflow PostCommit"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -89,13 +89,13 @@ jobs:
             -PkafkaBootstrapServer=10.128.0.40:9094,10.128.0.28:9094,10.128.0.165:9094 \
             -Pjava17Home=$JAVA_HOME_17_X64 \
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Python_Xlang_IO_Direct.yml
+++ b/.github/workflows/beam_PostCommit_Python_Xlang_IO_Direct.yml
@@ -63,7 +63,7 @@ jobs:
         job_name: ["beam_PostCommit_Python_Xlang_IO_Direct"]
         job_phrase: ["Run Python_Xlang_IO_Direct PostCommit"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -87,13 +87,13 @@ jobs:
             -PuseWheelDistribution \
             -Pjava17Home=$JAVA_HOME_17_X64
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Python_Xlang_Messaging_Direct.yml
+++ b/.github/workflows/beam_PostCommit_Python_Xlang_Messaging_Direct.yml
@@ -63,7 +63,7 @@ jobs:
         job_name: ["beam_PostCommit_Python_Xlang_Messaging_Direct"]
         job_phrase: ["Run Python_Xlang_Messaging_Direct PostCommit"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -82,13 +82,13 @@ jobs:
           gradle-command: :sdks:python:test-suites:direct:messagingCrossLanguagePostCommit
           arguments: -PuseWheelDistribution
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_SQL.yml
+++ b/.github/workflows/beam_PostCommit_SQL.yml
@@ -65,7 +65,7 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'apache/beam') ||
       github.event.comment.body == 'Run SQL PostCommit'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -79,13 +79,13 @@ jobs:
         with:
           gradle-command: :sqlPostCommit
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_TransformService_Direct.yml
+++ b/.github/workflows/beam_PostCommit_TransformService_Direct.yml
@@ -64,7 +64,7 @@ jobs:
         job_phrase: ["Run TransformService_Direct PostCommit"]
         python_version: ['3.10','3.14']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -90,13 +90,13 @@ jobs:
             -Pjava11Home=$JAVA_HOME_11_X64 \
             -PpythonVersion=${{ matrix.python_version }} \
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python ${{ matrix.python_version }} Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Website_Test.yml
+++ b/.github/workflows/beam_PostCommit_Website_Test.yml
@@ -63,7 +63,7 @@ jobs:
         job_name: ["beam_PostCommit_Website_Test"]
         job_phrase: ["Run Full Website Test"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PostCommit_XVR_Direct.yml
+++ b/.github/workflows/beam_PostCommit_XVR_Direct.yml
@@ -64,7 +64,7 @@ jobs:
         job_phrase: ["Run XVR_Direct PostCommit"]
         python_version: ['3.10','3.14']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -89,13 +89,13 @@ jobs:
             -Pjava17Home=$JAVA_HOME_17_X64 \
             -PskipNonPythonTask=${{ (matrix.python_version == '3.10' && true) || false }} \
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_XVR_Flink.yml
+++ b/.github/workflows/beam_PostCommit_XVR_Flink.yml
@@ -65,7 +65,7 @@ jobs:
         job_phrase: ["Run XVR_Flink PostCommit"]
         python_version: ['3.10','3.14']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -90,13 +90,13 @@ jobs:
             -PpythonVersion=${{ matrix.python_version }} \
             -PskipNonPythonTask=${{ (matrix.python_version == '3.10' && true) || false }} \
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_XVR_GoUsingJava_Dataflow.yml
+++ b/.github/workflows/beam_PostCommit_XVR_GoUsingJava_Dataflow.yml
@@ -66,7 +66,7 @@ jobs:
         job_name: ["beam_PostCommit_XVR_GoUsingJava_Dataflow"]
         job_phrase: ["Run XVR_GoUsingJava_Dataflow PostCommit"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -92,13 +92,13 @@ jobs:
               -Pjava17Home=$JAVA_HOME_17_X64 \
               -PuseDockerBuildx
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_XVR_JavaUsingPython_Dataflow.yml
+++ b/.github/workflows/beam_PostCommit_XVR_JavaUsingPython_Dataflow.yml
@@ -64,7 +64,7 @@ jobs:
         job_phrase: ["Run XVR_JavaUsingPython_Dataflow PostCommit"]
         python_version: ['3.10','3.14']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -88,13 +88,13 @@ jobs:
             -Pjava17Home=$JAVA_HOME_17_X64 \
             -PpythonVersion=${{ matrix.python_version }} \
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_XVR_PythonUsingJavaSQL_Dataflow.yml
+++ b/.github/workflows/beam_PostCommit_XVR_PythonUsingJavaSQL_Dataflow.yml
@@ -63,7 +63,7 @@ jobs:
         job_name: ["beam_PostCommit_XVR_PythonUsingJavaSQL_Dataflow"]
         job_phrase: ["Run XVR_PythonUsingJavaSQL_Dataflow PostCommit"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -85,13 +85,13 @@ jobs:
             -Pjava17Home=$JAVA_HOME_17_X64 \
             -PpythonVersion=3.14 \
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_XVR_PythonUsingJava_Dataflow.yml
+++ b/.github/workflows/beam_PostCommit_XVR_PythonUsingJava_Dataflow.yml
@@ -64,7 +64,7 @@ jobs:
         job_phrase: ["Run XVR_PythonUsingJava_Dataflow PostCommit"]
         python_version: ['3.10','3.14']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -88,13 +88,13 @@ jobs:
             -Pjava17Home=$JAVA_HOME_17_X64 \
             -PpythonVersion=${{ matrix.python_version }} \
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_XVR_Spark3.yml
+++ b/.github/workflows/beam_PostCommit_XVR_Spark3.yml
@@ -64,7 +64,7 @@ jobs:
         job_phrase: ["Run XVR_Spark3 PostCommit"]
         python_version: ['3.10','3.14']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -89,13 +89,13 @@ jobs:
             -PpythonVersion=${{ matrix.python_version }} \
             -PskipNonPythonTask=${{ (matrix.python_version == '3.10' && true) || false }} \
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'

--- a/.github/workflows/beam_PostCommit_Yaml_Xlang_Direct.yml
+++ b/.github/workflows/beam_PostCommit_Yaml_Xlang_Direct.yml
@@ -63,7 +63,7 @@ jobs:
         job_phrase: ["Run Yaml_Xlang_Direct PostCommit"]
         test_set: ["data", "databases", "messaging"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:
@@ -86,17 +86,16 @@ jobs:
           arguments: |
             -Pjava17Home=$JAVA_HOME_17_X64
       - name: Archive Python Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: Python Test Results
           path: '**/pytest*.xml'
       - name: Publish Python Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'
           comment_mode: ${{ github.event_name == 'issue_comment'  && 'always' || 'off' }}
           files: '**/pytest*.xml'
           large_files: true
-


### PR DESCRIPTION
Pin unpinned GitHub Actions to immutable commit SHAs. Defense against supply-chain attacks via mutable tags. Version tags retained as inline comments. See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions