### PR TITLE
[IcebergIO] Cache destination Row keys in AssignDestinationsAndPartitions

### DIFF
--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/AssignDestinationsAndPartitions.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/AssignDestinationsAndPartitions.java
@@ -84,6 +84,7 @@ class AssignDestinationsAndPartitions
     private transient @MonotonicNonNull Map<String, PartitionKey> partitionKeys;
     private transient @MonotonicNonNull Map<String, BeamRowWrapper> wrappers;
     private transient @MonotonicNonNull Map<String, Instant> lastRefreshTimes;
+    private transient @MonotonicNonNull Map<String, Row> keyCache;
 
     private final DynamicDestinations dynamicDestinations;
     private final IcebergCatalogConfig catalogConfig;
@@ -98,6 +99,7 @@ class AssignDestinationsAndPartitions
       this.wrappers = new HashMap<>();
       this.partitionKeys = new HashMap<>();
       this.lastRefreshTimes = new HashMap<>();
+      this.keyCache = new HashMap<>();
     }
 
     @ProcessElement
@@ -175,8 +177,13 @@ class AssignDestinationsAndPartitions
 
       String partitionPath = partitionKey.toPath();
 
-      Row destAndPartition =
-          Row.withSchema(OUTPUT_SCHEMA).addValues(tableIdentifier, partitionPath).build();
+      String cacheKey = tableIdentifier + "|" + partitionPath;
+      Row destAndPartition = checkStateNotNull(keyCache).get(cacheKey);
+      if (destAndPartition == null) {
+        destAndPartition =
+            Row.withSchema(OUTPUT_SCHEMA).addValues(tableIdentifier, partitionPath).build();
+        keyCache.put(cacheKey, destAndPartition);
+      }
 
       out.output(KV.of(destAndPartition, data));
     }


### PR DESCRIPTION
## Summary
- Add a `Map<String, Row> keyCache` in `AssignDestinationsAndPartitions.AssignDoFn` to reuse Row key objects across millions of input rows
- Only N distinct `(destination, partition)` combinations exist (e.g. 400 for a 400-bucket table), but every row currently allocates a new Row with schema validation overhead
- After the first N rows, all subsequent lookups are cache hits

## Motivation
Observed during production benchmarks at scale (39M users, 400 partitions, 99-column schema). Row allocation + schema validation dominated bundle processing time unnecessarily.

## Test plan
- [ ] Existing `AssignDestinationsAndPartitionsTest` passes
- [ ] Run IcebergIO integration tests
- [ ] Verify via profiling that Row allocation drops after initial cache warm-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)