### PR TITLE
[IcebergIO] Use GroupByKey for bounded inputs to avoid OOM

### DIFF
--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/WriteToPartitions.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/WriteToPartitions.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import org.apache.beam.sdk.coders.IterableCoder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.RowCoder;
+import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.GroupIntoBatches;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -64,27 +65,32 @@ class WriteToPartitions extends PTransform<PCollection<KV<Row, Row>>, IcebergWri
     RowCoder destinationCoder = RowCoder.of(AssignDestinationsAndPartitions.OUTPUT_SCHEMA);
     RowCoder dataCoder = RowCoder.of(dynamicDestinations.getDataSchema());
 
-    GroupIntoBatches<Row, Row> groupIntoPartitions =
-        GroupIntoBatches.ofByteSize(DEFAULT_BYTES_PER_FILE);
-    if (IcebergUtils.isUnbounded(input) && triggeringFrequency != null) {
-      groupIntoPartitions = groupIntoPartitions.withMaxBufferingDuration(triggeringFrequency);
-    }
+    if (IcebergUtils.isUnbounded(input)) {
+      GroupIntoBatches<Row, Row> groupIntoPartitions =
+          GroupIntoBatches.ofByteSize(DEFAULT_BYTES_PER_FILE);
+      if (triggeringFrequency != null) {
+        groupIntoPartitions = groupIntoPartitions.withMaxBufferingDuration(triggeringFrequency);
+      }
 
-    if (autoSharding) {
+      if (autoSharding) {
+        return input
+            .apply(groupIntoPartitions.withShardedKey())
+            .setCoder(
+                KvCoder.of(
+                    org.apache.beam.sdk.util.ShardedKey.Coder.of(destinationCoder),
+                    IterableCoder.of(dataCoder)))
+            .apply(
+                "DropShardId",
+                MapElements.into(kvs(rows(), iterables(rows())))
+                    .via(kv -> KV.of(kv.getKey().getKey(), kv.getValue())))
+            .setCoder(KvCoder.of(destinationCoder, IterableCoder.of(dataCoder)));
+      }
       return input
-          .apply(groupIntoPartitions.withShardedKey())
-          .setCoder(
-              KvCoder.of(
-                  org.apache.beam.sdk.util.ShardedKey.Coder.of(destinationCoder),
-                  IterableCoder.of(dataCoder)))
-          .apply(
-              "DropShardId",
-              MapElements.into(kvs(rows(), iterables(rows())))
-                  .via(kv -> KV.of(kv.getKey().getKey(), kv.getValue())))
+          .apply(groupIntoPartitions)
           .setCoder(KvCoder.of(destinationCoder, IterableCoder.of(dataCoder)));
     } else {
       return input
-          .apply(groupIntoPartitions)
+          .apply(GroupByKey.create())
           .setCoder(KvCoder.of(destinationCoder, IterableCoder.of(dataCoder)));
     }
   }


### PR DESCRIPTION
## Summary
- Replace `GroupIntoBatches` with `GroupByKey` for bounded (batch) inputs in `WriteToPartitions`
- Keep `GroupIntoBatches` only for unbounded (streaming) inputs where triggering semantics and optional `autoSharding` (via `withShardedKey`) are needed
- `GroupIntoBatches.ofByteSize()` materializes all values for a key into a Java `List` in memory — `RowCoder` reports wire size (~500 bytes/row) but actual heap is ~10× higher for nested schemas

## Motivation
Observed OOM on production pipelines with nested schemas (99 columns, 3 protobuf structs):
- `n4-standard-16` (64GB): GC thrashing at 99.79%, SDK harness killed
- `n4-highmem-48` (384GB): 277GB/377GB heap used for a single batch

`GroupByKey` returns a lazy `Iterable` backed by the shuffle service, consuming constant ~100MB memory regardless of partition size.

## Impact
- **Batch**: lazy iteration, O(100MB) memory regardless of shard size
- **Streaming**: unchanged — `GroupIntoBatches` with triggering + optional `autoSharding`
- `autoSharding` only meaningful for streaming (Dataflow dynamic key splitting)

## Test plan
- [ ] Existing `WriteToPartitionsTest` passes
- [ ] Run IcebergIO integration tests for both batch and streaming
- [ ] Verify no OOM on large-partition batch pipelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)