### PR TITLE
[IcebergIO] Fix stale openWriters count in RecordWriterManager

### DIFF
--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/RecordWriterManager.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/RecordWriterManager.java
@@ -163,7 +163,10 @@ class RecordWriterManager implements AutoCloseable {
 
       @Nullable RecordWriter writer = writers.getIfPresent(routingPartitionKey);
       if (writer == null && openWriters >= maxNumWriters) {
-        return false;
+        writers.cleanUp();
+        if (openWriters >= maxNumWriters) {
+          return false;
+        }
       }
       writer = fetchWriterForPartition(routingPartitionKey, writer);
       writer.write(record);


### PR DESCRIPTION
## Summary
- Add `writers.cleanUp()` before the `openWriters >= maxNumWriters` capacity check in `RecordWriterManager.DestinationState.write()`
- Guava Cache eviction is lazy — expired entries are only removed on subsequent access or explicit `cleanUp()`, not proactively
- Without this fix, `openWriters` stays stale after writers expire, causing 100% false spill for tables with more partitions than `maxNumWriters` (default 20)

## Motivation
With `DEFAULT_MAX_WRITERS_PER_BUNDLE = 20` and more than 20 partitions, every record for the 21st+ partition is rejected as if the writer pool is full, triggering the spill path. Observed on a 400-partition table: 100% of records spilled, causing disk exhaustion.

After the fix, expired writers are properly evicted before the capacity check, and spill only occurs when the pool is genuinely full.

## Test plan
- [ ] Existing `RecordWriterManagerTest` passes
- [ ] Run IcebergIO integration tests with >20 partitions
- [ ] Verify spill rate drops to near-zero for tables with idle partitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)