### PR TITLE
Retry starting SubprocessServer on failure

### DIFF
--- a/sdks/python/apache_beam/utils/subprocess_server.py
+++ b/sdks/python/apache_beam/utils/subprocess_server.py
@@ -201,45 +201,53 @@ class SubprocessServer(object):
     self.stop()
 
   def start(self):
-    try:
-      process, endpoint = self.start_process()
-      wait_secs = .1
-      channel_options = [
-          ("grpc.max_receive_message_length", -1),
-          ("grpc.max_send_message_length", -1),
-          # Default: 20000ms (20s), increased to 10 minutes for stability
-          ("grpc.keepalive_timeout_ms", 600_000),
-          # Default: 2, set to 0 to allow unlimited pings without data
-          ("grpc.http2.max_pings_without_data", 0),
-          # Default: False, set to True to allow keepalive pings when no calls
-          ("grpc.keepalive_permit_without_calls", True),
-          # Default: 2, set to 0 to allow unlimited ping strikes
-          ("grpc.http2.max_ping_strikes", 0),
-          # Default: 0 (disabled), enable socket reuse for better handling
-          ("grpc.so_reuseport", 1),
-      ]
-      self._grpc_channel = grpc.insecure_channel(
-          endpoint, options=channel_options)
-      channel_ready = grpc.channel_ready_future(self._grpc_channel)
-      while True:
-        if process is not None and process.poll() is not None:
-          _LOGGER.error("Failed to start job service with %s", process.args)
-          raise RuntimeError(
-              'Service failed to start up with error %s' % process.poll())
-        try:
-          channel_ready.result(timeout=wait_secs)
-          break
-        except (grpc.FutureTimeoutError, grpc.RpcError):
-          wait_secs *= 1.2
-          logging.log(
-              logging.WARNING if wait_secs > 1 else logging.DEBUG,
-              'Waiting for grpc channel to be ready at %s.',
-              endpoint)
-      return self._stub_class(self._grpc_channel)
-    except:  # pylint: disable=bare-except
-      _LOGGER.exception("Error bringing up service")
-      self.stop_force()
-      raise
+    max_retries = 3
+    for attempt in range(max_retries):
+      try:
+        process, endpoint = self.start_process()
+        wait_secs = .1
+        channel_options = [
+            ("grpc.max_receive_message_length", -1),
+            ("grpc.max_send_message_length", -1),
+            # Default: 20000ms (20s), increased to 10 minutes for stability
+            ("grpc.keepalive_timeout_ms", 600_000),
+            # Default: 2, set to 0 to allow unlimited pings without data
+            ("grpc.http2.max_pings_without_data", 0),
+            # Default: False, set to True to allow keepalive pings when no calls
+            ("grpc.keepalive_permit_without_calls", True),
+            # Default: 2, set to 0 to allow unlimited ping strikes
+            ("grpc.http2.max_ping_strikes", 0),
+            # Default: 0 (disabled), enable socket reuse for better handling
+            ("grpc.so_reuseport", 1),
+        ]
+        self._grpc_channel = grpc.insecure_channel(
+            endpoint, options=channel_options)
+        channel_ready = grpc.channel_ready_future(self._grpc_channel)
+        while True:
+          if process is not None and process.poll() is not None:
+            _LOGGER.error("Failed to start job service with %s", process.args)
+            raise RuntimeError(
+                'Service failed to start up with error %s' % process.poll())
+          try:
+            channel_ready.result(timeout=wait_secs)
+            break
+          except (grpc.FutureTimeoutError, grpc.RpcError):
+            wait_secs *= 1.2
+            logging.log(
+                logging.WARNING if wait_secs > 1 else logging.DEBUG,
+                'Waiting for grpc channel to be ready at %s.',
+                endpoint)
+        return self._stub_class(self._grpc_channel)
+      except Exception as e:
+        _LOGGER.warning(
+            "Error bringing up service (attempt %d of %d): %s",
+            attempt + 1,
+            max_retries,
+            e)
+        self.stop_force()
+        if attempt == max_retries - 1:
+          raise
+        time.sleep(1)
 
   def start_process(self):
     if self._owner_id is not None:

--- a/sdks/python/apache_beam/utils/subprocess_server.py
+++ b/sdks/python/apache_beam/utils/subprocess_server.py
@@ -248,6 +248,9 @@ class SubprocessServer(object):
         if attempt == max_retries - 1:
           raise
         time.sleep(1)
+      except:  # pylint: disable=bare-except
+        self.stop_force()
+        raise
 
   def start_process(self):
     if self._owner_id is not None:

--- a/sdks/python/apache_beam/utils/subprocess_server_test.py
+++ b/sdks/python/apache_beam/utils/subprocess_server_test.py
@@ -514,9 +514,15 @@ class CacheTest(unittest.TestCase):
       def poll(self):
         return 1  # Simulate that process exited/failed
 
+    constructor_calls = 0
+
+    def custom_constructor(*args):
+      nonlocal constructor_calls
+      constructor_calls += 1
+      return (dummy_process, "localhost:12345")
+
     dummy_process = DummyProcess()
-    cache = subprocess_server._SharedCache(
-        lambda *args: (dummy_process, "localhost:12345"), custom_destructor)
+    cache = subprocess_server._SharedCache(custom_constructor, custom_destructor)
 
     # 1. Register an independent, unrelated owner in the cache first.
     other_owner = cache.register()
@@ -536,11 +542,14 @@ class CacheTest(unittest.TestCase):
     self.assertEqual(cache._cache[cache_key].owners, {other_owner})
 
     # 2. Verify starting the server (which registers its own owner and retrieves from cache) raises RuntimeError
-    with self.assertRaises(RuntimeError):
-      server.start()
+    with patch('time.sleep'):
+      with self.assertRaises(RuntimeError):
+        server.start()
+    self.assertEqual(constructor_calls, 3)
 
-    # 3. Verify that the destructor was called on the process, meaning no leak (even though other_owner was still registered!)
-    self.assertEqual(destructor_calls, [(dummy_process, "localhost:12345")])
+    # 3. Verify that the destructor was called on the process for each retry attempt (3 total),
+    # meaning there is no leak (even though other_owner was still registered).
+    self.assertEqual(destructor_calls, [(dummy_process, "localhost:12345")] * 3)
 
     # 4. Verify that the server has cleaned up its owner_id
     self.assertIsNone(server._owner_id)

--- a/sdks/python/apache_beam/utils/subprocess_server_test.py
+++ b/sdks/python/apache_beam/utils/subprocess_server_test.py
@@ -522,7 +522,8 @@ class CacheTest(unittest.TestCase):
       return (dummy_process, "localhost:12345")
 
     dummy_process = DummyProcess()
-    cache = subprocess_server._SharedCache(custom_constructor, custom_destructor)
+    cache = subprocess_server._SharedCache(
+        custom_constructor, custom_destructor)
 
     # 1. Register an independent, unrelated owner in the cache first.
     other_owner = cache.register()


### PR DESCRIPTION
During dynamic port allocation, a race condition can occur when we select a random port but another thread or worker occupies it before our server can start, causing an "address already in use" error. 

To resolve this, we wrap the subprocess startup and connection sequence in a retry loop with a limit of 3 attempts.

An example failed test:
https://github.com/apache/beam/actions/runs/28321549831/job/83904243793

Traceback:
```
________________ CrossLanguageKinesisIOTest.test_kinesis_write _________________

self = <apache_beam.io.external.xlang_kinesisio_it_test.CrossLanguageKinesisIOTest testMethod=test_kinesis_write>

    @unittest.skipIf(
        TestPipeline().get_option('aws_kinesis_stream'),
        'Do not test on localstack when pipeline options were provided')
    def test_kinesis_write(self):
      # TODO: remove this test once
      # https://github.com/apache/beam/issues/20416 is resolved
>     self.run_kinesis_write()

apache_beam/io/external/xlang_kinesisio_it_test.py:97: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
apache_beam/io/external/xlang_kinesisio_it_test.py:105: in run_kinesis_write
    with TestPipeline(options=PipelineOptions(self.pipeline_args)) as p:
apache_beam/pipeline.py:652: in __exit__
    self.result = self.run()
                  ^^^^^^^^^^
apache_beam/testing/test_pipeline.py:119: in run
    result = super().run(
apache_beam/pipeline.py:563: in run
    return self._run_internal(test_runner_api)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
apache_beam/pipeline.py:629: in _run_internal
    return self.runner.run_pipeline(self, self._options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
apache_beam/runners/runner.py:180: in run_pipeline
    return self.run_portable_pipeline(
apache_beam/runners/portability/portable_runner.py:375: in run_portable_pipeline
    job_service_handle = self.create_job_service(options)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
apache_beam/runners/portability/portable_runner.py:289: in create_job_service
    return self.create_job_service_handle(server.start(), options)
                                          ^^^^^^^^^^^^^^
apache_beam/runners/portability/job_server.py:88: in start
    self._endpoint = self._job_server.start()
                     ^^^^^^^^^^^^^^^^^^^^^^^^
apache_beam/runners/portability/job_server.py:131: in start
    return self._server.start()
           ^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <apache_beam.utils.subprocess_server.SubprocessServer object at 0x7881fc5f21d0>

    def start(self):
      try:
INFO     FlinkJarJobServer:subprocess_server.py:266 	at org.apache.beam.runners.flink.FlinkJobServerDriver.main(FlinkJobServerDriver.java:77)
INFO     FlinkJarJobServer:subprocess_server.py:266 Caused by: org.apache.beam.vendor.grpc.v1p69p0.io.netty.channel.unix.Errors$NativeIoException: bind(..) failed: Address already in use
INFO     FlinkJarJobServer:subprocess_server.py:266 [main] INFO org.apache.beam.runners.jobsubmission.JobServerDriver - ArtifactStagingServer stopped on localhost:36825
INFO     FlinkJarJobServer:subprocess_server.py:266 [main] INFO org.apache.beam.runners.jobsubmission.JobServerDriver - Expansion stopped on localhost:44161
ERROR    apache_beam.utils.subprocess_server:subprocess_server.py:226 Failed to start job service with ('java', '-jar', '-Dslf4j.provider=org.slf4j.simple.SimpleServiceProvider', '-Dorg.slf4j.simpleLogger.log.org.apache.flink.streaming=error', '-Dorg.slf4j.simpleLogger.log.org.apache.flink.runtime=error', '-Dorg.slf4j.simpleLogger.log.org.apache.beam.runners.flink.FlinkPipelineRunner=warn', '-Dorg.slf4j.simpleLogger.log.org.apache.beam.runners.fnexecution.control=warn', '/runner/_work/beam/beam/runners/flink/1.20/job-server/build/libs/beam-runners-flink-1.20-job-server-2.76.0-SNAPSHOT.jar', '--flink-master', '[auto]', '--artifacts-dir', '/tmp/beam-temp_3pmqphj/artifactsixp2vgsm', '--job-port', '36825', '--artifact-port', '0', '--expansion-port', '0')
ERROR    apache_beam.utils.subprocess_server:subprocess_server.py:240 Error bringing up service
Traceback (most recent call last):
  File "/runner/_work/beam/beam/sdks/python/apache_beam/utils/subprocess_server.py", line 227, in start
    raise RuntimeError(
RuntimeError: Service failed to start up with error 0
WARNING  apache_beam.utils.subprocess_server:subprocess_server.py:311 Really destroying service at localhost:36825 with cmd: ('java', '-jar', '-Dslf4j.provider=org.slf4j.simple.SimpleServiceProvider', '-Dorg.slf4j.simpleLogger.log.org.apache.flink.streaming=error', '-Dorg.slf4j.simpleLogger.log.org.apache.flink.runtime=error', '-Dorg.slf4j.simpleLogger.log.org.apache.beam.runners.flink.FlinkPipelineRunner=warn', '-Dorg.slf4j.simpleLogger.log.org.apache.beam.runners.fnexecution.control=warn', '/runner/_work/beam/beam/runners/flink/1.20/job-server/build/libs/beam-runners-flink-1.20-job-server-2.76.0-SNAPSHOT.jar', '--flink-master', '[auto]', '--artifacts-dir', '/tmp/beam-temp_3pmqphj/artifactsixp2vgsm', '--job-port', '36825', '--artifact-port', '0', '--expansion-port', '0')
Really destroying service at localhost:52571 with cmd: ('java', '-jar', '-Dslf4j.provider=org.slf4j.simple.SimpleServiceProvider', '-Dorg.slf4j.simpleLogger.log.org.apache.flink.streaming=error', '-Dorg.slf4j.simpleLogger.log.org.apache.flink.runtime=error', '-Dorg.slf4j.simpleLogger.log.org.apache.beam.runners.flink.FlinkPipelineRunner=warn', '-Dorg.slf4j.simpleLogger.log.org.apache.beam.runners.fnexecution.control=warn', '/runner/_work/beam/beam/runners/flink/1.20/job-server/build/libs/beam-runners-flink-1.20-job-server-2.76.0-SNAPSHOT.jar', '--flink-master', '[auto]', '--artifacts-dir', '/tmp/beam-tempjp99srkd/artifactse8apq8m9', '--job-port', '52571', '--artifact-port', '0', '--expansion-port', '0')
WARNING  apache_beam.utils.subprocess_server:subprocess_server.py:311 Really destroying service at localhost:36579 with cmd: ['/opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/21.0.11-10.0.LTS/x64/bin/java', '-jar', '/runner/_work/beam/beam/sdks/java/io/amazon-web-services2/expansion-service/build/libs/beam-sdks-java-io-amazon-web-services2-expansion-service-2.76.0-SNAPSHOT.jar', '36579', '--filesToStage=/runner/_work/beam/beam/sdks/java/io/amazon-web-services2/expansion-service/build/libs/beam-sdks-java-io-amazon-web-services2-expansion-service-2.76.0-SNAPSHOT.jar', '--alsoStartLoopbackWorker']
```