### PR TITLE
[Interactive Beam] Fix caching deadlock, wait race conditions, and stale graph in notebooks

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/interactive_beam_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_beam_test.py
@@ -828,7 +828,7 @@ class InteractiveBeamComputeTest(unittest.TestCase):
     ])
 
     mock_clear_output.assert_called_once()
-    async_result.wait_for_completion()
+    async_result.wait_for_completion(timeout=60)
 
   def test_compute_dependency_wait_true(self):
     p = beam.Pipeline(ir.InteractiveRunner())
@@ -853,12 +853,12 @@ class InteractiveBeamComputeTest(unittest.TestCase):
       spy_wait.assert_called_with({pcoll2}, async_res2)
 
       # Let pcoll1 finish
-      async_res1.wait_for_completion()
+      async_res1.wait_for_completion(timeout=60)
       self.assertTrue(pcoll1 in self.env.computed_pcollections)
       self.assertFalse(self.env.is_pcollection_computing(pcoll1))
 
       # pcoll2 should now run and complete
-      async_res2.wait_for_completion()
+      async_res2.wait_for_completion(timeout=60)
       self.assertTrue(pcoll2 in self.env.computed_pcollections)
 
   @patch.object(ie.InteractiveEnvironment, 'is_pcollection_computing')
@@ -878,7 +878,7 @@ class InteractiveBeamComputeTest(unittest.TestCase):
                       '_execute_pipeline_fragment',
                       wraps=rm._execute_pipeline_fragment) as spy_execute:
       async_res2 = ib.compute(pcoll2, blocking=False, wait_for_inputs=False)
-      async_res2.wait_for_completion()
+      async_res2.wait_for_completion(timeout=60)
 
       # Assert that execute was called for pcoll2 without waiting
       spy_execute.assert_called_with({pcoll2}, async_res2, ANY, ANY)

--- a/sdks/python/apache_beam/runners/interactive/interactive_beam_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_beam_test.py
@@ -828,7 +828,7 @@ class InteractiveBeamComputeTest(unittest.TestCase):
     ])
 
     mock_clear_output.assert_called_once()
-    async_result.result(timeout=60)  # Let it finish
+    async_result.wait_for_completion()
 
   def test_compute_dependency_wait_true(self):
     p = beam.Pipeline(ir.InteractiveRunner())
@@ -878,7 +878,7 @@ class InteractiveBeamComputeTest(unittest.TestCase):
                       '_execute_pipeline_fragment',
                       wraps=rm._execute_pipeline_fragment) as spy_execute:
       async_res2 = ib.compute(pcoll2, blocking=False, wait_for_inputs=False)
-      async_res2.result(timeout=60)
+      async_res2.wait_for_completion()
 
       # Assert that execute was called for pcoll2 without waiting
       spy_execute.assert_called_with({pcoll2}, async_res2, ANY, ANY)

--- a/sdks/python/apache_beam/runners/interactive/interactive_beam_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_beam_test.py
@@ -853,12 +853,12 @@ class InteractiveBeamComputeTest(unittest.TestCase):
       spy_wait.assert_called_with({pcoll2}, async_res2)
 
       # Let pcoll1 finish
-      async_res1.result(timeout=60)
+      async_res1.wait_for_completion()
       self.assertTrue(pcoll1 in self.env.computed_pcollections)
       self.assertFalse(self.env.is_pcollection_computing(pcoll1))
 
       # pcoll2 should now run and complete
-      async_res2.result(timeout=60)
+      async_res2.wait_for_completion()
       self.assertTrue(pcoll2 in self.env.computed_pcollections)
 
   @patch.object(ie.InteractiveEnvironment, 'is_pcollection_computing')

--- a/sdks/python/apache_beam/runners/interactive/recording_manager.py
+++ b/sdks/python/apache_beam/runners/interactive/recording_manager.py
@@ -86,6 +86,7 @@ class AsyncComputationResult:
             bar_style='info',
         ) if IS_IPYTHON else None)
     self._cancel_requested = False
+    self._completed_event = threading.Event()
 
     if IS_IPYTHON:
       self._cancel_button.on_click(self._cancel_clicked)
@@ -151,27 +152,32 @@ class AsyncComputationResult:
     except TimeoutError:
       return None
 
+  def wait_for_completion(self):
+    self._completed_event.wait()
+
   def _on_done(self, future: Future):
-    self._env.unmark_pcollection_computing(self._pcolls)
-    self._recording_manager._async_computations.pop(self._display_id, None)
+    try:
+      if future.cancelled():
+        self.update_display('Computation Cancelled.', 1.0)
+        return
 
-    if future.cancelled():
-      self.update_display('Computation Cancelled.', 1.0)
-      return
-
-    exc = future.exception()
-    if exc:
-      self.update_display(f'Error: {exc}', 1.0)
-      _LOGGER.error('Asynchronous computation failed: %s', exc, exc_info=exc)
-    else:
-      self.update_display('Computation Finished Successfully.', 1.0)
-      res = future.result()
-      if res and res.state == PipelineState.DONE:
-        self._env.mark_pcollection_computed(self._pcolls)
+      exc = future.exception()
+      if exc:
+        self.update_display(f'Error: {exc}', 1.0)
+        _LOGGER.error('Asynchronous computation failed: %s', exc, exc_info=exc)
       else:
-        _LOGGER.warning(
-            'Async computation finished but state is not DONE: %s',
-            res.state if res else 'Unknown')
+        self.update_display('Computation Finished Successfully.', 1.0)
+        res = future.result()
+        if res and res.state == PipelineState.DONE:
+          self._env.mark_pcollection_computed(self._pcolls)
+        else:
+          _LOGGER.warning(
+              'Async computation finished but state is not DONE: %s',
+              res.state if res else 'Unknown')
+    finally:
+      self._env.unmark_pcollection_computing(self._pcolls)
+      self._recording_manager._async_computations.pop(self._display_id, None)
+      self._completed_event.set()
 
   def cancel(self):
     if self._future.done():
@@ -438,7 +444,6 @@ class RecordingManager:
     self._executor = ThreadPoolExecutor(max_workers=os.cpu_count())
     self._env = ie.current_env()
     self._async_computations: dict[str, AsyncComputationResult] = {}
-    self._pipeline_graph = None
 
   def _execute_pipeline_fragment(
       self,
@@ -710,19 +715,13 @@ class RecordingManager:
       return async_result
 
   def _get_pipeline_graph(self):
-    """Lazily initializes and returns the PipelineGraph."""
-    if self._pipeline_graph is None:
-      try:
-        # Try to create the graph.
-        self._pipeline_graph = PipelineGraph(self.user_pipeline)
-      except (ImportError, NameError, AttributeError):
-        # If pydot is missing, PipelineGraph() might crash.
-        _LOGGER.warning(
-            "Could not create PipelineGraph (pydot missing?). " \
-            "Async features disabled."
-        )
-        self._pipeline_graph = None
-    return self._pipeline_graph
+    """Initializes and returns the PipelineGraph."""
+    try:
+      # Try to create the graph.
+      return PipelineGraph(self.user_pipeline)
+    except (ImportError, NameError, AttributeError):
+      # If pydot is missing, PipelineGraph() might crash.
+      return None
 
   def _get_pcoll_id_map(self):
     """Creates a map from PCollection object to its ID in the proto."""
@@ -800,10 +799,15 @@ class RecordingManager:
     """Waits for any dependencies of the given
     PCollections that are currently being computed."""
     dependencies = self._get_all_dependencies(pcolls)
+    if async_result is None:
+      pcolls_to_check = dependencies.union(pcolls)
+    else:
+      pcolls_to_check = dependencies
     computing_deps: dict[beam.pvalue.PCollection, AsyncComputationResult] = {}
 
-    for dep in dependencies:
-      if self._env.is_pcollection_computing(dep):
+    for dep in pcolls_to_check:
+      is_computing = self._env.is_pcollection_computing(dep)
+      if is_computing:
         for comp in self._async_computations.values():
           if dep in comp._pcolls:
             computing_deps[dep] = comp
@@ -820,17 +824,16 @@ class RecordingManager:
         len(computing_deps),
         computing_deps.keys())
 
-    futures_to_wait = list(
-        set(comp._future for comp in computing_deps.values()))
+    results_to_wait = list(set(comp for comp in computing_deps.values()))
 
     try:
-      for i, future in enumerate(futures_to_wait):
+      for i, comp in enumerate(results_to_wait):
         if async_result:
           async_result.update_display(
-              f'Waiting for dependency {i + 1}/{len(futures_to_wait)}...',
-              progress=0.05 + 0.05 * (i / len(futures_to_wait)),
+              f'Waiting for dependency {i + 1}/{len(results_to_wait)}...',
+              progress=0.05 + 0.05 * (i / len(results_to_wait)),
           )
-        future.result()
+        comp.wait_for_completion()
       if async_result:
         async_result.update_display('Dependencies finished.', progress=0.1)
       _LOGGER.info('Dependencies finished successfully.')
@@ -891,23 +894,32 @@ class RecordingManager:
             'Cannot record because a dependency failed to compute'
             ' asynchronously.')
 
-      self._clear()
+      # Recalculate uncomputed PCollections because some may have finished computing during the wait
+      computed_pcolls = set(
+          pcoll for pcoll in pcolls
+          if pcoll in ie.current_env().computed_pcollections)
+      uncomputed_pcolls = set(pcolls).difference(computed_pcolls)
 
-      merged_options = pipeline_options.PipelineOptions(
-          **{
-              **self.user_pipeline.options.get_all_options(
-                  drop_default=True, retain_unknown_options=True),
-              **options.get_all_options(
-                  drop_default=True, retain_unknown_options=True)
-          }) if options else self.user_pipeline.options
+      if uncomputed_pcolls:
+        self._clear()
 
-      cache_path = ie.current_env().options.cache_root
-      is_remote_run = cache_path and ie.current_env(
-      ).options.cache_root.startswith('gs://')
-      pf.PipelineFragment(
-          list(uncomputed_pcolls), merged_options,
-          runner=runner).run(blocking=is_remote_run)
-      result = ie.current_env().pipeline_result(self.user_pipeline)
+        merged_options = pipeline_options.PipelineOptions(
+            **{
+                **self.user_pipeline.options.get_all_options(
+                    drop_default=True, retain_unknown_options=True),
+                **options.get_all_options(
+                    drop_default=True, retain_unknown_options=True)
+            }) if options else self.user_pipeline.options
+
+        cache_path = ie.current_env().options.cache_root
+        is_remote_run = cache_path and ie.current_env(
+        ).options.cache_root.startswith('gs://')
+        pf.PipelineFragment(
+            list(uncomputed_pcolls), merged_options,
+            runner=runner).run(blocking=is_remote_run)
+        result = ie.current_env().pipeline_result(self.user_pipeline)
+      else:
+        result = ie.current_env().pipeline_result(self.user_pipeline)
     else:
       result = None
 

--- a/sdks/python/apache_beam/runners/interactive/recording_manager.py
+++ b/sdks/python/apache_beam/runners/interactive/recording_manager.py
@@ -176,7 +176,8 @@ class AsyncComputationResult:
               res.state if res else 'Unknown')
     finally:
       self._env.unmark_pcollection_computing(self._pcolls)
-      self._recording_manager._async_computations.pop(self._display_id, None)
+      with self._recording_manager._lock:
+        self._recording_manager._async_computations.pop(self._display_id, None)
       self._completed_event.set()
 
   def cancel(self):
@@ -444,6 +445,7 @@ class RecordingManager:
     self._executor = ThreadPoolExecutor(max_workers=os.cpu_count())
     self._env = ie.current_env()
     self._async_computations: dict[str, AsyncComputationResult] = {}
+    self._lock = threading.Lock()
 
   def _execute_pipeline_fragment(
       self,
@@ -699,7 +701,8 @@ class RecordingManager:
       future = Future()
       async_result = AsyncComputationResult(
           future, pcolls_to_compute, self.user_pipeline, self)
-      self._async_computations[async_result._display_id] = async_result
+      with self._lock:
+        self._async_computations[async_result._display_id] = async_result
       self._env.mark_pcollection_computing(pcolls_to_compute)
 
       def task():
@@ -805,10 +808,13 @@ class RecordingManager:
       pcolls_to_check = dependencies
     computing_deps: dict[beam.pvalue.PCollection, AsyncComputationResult] = {}
 
+    with self._lock:
+      async_computations_copy = list(self._async_computations.values())
+
     for dep in pcolls_to_check:
       is_computing = self._env.is_pcollection_computing(dep)
       if is_computing:
-        for comp in self._async_computations.values():
+        for comp in async_computations_copy:
           if dep in comp._pcolls:
             computing_deps[dep] = comp
             break

--- a/sdks/python/apache_beam/runners/interactive/recording_manager.py
+++ b/sdks/python/apache_beam/runners/interactive/recording_manager.py
@@ -152,8 +152,15 @@ class AsyncComputationResult:
     except TimeoutError:
       return None
 
-  def wait_for_completion(self):
-    self._completed_event.wait()
+  def wait_for_completion(self, timeout=None):
+    if not self._completed_event.wait(timeout=timeout):
+      raise TimeoutError(
+          'Timeout waiting for asynchronous computation completion.')
+    if self._future.cancelled():
+      raise RuntimeError('Asynchronous computation was cancelled.')
+    exc = self.exception()
+    if exc:
+      raise exc
 
   def _on_done(self, future: Future):
     try:
@@ -724,6 +731,9 @@ class RecordingManager:
       return PipelineGraph(self.user_pipeline)
     except (ImportError, NameError, AttributeError):
       # If pydot is missing, PipelineGraph() might crash.
+      _LOGGER.warning(
+          "Could not create PipelineGraph (pydot missing?). "
+          "Async features disabled.")
       return None
 
   def _get_pcoll_id_map(self):

--- a/sdks/python/apache_beam/runners/interactive/recording_manager.py
+++ b/sdks/python/apache_beam/runners/interactive/recording_manager.py
@@ -454,6 +454,7 @@ class RecordingManager:
     self._env = ie.current_env()
     self._async_computations: dict[str, AsyncComputationResult] = {}
     self._lock = threading.Lock()
+    self._pipeline_graph = None
     self._applied_labels_snapshot = set()
 
   def _execute_pipeline_fragment(
@@ -859,7 +860,7 @@ class RecordingManager:
       self,
       pcolls: Iterable[beam.pvalue.PCollection],
   ) -> set[beam.pvalue.PCollection]:
-    """Helper to filter out already computed PCollections from the environment."""
+    """Filter out already computed PCollections from the environment."""
     current_env = ie.current_env()
     computed = {
         pcoll

--- a/sdks/python/apache_beam/runners/interactive/recording_manager.py
+++ b/sdks/python/apache_beam/runners/interactive/recording_manager.py
@@ -25,6 +25,7 @@ import warnings
 from concurrent.futures import Future
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
+from typing import Iterable
 from typing import Optional
 from typing import Union
 
@@ -453,6 +454,7 @@ class RecordingManager:
     self._env = ie.current_env()
     self._async_computations: dict[str, AsyncComputationResult] = {}
     self._lock = threading.Lock()
+    self._applied_labels_snapshot = set()
 
   def _execute_pipeline_fragment(
       self,
@@ -513,24 +515,10 @@ class RecordingManager:
       pipeline_result = self._execute_pipeline_fragment(
           pcolls_to_compute, async_result, runner, options)
 
-      # if pipeline_result.state == PipelineState.DONE:
-      #   self._env.mark_pcollection_computed(pcolls_to_compute)
-      #   _LOGGER.info(
-      #       'Asynchronous computation finished successfully for'
-      #       f' {len(pcolls_to_compute)} PCollections.'
-      #   )
-      # else:
-      #   _LOGGER.error(
-      #       'Asynchronous computation failed for'
-      #       f' {len(pcolls_to_compute)} PCollections. State:'
-      #       f' {pipeline_result.state}'
-      #   )
       return pipeline_result
     except Exception as e:
       _LOGGER.exception('Exception during asynchronous computation: %s', e)
       raise
-    # finally:
-    #   self._env.unmark_pcollection_computing(pcolls_to_compute)
 
   def _watch(self, pcolls: list[beam.pvalue.PCollection]) -> None:
     """Watch any pcollections not being watched.
@@ -589,7 +577,7 @@ class RecordingManager:
     if cache_manager:
       cache_manager.cleanup()
 
-  def cancel(self: None) -> None:
+  def cancel(self) -> None:
     """Cancels the current background recording job."""
 
     bcj.attempt_to_cancel_background_caching_job(self.user_pipeline)
@@ -725,16 +713,23 @@ class RecordingManager:
       return async_result
 
   def _get_pipeline_graph(self):
-    """Initializes and returns the PipelineGraph."""
-    try:
-      # Try to create the graph.
-      return PipelineGraph(self.user_pipeline)
-    except (ImportError, NameError, AttributeError):
-      # If pydot is missing, PipelineGraph() might crash.
-      _LOGGER.warning(
-          "Could not create PipelineGraph (pydot missing?). "
-          "Async features disabled.")
-      return None
+    """Lazily initializes and returns the PipelineGraph, rebuilding it
+    only if the pipeline transforms have changed.
+    """
+    if (self._pipeline_graph is None or
+        self._applied_labels_snapshot != self.user_pipeline.applied_labels):
+      try:
+        # Try to create the graph.
+        self._pipeline_graph = PipelineGraph(self.user_pipeline)
+        self._applied_labels_snapshot = set(self.user_pipeline.applied_labels)
+      except (ImportError, NameError, AttributeError):
+        # If pydot is missing, PipelineGraph() might crash.
+        _LOGGER.warning(
+            "Could not create PipelineGraph (pydot missing?). "
+            "Async features disabled.")
+        self._pipeline_graph = None
+        self._applied_labels_snapshot = set()
+    return self._pipeline_graph
 
   def _get_pcoll_id_map(self):
     """Creates a map from PCollection object to its ID in the proto."""
@@ -860,6 +855,18 @@ class RecordingManager:
       _LOGGER.error('Dependency computation failed: %s', e, exc_info=e)
       return False
 
+  def _get_uncomputed_pcolls(
+      self,
+      pcolls: Iterable[beam.pvalue.PCollection],
+  ) -> set[beam.pvalue.PCollection]:
+    """Helper to filter out already computed PCollections from the environment."""
+    current_env = ie.current_env()
+    computed = {
+        pcoll
+        for pcoll in pcolls if pcoll in current_env.computed_pcollections
+    }
+    return set(pcolls).difference(computed)
+
   def record(
       self,
       pcolls: list[beam.pvalue.PCollection],
@@ -897,47 +904,46 @@ class RecordingManager:
     self._watch(pcolls)
     self.record_pipeline()
 
-    # Get the subset of computed PCollections. These do not to be recomputed.
-    computed_pcolls = set(
-        pcoll for pcoll in pcolls
-        if pcoll in ie.current_env().computed_pcollections)
+    # Early check and return if everything is already computed
+    uncomputed_pcolls = self._get_uncomputed_pcolls(pcolls)
+    if not uncomputed_pcolls:
+      recording = Recording(
+          self.user_pipeline, pcolls, None, max_n, max_duration_secs)
+      self._recordings.add(recording)
+      return recording
 
-    # Start a pipeline fragment to start computing the PCollections.
-    uncomputed_pcolls = set(pcolls).difference(computed_pcolls)
-    if uncomputed_pcolls:
-      if not self._wait_for_dependencies(uncomputed_pcolls):
-        raise RuntimeError(
-            'Cannot record because a dependency failed to compute'
-            ' asynchronously.')
+    # Wait for dependencies if there are uncomputed PCollections
+    if not self._wait_for_dependencies(uncomputed_pcolls):
+      raise RuntimeError(
+          'Cannot record because a dependency failed to compute'
+          ' asynchronously.')
 
-      # Recalculate uncomputed PCollections because some may have finished computing during the wait
-      computed_pcolls = set(
-          pcoll for pcoll in pcolls
-          if pcoll in ie.current_env().computed_pcollections)
-      uncomputed_pcolls = set(pcolls).difference(computed_pcolls)
+    # Re-evaluate uncomputed PCollections
+    uncomputed_pcolls = self._get_uncomputed_pcolls(pcolls)
+    if not uncomputed_pcolls:
+      recording = Recording(
+          self.user_pipeline, pcolls, None, max_n, max_duration_secs)
+      self._recordings.add(recording)
+      return recording
 
-      if uncomputed_pcolls:
-        self._clear()
+    # Flattened execution path (no indentation needed)
+    self._clear()
 
-        merged_options = pipeline_options.PipelineOptions(
-            **{
-                **self.user_pipeline.options.get_all_options(
-                    drop_default=True, retain_unknown_options=True),
-                **options.get_all_options(
-                    drop_default=True, retain_unknown_options=True)
-            }) if options else self.user_pipeline.options
+    merged_options = pipeline_options.PipelineOptions(
+        **{
+            **self.user_pipeline.options.get_all_options(
+                drop_default=True, retain_unknown_options=True),
+            **options.get_all_options(
+                drop_default=True, retain_unknown_options=True)
+        }) if options else self.user_pipeline.options
 
-        cache_path = ie.current_env().options.cache_root
-        is_remote_run = cache_path and ie.current_env(
-        ).options.cache_root.startswith('gs://')
-        pf.PipelineFragment(
-            list(uncomputed_pcolls), merged_options,
-            runner=runner).run(blocking=is_remote_run)
-        result = ie.current_env().pipeline_result(self.user_pipeline)
-      else:
-        result = ie.current_env().pipeline_result(self.user_pipeline)
-    else:
-      result = None
+    cache_path = ie.current_env().options.cache_root
+    is_remote_run = cache_path and ie.current_env(
+    ).options.cache_root.startswith('gs://')
+    pf.PipelineFragment(
+        list(uncomputed_pcolls), merged_options,
+        runner=runner).run(blocking=is_remote_run)
+    result = ie.current_env().pipeline_result(self.user_pipeline)
 
     recording = Recording(
         self.user_pipeline, pcolls, result, max_n, max_duration_secs)

--- a/sdks/python/apache_beam/runners/interactive/recording_manager_test.py
+++ b/sdks/python/apache_beam/runners/interactive/recording_manager_test.py
@@ -1133,7 +1133,11 @@ class RecordingManagerTest(unittest.TestCase):
     self.assertIsNot(graph1, graph2)
 
     # Verify that the new graph contains the newly added transform
-    self.assertIn('Map1', graph2._pipeline_proto.components.transforms)
+    transform_names = [
+        t.unique_name
+        for t in graph2._pipeline_proto.components.transforms.values()
+    ]
+    self.assertIn('Map1', transform_names)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/interactive/recording_manager_test.py
+++ b/sdks/python/apache_beam/runners/interactive/recording_manager_test.py
@@ -1139,6 +1139,36 @@ class RecordingManagerTest(unittest.TestCase):
     ]
     self.assertIn('Map1', transform_names)
 
+  def test_wait_for_completion_raises_exception_on_failure(self):
+    future = Future()
+    async_res = AsyncComputationResult(
+        future, set(), beam.Pipeline(InteractiveRunner()), MagicMock())
+    # Set the future exception
+    exc = ValueError("computation error")
+    future.set_exception(exc)
+    async_res._completed_event.set()  # Simulate completion
+    with self.assertRaises(ValueError) as context:
+      async_res.wait_for_completion()
+    self.assertEqual(context.exception, exc)
+
+  def test_wait_for_completion_raises_error_on_cancellation(self):
+    future = Future()
+    async_res = AsyncComputationResult(
+        future, set(), beam.Pipeline(InteractiveRunner()), MagicMock())
+    future.cancel()
+    async_res._completed_event.set()
+    with self.assertRaises(RuntimeError) as context:
+      async_res.wait_for_completion()
+    self.assertIn('computation was cancelled', str(context.exception))
+
+  def test_wait_for_completion_raises_timeout_error(self):
+    future = Future()
+    async_res = AsyncComputationResult(
+        future, set(), beam.Pipeline(InteractiveRunner()), MagicMock())
+    # completed_event is NOT set, so wait will timeout
+    with self.assertRaises(TimeoutError):
+      async_res.wait_for_completion(timeout=0.01)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/sdks/python/apache_beam/runners/interactive/recording_manager_test.py
+++ b/sdks/python/apache_beam/runners/interactive/recording_manager_test.py
@@ -1148,7 +1148,7 @@ class RecordingManagerTest(unittest.TestCase):
     future.set_exception(exc)
     async_res._completed_event.set()  # Simulate completion
     with self.assertRaises(ValueError) as context:
-      async_res.wait_for_completion()
+      async_res.wait_for_completion(timeout=60)
     self.assertEqual(context.exception, exc)
 
   def test_wait_for_completion_raises_error_on_cancellation(self):
@@ -1158,7 +1158,7 @@ class RecordingManagerTest(unittest.TestCase):
     future.cancel()
     async_res._completed_event.set()
     with self.assertRaises(RuntimeError) as context:
-      async_res.wait_for_completion()
+      async_res.wait_for_completion(timeout=60)
     self.assertIn('computation was cancelled', str(context.exception))
 
   def test_wait_for_completion_raises_timeout_error(self):

--- a/sdks/python/apache_beam/runners/interactive/recording_manager_test.py
+++ b/sdks/python/apache_beam/runners/interactive/recording_manager_test.py
@@ -1062,7 +1062,7 @@ class RecordingManagerTest(unittest.TestCase):
     ie.current_env().mark_pcollection_computing({p1})
 
     self.assertTrue(rm._wait_for_dependencies({p2}))
-    mock_future.result.assert_called_once()
+    mock_async_res.wait_for_completion.assert_called_once()
     ie.current_env().unmark_pcollection_computing({p1})
 
   def test_wait_for_dependencies_async_result(self):
@@ -1122,7 +1122,7 @@ class RecordingManagerTest(unittest.TestCase):
     # First call: graph is created
     graph1 = rm._get_pipeline_graph()
     self.assertIsNotNone(graph1)
-    self.assertEqual(graph1.user_pipeline, p)
+    self.assertEqual(graph1._pipeline_instrument.user_pipeline, p)
 
     # Add a new transform to the pipeline
     pcoll2 = pcoll1 | 'Map1' >> beam.Map(lambda x: x + 1)

--- a/sdks/python/apache_beam/runners/interactive/recording_manager_test.py
+++ b/sdks/python/apache_beam/runners/interactive/recording_manager_test.py
@@ -1065,6 +1065,76 @@ class RecordingManagerTest(unittest.TestCase):
     mock_future.result.assert_called_once()
     ie.current_env().unmark_pcollection_computing({p1})
 
+  def test_wait_for_dependencies_async_result(self):
+    p = beam.Pipeline(InteractiveRunner())
+    pcoll = p | beam.Create([1])
+    rm = RecordingManager(p)
+
+    # Mock a background computation for pcoll
+    async_res = MagicMock(spec=AsyncComputationResult)
+    async_res._pcolls = {pcoll}
+    rm._async_computations['id1'] = async_res
+    ie.current_env().mark_pcollection_computing({pcoll})
+
+    # Case 1: Called from main thread (async_result=None)
+    # It should wait for pcoll's background job completion event
+    with patch.object(async_res, 'wait_for_completion') as mock_wait:
+      with patch.object(rm, '_get_all_dependencies', return_value=set()):
+        rm._wait_for_dependencies({pcoll}, async_result=None)
+        mock_wait.assert_called_once()
+
+    # Case 2: Called from background thread (async_result=async_res)
+    # It should NOT wait (prevents self-deadlock)
+    with patch.object(async_res, 'wait_for_completion') as mock_wait:
+      with patch.object(rm, '_get_all_dependencies', return_value=set()):
+        rm._wait_for_dependencies({pcoll}, async_result=async_res)
+        mock_wait.assert_not_called()
+
+  def test_record_recalculates_uncomputed_pcolls_after_wait(self):
+    from apache_beam.runners.interactive import pipeline_fragment as pf
+    p = beam.Pipeline(InteractiveRunner())
+    pcoll = p | beam.Create([1])
+    rm = RecordingManager(p)
+
+    # Mock wait_for_dependencies to simulate pcoll completing during the wait
+    def mock_wait(pcolls, async_result=None):
+      # Simulate pcoll completing by marking it computed
+      ie.current_env().mark_pcollection_computed({pcoll})
+      return True
+
+    with patch.object(rm, '_wait_for_dependencies', side_effect=mock_wait), \
+         patch.object(rm, '_clear') as mock_clear, \
+         patch.object(pf, 'PipelineFragment') as mock_fragment:
+
+      rm.record([pcoll], max_n=10, max_duration='inf')
+
+      # Since pcoll was marked computed during the wait,
+      # uncomputed_pcolls becomes empty.
+      # So _clear() and PipelineFragment should NOT be called.
+      mock_clear.assert_not_called()
+      mock_fragment.assert_not_called()
+
+  def test_get_pipeline_graph_not_cached(self):
+    p = beam.Pipeline(InteractiveRunner())
+    pcoll1 = p | 'Create1' >> beam.Create([1])
+    rm = RecordingManager(p)
+
+    # First call: graph is created
+    graph1 = rm._get_pipeline_graph()
+    self.assertIsNotNone(graph1)
+    self.assertEqual(graph1.user_pipeline, p)
+
+    # Add a new transform to the pipeline
+    pcoll2 = pcoll1 | 'Map1' >> beam.Map(lambda x: x + 1)
+
+    # Second call: graph should be updated and contain the new Map1 transform
+    graph2 = rm._get_pipeline_graph()
+    self.assertIsNotNone(graph2)
+    self.assertIsNot(graph1, graph2)
+
+    # Verify that the new graph contains the newly added transform
+    self.assertIn('Map1', graph2._pipeline_proto.components.transforms)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/sdks/python/apache_beam/runners/interactive/recording_manager_test.py
+++ b/sdks/python/apache_beam/runners/interactive/recording_manager_test.py
@@ -937,20 +937,22 @@ class RecordingManagerTest(unittest.TestCase):
     p = beam.Pipeline(InteractiveRunner())
     numbers = p | 'numbers' >> beam.Create([0, 1, 2])
 
-    # Set the cache directory for Interactive Beam to be in a GCS bucket.
-    ib.options.cache_root = 'gs://test-bucket/'
+    original_cache_root = ib.options.cache_root
+    try:
+      # Set the cache directory for Interactive Beam to be in a GCS bucket.
+      ib.options.cache_root = 'gs://test-bucket/'
 
-    # Create the recording objects. By calling `record` a new PipelineFragment
-    # is started to compute the given PCollections and cache to disk.
-    rm = RecordingManager(p)
+      # Create the recording objects. By calling `record` a new PipelineFragment
+      # is started to compute the given PCollections and cache to disk.
+      rm = RecordingManager(p)
 
-    # Run record() and check if the PipelineFragment.run had blocking set to
-    # True due to the GCS cache_root value.
-    rm.record([numbers], max_n=3, max_duration=500)
-    mock_pipeline_fragment.assert_called_with(blocking=True)
-
-    # Reset cache_root value.
-    ib.options.cache_root = None
+      # Run record() and check if the PipelineFragment.run had blocking set to
+      # True due to the GCS cache_root value.
+      rm.record([numbers], max_n=3, max_duration=500)
+      mock_pipeline_fragment.assert_called_with(blocking=True)
+    
+    finally:
+      ib.options.cache_root = original_cache_root
 
   def test_compute_async_blocking(self):
     p = beam.Pipeline(InteractiveRunner())

--- a/sdks/python/apache_beam/runners/interactive/recording_manager_test.py
+++ b/sdks/python/apache_beam/runners/interactive/recording_manager_test.py
@@ -950,7 +950,7 @@ class RecordingManagerTest(unittest.TestCase):
       # True due to the GCS cache_root value.
       rm.record([numbers], max_n=3, max_duration=500)
       mock_pipeline_fragment.assert_called_with(blocking=True)
-    
+
     finally:
       ib.options.cache_root = original_cache_root
 

--- a/sdks/python/apache_beam/runners/interactive/recording_manager_test.py
+++ b/sdks/python/apache_beam/runners/interactive/recording_manager_test.py
@@ -1169,6 +1169,64 @@ class RecordingManagerTest(unittest.TestCase):
     with self.assertRaises(TimeoutError):
       async_res.wait_for_completion(timeout=0.01)
 
+  def test_get_uncomputed_pcolls(self):
+    p = beam.Pipeline(InteractiveRunner())
+    p1 = p | 'C1' >> beam.Create([1])
+    p2 = p | 'C2' >> beam.Create([2])
+    ib.watch(locals())
+    ie.current_env().track_user_pipelines()
+
+    rm = RecordingManager(p)
+
+    # Initially both are uncomputed
+    self.assertEqual(rm._get_uncomputed_pcolls([p1, p2]), {p1, p2})
+
+    # Mark p1 as computed
+    ie.current_env().mark_pcollection_computed([p1])
+    self.assertEqual(rm._get_uncomputed_pcolls([p1, p2]), {p2})
+
+    # Cleanup
+    ie.current_env().evict_computed_pcollections()
+
+  def test_get_pipeline_graph_caching(self):
+    p = beam.Pipeline(InteractiveRunner())
+    p1 = p | 'C1' >> beam.Create([1])
+    ib.watch(locals())
+    ie.current_env().track_user_pipelines()
+
+    rm = RecordingManager(p)
+    graph1 = rm._get_pipeline_graph()
+    graph2 = rm._get_pipeline_graph()
+
+    # Graph instance is cached and reused when pipeline transforms have not changed
+    self.assertIs(graph1, graph2)
+
+    # Applying a new transform updates user_pipeline.applied_labels
+    _ = p1 | 'M1' >> beam.Map(lambda x: x)
+    graph3 = rm._get_pipeline_graph()
+
+    # Graph is rebuilt because pipeline applied_labels changed
+    self.assertIsNot(graph1, graph3)
+
+  def test_record_early_return_when_all_computed(self):
+    p = beam.Pipeline(InteractiveRunner())
+    p1 = p | 'C1' >> beam.Create([1])
+    ib.watch(locals())
+    ie.current_env().track_user_pipelines()
+
+    rm = RecordingManager(p)
+    ie.current_env().mark_pcollection_computed([p1])
+
+    with patch.object(rm, '_execute_pipeline_fragment') as mock_exec:
+      recording = rm.record([p1], max_n=10, max_duration=100)
+      # Fragment execution must NOT be called
+      mock_exec.assert_not_called()
+      self.assertIsNone(recording._result)
+      self.assertEqual(
+          recording.wait_until_finish(), beam.runners.runner.PipelineState.DONE)
+
+    ie.current_env().evict_computed_pcollections()
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This PR resolves several critical caching issues in Interactive Beam when executing pipelines in notebook environments (like Colab), preventing deadlocks, duplicate execution of runner jobs, and stale dependency resolution.

### Changes:
1. **Fix Background Thread Deadlock**: 
   Updated `_wait_for_dependencies` to skip checking the target PCollection itself when executing inside the background thread (indicated by the presence of `async_result`). This avoids a self-deadlock where the background thread blocked waiting for its own future to resolve.
   
2. **Fix Wait Race Condition**:
   Previously, calling `future.result()` in `_wait_for_dependencies` was insufficient because the future resolves *before* the `_on_done` callback finishes executing to mark the PCollection as computed. This created a race condition where the main thread resumed, saw the PCollection was still "uncomputed", and started a duplicate execution job.
   We resolved this by introducing a `threading.Event` (`_completed_event`) in `AsyncComputationResult` that is set at the very end of `_on_done`. The main thread now blocks on `comp.wait_for_completion()`, guaranteeing that it only continues after the PCollection is fully marked as computed.

3. **Recalculate Uncomputed PCollections**:
   Updated `record()` to recalculate the subset of remaining uncomputed PCollections *after* the dependency wait completes. If a PCollection finished computing during the wait, it skips the duplicate fragment execution.

4. **Fix Stale Pipeline Graph**:
   Removed caching of the `PipelineGraph` in `RecordingManager`. Re-creating the graph dynamically ensures that any new transforms added by users in subsequent notebook cells are correctly detected and resolved as dependencies.

5. **Unit Tests Added**:
   Added three new tests to `recording_manager_test.py` covering:
   - Deadlock avoidance and waiting behavior depending on `async_result`.
   - Dynamic recreation of the `PipelineGraph` when new transforms are appended.
   - Recalculation of uncomputed PCollections in `record()` after wait completion.

------------------------

fixes #37220
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
