### PR TITLE
Fix lost state updates in Set state

### DIFF
--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -653,8 +653,7 @@ class SynchronousSetRuntimeState(userstate.SetRuntimeState):
 
     if rewrite and accumulator:
       # Compaction writes are asynchronous; queue them so they are not lost.
-      self._futures.append(
-          self._state_handler.clear(self._state_key))
+      self._futures.append(self._state_handler.clear(self._state_key))
       self._futures.append(
           self._state_handler.extend(
               self._state_key, self._value_coder.get_impl(), accumulator))
@@ -671,8 +670,7 @@ class SynchronousSetRuntimeState(userstate.SetRuntimeState):
   def add(self, value: Any) -> None:
     if self._cleared:
       # This is a good time explicitly clear.
-      self._futures.append(
-          self._state_handler.clear(self._state_key))
+      self._futures.append(self._state_handler.clear(self._state_key))
       self._cleared = False
 
     self._added_elements.add(value)
@@ -691,7 +689,8 @@ class SynchronousSetRuntimeState(userstate.SetRuntimeState):
     if self._added_elements:
       to_await.append(
           self._state_handler.extend(
-              self._state_key, self._value_coder.get_impl(),
+              self._state_key,
+              self._value_coder.get_impl(),
               self._added_elements))
       self._added_elements = set()
 

--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -641,6 +641,8 @@ class SynchronousSetRuntimeState(userstate.SetRuntimeState):
     self._value_coder = value_coder
     self._cleared = False
     self._added_elements: set[Any] = set()
+    # Track outstanding async state requests to await them at commit time.
+    self._futures = []
 
   def _compact_data(self, rewrite=True):
     accumulator = set(
@@ -650,9 +652,12 @@ class SynchronousSetRuntimeState(userstate.SetRuntimeState):
             self._added_elements))
 
     if rewrite and accumulator:
-      self._state_handler.clear(self._state_key)
-      self._state_handler.extend(
-          self._state_key, self._value_coder.get_impl(), accumulator)
+      # Compaction writes are asynchronous; queue them so they are not lost.
+      self._futures.append(
+          self._state_handler.clear(self._state_key))
+      self._futures.append(
+          self._state_handler.extend(
+              self._state_key, self._value_coder.get_impl(), accumulator))
 
       # Since everthing is already committed so we can safely reinitialize
       # added_elements here.
@@ -666,7 +671,8 @@ class SynchronousSetRuntimeState(userstate.SetRuntimeState):
   def add(self, value: Any) -> None:
     if self._cleared:
       # This is a good time explicitly clear.
-      self._state_handler.clear(self._state_key)
+      self._futures.append(
+          self._state_handler.clear(self._state_key))
       self._cleared = False
 
     self._added_elements.add(value)
@@ -678,15 +684,24 @@ class SynchronousSetRuntimeState(userstate.SetRuntimeState):
     self._added_elements = set()
 
   def commit(self) -> None:
-    to_await = None
+    to_await = []
     if self._cleared:
-      to_await = self._state_handler.clear(self._state_key)
+      to_await.append(self._state_handler.clear(self._state_key))
+      self._cleared = False
     if self._added_elements:
-      to_await = self._state_handler.extend(
-          self._state_key, self._value_coder.get_impl(), self._added_elements)
-    if to_await:
-      # To commit, we need to wait on the last state request future to complete.
-      to_await.get()
+      to_await.append(
+          self._state_handler.extend(
+              self._state_key, self._value_coder.get_impl(),
+              self._added_elements))
+      self._added_elements = set()
+
+    # Block on all outstanding async state requests to ensure data is committed.
+    all_futures = self._futures + to_await
+    self._futures = []
+
+    for f in all_futures:
+      if f:
+        f.get()
 
 
 class RangeSet:

--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -682,12 +682,11 @@ class SynchronousSetRuntimeState(userstate.SetRuntimeState):
     self._added_elements = set()
 
   def commit(self) -> None:
-    to_await = []
     if self._cleared:
-      to_await.append(self._state_handler.clear(self._state_key))
+      self._futures.append(self._state_handler.clear(self._state_key))
       self._cleared = False
     if self._added_elements:
-      to_await.append(
+      self._futures.append(
           self._state_handler.extend(
               self._state_key,
               self._value_coder.get_impl(),
@@ -695,7 +694,9 @@ class SynchronousSetRuntimeState(userstate.SetRuntimeState):
       self._added_elements = set()
 
     # Block on all outstanding async state requests to ensure data is committed.
-    all_futures = self._futures + to_await
+    # We must swap and clear self._futures before awaiting them. Awaiting a future
+    # yields control, during which new futures could be appended to self._futures.
+    all_futures = self._futures
     self._futures = []
 
     for f in all_futures:

--- a/sdks/python/apache_beam/transforms/userstate_test.py
+++ b/sdks/python/apache_beam/transforms/userstate_test.py
@@ -720,7 +720,8 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
       assert_that(actual_values, equal_to([1, 3, 6, 10, 10]))
 
   # Mock random to always return 1.0 to force compaction on every add.
-  @mock.patch('apache_beam.runners.worker.bundle_processor.random.random', lambda: 1.0)
+  @mock.patch(
+      'apache_beam.runners.worker.bundle_processor.random.random', lambda: 1.0)
   def test_stateful_set_state_compaction_race_portably(self):
     from apache_beam.runners.worker.sdk_worker import GrpcStateHandler
     from apache_beam.runners.worker.sdk_worker import _Future
@@ -734,12 +735,14 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
       if request.HasField('append') or request.HasField('clear'):
         future = _Future()
         instruction_id = getattr(self._context, 'process_instruction_id', None)
+
         def run():
           time.sleep(0.5)
           self._context.process_instruction_id = instruction_id
           underlying_future = old_request(self, request)
           underlying_future.wait()
           future.set(underlying_future.get())
+
         t = threading.Thread(target=run, daemon=True)
         t.start()
         return future
@@ -747,7 +750,6 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
         return old_request(self, request)
 
     GrpcStateHandler._request = delayed_request
-
 
     class SetStatefulDoFn(beam.DoFn):
 
@@ -768,16 +770,16 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
       ])
       with TestPipeline(runner='PrismRunner', options=options) as p:
         test_stream = (
-            TestStream(coder=beam.coders.TupleCoder((beam.coders.StrUtf8Coder(), beam.coders.VarIntCoder())))
-            .advance_watermark_to(10)
-            .add_elements([('key', 1)])
-            .advance_watermark_to(20)
-            .add_elements([('key', 2)])
-            .advance_watermark_to(30)
-        )
+            TestStream(
+                coder=beam.coders.TupleCoder((
+                    beam.coders.StrUtf8Coder(), beam.coders.VarIntCoder()
+                ))).advance_watermark_to(10).add_elements([
+                    ('key', 1)
+                ]).advance_watermark_to(20).add_elements([
+                    ('key', 2)
+                ]).advance_watermark_to(30))
         actual_values = (p | test_stream | beam.ParDo(SetStatefulDoFn()))
         assert_that(actual_values, equal_to([1, 3]))
-
 
     finally:
       GrpcStateHandler._request = old_request

--- a/sdks/python/apache_beam/transforms/userstate_test.py
+++ b/sdks/python/apache_beam/transforms/userstate_test.py
@@ -18,6 +18,9 @@
 """Unit tests for the Beam State and Timer API interfaces."""
 # pytype: skip-file
 
+import queue
+import threading
+import time
 import unittest
 from typing import Any
 
@@ -34,6 +37,8 @@ from apache_beam.portability import common_urns
 from apache_beam.portability.api import beam_runner_api_pb2
 from apache_beam.runners import pipeline_context
 from apache_beam.runners.common import DoFnSignature
+from apache_beam.runners.worker.sdk_worker import GrpcStateHandler
+from apache_beam.runners.worker.sdk_worker import _Future
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.test_stream import TestStream
 from apache_beam.testing.util import assert_that
@@ -723,12 +728,6 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
   @mock.patch(
       'apache_beam.runners.worker.bundle_processor.random.random', lambda: 1.0)
   def test_stateful_set_state_compaction_race_portably(self):
-    from apache_beam.runners.worker.sdk_worker import GrpcStateHandler
-    from apache_beam.runners.worker.sdk_worker import _Future
-    import time
-    import threading
-    import queue
-
     old_request = GrpcStateHandler._request
     request_queue = queue.Queue()
 

--- a/sdks/python/apache_beam/transforms/userstate_test.py
+++ b/sdks/python/apache_beam/transforms/userstate_test.py
@@ -727,24 +727,29 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
     from apache_beam.runners.worker.sdk_worker import _Future
     import time
     import threading
+    import queue
 
     old_request = GrpcStateHandler._request
+    request_queue = queue.Queue()
+
+    def worker():
+      while True:
+        handler, request, future, instruction_id = request_queue.get()
+        time.sleep(0.1)  # Simulate latency for each request sequentially.
+        handler._context.process_instruction_id = instruction_id
+        underlying_future = old_request(handler, request)
+        underlying_future.wait()
+        future.set(underlying_future.get())
+        request_queue.task_done()
+
+    t = threading.Thread(target=worker, daemon=True)
+    t.start()
 
     def delayed_request(self, request):
-      # Delay append and clear requests to simulate slow state updates.
       if request.HasField('append') or request.HasField('clear'):
         future = _Future()
         instruction_id = getattr(self._context, 'process_instruction_id', None)
-
-        def run():
-          time.sleep(0.5)
-          self._context.process_instruction_id = instruction_id
-          underlying_future = old_request(self, request)
-          underlying_future.wait()
-          future.set(underlying_future.get())
-
-        t = threading.Thread(target=run, daemon=True)
-        t.start()
+        request_queue.put((self, request, future, instruction_id))
         return future
       else:
         return old_request(self, request)

--- a/sdks/python/apache_beam/transforms/userstate_test.py
+++ b/sdks/python/apache_beam/transforms/userstate_test.py
@@ -719,6 +719,69 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
       actual_values = (values | beam.ParDo(SetStatefulDoFn()))
       assert_that(actual_values, equal_to([1, 3, 6, 10, 10]))
 
+  # Mock random to always return 1.0 to force compaction on every add.
+  @mock.patch('apache_beam.runners.worker.bundle_processor.random.random', lambda: 1.0)
+  def test_stateful_set_state_compaction_race_portably(self):
+    from apache_beam.runners.worker.sdk_worker import GrpcStateHandler
+    from apache_beam.runners.worker.sdk_worker import _Future
+    import time
+    import threading
+
+    old_request = GrpcStateHandler._request
+
+    def delayed_request(self, request):
+      # Delay append and clear requests to simulate slow state updates.
+      if request.HasField('append') or request.HasField('clear'):
+        future = _Future()
+        instruction_id = getattr(self._context, 'process_instruction_id', None)
+        def run():
+          time.sleep(0.5)
+          self._context.process_instruction_id = instruction_id
+          underlying_future = old_request(self, request)
+          underlying_future.wait()
+          future.set(underlying_future.get())
+        t = threading.Thread(target=run, daemon=True)
+        t.start()
+        return future
+      else:
+        return old_request(self, request)
+
+    GrpcStateHandler._request = delayed_request
+
+
+    class SetStatefulDoFn(beam.DoFn):
+
+      SET_STATE = SetStateSpec('buffer', VarIntCoder())
+
+      def process(self, element, set_state=beam.DoFn.StateParam(SET_STATE)):
+        _, value = element
+        aggregated_value = 0
+        set_state.add(value)
+        for saved_value in set_state.read():
+          aggregated_value += saved_value
+        yield aggregated_value
+
+    try:
+      options = PipelineOptions([
+          '--max_cache_memory_usage_mb=100',
+          '--environment_type=LOOPBACK',
+      ])
+      with TestPipeline(runner='PrismRunner', options=options) as p:
+        test_stream = (
+            TestStream(coder=beam.coders.TupleCoder((beam.coders.StrUtf8Coder(), beam.coders.VarIntCoder())))
+            .advance_watermark_to(10)
+            .add_elements([('key', 1)])
+            .advance_watermark_to(20)
+            .add_elements([('key', 2)])
+            .advance_watermark_to(30)
+        )
+        actual_values = (p | test_stream | beam.ParDo(SetStatefulDoFn()))
+        assert_that(actual_values, equal_to([1, 3]))
+
+
+    finally:
+      GrpcStateHandler._request = old_request
+
   def test_stateful_set_state_clean_portably(self):
     class SetStateClearingStatefulDoFn(beam.DoFn):
 

--- a/sdks/python/apache_beam/transforms/userstate_test.py
+++ b/sdks/python/apache_beam/transforms/userstate_test.py
@@ -772,7 +772,7 @@ class StatefulDoFnOnDirectRunnerTest(unittest.TestCase):
           '--max_cache_memory_usage_mb=100',
           '--environment_type=LOOPBACK',
       ])
-      with TestPipeline(runner='PrismRunner', options=options) as p:
+      with TestPipeline(options=options) as p:
         test_stream = (
             TestStream(
                 coder=beam.coders.TupleCoder((


### PR DESCRIPTION
This PR fixes a race condition in `SynchronousSetRuntimeState` where asynchronous state requests triggered by state compaction or early clears were not being awaited. 

When elements are added to `SynchronousSetRuntimeState`, it occasionally triggers data compaction (`_compact_data`) which launches asynchronous `clear` and `extend` requests to the State Handler. However, these futures were not tracked previously. The `commit()` method only blocked on the last futures generated during the commit phase, causing outstanding compaction futures to complete out of order or after the bundle processor finished, resulting in lost state updates.

An example failed test:
https://github.com/apache/beam/actions/runs/28001498086/job/82874623596

Traceback:
```
_______ StatefulDoFnOnDirectRunnerTest.test_stateful_set_state_portably ________
[gw2] linux -- Python 3.10.20 /runner/_work/beam/beam/sdks/python/test-suites/tox/py310/build/srcs/sdks/python/target/.tox-py310/py310/bin/python

self = <apache_beam.transforms.userstate_test.StatefulDoFnOnDirectRunnerTest testMethod=test_stateful_set_state_portably>

    def test_stateful_set_state_portably(self):
      class SetStatefulDoFn(beam.DoFn):
    
        SET_STATE = SetStateSpec('buffer', VarIntCoder())
    
        def process(self, element, set_state=beam.DoFn.StateParam(SET_STATE)):
          _, value = element
          aggregated_value = 0
          set_state.add(value)
          for saved_value in set_state.read():
            aggregated_value += saved_value
          yield aggregated_value
    
>     with TestPipeline() as p:

apache_beam/transforms/userstate_test.py:715: 
...
    
      if duration:
        state_thread = threading.Thread(
            target=functools.partial(self._observe_state, message_thread),
            name='wait_until_finish_state_observer')
        state_thread.daemon = True
        state_thread.start()
        start_time = time.time()
        duration_secs = duration / 1000
        while (time.time() - start_time < duration_secs and
               state_thread.is_alive()):
          time.sleep(1)
      else:
        self._observe_state(message_thread)
    
      if self._runtime_exception:
>       raise self._runtime_exception
E       RuntimeError: Pipeline job-045 failed in state FAILED: bundle inst010 stage-009 failed:Traceback (most recent call last):
E         File "apache_beam/runners/common.py", line 1499, in apache_beam.runners.common.DoFnRunner.process
E           return self.do_fn_invoker.invoke_process(windowed_value)
E         File "apache_beam/runners/common.py", line 913, in apache_beam.runners.common.PerWindowInvoker.invoke_process
E           self._invoke_process_per_window(
E         File "apache_beam/runners/common.py", line 1058, in apache_beam.runners.common.PerWindowInvoker._invoke_process_per_window
E           self.process_method(*args_for_process, **kwargs_for_process),
E         File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py310/build/srcs/sdks/python/target/.tox-py310/py310/lib/python3.10/site-packages/apache_beam/transforms/core.py", line 2126, in <lambda>
E           wrapper = lambda x, *args, **kwargs: [fn(x, *args, **kwargs)]
E         File "/runner/_work/beam/beam/sdks/python/test-suites/tox/py310/build/srcs/sdks/python/target/.tox-py310/py310/lib/python3.10/site-packages/apache_beam/testing/util.py", line 202, in _equal
E           raise BeamAssertException(msg)
E       apache_beam.testing.util.BeamAssertException: Failed assert: [1, 3, 6, 10, 10] == [1, 4, 6, 3, 7], unexpected elements [4, 7], missing elements [10, 10]
E       
```

In this failed scenario, processing the first bundle `[1, 3, 2]` produces `[1, 4, 6]`. However, a compaction occurs prior to the commit. While the `clear` and `extend` requests are dispatched to the state handler, the bundle boundary's `commit()` does not await them. As a result, the `extend` call is not invoked before the bundle finishes, and the runner state remains empty. When `[3, 4]` subsequently arrives, it reads an empty state from the runner and yields `[3, 7]`.
