### PR TITLE
Fix flaky test by acking messages asap in pubsub test

### DIFF
--- a/sdks/python/apache_beam/io/gcp/pubsub_integration_test.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub_integration_test.py
@@ -363,7 +363,6 @@ class PubSubIntegrationTest(unittest.TestCase):
       # Retry pulling to handle PubSub delivery delays
       received_messages = []
       received_message_ids = set()
-      ack_ids = []
       deadline = time.time() + 60  # wait up to 60 seconds
       while time.time() < deadline:
         response = self.sub_client.pull(
@@ -371,8 +370,18 @@ class PubSubIntegrationTest(unittest.TestCase):
                 'subscription': ordering_sub.name,
                 'max_messages': 10,
             })
+        # Acknowledge received messages immediately. This is critical when message
+        # ordering is enabled because outstanding (unacknowledged) messages block
+        # the delivery of subsequent messages with the same ordering key.
+        ack_ids = [msg.ack_id for msg in response.received_messages]
+        if ack_ids:
+          self.sub_client.acknowledge(
+              request={
+                  'subscription': ordering_sub.name,
+                  'ack_ids': ack_ids,
+              })
+
         for msg in response.received_messages:
-          ack_ids.append(msg.ack_id)
           # Pub/Sub guarantees at-least-once delivery, so we must deduplicate
           # messages by message_id to handle potential duplicate deliveries.
           if msg.message.message_id not in received_message_ids:
@@ -391,13 +400,6 @@ class PubSubIntegrationTest(unittest.TestCase):
       self.assertEqual(received_map[b'order_data001'].ordering_key, 'key1')
       self.assertEqual(received_map[b'order_data002'].ordering_key, 'key1')
       self.assertEqual(received_map[b'order_data003'].ordering_key, 'key2')
-
-      if ack_ids:
-        self.sub_client.acknowledge(
-            request={
-                'subscription': ordering_sub.name,
-                'ack_ids': ack_ids,
-            })
     finally:
       self.sub_client.delete_subscription(
           request={'subscription': ordering_sub.name})


### PR DESCRIPTION
This PR resolves a flakiness issue in `test_batch_write_with_ordering_key` by acknowledging pulled messages immediately inside the retry loop instead of waiting until the loop finishes.

Follow-up to #39134 and addressing the previous comment https://github.com/apache/beam/pull/39134#discussion_r3485803336

Failed run:
https://github.com/apache/beam/runs/84438206754

Traceback:
```
self = <apache_beam.io.gcp.pubsub_integration_test.PubSubIntegrationTest testMethod=test_batch_write_with_ordering_key>

    @pytest.mark.it_postcommit
    def test_batch_write_with_ordering_key(self):
      """Test WriteToPubSub in batch mode with ordering keys.
    
  ...
        # Retry pulling to handle PubSub delivery delays
        received_messages = []
        received_message_ids = set()
        ack_ids = []
        deadline = time.time() + 60  # wait up to 60 seconds
        while time.time() < deadline:
          response = self.sub_client.pull(
              request={
                  'subscription': ordering_sub.name,
                  'max_messages': 10,
              })
          for msg in response.received_messages:
            ack_ids.append(msg.ack_id)
            # Pub/Sub guarantees at-least-once delivery, so we must deduplicate
            # messages by message_id to handle potential duplicate deliveries.
            if msg.message.message_id not in received_message_ids:
              received_message_ids.add(msg.message.message_id)
              received_messages.append(msg)
          if len(received_messages) >= len(test_messages):
            break
          time.sleep(5)
    
>       self.assertEqual(len(received_messages), len(test_messages))
E       AssertionError: 2 != 3

apache_beam/io/gcp/pubsub_integration_test.py:385: AssertionError
```