### PR TITLE
Fix download_files() in python-release.

### DIFF
--- a/release/src/main/python-release/python_release_automation_utils.sh
+++ b/release/src/main/python-release/python_release_automation_utils.sh
@@ -82,23 +82,25 @@ function get_version() {
 #######################################
 function download_files() {
   if [[ $1 = *"wheel"* ]]; then
-    if [[ $2 == "python3.7" ]]; then
-      BEAM_PYTHON_SDK_WHL="apache_beam-$VERSION*-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-    elif [[ $2 == "python3.8" ]]; then
-      BEAM_PYTHON_SDK_WHL="apache_beam-$VERSION*-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-    elif [[ $2 == "python3.9" ]]; then
-      BEAM_PYTHON_SDK_WHL="apache_beam-$VERSION*-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-    elif [[ $2 == "python3.10" ]]; then
-      BEAM_PYTHON_SDK_WHL="apache_beam-$VERSION*-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+    if [[ $2 == "python3.10" ]]; then
+      BEAM_PYTHON_SDK_WHL="apache_beam-$VERSION*-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+    elif [[ $2 == "python3.11" ]]; then
+      BEAM_PYTHON_SDK_WHL="apache_beam-$VERSION*-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+    elif [[ $2 == "python3.12" ]]; then
+      BEAM_PYTHON_SDK_WHL="apache_beam-$VERSION*-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+    elif [[ $2 == "python3.13" ]]; then
+      BEAM_PYTHON_SDK_WHL="apache_beam-$VERSION*-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+    elif [[ $2 == "python3.14" ]]; then
+      BEAM_PYTHON_SDK_WHL="apache_beam-$VERSION*-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
     else
       echo "Unable to determine a Beam wheel for interpreter version $2."
       exit 1
     fi
 
-    wget -r -l2 --no-parent -nd -A "$BEAM_PYTHON_SDK_WHL*" $RC_STAGING_URL
+    wget -e robots=off -r -l2 --no-parent -nd -A "$BEAM_PYTHON_SDK_WHL*" $RC_STAGING_URL
   else
-    BEAM_PYTHON_SDK_ZIP="apache-beam-$VERSION.tar.gz"
-    wget -r -l2 --no-parent -nd -A "$BEAM_PYTHON_SDK_ZIP*" $RC_STAGING_URL
+    BEAM_PYTHON_SDK_ZIP="apache_beam-$VERSION.tar.gz"
+    wget -e robots=off -r -l2 --no-parent -nd -A "$BEAM_PYTHON_SDK_ZIP*" $RC_STAGING_URL
   fi
 }
 

--- a/release/src/main/python-release/python_release_automation_utils.sh
+++ b/release/src/main/python-release/python_release_automation_utils.sh
@@ -97,10 +97,10 @@ function download_files() {
       exit 1
     fi
 
-    wget -e robots=off -r -l2 --no-parent -nd -A "$BEAM_PYTHON_SDK_WHL*" $RC_STAGING_URL
+    wget -e robots=off -r -l2 --no-parent -nd -A "$BEAM_PYTHON_SDK_WHL*" "$RC_STAGING_URL"
   else
     BEAM_PYTHON_SDK_ZIP="apache_beam-$VERSION.tar.gz"
-    wget -e robots=off -r -l2 --no-parent -nd -A "$BEAM_PYTHON_SDK_ZIP*" $RC_STAGING_URL
+    wget -e robots=off -r -l2 --no-parent -nd -A "$BEAM_PYTHON_SDK_ZIP*" "$RC_STAGING_URL"
   fi
 }
 


### PR DESCRIPTION
This PR fixes the broken scripts in python release automation.

- Update download_files() in python_release_automation_utils.sh to support Python 3.10 - 3.14.
- Update manylinux wheel filename pattern for newer release artifacts.
- Pass `-e robots=off` to wget to avoid robots.txt blocking artifact downloads.

Verified that the files can be downloaded successfully with the updated `download_files()` using the following script:
```bash
set -e
set -v

SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
source "$SCRIPT_DIR/python_release_automation_utils.sh"

export VERSION=2.74.0
export RC_STAGING_URL="https://dist.apache.org/repos/dist/dev/beam/$VERSION/python"
for version in 3.10 3.11 3.12 3.13 3.14
do
  download_files "wheel" "python${version}"
  download_files "tar" "python${version}"
done
```