### PR TITLE
Fix Flink runner tests on Java 21

### DIFF
--- a/.github/trigger_files/beam_PreCommit_Java.json
+++ b/.github/trigger_files/beam_PreCommit_Java.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run.",
-  "modification": 8
+  "modification": 9
 }

--- a/.github/trigger_files/beam_PreCommit_Java.json
+++ b/.github/trigger_files/beam_PreCommit_Java.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run.",
-  "modification": 7
+  "modification": 8
 }

--- a/.github/trigger_files/beam_PreCommit_Java.json
+++ b/.github/trigger_files/beam_PreCommit_Java.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run.",
-  "modification": 1
+  "modification": 7
 }

--- a/runners/flink/flink_runner.gradle
+++ b/runners/flink/flink_runner.gradle
@@ -180,6 +180,22 @@ if (use_override) {
   }
 }
 
+def flinkTestJvmArgs() {
+  def testJavaVer = project.findProperty('testJavaVersion') ? (project.property('testJavaVersion') as int) : JavaVersion.current().majorVersion.toInteger()
+  if (testJavaVer >= 17) {
+    return [
+      "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+      "--add-opens=java.base/java.nio=ALL-UNNAMED",
+      "--add-opens=java.base/java.util=ALL-UNNAMED",
+      "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
+      "--add-opens=java.base/java.lang=ALL-UNNAMED",
+      "-Djava.security.manager=allow",
+    ]
+  } else {
+    return []
+  }
+}
+
 test {
   systemProperty "log4j.configuration", "log4j-test.properties"
   // Change log level to debug:
@@ -187,6 +203,7 @@ test {
   // Change log level to debug only for the package and nested packages:
   // systemProperty "org.slf4j.simpleLogger.log.org.apache.beam.runners.flink.translation.wrappers.streaming", "debug"
   jvmArgs "-XX:-UseGCOverheadLimit"
+  jvmArgs += flinkTestJvmArgs()
   if (System.getProperty("beamSurefireArgline")) {
     jvmArgs System.getProperty("beamSurefireArgline")
   }

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkSubmissionTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkSubmissionTest.java
@@ -19,11 +19,12 @@ package org.apache.beam.runners.flink;
 
 import java.io.File;
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.Permission;
 import java.util.Collection;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -230,21 +231,50 @@ public class FlinkSubmissionTest {
    * We modify the JVM's environment variables here. This is necessary for the end-to-end test
    * because Flink's CliFrontend requires a Flink configuration file for which the location can only
    * be set using the {@code ConfigConstants.ENV_FLINK_CONF_DIR} environment variable.
+   *
+   * <p>On Unix JDKs, {@code ProcessEnvironment.theEnvironment} is a {@code Map<Variable,Value>}.
+   * {@code System.getenv(String)} looks up {@code Variable} keys, so inserting plain {@code String}
+   * keys (via {@code putAll}) is a no-op for lookups and leaves Flink unable to find {@code
+   * FLINK_CONF_DIR}. On Windows the map uses {@code String} keys (plus a case-insensitive map).
    */
+  @SuppressWarnings("unchecked")
   private static void modifyEnv(Map<String, String> env) throws Exception {
-    Class processEnv = Class.forName("java.lang.ProcessEnvironment");
-    Field envField = processEnv.getDeclaredField("theUnmodifiableEnvironment");
+    Class<?> processEnvironment = Class.forName("java.lang.ProcessEnvironment");
 
-    Field modifiersField = Field.class.getDeclaredField("modifiers");
-    modifiersField.setAccessible(true);
-    modifiersField.setInt(envField, envField.getModifiers() & ~Modifier.FINAL);
+    Field theEnvironmentField = processEnvironment.getDeclaredField("theEnvironment");
+    theEnvironmentField.setAccessible(true);
+    Map<Object, Object> envMap = (Map<Object, Object>) theEnvironmentField.get(null);
+    envMap.clear();
+    try {
+      // Unix: keys/values are ProcessEnvironment$Variable / $Value, not String.
+      Class<?> variableClass = Class.forName("java.lang.ProcessEnvironment$Variable");
+      Class<?> valueClass = Class.forName("java.lang.ProcessEnvironment$Value");
+      Method valueOfVariable = variableClass.getDeclaredMethod("valueOf", String.class);
+      Method valueOfValue = valueClass.getDeclaredMethod("valueOf", String.class);
+      valueOfVariable.setAccessible(true);
+      valueOfValue.setAccessible(true);
+      for (Map.Entry<String, String> entry : env.entrySet()) {
+        envMap.put(
+            valueOfVariable.invoke(null, entry.getKey()),
+            valueOfValue.invoke(null, entry.getValue()));
+      }
+    } catch (ClassNotFoundException e) {
+      // Windows (and similar): theEnvironment uses String keys.
+      envMap.putAll(env);
+    }
 
-    envField.setAccessible(true);
-    envField.set(null, env);
-    envField.setAccessible(false);
-
-    modifiersField.setInt(envField, envField.getModifiers() & Modifier.FINAL);
-    modifiersField.setAccessible(false);
+    // Windows: System.getenv(String) reads the case-insensitive map.
+    if (System.getProperty("os.name", "").toLowerCase(Locale.ROOT).startsWith("windows")) {
+      Field theCaseInsensitiveEnvironmentField =
+          processEnvironment.getDeclaredField("theCaseInsensitiveEnvironment");
+      theCaseInsensitiveEnvironmentField.setAccessible(true);
+      Map<String, String> ciEnvMap =
+          (Map<String, String>) theCaseInsensitiveEnvironmentField.get(null);
+      if (ciEnvMap != null) {
+        ciEnvMap.clear();
+        ciEnvMap.putAll(env);
+      }
+    }
   }
 
   /** Prevents the CliFrontend from calling System.exit. */

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkSubmissionTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkSubmissionTest.java
@@ -232,23 +232,26 @@ public class FlinkSubmissionTest {
    * because Flink's CliFrontend requires a Flink configuration file for which the location can only
    * be set using the {@code ConfigConstants.ENV_FLINK_CONF_DIR} environment variable.
    *
-   * <p>On Unix JDKs, {@code ProcessEnvironment.theEnvironment} is a {@code Map<Variable,Value>}.
-   * {@code System.getenv(String)} looks up {@code Variable} keys, so inserting plain {@code String}
-   * keys (via {@code putAll}) is a no-op for lookups and leaves Flink unable to find {@code
-   * FLINK_CONF_DIR}. On Windows the map uses {@code String} keys (plus a case-insensitive map).
+   * <p>On Unix, {@code theEnvironment} uses {@code Variable}/{@code Value} keys; {@code putAll} with
+   * {@code String} keys does not work for {@code System.getenv(String)} lookups.
    */
   @SuppressWarnings("unchecked")
   private static void modifyEnv(Map<String, String> env) throws Exception {
-    Class<?> processEnvironment = Class.forName("java.lang.ProcessEnvironment");
-
-    Field theEnvironmentField = processEnvironment.getDeclaredField("theEnvironment");
+    Class processEnv = Class.forName("java.lang.ProcessEnvironment");
+    Field theEnvironmentField = processEnv.getDeclaredField("theEnvironment");
     theEnvironmentField.setAccessible(true);
     Map<Object, Object> envMap = (Map<Object, Object>) theEnvironmentField.get(null);
     envMap.clear();
+
+    Class<?> variableClass = null;
+    Class<?> valueClass = null;
     try {
-      // Unix: keys/values are ProcessEnvironment$Variable / $Value, not String.
-      Class<?> variableClass = Class.forName("java.lang.ProcessEnvironment$Variable");
-      Class<?> valueClass = Class.forName("java.lang.ProcessEnvironment$Value");
+      variableClass = Class.forName("java.lang.ProcessEnvironment$Variable");
+      valueClass = Class.forName("java.lang.ProcessEnvironment$Value");
+    } catch (ClassNotFoundException e) {
+      // Windows: theEnvironment uses String keys.
+    }
+    if (variableClass != null && valueClass != null) {
       Method valueOfVariable = variableClass.getDeclaredMethod("valueOf", String.class);
       Method valueOfValue = valueClass.getDeclaredMethod("valueOf", String.class);
       valueOfVariable.setAccessible(true);
@@ -258,18 +261,14 @@ public class FlinkSubmissionTest {
             valueOfVariable.invoke(null, entry.getKey()),
             valueOfValue.invoke(null, entry.getValue()));
       }
-    } catch (ClassNotFoundException e) {
-      // Windows (and similar): theEnvironment uses String keys.
+    } else {
       envMap.putAll(env);
     }
 
-    // Windows: System.getenv(String) reads the case-insensitive map.
     if (System.getProperty("os.name", "").toLowerCase(Locale.ROOT).startsWith("windows")) {
-      Field theCaseInsensitiveEnvironmentField =
-          processEnvironment.getDeclaredField("theCaseInsensitiveEnvironment");
-      theCaseInsensitiveEnvironmentField.setAccessible(true);
-      Map<String, String> ciEnvMap =
-          (Map<String, String>) theCaseInsensitiveEnvironmentField.get(null);
+      Field ciEnvField = processEnv.getDeclaredField("theCaseInsensitiveEnvironment");
+      ciEnvField.setAccessible(true);
+      Map<String, String> ciEnvMap = (Map<String, String>) ciEnvField.get(null);
       if (ciEnvMap != null) {
         ciEnvMap.clear();
         ciEnvMap.putAll(env);

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkSubmissionTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkSubmissionTest.java
@@ -232,8 +232,8 @@ public class FlinkSubmissionTest {
    * because Flink's CliFrontend requires a Flink configuration file for which the location can only
    * be set using the {@code ConfigConstants.ENV_FLINK_CONF_DIR} environment variable.
    *
-   * <p>On Unix, {@code theEnvironment} uses {@code Variable}/{@code Value} keys; {@code putAll} with
-   * {@code String} keys does not work for {@code System.getenv(String)} lookups.
+   * <p>On Unix, {@code theEnvironment} uses {@code Variable}/{@code Value} keys; {@code putAll}
+   * with {@code String} keys does not work for {@code System.getenv(String)} lookups.
    */
   @SuppressWarnings("unchecked")
   private static void modifyEnv(Map<String, String> env) throws Exception {

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapperTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapperTest.java
@@ -665,15 +665,16 @@ public class UnboundedSourceWrapperTest {
         // Wait to see if the wrapper shuts down immediately in case it doesn't have readers
         if (!shouldHaveReaders) {
           // The expected state is for finalizeSource to sleep instead of exiting
-          while (true) {
-            StackTraceElement[] callStack = thread.getStackTrace();
-            if (callStack.length >= 2
-                && "sleep".equals(callStack[0].getMethodName())
-                && "finalizeSource".equals(callStack[1].getMethodName())) {
+          long deadlineNs = System.nanoTime() + 9_000_000_000L;
+          boolean reachedFinalizeSource = false;
+          while (System.nanoTime() < deadlineNs) {
+            if (isInFinalizeSource(thread.getStackTrace())) {
+              reachedFinalizeSource = true;
               break;
             }
             Thread.sleep(10);
           }
+          assertThat(reachedFinalizeSource, is(true));
         }
         // Source should still be running even if there are no readers
         assertThat(sourceWrapper.isRunning(), is(true));
@@ -692,6 +693,15 @@ public class UnboundedSourceWrapperTest {
         thread.join(1000);
       }
       assertThat(thread.isAlive(), is(false));
+    }
+
+    private static boolean isInFinalizeSource(StackTraceElement[] callStack) {
+      for (StackTraceElement frame : callStack) {
+        if ("finalizeSource".equals(frame.getMethodName())) {
+          return true;
+        }
+      }
+      return false;
     }
 
     @Test

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapperTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapperTest.java
@@ -665,16 +665,12 @@ public class UnboundedSourceWrapperTest {
         // Wait to see if the wrapper shuts down immediately in case it doesn't have readers
         if (!shouldHaveReaders) {
           // The expected state is for finalizeSource to sleep instead of exiting
-          long deadlineNs = System.nanoTime() + 9_000_000_000L;
-          boolean reachedFinalizeSource = false;
-          while (System.nanoTime() < deadlineNs) {
+          while (true) {
             if (isInFinalizeSource(thread.getStackTrace())) {
-              reachedFinalizeSource = true;
               break;
             }
             Thread.sleep(10);
           }
-          assertThat(reachedFinalizeSource, is(true));
         }
         // Source should still be running even if there are no readers
         assertThat(sourceWrapper.isRunning(), is(true));


### PR DESCRIPTION
Fixes: #39252
Successful run: https://github.com/apache/beam/actions/runs/29061791187

After switching to Java 21, Flink runner tests started failing in PreCommit Java

The main problems were:

- Flink/Kryo tests needed extra JVM --add-opens flags on Java 21
- FlinkSubmissionTest used old reflection tricks that do not work on newer Java (Field.modifiers, wrong env map update)
- System.setSecurityManager() needs -Djava.security.manager=allow on Java 21
- On Linux , modifyEnv() was putting plain String keys into ProcessEnvironment.theEnvironment, but that map uses Variable/Value keys, so FLINK_CONF_DIR was not visible and tests timed out waiting for jobs

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
