### PR TITLE
Fix BeamRowWrapperTest microsecond precision flake

### DIFF
--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/BeamRowWrapperTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/BeamRowWrapperTest.java
@@ -85,6 +85,8 @@ public class BeamRowWrapperTest {
                   Types.NestedField.required(1, "nested_int", Types.IntegerType.get()))),
           Types.NestedField.required(14, "pass_through_field", Types.IntegerType.get()));
   private static final UUID TEST_UUID = UUID.randomUUID();
+  private static final Instant TEST_MICROS_INSTANT =
+      Instant.ofEpochSecond(1_609_459_200L, 123_456_000);
   private static final Row NESTED_ROW = Row.withSchema(NESTED_BEAM_SCHEMA).addValue(999).build();
   private static final Row ROW =
       Row.withSchema(BEAM_SCHEMA)
@@ -99,7 +101,7 @@ public class BeamRowWrapperTest {
                   .array(),
               new BigDecimal("123.45"),
               org.joda.time.Instant.now(),
-              Instant.now(),
+              TEST_MICROS_INSTANT,
               LocalDateTime.now(ZoneId.systemDefault()),
               LocalDate.now(ZoneId.systemDefault()),
               LocalTime.now(ZoneId.systemDefault()),
@@ -180,10 +182,7 @@ public class BeamRowWrapperTest {
 
   @Test
   public void testMicrosInstantLogicalTypeConversion() {
-    Instant javaInstant = ROW.getLogicalTypeValue(7, Instant.class);
-    long expectedMicrosInstant =
-        TimeUnit.SECONDS.toMicros(javaInstant.getEpochSecond()) + javaInstant.getNano() / 1000;
-    assertEquals(expectedMicrosInstant, (long) WRAPPER.get(7, Long.class));
+    assertEquals(1_609_459_200_123_456L, (long) WRAPPER.get(7, Long.class));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes #39266.

`BeamRowWrapperTest` used `Instant.now()` for a `MicrosInstant` field. Java 21 can return nanosecond-precision values, while `MicrosInstant` intentionally rejects precision finer than microseconds. The static row fixture therefore failed to initialize and all 18 tests in the class failed.

Use a deterministic, microsecond-aligned `Instant` fixture and assert its exact converted value. Production behavior remains unchanged.

## Repro command

```bash
env JAVA_HOME=$HOME/.sdkman/candidates/java/21.0.6-tem \
  PATH=$HOME/.sdkman/candidates/java/21.0.6-tem/bin:$PATH \
  ./gradlew --no-daemon --console=plain \
  :sdks:java:io:iceberg:test \
  --tests org.apache.beam.sdk.io.iceberg.BeamRowWrapperTest
```

Before this change: 18 tests failed from the static initializer. After this change: targeted class passes.

## Testing

- Java 21 targeted `BeamRowWrapperTest`: passed
- Java 21 `:sdks:java:io:iceberg:build`: passed
- `:sdks:java:io:iceberg:spotlessCheck`: passed

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes. Not applicable: test-only fix.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf). Not applicable: small test-only fix.

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
