### PR TITLE
Fix GCP IO tests on Java 21

### DIFF
--- a/sdks/java/io/google-cloud-platform/build.gradle
+++ b/sdks/java/io/google-cloud-platform/build.gradle
@@ -30,6 +30,11 @@ applyJavaNature(
 description = "Apache Beam :: SDKs :: Java :: IO :: Google Cloud Platform"
 ext.summary = "IO library to read and write Google Cloud Platform systems from Beam."
 
+tasks.withType(Test).configureEach {
+  // Open java.nio for Apache Arrow direct memory access under Java 17+
+  jvmArgs '--add-opens=java.base/java.nio=ALL-UNNAMED'
+}
+
 dependencies {
   implementation(enforcedPlatform(library.java.google_cloud_platform_libraries_bom))
   implementation project(path: ":model:pipeline", configuration: "shadow")

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BeamRowToStorageApiProtoTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BeamRowToStorageApiProtoTest.java
@@ -62,6 +62,11 @@ import org.junit.runners.JUnit4;
 /** Unit tests form {@link BeamRowToStorageApiProto}. */
 @RunWith(JUnit4.class)
 public class BeamRowToStorageApiProtoTest {
+  private static final LocalTime TEST_TIME_MICROS = LocalTime.of(12, 30, 45, 123_456_000);
+  private static final LocalDateTime TEST_DATETIME_MICROS =
+      LocalDateTime.of(2024, 1, 15, 12, 30, 45, 123_456_000);
+  private static final java.time.Instant TEST_INSTANT_MICROS =
+      java.time.Instant.parse("2024-01-15T12:30:45.123456Z");
   private static final java.time.Instant TEST_INSTANT_NANOS =
       java.time.Instant.parse("2024-01-15T12:30:45.123456789Z");
 
@@ -254,9 +259,9 @@ public class BeamRowToStorageApiProtoTest {
           .withFieldValue("arrayNullValue", null)
           .withFieldValue("iterableValue", ImmutableList.of("blue", "red", "two", "one"))
           .withFieldValue("sqlDateValue", LocalDate.now(ZoneOffset.UTC))
-          .withFieldValue("sqlTimeValue", LocalTime.now(ZoneOffset.UTC))
-          .withFieldValue("sqlDatetimeValue", LocalDateTime.now(ZoneOffset.UTC))
-          .withFieldValue("sqlTimestampValue", java.time.Instant.now().plus(123, ChronoUnit.MICROS))
+          .withFieldValue("sqlTimeValue", TEST_TIME_MICROS)
+          .withFieldValue("sqlDatetimeValue", TEST_DATETIME_MICROS)
+          .withFieldValue("sqlTimestampValue", TEST_INSTANT_MICROS)
           .withFieldValue("enumValue", TEST_ENUM.valueOf("RED"))
           .build();
   private static final Map<String, Object> BASE_PROTO_EXPECTED_FIELDS =


### PR DESCRIPTION
Fixes #39267.

Java 21 GCP IO precommit tests fail for two independent reasons:

* `BeamRowToStorageApiProtoTest` initializes microsecond logical types from wall-clock values that can contain nanosecond precision.
* Apache Arrow direct-memory access requires the `java.nio` package to be open.

This change uses fixed, microsecond-aligned values for affected logical types and opens `java.nio` for GCP IO test tasks, matching Beam's Arrow module configuration.

Validation:

* Java 21 full GCP IO unit suite and Spotless check
* Java 21 targeted Beam row and Arrow regression tests
* Java 17 targeted Beam row and Arrow regression tests
* GCP IO test Checkstyle

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] `CHANGES.md` update not needed for a test-only fix.
 - [x] Apache Individual Contributor License Agreement not needed for this small contribution.

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)
