### PR TITLE
Substitute org.lz4:lz4-java with at.yawk.lz4:lz4-java in all subprojects

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1056,3 +1056,22 @@ if (project.hasProperty("testJavaVersion")) {
     }
   }
 }
+
+subprojects {
+  configurations {
+    configureEach {
+      resolutionStrategy {
+        dependencySubstitution {
+          // Substitute dependencies (including transitive) on org.lz4:lz4-java regardless of capability conflicts.
+          // All published versions of org.lz4:lz4-java have known vulnerabilities.
+          // At present, all versions of at.yawk.lz4:lz4-java <1.10.1 have known vulnerabilities.
+          // Substituting org.lz4:lz4-java ensures that at.yawk.lz4:lz4-java is always selected.
+          // Gradle resolves version conflicts by selecting the highest version by default.
+          // Gradle only resolves capability conflicts when multiple modules provide the same capability.
+          // This would allow org.lz4:lz4-java to still be selected, which is undesirable because of vulnerabilities.
+          substitute(module("org.lz4:lz4-java")).using(module("at.yawk.lz4:lz4-java:1.10.1"))
+        }
+      }
+    }
+  }
+}

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -954,18 +954,6 @@ class BeamModulePlugin implements Plugin<Project> {
 
     /** ***********************************************************************************************/
 
-    // Resolves a capability conflict for a given configuration by selecting the preferred capability provider.
-    project.ext.resolveCapabilitiesConflict = { Configuration configuration, String capability, String preferred ->
-      configuration.resolutionStrategy.capabilitiesResolution.withCapability(capability) {
-        def candidate = candidates.find { it.id.toString().contains(preferred) }
-        if (candidate != null) {
-          select(candidate)
-        } else {
-          selectHighestVersion()
-        }
-      }
-    }
-
     // Returns a string representing the relocated path to be used with the shadow plugin when
     // given a suffix such as "com.google.common".
     project.ext.getJavaRelocatedPath = { String suffix ->

--- a/examples/java/common.gradle
+++ b/examples/java/common.gradle
@@ -35,8 +35,6 @@ configurations.sparkRunnerPreCommit {
   exclude group: "org.slf4j", module: "jul-to-slf4j"
   exclude group: "org.slf4j", module: "slf4j-jdk14"
 }
-resolveCapabilitiesConflict(configurations.flinkRunnerPreCommit, 'org.lz4:lz4-java', 'at.yawk.lz4')
-
 
 dependencies {
   directRunnerPreCommit project(path: ":runners:direct-java", configuration: "shadow")

--- a/runners/flink/2.1/build.gradle
+++ b/runners/flink/2.1/build.gradle
@@ -41,10 +41,3 @@ project.ext {
 
 // Load the main build script which contains all build logic.
 apply from: "../flink_runner.gradle"
-
-// Flink 2.1 uses at.yawk.lz4:lz4-java instead of org.lz4:lz4-java
-// Explicitly prefer Flink's at.yawk.lz4 version to resolve capability conflict
-configurations.all {
-  resolveCapabilitiesConflict(it, 'org.lz4:lz4-java', 'at.yawk.lz4')
-}
-

--- a/runners/flink/2.1/job-server/build.gradle
+++ b/runners/flink/2.1/job-server/build.gradle
@@ -29,10 +29,3 @@ project.ext {
 
 // Load the main build script which contains all build logic.
 apply from: "$basePath/flink_job_server.gradle"
-
-// Flink 2.1 uses at.yawk.lz4:lz4-java instead of org.lz4:lz4-java
-// Explicitly prefer Flink's at.yawk.lz4 version to resolve capability conflict
-configurations.all {
-  resolveCapabilitiesConflict(it, 'org.lz4:lz4-java', 'at.yawk.lz4')
-}
-

--- a/runners/flink/2.2/build.gradle
+++ b/runners/flink/2.2/build.gradle
@@ -56,10 +56,3 @@ project.ext {
 
 // Load the main build script which contains all build logic.
 apply from: "../flink_runner.gradle"
-
-// Flink 2.2 uses at.yawk.lz4:lz4-java instead of org.lz4:lz4-java
-// Explicitly prefer Flink's at.yawk.lz4 version to resolve capability conflict
-configurations.all {
-  resolveCapabilitiesConflict(it, 'org.lz4:lz4-java', 'at.yawk.lz4')
-}
-

--- a/runners/flink/2.2/job-server/build.gradle
+++ b/runners/flink/2.2/job-server/build.gradle
@@ -29,10 +29,3 @@ project.ext {
 
 // Load the main build script which contains all build logic.
 apply from: "$basePath/flink_job_server.gradle"
-
-// Flink 2.2 uses at.yawk.lz4:lz4-java instead of org.lz4:lz4-java
-// Explicitly prefer Flink's at.yawk.lz4 version to resolve capability conflict
-configurations.all {
-  resolveCapabilitiesConflict(it, 'org.lz4:lz4-java', 'at.yawk.lz4')
-}
-

--- a/sdks/java/testing/nexmark/build.gradle
+++ b/sdks/java/testing/nexmark/build.gradle
@@ -103,10 +103,6 @@ dependencies {
   gradleRun project(path: nexmarkRunnerDependency, configuration: runnerConfiguration)
 }
 
-if (isFlink2) {
-  resolveCapabilitiesConflict(configurations.gradleRun, 'org.lz4:lz4-java', 'at.yawk.lz4')
-}
-
 if (isSparkRunner) {
   configurations.gradleRun {
     // Using Spark runner causes a StackOverflowError if slf4j-jdk14 is on the classpath

--- a/sdks/java/testing/tpcds/build.gradle
+++ b/sdks/java/testing/tpcds/build.gradle
@@ -94,10 +94,6 @@ dependencies {
     gradleRun project(path: tpcdsRunnerDependency, configuration: runnerConfiguration)
 }
 
-if (isFlink2) {
-    resolveCapabilitiesConflict(configurations.gradleRun, 'org.lz4:lz4-java', 'at.yawk.lz4')
-}
-
 if (isSpark) {
     configurations.gradleRun {
       exclude group: "org.slf4j", module: "slf4j-jdk14"


### PR DESCRIPTION
Initially I ran into capability conflicts with #39284 and #39285 because Kafka 3.9.2 and up depend on at.yawk.lz4:lz4-java.
I figured I'd set up conflict resolution for org.lz4:lz4-java and at.yawk.lz4:lz4-java at the root, but realized that usage of org.lz4:lz4-java is undesirable to begin with because it's unmaintained and every version has known security vulnerabilities.
Capability conflict resolution isn't enough to replace every dependency (including transitive) on org.lz4:lz4-java, but this can be solved with dependency substitutions instead (including transitive). Building KafkaIO (prior to #39284) on its own does not trigger a capability conflict since no modules providing the org.lz4:lz4-java capability are requested by dependencies of KafkaIO.

KafkaIO specifies a compileOnly/provided dependency on Kafka client libraries so the substitution shouldn't propagate in any Beam artifacts, which means that users of KafkaIO are responsible for substituting `org.lz4:lz4-java` where/when applicable.
The substitution would be propagated in Beam artifacts with a direct or transitive implementation dependency on `org.lz4:lz4-java`, meaning that any dependency on Beam artifacts will transitively include `at.yawk.lz4:lz4-java` instead.

If the above is considered overly paranoid, then retaining the current resolution strategy while simplifying maintenance of capability conflict resolution for org.lz4:lz4-java looks something like this:
```
subprojects {
  configurations {
    configureEach {
      resolutionStrategy {
        capabilitiesResolution {
          withCapability("org.lz4:lz4-java") {
            selectHighestVersion()
          }
        }
      }
    }
  }
}
```

This would at least unburden contributors and maintainers from patching new capability conflicts when dependency upgrades replace `org.lz4:lz4-java` as is the case for #39284.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
