### PR TITLE
[Java] Cache DoFn invoker constructors per instance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -82,7 +82,7 @@
 ## Bugfixes
 
 * Fixed unbounded checkpoint state growth for splittable DoFns that self-checkpoint on the portable Flink runner (Java) ([#27648](https://github.com/apache/beam/issues/27648)).
-* Avoided repeated Java `DoFn` type descriptor resolution when creating cached invokers ([#39309](https://github.com/apache/beam/issues/39309)).
+* Improved Java pipeline performance by avoiding repeated `DoFn` type descriptor resolution when creating cached invokers ([#39309](https://github.com/apache/beam/issues/39309)).
 * Fixed X (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
 
 ## Security Fixes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -82,6 +82,7 @@
 ## Bugfixes
 
 * Fixed unbounded checkpoint state growth for splittable DoFns that self-checkpoint on the portable Flink runner (Java) ([#27648](https://github.com/apache/beam/issues/27648)).
+* Avoided repeated Java `DoFn` type descriptor resolution when creating cached invokers ([#39309](https://github.com/apache/beam/issues/39309)).
 * Fixed X (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
 
 ## Security Fixes

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.description.field.FieldDescription;
 import net.bytebuddy.description.method.MethodDescription;
@@ -113,6 +114,7 @@ import org.apache.beam.sdk.util.UserCodeException;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.sdk.values.TypeDescriptors;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.MoreObjects;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.MapMaker;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Maps;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.primitives.Primitives;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
@@ -242,6 +244,22 @@ class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
   private final Map<InvokerCacheKey, Constructor<?>> byteBuddyInvokerConstructorCache =
       new ConcurrentHashMap<>();
 
+  /**
+   * A weak, identity-keyed cache of the constructor selected for each {@link DoFn} instance.
+   *
+   * <p>Selecting a constructor resolves the {@link DoFn}'s input and output type descriptors. Some
+   * runners create a new invoker for the same {@link DoFn} at every bundle boundary, so doing that
+   * work on every invocation can be expensive. A deserialized {@link DoFn} is a new instance, so
+   * its constructor is selected again; later invoker creation for that instance reuses the cached
+   * selection.
+   *
+   * <p>The constructor values do not reference their {@link DoFn} keys, and weak keys allow unused
+   * instances to be collected. {@link MapMaker#weakKeys} also uses identity equality, which is
+   * required because separate instances of the same class may have different generic types.
+   */
+  private final ConcurrentMap<DoFn<?, ?>, Constructor<?>> byteBuddyInvokerConstructorInstanceCache =
+      new MapMaker().weakKeys().makeMap();
+
   private ByteBuddyDoFnInvokerFactory() {}
 
   /** Returns the {@link DoFnInvoker} for the given {@link DoFn}. */
@@ -330,6 +348,43 @@ class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
         signature.fnClass(),
         fn.getClass());
 
+    Constructor<?> invokerConstructor =
+        byteBuddyInvokerConstructorInstanceCache.computeIfAbsent(
+            fn, unused -> getByteBuddyInvokerConstructor(signature, fn));
+
+    try {
+      @SuppressWarnings("unchecked")
+      DoFnInvokerBase<InputT, OutputT, DoFn<InputT, OutputT>> invoker =
+          (DoFnInvokerBase<InputT, OutputT, DoFn<InputT, OutputT>>)
+              invokerConstructor.newInstance(fn);
+
+      if (signature.onTimerMethods() != null) {
+        for (OnTimerMethod onTimerMethod : signature.onTimerMethods().values()) {
+          invoker.addOnTimerInvoker(
+              onTimerMethod.id(), OnTimerInvokers.forTimer(fn, onTimerMethod.id()));
+        }
+      }
+
+      if (signature.onTimerFamilyMethods() != null) {
+        for (DoFnSignature.OnTimerFamilyMethod onTimerFamilyMethod :
+            signature.onTimerFamilyMethods().values()) {
+          invoker.addOnTimerFamilyInvoker(
+              onTimerFamilyMethod.id(),
+              OnTimerInvokers.forTimerFamily(fn, onTimerFamilyMethod.id()));
+        }
+      }
+      return invoker;
+    } catch (InstantiationException
+        | IllegalAccessException
+        | IllegalArgumentException
+        | InvocationTargetException
+        | SecurityException e) {
+      throw new RuntimeException("Unable to bind invoker for " + fn.getClass(), e);
+    }
+  }
+
+  private <InputT, OutputT> Constructor<?> getByteBuddyInvokerConstructor(
+      DoFnSignature signature, DoFn<InputT, OutputT> fn) {
     // Extract input and output type descriptors to distinguish generic instantiations.
     // Fall back to Object.class if unavailable. When type info is lost, different generic
     // instantiations share an invoker, which is acceptable since the DoFn class in the cache
@@ -358,35 +413,7 @@ class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
       outputType = (TypeDescriptor<OutputT>) TypeDescriptor.of(Object.class);
     }
 
-    try {
-      @SuppressWarnings("unchecked")
-      DoFnInvokerBase<InputT, OutputT, DoFn<InputT, OutputT>> invoker =
-          (DoFnInvokerBase<InputT, OutputT, DoFn<InputT, OutputT>>)
-              getByteBuddyInvokerConstructor(signature, inputType, outputType).newInstance(fn);
-
-      if (signature.onTimerMethods() != null) {
-        for (OnTimerMethod onTimerMethod : signature.onTimerMethods().values()) {
-          invoker.addOnTimerInvoker(
-              onTimerMethod.id(), OnTimerInvokers.forTimer(fn, onTimerMethod.id()));
-        }
-      }
-
-      if (signature.onTimerFamilyMethods() != null) {
-        for (DoFnSignature.OnTimerFamilyMethod onTimerFamilyMethod :
-            signature.onTimerFamilyMethods().values()) {
-          invoker.addOnTimerFamilyInvoker(
-              onTimerFamilyMethod.id(),
-              OnTimerInvokers.forTimerFamily(fn, onTimerFamilyMethod.id()));
-        }
-      }
-      return invoker;
-    } catch (InstantiationException
-        | IllegalAccessException
-        | IllegalArgumentException
-        | InvocationTargetException
-        | SecurityException e) {
-      throw new RuntimeException("Unable to bind invoker for " + fn.getClass(), e);
-    }
+    return getByteBuddyInvokerConstructor(signature, inputType, outputType);
   }
 
   /**

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
@@ -82,6 +82,7 @@ import org.apache.beam.sdk.values.OutputBuilder;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.sdk.values.TypeDescriptors;
 import org.apache.beam.sdk.values.WindowedValues;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.Instant;
 import org.junit.Before;
 import org.junit.Rule;
@@ -1440,6 +1441,18 @@ public class DoFnInvokersTest {
       public TypeDescriptor<T> getOutputTypeDescriptor() {
         return typeDescriptor;
       }
+
+      // Deliberately make separate instances equal. The per-instance cache must use identity
+      // because equal instances can have different generic types.
+      @Override
+      public boolean equals(@Nullable Object other) {
+        return other instanceof DynamicTypeDoFn;
+      }
+
+      @Override
+      public int hashCode() {
+        return 0;
+      }
     }
 
     DoFn<String, String> stringFn = new DynamicTypeDoFn<>(TypeDescriptors.strings());
@@ -1455,5 +1468,39 @@ public class DoFnInvokersTest {
         "Critical bug: Beam returned the same cached class for different generic types.",
         stringInvoker.getClass(),
         intInvoker.getClass());
+  }
+
+  @Test
+  public void testTypeDescriptorResolutionIsCachedPerDoFnInstance() {
+    class CountingTypeDoFn extends DoFn<String, String> {
+      private int inputTypeDescriptorCalls;
+      private int outputTypeDescriptorCalls;
+
+      @ProcessElement
+      public void processElement(@Element String element, OutputReceiver<String> out) {
+        out.output(element);
+      }
+
+      @Override
+      public TypeDescriptor<String> getInputTypeDescriptor() {
+        inputTypeDescriptorCalls++;
+        return TypeDescriptors.strings();
+      }
+
+      @Override
+      public TypeDescriptor<String> getOutputTypeDescriptor() {
+        outputTypeDescriptorCalls++;
+        return TypeDescriptors.strings();
+      }
+    }
+
+    CountingTypeDoFn fn = new CountingTypeDoFn();
+
+    DoFnInvoker<String, String> firstInvoker = DoFnInvokers.invokerFor(fn);
+    DoFnInvoker<String, String> secondInvoker = DoFnInvokers.invokerFor(fn);
+
+    assertSame(firstInvoker.getClass(), secondInvoker.getClass());
+    assertEquals(1, fn.inputTypeDescriptorCalls);
+    assertEquals(1, fn.outputTypeDescriptorCalls);
   }
 }


### PR DESCRIPTION
## Summary

`ByteBuddyDoFnInvokerFactory` currently resolves a `DoFn`'s input and output type descriptors before every generated-constructor cache lookup. Runners that create a new invoker at each bundle boundary therefore repeat reflective generic-type resolution even when they reuse the same `DoFn` instance and the constructor cache hits.

This change adds a weak, identity-keyed cache from each live `DoFn` instance to its selected generated constructor. A new or deserialized instance still resolves its descriptors and uses the existing `(DoFn class, input type, output type)` constructor cache. Later invoker creation for that instance skips descriptor resolution.

The constructor value does not reference its `DoFn` key, so weak keys remain collectible. Identity equality is intentional: separate instances that compare equal can still expose different generic descriptors.

The patch preserves the generic cache-collision fix from #37355. It also strengthens that regression test by using equal `DoFn` instances with different descriptors.

Fixes #39309.

## Validation

- `./gradlew :sdks:java:core:test --tests org.apache.beam.sdk.transforms.reflect.DoFnInvokersTest`
- `./gradlew :sdks:java:core:check`

Both pass on Java 21. The full core check includes formatting, compilation, unit tests, Checkstyle, SpotBugs, Javadocs, and shaded-JAR validation.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Mention the appropriate issue in your description (`Fixes #39309`).
- [x] Update `CHANGES.md` with noteworthy changes.
- [x] This is not a large contribution; an ICLA is not required for its size.

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).
