### PR TITLE
Remove google-perftools from the default image.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,7 +73,7 @@
 
 ## Breaking Changes
 
-* X behavior was changed ([#X](https://github.com/apache/beam/issues/X)).
+* (Python) Removed `google-perftools` from the SDK container images. Users who wish to use `--profiler_agent=tcmalloc` should install google-perftools APT package in their custom container images separately ([#39323](https://github.com/apache/beam/issues/39323)).
 
 ## Deprecations
 

--- a/sdks/python/container/Dockerfile
+++ b/sdks/python/container/Dockerfile
@@ -45,8 +45,6 @@ RUN  \
        ccache \
        # Required for using Beam Python SDK on ARM machines.
        libgeos-dev \
-       # Required for memory profiling with tcmalloc.
-       google-perftools \
        && \
 
     rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
Follow up for #38853 #20298.