### PR TITLE
Make FirestoreV1 Transform bases public for worker access

### DIFF
--- a/.github/trigger_files/beam_PostCommit_Java_DataflowV1.json
+++ b/.github/trigger_files/beam_PostCommit_Java_DataflowV1.json
@@ -3,6 +3,6 @@
   "https://github.com/apache/beam/pull/34902": "Introducing OutputBuilder",
   "https://github.com/apache/beam/pull/35177": "Introducing WindowedValueReceiver to runners",
     "comment": "Modify this file in a trivial way to cause this test suite to run",
-    "modification": 9,
+    "modification": 10,
   "https://github.com/apache/beam/pull/35159": "moving WindowedValue and making an interface"
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/firestore/FirestoreV1.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/firestore/FirestoreV1.java
@@ -1410,7 +1410,7 @@ public final class FirestoreV1 {
   }
 
   /** DoFn to output CollectionIds from a {@link ListCollectionIdsResponse}. */
-  private static final class FlattenListCollectionIdsResponse
+  static final class FlattenListCollectionIdsResponse
       extends DoFn<ListCollectionIdsResponse, String> {
     @ProcessElement
     public void processElement(ProcessContext c) {
@@ -1419,7 +1419,7 @@ public final class FirestoreV1 {
   }
 
   /** DoFn to output {@link Document}s from a {@link ListDocumentsResponse}. */
-  private static final class ListDocumentsResponseToDocument
+  static final class ListDocumentsResponseToDocument
       extends DoFn<ListDocumentsResponse, Document> {
     @ProcessElement
     public void processElement(ProcessContext c) {
@@ -1826,7 +1826,7 @@ public final class FirestoreV1 {
    * @param <BldrT> The type of the type safe builder which is used to build and instance of {@link
    *     TrfmT}
    */
-  private abstract static class Transform<
+  public abstract static class Transform<
           InT extends PInput,
           OutT extends POutput,
           TrfmT extends Transform<InT, OutT, TrfmT, BldrT>,
@@ -1880,7 +1880,7 @@ public final class FirestoreV1 {
      * @param <BldrT> The type of the type safe builder which is used to build and instance of
      *     {@link TrfmT}
      */
-    abstract static class Builder<
+    public abstract static class Builder<
         InT extends PInput,
         OutT extends POutput,
         TrfmT extends Transform<InT, OutT, TrfmT, BldrT>,
@@ -2018,7 +2018,7 @@ public final class FirestoreV1 {
     }
   }
 
-  private abstract static class ReadTransform<
+  public abstract static class ReadTransform<
           InT extends PInput,
           OutT extends POutput,
           TrfmT extends ReadTransform<InT, OutT, TrfmT, BldrT>,
@@ -2041,7 +2041,7 @@ public final class FirestoreV1 {
     @Override
     public abstract BldrT toBuilder();
 
-    abstract static class Builder<
+    public abstract static class Builder<
             InT extends PInput,
             OutT extends POutput,
             TrfmT extends ReadTransform<InT, OutT, TrfmT, BldrT>,


### PR DESCRIPTION
After Java 21 bump on #39205, PostCommit Java Dataflow V1 started failing on FirestoreV1IT (batchGet, listDocuments, runQuery, partitionQuery).

The crash is IllegalAccessError on FirestoreV1$ReadTransform while the Dataflow worker loads IT DoFns and java 21 compiles BaseFirestoreIT with references to private nested types (Transform / ReadTransform) from withProjectId / withDatabaseId on the classic worker that trips getSimpleName() inside DoFnSignatures.

so the fix is making Transform, ReadTransform, and their Builders public and also make two worker DoFns package-private to match the other Firestore DoFns.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
