### PR TITLE
Fix test_get_python_sdk_name to use supported Python version

### DIFF
--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
@@ -1265,5 +1265,7 @@ def _verify_interpreter_version_is_supported(pipeline_options):
       'Dataflow runner currently supports Python versions %s, got %s.%s.\n'
       'To ignore this requirement and start a job '
       'using an unsupported version of Python interpreter, pass '
-      '--experiment use_unsupported_python_version pipeline option.' %
-      (_PYTHON_VERSIONS_SUPPORTED_BY_DATAFLOW, sys.version_info[0], sys.version_info[1]))
+      '--experiment use_unsupported_python_version pipeline option.' % (
+          _PYTHON_VERSIONS_SUPPORTED_BY_DATAFLOW,
+          sys.version_info[0],
+          sys.version_info[1]))

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
@@ -1262,8 +1262,8 @@ def _verify_interpreter_version_is_supported(pipeline_options):
     return
 
   raise Exception(
-      'Dataflow runner currently supports Python versions %s, got %s.\n'
+      'Dataflow runner currently supports Python versions %s, got %s.%s.\n'
       'To ignore this requirement and start a job '
       'using an unsupported version of Python interpreter, pass '
       '--experiment use_unsupported_python_version pipeline option.' %
-      (_PYTHON_VERSIONS_SUPPORTED_BY_DATAFLOW, sys.version))
+      (_PYTHON_VERSIONS_SUPPORTED_BY_DATAFLOW, sys.version_info[0], sys.version_info[1]))

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
@@ -1030,6 +1030,9 @@ class UtilTest(unittest.TestCase):
     self.assertNotIn(
         'use_multiple_sdk_containers', environment.proto.experiments)
 
+  # Note: We mock Python to 3.11 here. Keep this mocked version aligned with a
+  # version in _PYTHON_VERSIONS_SUPPORTED_BY_DATAFLOW to prevent test failures
+  # on release (non-dev) builds.
   @mock.patch(
       'apache_beam.runners.dataflow.internal.apiclient.sys.version_info',
       (3, 11))

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
@@ -1032,7 +1032,7 @@ class UtilTest(unittest.TestCase):
 
   @mock.patch(
       'apache_beam.runners.dataflow.internal.apiclient.sys.version_info',
-      (3, 9))
+      (3, 11))
   def test_get_python_sdk_name(self):
     pipeline_options = PipelineOptions([
         '--project',
@@ -1051,7 +1051,7 @@ class UtilTest(unittest.TestCase):
                                         '1',
                                         FAKE_PIPELINE_URL)
     self.assertEqual(
-        'Apache Beam Python 3.9 SDK', environment._get_python_sdk_name())
+        'Apache Beam Python 3.11 SDK', environment._get_python_sdk_name())
 
   @mock.patch(
       'apache_beam.runners.dataflow.internal.apiclient.sys.version_info',


### PR DESCRIPTION
Update sys.version_info mock from 3.9 to 3.11 in test_get_python_sdk_name and format version check error message using sys.version_info for consistency.

This is needed to fix the failure of `UtilTest::test_get_python_sdk_name` on a post-release branch, where Beam version has no `dev` in it.

Failed test run:
https://github.com/apache/beam/actions/runs/29345736526/job/87128821341?pr=39325

Traceback:
(Notice that the error message is misleading though because it does not use the mocked variable. This has also been fixed in this PR)
```
______________________ UtilTest.test_get_python_sdk_name _______________________
[gw0] linux -- Python 3.10.20 /runner/_work/beam/beam/sdks/python/test-suites/tox/py310/build/srcs/sdks/python/target/.tox-py310-cloud/py310-cloud/bin/python

self = <apache_beam.runners.dataflow.internal.apiclient_test.UtilTest testMethod=test_get_python_sdk_name>

    @mock.patch(
        'apache_beam.runners.dataflow.internal.apiclient.sys.version_info',
        (3, 9))
    def test_get_python_sdk_name(self):
      pipeline_options = PipelineOptions([
          '--project',
          'test_project',
          '--job_name',
          'test_job_name',
          '--temp_location',
          'gs://test-location/temp',
          '--experiments',
          'beam_fn_api',
          '--experiments',
          'use_multiple_sdk_containers'
      ])
>     environment = apiclient.Environment([],
                                          pipeline_options,
                                          '1',
                                          FAKE_PIPELINE_URL)

apache_beam/runners/dataflow/internal/apiclient_test.py:1049: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
target/.tox-py310-cloud/py310-cloud/lib/python3.10/site-packages/apache_beam/runners/dataflow/internal/apiclient.py:139: in __init__
    _verify_interpreter_version_is_supported(options)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

pipeline_options = <apache_beam.options.pipeline_options.PipelineOptions object at 0x7dac1838b160>

    def _verify_interpreter_version_is_supported(pipeline_options):
      if ('%s.%s' % (sys.version_info[0], sys.version_info[1])
          in _PYTHON_VERSIONS_SUPPORTED_BY_DATAFLOW):
        return
    
      if 'dev' in beam_version.__version__:
        return
    
      debug_options = pipeline_options.view_as(DebugOptions)
      if (debug_options.experiments and
          'use_unsupported_python_version' in debug_options.experiments):
        return
    
>     raise Exception(
          'Dataflow runner currently supports Python versions %s, got %s.\n'
          'To ignore this requirement and start a job '
          'using an unsupported version of Python interpreter, pass '
          '--experiment use_unsupported_python_version pipeline option.' %
          (_PYTHON_VERSIONS_SUPPORTED_BY_DATAFLOW, sys.version))
E     Exception: Dataflow runner currently supports Python versions ['3.10', '3.11', '3.12', '3.13', '3.14'], got 3.10.20 (main, Jun 16 2026, 21:01:32) [GCC 13.3.0].
E     To ignore this requirement and start a job using an unsupported version of Python interpreter, pass --experiment use_unsupported_python_version pipeline option.
```