### PR TITLE
Fix artifact staging filenames on Windows

### DIFF
--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/artifact/ArtifactStagingService.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/artifact/ArtifactStagingService.java
@@ -510,8 +510,10 @@ public class ArtifactStagingService
         // all path separators.
         List<String> components = Splitter.onPattern("[^A-Za-z-_.]]").splitToList(path);
         String base = components.get(components.size() - 1);
+        String sanitizedEnvironment = environment.replaceAll("[<>:\"/\\\\|?*]", "_");
         return clip(
-            String.format("%s-%s-%s", idGenerator.getId(), clip(environment, 25), base), 100);
+            String.format("%s-%s-%s", idGenerator.getId(), clip(sanitizedEnvironment, 25), base),
+            100);
       }
 
       private String clip(String s, int maxLength) {

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/artifact/ArtifactStagingServiceTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/artifact/ArtifactStagingServiceTest.java
@@ -166,6 +166,27 @@ public class ArtifactStagingServiceTest {
     checkArtifacts(contentsList, staged.get("env2"));
   }
 
+  @Test
+  public void testStageArtifactsWithInvalidFilenameCharacters()
+      throws InterruptedException, ExecutionException {
+    String environment = "0:ref_Environment_default";
+    List<String> contentsList = ImmutableList.of("artifact-content");
+
+    stagingService.registerJob(
+        "stagingToken",
+        ImmutableMap.of(
+            environment,
+            Lists.transform(contentsList, FakeArtifactRetrievalService::resolvedArtifact)));
+
+    ArtifactStagingService.offer(new FakeArtifactRetrievalService(), stagingStub, "stagingToken");
+
+    Map<String, List<RunnerApi.ArtifactInformation>> staged =
+        stagingService.getStagedArtifacts("stagingToken");
+
+    assertEquals(1, staged.size());
+    checkArtifacts(contentsList, staged.get(environment));
+  }
+
   private void checkArtifacts(
       List<String> expectedContents, List<RunnerApi.ArtifactInformation> staged) {
     assertEquals(


### PR DESCRIPTION
Fixes #39336

## What is the issue?

Artifact staging can fail on Windows when an environment ID contains characters that are invalid in Windows filenames, such as `:`. The environment ID was previously embedded directly into the generated staging filename, causing an `InvalidPathException` before the pipeline could run.

## What does this PR do?

* Sanitizes Windows-invalid filename characters in environment IDs before using them in staged artifact filenames.
* Adds a regression test using an environment ID containing `:` to verify that artifact staging succeeds on Windows.

## Testing

* `./gradlew :runners:java-fn-execution:test --tests "org.apache.beam.runners.fnexecution.artifact.ArtifactStagingServiceTest"`
* `./gradlew :runners:java-fn-execution:spotlessCheck`
* `./gradlew :runners:java-fn-execution:check`

All tests and checks pass successfully.
