### PR TITLE
Fix beamTestPipelineOptions quote loss on Windows for ValidatesRunner tasks

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -96,6 +96,17 @@ class BeamModulePlugin implements Plugin<Project> {
     }
   }
 
+  // Serializes pipeline options to JSON for the beamTestPipelineOptions system property.
+  // On Windows each option is wrapped in literal quotes so the JSON survives the quote
+  // stripping applied to the forked test JVM's command line.
+  // See https://github.com/apache/beam/issues/39332.
+  static def toBeamTestPipelineOptionsJson(def options) {
+    if (System.properties['os.name'].toLowerCase().contains('windows')) {
+      return JsonOutput.toJson(options.collect { "\"$it\"" })
+    }
+    return JsonOutput.toJson(options)
+  }
+
   /** A class defining the set of configurable properties accepted by applyJavaNature. */
   static class JavaNatureConfiguration {
     /** Controls whether the spotbugs plugin is enabled and configured. */
@@ -2249,12 +2260,8 @@ class BeamModulePlugin implements Plugin<Project> {
             }
           }
 
-          // Windows handles quotation marks differently
-          if (pipelineOptionsString && System.properties['os.name'].toLowerCase().contains('windows')) {
-            def allOptionsListFormatted = allOptionsList.collect { "\"$it\"" }
-            pipelineOptionsStringFormatted = JsonOutput.toJson(allOptionsListFormatted)
-          } else if (pipelineOptionsString) {
-            pipelineOptionsStringFormatted = JsonOutput.toJson(allOptionsList)
+          if (pipelineOptionsString) {
+            pipelineOptionsStringFormatted = toBeamTestPipelineOptionsJson(allOptionsList)
           }
 
           systemProperties.beamTestPipelineOptions = pipelineOptionsStringFormatted ?: pipelineOptionsString
@@ -2691,7 +2698,7 @@ class BeamModulePlugin implements Plugin<Project> {
       if (config.jobServerConfig) {
         beamTestPipelineOptions.add("--jobServerConfig=${config.jobServerConfig}")
       }
-      config.systemProperties.put("beamTestPipelineOptions", JsonOutput.toJson(beamTestPipelineOptions))
+      config.systemProperties.put("beamTestPipelineOptions", toBeamTestPipelineOptionsJson(beamTestPipelineOptions))
       project.tasks.register(name, Test) {
         group = "Verification"
         description = "Validates the PortableRunner with JobServer ${config.jobServerDriver}"
@@ -2857,7 +2864,7 @@ class BeamModulePlugin implements Plugin<Project> {
         def javaTask = project.tasks.register(config.name+"JavaUsing"+sdk, Test) {
           group = "Verification"
           description = "Validates runner for cross-language capability of using ${sdk} transforms from Java SDK"
-          systemProperty "beamTestPipelineOptions", JsonOutput.toJson(config.javaPipelineOptions)
+          systemProperty "beamTestPipelineOptions", toBeamTestPipelineOptionsJson(config.javaPipelineOptions)
           systemProperty "expansionJar", expansionJar
           systemProperty "expansionPort", port
           systemProperty "semiPersistDir", config.semiPersistDir


### PR DESCRIPTION
Fixes #39332.

On Windows, Gradle forks the test JVM with `-DbeamTestPipelineOptions=<compact JSON>` on the command line. `ProcessBuilder` only quotes arguments that contain whitespace, so the argument is passed unquoted, the Windows C runtime strips the JSON's `"` characters, and `TestPipeline.testingPipelineOptions()` fails with `JsonParseException` before any pipeline runs. Every test in the task fails at `TestPipeline.create()`.

The repo already handles this in two places by wrapping each option in literal quotes so one quoting layer survives: `runners/direct-java/build.gradle` (`pipelineOptionsStringCrossPlatformHandling`, BEAM-11365) and the inline handling in `enableJavaPerformanceTesting` (BEAM-10682). This PR consolidates that treatment into a shared static helper `toBeamTestPipelineOptionsJson` in `BeamModulePlugin` and applies it to the two ValidatesRunner paths that were missing it:

- `createPortableValidatesRunnerTask`
- `createCrossLanguageValidatesRunnerTask`

The existing inline handling in `enableJavaPerformanceTesting` is refactored onto the same helper. On non-Windows platforms the helper emits exactly the same JSON as before (`JsonOutput.toJson(options)`), so CI behavior is unchanged; the wrapping branch only executes on Windows.

Verified on Windows 11, JDK 11:

- The standalone `ProcessBuilder` reproduction from #39332, using the exact options of the Spark portable VR batch task: the current format loses every quote in the child JVM; the wrapped format arrives byte-identical to the intended JSON.
- `gradlew :runners:spark:3:job-server:validatesPortableRunnerBatch --tests "*SplittableDoFnTest*"`, which previously failed 9/9 with `JsonParseException` at `TestPipeline.create()`: after this change the `JsonParseException` count is 0/9. The forked worker's command line shows the property arriving intact (`jps -v`: `-DbeamTestPipelineOptions=["--runner=org.apache.beam.runners.portability.testing.TestPortableRunner",...]`), and all 9 tests parse their options, create the `TestPipeline`, and submit pipelines to the job server. They then hit #39364, a separate pre-existing Windows bug in artifact staging that this fix unmasked; this change is a prerequisite for any local Java VR signal on Windows.
