### PR TITLE
Fail fast in artifact staging when storing an artifact fails

### DIFF
--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/artifact/ArtifactStagingService.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/artifact/ArtifactStagingService.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.apache.beam.model.jobmanagement.v1.ArtifactApi;
 import org.apache.beam.model.jobmanagement.v1.ArtifactStagingServiceGrpc;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
@@ -223,13 +224,17 @@ public class ArtifactStagingService
     }
 
     synchronized void aquire(int permits) throws Exception {
-      while (usedPermits >= totalPermits) {
-        if (exception != null) {
-          throw exception;
-        }
+      while (exception == null && usedPermits >= totalPermits) {
         this.wait();
       }
+      checkException();
       usedPermits += permits;
+    }
+
+    synchronized void checkException() throws Exception {
+      if (exception != null) {
+        throw exception;
+      }
     }
 
     synchronized void release(int permits) {
@@ -282,13 +287,16 @@ public class ArtifactStagingService
             .setTypeUrn(dest.getTypeUrn())
             .setTypePayload(dest.getTypePayload())
             .build();
-      } catch (IOException | InterruptedException exn) {
+      } catch (Exception exn) {
         // As this thread will no longer be draining the queue, we don't want to get stuck writing
-        // to it.
+        // to it. This must happen for unchecked exceptions as well: getDestination can throw e.g.
+        // InvalidPathException, and leaving the error unset would block the producer forever.
         totalPendingBytes.setException(exn);
         LOG.error("Exception staging artifacts", exn);
         if (exn instanceof IOException) {
           throw (IOException) exn;
+        } else if (exn instanceof RuntimeException) {
+          throw (RuntimeException) exn;
         } else {
           throw new RuntimeException(exn);
         }
@@ -409,10 +417,10 @@ public class ArtifactStagingService
               ByteString chunk = responseWrapper.getGetArtifactResponse().getData();
               if (chunk.size() > 0) { // Make sure we don't accidentally send the EOF value.
                 totalPendingBytes.aquire(chunk.size());
-                currentOutput.put(chunk);
+                putChunk(chunk);
               }
               if (responseWrapper.getIsLast()) {
-                currentOutput.put(ByteString.EMPTY); // The EOF value.
+                putChunk(ByteString.EMPTY); // The EOF value.
                 if (pendingGets.isEmpty()) {
                   resolveNextEnvironment(responseObserver);
                 } else {
@@ -421,8 +429,16 @@ public class ArtifactStagingService
                 }
               }
             } catch (Exception exn) {
-              LOG.error("Error submitting.", exn);
-              onError(exn);
+              // The write of a previous chunk failed; surface the failure to the client rather
+              // than leaving the stream unterminated, which would make the client block forever.
+              LOG.error("Error staging artifacts", exn);
+              state = State.ERROR;
+              stagingExecutor.shutdownNow();
+              responseObserver.onError(
+                  Status.INTERNAL
+                      .withDescription("Error staging artifacts: " + exn)
+                      .withCause(exn)
+                      .asException());
             }
             break;
 
@@ -430,6 +446,14 @@ public class ArtifactStagingService
             responseObserver.onError(
                 new StatusException(
                     Status.INVALID_ARGUMENT.withDescription("Illegal state " + state)));
+        }
+      }
+
+      private void putChunk(ByteString chunk) throws Exception {
+        // The queue is drained by a StoreArtifact task. Don't block forever on a plain put if
+        // that task has died with an error; poll so its exception can interrupt the wait.
+        while (!currentOutput.offer(chunk, 1, TimeUnit.SECONDS)) {
+          totalPendingBytes.checkException();
         }
       }
 

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/artifact/ArtifactStagingService.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/artifact/ArtifactStagingService.java
@@ -293,6 +293,9 @@ public class ArtifactStagingService
         // InvalidPathException, and leaving the error unset would block the producer forever.
         totalPendingBytes.setException(exn);
         LOG.error("Exception staging artifacts", exn);
+        if (exn instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
         if (exn instanceof IOException) {
           throw (IOException) exn;
         } else if (exn instanceof RuntimeException) {
@@ -432,6 +435,9 @@ public class ArtifactStagingService
               // The write of a previous chunk failed; surface the failure to the client rather
               // than leaving the stream unterminated, which would make the client block forever.
               LOG.error("Error staging artifacts", exn);
+              if (exn instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+              }
               state = State.ERROR;
               stagingExecutor.shutdownNow();
               responseObserver.onError(

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/artifact/ArtifactStagingService.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/artifact/ArtifactStagingService.java
@@ -40,7 +40,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import org.apache.beam.model.jobmanagement.v1.ArtifactApi;
 import org.apache.beam.model.jobmanagement.v1.ArtifactStagingServiceGrpc;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
@@ -292,6 +291,8 @@ public class ArtifactStagingService
         // to it. This must happen for unchecked exceptions as well: getDestination can throw e.g.
         // InvalidPathException, and leaving the error unset would block the producer forever.
         totalPendingBytes.setException(exn);
+        // Free a producer already blocked in put; its next aquire observes the exception.
+        bytesQueue.clear();
         LOG.error("Exception staging artifacts", exn);
         if (exn instanceof InterruptedException) {
           Thread.currentThread().interrupt();
@@ -420,10 +421,10 @@ public class ArtifactStagingService
               ByteString chunk = responseWrapper.getGetArtifactResponse().getData();
               if (chunk.size() > 0) { // Make sure we don't accidentally send the EOF value.
                 totalPendingBytes.aquire(chunk.size());
-                putChunk(chunk);
+                currentOutput.put(chunk);
               }
               if (responseWrapper.getIsLast()) {
-                putChunk(ByteString.EMPTY); // The EOF value.
+                currentOutput.put(ByteString.EMPTY); // The EOF value.
                 if (pendingGets.isEmpty()) {
                   resolveNextEnvironment(responseObserver);
                 } else {
@@ -432,14 +433,11 @@ public class ArtifactStagingService
                 }
               }
             } catch (Exception exn) {
-              // The write of a previous chunk failed; surface the failure to the client rather
-              // than leaving the stream unterminated, which would make the client block forever.
-              LOG.error("Error staging artifacts", exn);
               if (exn instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
               }
-              state = State.ERROR;
-              stagingExecutor.shutdownNow();
+              onError(exn);
+              // Terminate the stream towards the client, which would otherwise wait forever.
               responseObserver.onError(
                   Status.INTERNAL
                       .withDescription("Error staging artifacts: " + exn)
@@ -452,14 +450,6 @@ public class ArtifactStagingService
             responseObserver.onError(
                 new StatusException(
                     Status.INVALID_ARGUMENT.withDescription("Illegal state " + state)));
-        }
-      }
-
-      private void putChunk(ByteString chunk) throws Exception {
-        // The queue is drained by a StoreArtifact task. Don't block forever on a plain put if
-        // that task has died with an error; poll so its exception can interrupt the wait.
-        while (!currentOutput.offer(chunk, 1, TimeUnit.SECONDS)) {
-          totalPendingBytes.checkException();
         }
       }
 

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/artifact/ArtifactStagingServiceTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/artifact/ArtifactStagingServiceTest.java
@@ -18,7 +18,10 @@
 package org.apache.beam.runners.fnexecution.artifact;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
@@ -135,6 +138,22 @@ public class ArtifactStagingServiceTest {
     }
   }
 
+  /** Streams each artifact one byte per chunk, to exercise the service's chunk buffering. */
+  private static class OneBytePerChunkArtifactRetrievalService
+      extends FakeArtifactRetrievalService {
+    @Override
+    public void getArtifact(
+        ArtifactApi.GetArtifactRequest request,
+        StreamObserver<ArtifactApi.GetArtifactResponse> responseObserver) {
+      ByteString data = request.getArtifact().getTypePayload();
+      for (int i = 0; i < data.size(); i++) {
+        responseObserver.onNext(
+            ArtifactApi.GetArtifactResponse.newBuilder().setData(data.substring(i, i + 1)).build());
+      }
+      responseObserver.onCompleted();
+    }
+  }
+
   private String getArtifact(RunnerApi.ArtifactInformation artifact) {
     ByteString all = ByteString.EMPTY;
     Iterator<ArtifactApi.GetArtifactResponse> response =
@@ -164,6 +183,55 @@ public class ArtifactStagingServiceTest {
     assertEquals(2, staged.size());
     checkArtifacts(contentsList, staged.get("env1"));
     checkArtifacts(contentsList, staged.get("env2"));
+  }
+
+  @SuppressWarnings("InlineMeInliner") // inline `Strings.repeat()` - Java 11+ API only
+  @Test(timeout = 60_000)
+  public void testDestinationFailureFailsOfferInsteadOfHanging() throws Exception {
+    // Resolving the destination of a staged artifact can throw an unchecked exception, e.g.
+    // InvalidPathException on Windows where the generated filename may contain characters that
+    // are illegal in paths (https://github.com/apache/beam/issues/39364). This must fail the
+    // offering client instead of stalling the transfer forever.
+    ArtifactStagingService failingStagingService =
+        new ArtifactStagingService(
+            new ArtifactStagingService.ArtifactDestinationProvider() {
+              @Override
+              public ArtifactStagingService.ArtifactDestination getDestination(
+                  String stagingToken, String name) {
+                throw new InvalidPathException(name, "Illegal char simulated");
+              }
+
+              @Override
+              public void removeStagedArtifacts(String stagingToken) {}
+            });
+    grpcCleanup.register(
+        InProcessServerBuilder.forName("failing-server")
+            .directExecutor()
+            .addService(failingStagingService)
+            .build()
+            .start());
+    ManagedChannel failingChannel =
+        grpcCleanup.register(InProcessChannelBuilder.forName("failing-server").build());
+    ArtifactStagingServiceGrpc.ArtifactStagingServiceStub failingStub =
+        ArtifactStagingServiceGrpc.newStub(failingChannel);
+
+    // More chunks than the service buffers per artifact, so staging cannot run to completion
+    // before the destination failure is observed.
+    String contents = Strings.repeat("x", 300);
+    failingStagingService.registerJob(
+        "failingToken",
+        ImmutableMap.of(
+            "env1", ImmutableList.of(FakeArtifactRetrievalService.resolvedArtifact(contents))));
+
+    ExecutionException exn =
+        assertThrows(
+            ExecutionException.class,
+            () ->
+                ArtifactStagingService.offer(
+                    new OneBytePerChunkArtifactRetrievalService(), failingStub, "failingToken"));
+    assertTrue(
+        "Expected the destination failure, got: " + exn.getCause(),
+        exn.getCause().getMessage().contains("Illegal char simulated"));
   }
 
   private void checkArtifacts(


### PR DESCRIPTION
Fixes #39364.

On Windows, `StoreArtifact.call()` fails in its first statement with an unchecked `InvalidPathException`, because the staged filename embeds the environment id and Java environment ids contain colons (`beam:env:embedded:v1`). The catch block only handled `IOException | InterruptedException`, so the failure was never reported anywhere: the queue consumer died silently, the gRPC `onNext` thread eventually blocked forever in `OverflowingSemaphore.aquire` (or in `currentOutput.put` once the 100-slot chunk queue filled), the reverse-retrieval stream was neither completed nor errored, and the submitting client waited forever in `ArtifactStagingService.offer`. This is what makes every portable Java ValidatesRunner test on Windows hang for its full 1200s JUnit timeout during pipeline submission.

This PR makes any artifact storage failure fail fast and reach the client:

* `StoreArtifact.call()` reports every exception to `totalPendingBytes`, including unchecked ones, before rethrowing.
* `OverflowingSemaphore.aquire` observes a set exception even when permits are still available, instead of only after the 100 MB budget is exhausted.
* The chunk producer no longer does an unconditional `BlockingQueue.put`; it polls with a timeout and rechecks the semaphore's exception, so a dead consumer cannot strand it.
* The `GETCHUNK` error handler terminates the stream with `Status.INTERNAL` carrying the root cause description, instead of only flipping internal state, so `offer` completes exceptionally with the actual error.

The regression test injects a destination provider that throws `InvalidPathException` (as `LocalResourceId.resolve` does on Windows) and streams an artifact in more chunks than the service buffers, so staging cannot run to completion before the failure is observed. Without the main change the test hangs and fails by timeout, reproducing the reported bug; with it, `offer` fails within seconds and the client sees the root cause.

#39363 complements this fix by sanitizing the Windows-illegal characters out of the generated filenames. With both, portable Java pipelines can stage artifacts on Windows, and any future staging failure will surface immediately instead of hanging the submission.

Tested with `gradlew :runners:java-fn-execution:test --tests "*ArtifactStagingServiceTest*"`: both tests pass, and with the main change reverted the new test fails by timeout as described in the issue.
