### PR TITLE
Revert "remove zizmor"

### DIFF
--- a/.github/workflows/beam_PreCommit_GHA.yml
+++ b/.github/workflows/beam_PreCommit_GHA.yml
@@ -42,7 +42,7 @@ permissions:
   packages: read
   pages: read
   repository-projects: read
-  security-events: read
+  security-events: write
   statuses: read
 
 # This allows a subsequently queued workflow run to interrupt previous runs
@@ -80,6 +80,10 @@ jobs:
         comment_phrase: ${{ matrix.job_phrase }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
         github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
+    - name: Run zizmor
+      uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0
+      with:
+        advanced-security: true
     - name: Setup environment
       uses: ./.github/actions/setup-environment-action
       with:


### PR DESCRIPTION
1. Reverts apache/beam#39355
2. Zizmor version 6.0 was allowed listed a few hours ago - https://github.com/apache/infrastructure-actions/blame/main/approved_patterns.yml
3. Run success - https://github.com/apache/beam/actions/runs/29592389496/job/87924423683
