### PR TITLE
[Python] Reuse Milvus client in RAG vector sink write path

### DIFF
--- a/sdks/python/apache_beam/ml/rag/ingestion/milvus_search.py
+++ b/sdks/python/apache_beam/ml/rag/ingestion/milvus_search.py
@@ -287,16 +287,18 @@ class _MilvusSink:
     """Writes a batch of documents to the Milvus collection.
 
     Performs an upsert operation to insert new documents or update existing
-    ones based on primary key. After the upsert, flushes the collection to
-    ensure data persistence.
+    ones based on primary key, reusing the client established in ``__enter__``.
+
+    Note:
+      This submits the upsert to Milvus; it does not call ``flush()`` on the
+      collection. Newly written rows become queryable according to Milvus'
+      normal segment-sync behavior. Callers that require immediate
+      read-after-write visibility should flush the collection explicitly.
 
     Args:
       documents: List of dictionaries representing Milvus records to write.
         Each dictionary should contain fields matching the collection schema.
     """
-    self._client = MilvusClient(
-        **unpack_dataclass_with_kwargs(self._connection_params))
-
     resp = self._client.upsert(
         collection_name=self._write_config.collection_name,
         partition_name=self._write_config.partition_name,

--- a/sdks/python/apache_beam/ml/rag/ingestion/milvus_search.py
+++ b/sdks/python/apache_beam/ml/rag/ingestion/milvus_search.py
@@ -348,3 +348,4 @@ class _MilvusSink:
     _ = exc_type, exc_val, exc_tb  # Unused parameters
     if self._client:
       self._client.close()
+      self._client = None

--- a/sdks/python/apache_beam/ml/rag/ingestion/milvus_search_test.py
+++ b/sdks/python/apache_beam/ml/rag/ingestion/milvus_search_test.py
@@ -149,8 +149,9 @@ class TestMilvusSinkClientReuse(unittest.TestCase):
         self.assertEqual(mock_client_cls.call_count, 1)
         self.assertEqual(mock_client_cls.return_value.upsert.call_count, 2)
 
-      # Client closed once on __exit__.
+      # Client closed once on __exit__, and cleared so the sink can be reused.
       self.assertEqual(mock_client_cls.return_value.close.call_count, 1)
+      self.assertIsNone(sink._client)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/ml/rag/ingestion/milvus_search_test.py
+++ b/sdks/python/apache_beam/ml/rag/ingestion/milvus_search_test.py
@@ -15,12 +15,15 @@
 # limitations under the License.
 #
 import unittest
+from unittest import mock
 
 from parameterized import parameterized
 
 try:
+  from apache_beam.ml.rag.ingestion import milvus_search as milvus_search_module
   from apache_beam.ml.rag.ingestion.milvus_search import MilvusVectorWriterConfig
   from apache_beam.ml.rag.ingestion.milvus_search import MilvusWriteConfig
+  from apache_beam.ml.rag.ingestion.milvus_search import _MilvusSink
   from apache_beam.ml.rag.utils import MilvusConnectionParameters
 except ImportError as e:
   raise unittest.SkipTest(f'Milvus dependencies not installed: {str(e)}')
@@ -117,6 +120,37 @@ class TestMilvusVectorWriterConfig(unittest.TestCase):
           connection_params=connection_params, write_config=write_config)
 
     self.assertIn(expected_error_msg, str(context.exception))
+
+
+class TestMilvusSinkClientReuse(unittest.TestCase):
+  """Unit tests for Milvus sink client reuse.
+
+  Verifies that ``_MilvusSink.write`` reuses the client established in
+  ``__enter__`` instead of constructing (and leaking) a new client on every
+  write.
+  """
+  def _sink(self):
+    connection_params = MilvusConnectionParameters(uri="http://localhost:19530")
+    write_config = MilvusWriteConfig(collection_name="test_collection")
+    return _MilvusSink(connection_params, write_config)
+
+  def test_write_reuses_enter_client(self):
+    """write() must not construct a new MilvusClient per call."""
+    with mock.patch.object(milvus_search_module,
+                           'MilvusClient') as mock_client_cls:
+      with self._sink() as sink:
+        # One client created on __enter__.
+        self.assertEqual(mock_client_cls.call_count, 1)
+
+        sink.write([{"id": 1}])
+        sink.write([{"id": 2}])
+
+        # write() reuses that client; no new construction.
+        self.assertEqual(mock_client_cls.call_count, 1)
+        self.assertEqual(mock_client_cls.return_value.upsert.call_count, 2)
+
+      # Client closed once on __exit__.
+      self.assertEqual(mock_client_cls.return_value.close.call_count, 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
fixes #39377

`_MilvusSink.write()` was creating a new `MilvusClient` on every call. But `__enter__` already creates one (with retry). So the write path threw away the retried client, made a fresh one without retry, and the old one never got closed — it just leaks, since `MilvusClient` has no `__del__`. `__exit__` only closes the last client.

Also the `write()` docstring said it flushes the collection for durability, but there's no `flush()` call anywhere.

This PR:
- reuses the client from `__enter__` for the upsert instead of building a new one
- fixes the docstring to describe what actually happens (no flush)
- adds a unit test that checks `write()` reuses the same client (one created, one closed) with a mocked `MilvusClient`

Follow-up (not here): the sink still opens/closes a connection per batch in `_flush()`. Moving that to the DoFn `setup()`/`teardown()` would give one client per worker. Left out to keep this small.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
