### PR TITLE
(IcebergIO) Support PartitionSpec/SortOrder on dynamic table creation via IcebergIO

### DIFF
--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/DynamicDestinations.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/DynamicDestinations.java
@@ -18,10 +18,12 @@
 package org.apache.beam.sdk.io.iceberg;
 
 import java.io.Serializable;
+import java.util.List;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.ValueInSingleWindow;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public interface DynamicDestinations extends Serializable {
 
@@ -34,6 +36,14 @@ public interface DynamicDestinations extends Serializable {
   String getTableStringIdentifier(ValueInSingleWindow<Row> element);
 
   static DynamicDestinations singleTable(TableIdentifier tableId, Schema inputSchema) {
-    return new OneTableDynamicDestinations(tableId, inputSchema);
+    return new OneTableDynamicDestinations(tableId, inputSchema, null, null);
+  }
+
+  static DynamicDestinations singleTable(
+      TableIdentifier tableId,
+      Schema inputSchema,
+      @Nullable List<String> partitionFields,
+      @Nullable List<String> sortFields) {
+    return new OneTableDynamicDestinations(tableId, inputSchema, partitionFields, sortFields);
   }
 }

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergIO.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergIO.java
@@ -409,6 +409,10 @@ public class IcebergIO {
 
     abstract @Nullable Map<String, String> getWriteProperties();
 
+    abstract @Nullable List<String> getPartitionFields();
+
+    abstract @Nullable List<String> getSortFields();
+
     abstract Builder toBuilder();
 
     @AutoValue.Builder
@@ -428,6 +432,10 @@ public class IcebergIO {
       abstract Builder setAutoSharding(boolean autoSharding);
 
       abstract Builder setWriteProperties(Map<String, String> writeProperties);
+
+      abstract Builder setPartitionFields(List<String> partitionFields);
+
+      abstract Builder setSortFields(List<String> sortFields);
 
       abstract WriteRows build();
     }
@@ -483,6 +491,26 @@ public class IcebergIO {
       return toBuilder().setWriteProperties(writeProperties).build();
     }
 
+    /**
+     * Defines the desired Partition Spec to be applied when the Iceberg table must be dynamically
+     * created, e.g. `bucket(id_field, 32)` or `day(timestamp_field)`
+     *
+     * <p>See: https://iceberg.apache.org/spec/#partitioning
+     */
+    public WriteRows withPartitionSpec(List<String> partitionFields) {
+      return toBuilder().setPartitionFields(partitionFields).build();
+    }
+
+    /**
+     * Defines the desired Sort Order to be applied when the Iceberg table must be dynamically
+     * created, e.g. `int_field desc` or `bucket(modulo_5, 4) asc nulls last`
+     *
+     * <p>See: https://iceberg.apache.org/spec/#sorting
+     */
+    public WriteRows withSortOrder(List<String> sortFields) {
+      return toBuilder().setSortFields(sortFields).build();
+    }
+
     @Override
     public IcebergWriteResult expand(PCollection<Row> input) {
       List<?> allToArgs = Arrays.asList(getTableIdentifier(), getDynamicDestinations());
@@ -494,7 +522,10 @@ public class IcebergIO {
       if (destinations == null) {
         destinations =
             DynamicDestinations.singleTable(
-                Preconditions.checkNotNull(getTableIdentifier()), input.getSchema());
+                Preconditions.checkNotNull(getTableIdentifier()),
+                input.getSchema(),
+                getPartitionFields(),
+                getSortFields());
       }
 
       // Assign destinations before re-windowing to global in WriteToDestinations because

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergIO.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergIO.java
@@ -497,7 +497,7 @@ public class IcebergIO {
      *
      * <p>See: https://iceberg.apache.org/spec/#partitioning
      */
-    public WriteRows withPartitionSpec(List<String> partitionFields) {
+    public WriteRows withPartitionFields(List<String> partitionFields) {
       return toBuilder().setPartitionFields(partitionFields).build();
     }
 

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/OneTableDynamicDestinations.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/OneTableDynamicDestinations.java
@@ -23,6 +23,7 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.List;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.ValueInSingleWindow;
@@ -30,6 +31,7 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.Vi
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 class OneTableDynamicDestinations implements DynamicDestinations, Externalizable {
   // TableId represented as String for serializability
@@ -37,6 +39,8 @@ class OneTableDynamicDestinations implements DynamicDestinations, Externalizable
 
   private transient @MonotonicNonNull TableIdentifier tableId;
   private transient @MonotonicNonNull Schema rowSchema;
+  private transient @Nullable List<String> partitionFields;
+  private transient @Nullable List<String> sortFields;
 
   @VisibleForTesting
   TableIdentifier getTableIdentifier() {
@@ -46,9 +50,15 @@ class OneTableDynamicDestinations implements DynamicDestinations, Externalizable
     return tableId;
   }
 
-  OneTableDynamicDestinations(TableIdentifier tableId, Schema rowSchema) {
+  OneTableDynamicDestinations(
+      TableIdentifier tableId,
+      Schema rowSchema,
+      @Nullable List<String> partitionFields,
+      @Nullable List<String> sortFields) {
     this.tableIdString = IcebergUtils.tableIdentifierToString(tableId);
     this.rowSchema = rowSchema;
+    this.partitionFields = partitionFields;
+    this.sortFields = sortFields;
   }
 
   @Override
@@ -68,9 +78,18 @@ class OneTableDynamicDestinations implements DynamicDestinations, Externalizable
 
   @Override
   public IcebergDestination instantiateDestination(String unused) {
+    @Nullable IcebergTableCreateConfig createConfig = null;
+    if (partitionFields != null || sortFields != null) {
+      createConfig =
+          IcebergTableCreateConfig.builder()
+              .setSchema(checkStateNotNull(rowSchema))
+              .setPartitionFields(partitionFields)
+              .setSortFields(sortFields)
+              .build();
+    }
     return IcebergDestination.builder()
         .setTableIdentifier(getTableIdentifier())
-        .setTableCreateConfig(null)
+        .setTableCreateConfig(createConfig)
         .setFileFormat(FileFormat.PARQUET)
         .build();
   }
@@ -78,14 +97,22 @@ class OneTableDynamicDestinations implements DynamicDestinations, Externalizable
   // Need a public default constructor for custom serialization
   public OneTableDynamicDestinations() {}
 
+  @SuppressWarnings("nullness")
   @Override
   public void writeExternal(ObjectOutput out) throws IOException {
     out.writeUTF(checkStateNotNull(tableIdString));
+    out.writeObject(rowSchema);
+    out.writeObject(partitionFields);
+    out.writeObject(sortFields);
   }
 
+  @SuppressWarnings("nullness")
   @Override
-  public void readExternal(ObjectInput in) throws IOException {
+  public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
     tableIdString = in.readUTF();
     tableId = IcebergUtils.parseTableIdentifier(tableIdString);
+    rowSchema = (Schema) in.readObject();
+    partitionFields = (List<String>) in.readObject();
+    sortFields = (List<String>) in.readObject();
   }
 }

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/WritePartitionedRowsToFiles.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/WritePartitionedRowsToFiles.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
@@ -189,6 +190,8 @@ class WritePartitionedRowsToFiles
       @Nullable IcebergTableCreateConfig createConfig = destination.getTableCreateConfig();
       PartitionSpec partitionSpec =
           createConfig != null ? createConfig.getPartitionSpec() : PartitionSpec.unpartitioned();
+      SortOrder sortOrder =
+          createConfig != null ? createConfig.getSortOrder() : SortOrder.unsorted();
       Map<String, String> tableProperties =
           createConfig != null && createConfig.getTableProperties() != null
               ? createConfig.getTableProperties()
@@ -217,13 +220,19 @@ class WritePartitionedRowsToFiles
         org.apache.iceberg.Schema tableSchema = IcebergUtils.beamSchemaToIcebergSchema(dataSchema);
         try {
           Table table =
-              catalog.createTable(identifier, tableSchema, partitionSpec, tableProperties);
+              catalog
+                  .buildTable(identifier, tableSchema)
+                  .withPartitionSpec(partitionSpec)
+                  .withSortOrder(sortOrder)
+                  .withProperties(tableProperties)
+                  .create();
           LOG.info(
               "Created Iceberg table '{}' with schema: {}\n"
-                  + ", partition spec: {}, table properties: {}",
+                  + ", partition spec: {}, sort order: {}, table properties: {}",
               identifier,
               tableSchema,
               partitionSpec,
+              sortOrder,
               tableProperties);
           return table;
         } catch (AlreadyExistsException ignored) {

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/IcebergIOWriteTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/IcebergIOWriteTest.java
@@ -76,7 +76,10 @@ import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.NullOrder;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.SortDirection;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
@@ -774,5 +777,56 @@ public class IcebergIOWriteTest implements Serializable {
             .next()
             .getCommitted();
     assertEquals(5L, numWaves);
+  }
+
+  @Test
+  public void testCreateTableWithPartitionSpecAndSortOrder() {
+    TableIdentifier tableId =
+        TableIdentifier.of(
+            "default", "sorted_partitioned_" + Long.toString(UUID.randomUUID().hashCode(), 16));
+
+    Schema beamSchema = IcebergUtils.icebergSchemaToBeamSchema(TestFixtures.SCHEMA);
+
+    Map<String, String> catalogProps =
+        ImmutableMap.<String, String>builder()
+            .put("type", CatalogUtil.ICEBERG_CATALOG_TYPE_HADOOP)
+            .put("warehouse", warehouse.location)
+            .build();
+
+    IcebergCatalogConfig catalog =
+        IcebergCatalogConfig.builder()
+            .setCatalogName("name")
+            .setCatalogProperties(catalogProps)
+            .build();
+
+    testPipeline
+        .apply("Records To Add", Create.of(TestFixtures.asRows(TestFixtures.FILE1SNAPSHOT1)))
+        .setRowSchema(beamSchema)
+        .apply(
+            "Append To Table",
+            writeTransform(catalog, tableId)
+                .withPartitionSpec(ImmutableList.of("bucket(id, 2)"))
+                .withSortOrder(ImmutableList.of("data asc nulls first")));
+
+    testPipeline.run().waitUntilFinish();
+
+    Table table = warehouse.loadTable(tableId);
+
+    // verify partition spec
+    PartitionSpec spec = table.spec();
+    assertTrue(spec.isPartitioned());
+    assertEquals(1, spec.fields().size());
+    assertEquals("id_bucket", spec.fields().get(0).name());
+
+    // verify sort order
+    SortOrder sortOrder = table.sortOrder();
+    assertTrue(sortOrder.isSorted());
+    assertEquals(1, sortOrder.fields().size());
+    assertEquals(SortDirection.ASC, sortOrder.fields().get(0).direction());
+    assertEquals(NullOrder.NULLS_FIRST, sortOrder.fields().get(0).nullOrder());
+
+    // verify data was written correctly
+    List<Record> writtenRecords = ImmutableList.copyOf(IcebergGenerics.read(table).build());
+    assertThat(writtenRecords, Matchers.containsInAnyOrder(TestFixtures.FILE1SNAPSHOT1.toArray()));
   }
 }

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/IcebergIOWriteTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/IcebergIOWriteTest.java
@@ -805,7 +805,7 @@ public class IcebergIOWriteTest implements Serializable {
         .apply(
             "Append To Table",
             writeTransform(catalog, tableId)
-                .withPartitionSpec(ImmutableList.of("bucket(id, 2)"))
+                .withPartitionFields(ImmutableList.of("bucket(id, 2)"))
                 .withSortOrder(ImmutableList.of("data asc nulls first")));
 
     testPipeline.run().waitUntilFinish();


### PR DESCRIPTION
https://github.com/apache/beam/pull/38269 added SortOrder support to Iceberg writes via Managed IO, but it's not accessible through IcebergIO directly. This PR adds support for setting SortOrder+PartitionSpec through the IcebergIO.writeRows builder.

It does make serialization of the transform more complex which might be antithetical to the goal of keeping new transforms as portable as possible -- cc @ahmedabu98, let me know if not exposing these params via `IcebergIO` was by design and if I should just switch to ManagedIO if I need to specify.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
