### PR TITLE
Isolate Python 3.14 SDK snapshot publishes from the main matrix

### DIFF
--- a/.github/workflows/beam_Publish_Beam_SDK_Snapshots.yml
+++ b/.github/workflows/beam_Publish_Beam_SDK_Snapshots.yml
@@ -88,8 +88,16 @@ jobs:
         # This is needed to run pipelines that use the default environment at HEAD, for example, when a
         # pipeline uses an expansion service built from HEAD.
         run: |
-          BEAM_VERSION_LINE=$(cat gradle.properties | grep "sdk_version")
-          echo "BEAM_VERSION=${BEAM_VERSION_LINE#*sdk_version=}" >> $GITHUB_ENV
+          BEAM_VERSION=$(grep -E '^sdk_version=' gradle.properties | cut -d= -f2-)
+          if [[ ! "${BEAM_VERSION}" =~ ^[0-9A-Za-z._-]+$ ]]; then
+            echo "Invalid sdk_version in gradle.properties: ${BEAM_VERSION}"
+            exit 1
+          fi
+          {
+            echo "BEAM_VERSION<<EOF"
+            echo "${BEAM_VERSION}"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
       - name: Set latest tag only on master branch
         if: github.ref == 'refs/heads/master'
         run: echo "LATEST_TAG=,latest" >> $GITHUB_ENV
@@ -158,8 +166,16 @@ jobs:
           github_job: ${{ matrix.job_name }} (${{ matrix.container_task }})
       - name: Find Beam Version
         run: |
-          BEAM_VERSION_LINE=$(cat gradle.properties | grep "sdk_version")
-          echo "BEAM_VERSION=${BEAM_VERSION_LINE#*sdk_version=}" >> $GITHUB_ENV
+          BEAM_VERSION=$(grep -E '^sdk_version=' gradle.properties | cut -d= -f2-)
+          if [[ ! "${BEAM_VERSION}" =~ ^[0-9A-Za-z._-]+$ ]]; then
+            echo "Invalid sdk_version in gradle.properties: ${BEAM_VERSION}"
+            exit 1
+          fi
+          {
+            echo "BEAM_VERSION<<EOF"
+            echo "${BEAM_VERSION}"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
       - name: Set latest tag only on master branch
         if: github.ref == 'refs/heads/master'
         run: echo "LATEST_TAG=,latest" >> $GITHUB_ENV

--- a/.github/workflows/beam_Publish_Beam_SDK_Snapshots.yml
+++ b/.github/workflows/beam_Publish_Beam_SDK_Snapshots.yml
@@ -62,12 +62,10 @@ jobs:
           - "python:container:py311:docker"
           - "python:container:py312:docker"
           - "python:container:py313:docker"
-          - "python:container:py314:docker"
           - "python:container:distroless:py310:docker"
           - "python:container:distroless:py311:docker"
           - "python:container:distroless:py312:docker"
           - "python:container:distroless:py313:docker"
-          - "python:container:distroless:py314:docker"
           - "python:container:ml:py310:docker"
           - "python:container:ml:py311:docker"
           - "python:container:ml:py312:docker"
@@ -114,6 +112,70 @@ jobs:
           java-version: default
       - name: Setup Python environment
         if: ${{ startsWith(matrix.container_task, 'python') }}
+        uses: ./.github/actions/setup-environment-action
+        with:
+          python-version: default
+      - name: run Publish Beam SDK Snapshots script
+        uses: ./.github/actions/gradle-command-self-hosted-action
+        with:
+          gradle-command: :sdks:${{ matrix.container_task }}
+          arguments: |
+            -Pdocker-repository-root=gcr.io/apache-beam-testing/beam-sdk \
+            -Pdocker-tag-list=${{ github.sha }},${BEAM_VERSION}${LATEST_TAG} \
+            -Pcontainer-architecture-list=arm64,amd64 \
+            -Ppush-containers \
+            -Pdocker-pull-licenses
+
+  beam_Publish_Beam_SDK_Snapshots_py314:
+    needs: beam_Publish_Beam_SDK_Snapshots
+    if: |
+      always() &&
+      !cancelled() &&
+      (github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && github.repository == 'apache/beam'))
+    runs-on: [self-hosted, ubuntu-24.04, main]
+    timeout-minutes: 300
+    name: ${{ matrix.job_name }} (${{ matrix.container_task }})
+    strategy:
+      fail-fast: false
+      matrix:
+        job_name: ["beam_Publish_Beam_SDK_Snapshots"]
+        job_phrase: ["N/A"]
+        container_task:
+          - "python:container:py314:docker"
+          - "python:container:distroless:py314:docker"
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+      - name: Setup repository
+        uses: ./.github/actions/setup-action
+        with:
+          comment_phrase: ${{ matrix.job_phrase }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_job: ${{ matrix.job_name }} (${{ matrix.container_task }})
+      - name: Find Beam Version
+        run: |
+          BEAM_VERSION_LINE=$(cat gradle.properties | grep "sdk_version")
+          echo "BEAM_VERSION=${BEAM_VERSION_LINE#*sdk_version=}" >> $GITHUB_ENV
+      - name: Set latest tag only on master branch
+        if: github.ref == 'refs/heads/master'
+        run: echo "LATEST_TAG=,latest" >> $GITHUB_ENV
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
+      - name: Authenticate on GCP
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
+        with:
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
+      - name: GCloud Docker credential helper
+        run: |
+          gcloud auth configure-docker ${{ env.docker_registry }}
+      - name: Setup Python environment
         uses: ./.github/actions/setup-environment-action
         with:
           python-version: default


### PR DESCRIPTION
Follow up to the Python 3.14 CI slowness work (#39401 / #39402): py314 multiarch snapshot builds are much slower and contend with other snapshot matrix jobs on the self-hosted pool

- Remove py314 / distroless:py314 from the main Snapshots matrix
- Add a separate job that runs after the main matrix (needs: + always() && !cancelled())
- Keeps py314 publishing, but stops it from starving faster snapshot publishes
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
