### PR TITLE
Add equal_to_approx matcher for approximate numeric assertions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,6 +70,7 @@
 
 * (Python) Removed the `envoy-data-plane` (and transitive `betterproto`) dependency; `EnvoyRateLimiter` now uses a small vendored protobuf definition instead, resolving dependency conflicts for downstream projects ([#37854](https://github.com/apache/beam/issues/37854)).
 * (Java) Supported acknowledge mode for JmsIO ([#39253](https://github.com/apache/beam/issues/39253)).
+* (Python) Added `equal_to_approx`, an `assert_that` matcher that compares numeric pipeline outputs with a configurable tolerance ([#18028](https://github.com/apache/beam/issues/18028)).
 * X feature added (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
 
 ## Breaking Changes

--- a/sdks/python/apache_beam/testing/util.py
+++ b/sdks/python/apache_beam/testing/util.py
@@ -237,11 +237,24 @@ def row_namedtuple_equals_fn(expected, actual, fallback_equals_fn=None):
 def equal_to_approx(expected, rel_tol=1e-09, abs_tol=0.0):
   """Matcher used by assert_that that compares numeric elements approximately.
 
-  Behaves like equal_to for ordering and membership, but real number elements,
-  including numbers nested in tuples or lists, are compared with math.isclose
-  using the given rel_tol and abs_tol rather than exact equality. All other
-  elements are compared with == (equal_to's Row and NamedTuple handling is not
-  applied). Useful for pipelines that produce floating point results.
+  Behaves similarly to `equal_to` for sequence ordering and membership, but any
+  real number elements (integers and floats) are compared using `math.isclose`
+  instead of exact equality.
+
+  Approximate comparisons are also applied to real numbers nested within lists
+  and tuples. Note that `equal_to`'s advanced handling for Beam `Row` and
+  `NamedTuple` is not supported here. All other elements are compared using
+  standard `==` equality.
+
+  Args:
+    expected: The expected output or sequence to compare against.
+    rel_tol: The relative tolerance used by `math.isclose` (default: 1e-09).
+    abs_tol: The absolute tolerance used by `math.isclose` (default: 0.0).
+
+  Example:
+    assert_that(
+        pipeline | beam.Create([1.000000001, 2.0]),
+        equal_to_approx([1.0, 2.0]))
   """
   def _approx_equals(expected_element, actual_element):
     return _elements_approx_equal(

--- a/sdks/python/apache_beam/testing/util.py
+++ b/sdks/python/apache_beam/testing/util.py
@@ -22,6 +22,8 @@
 import collections
 import glob
 import io
+import math
+import numbers
 import tempfile
 from typing import Any
 from typing import Iterable
@@ -44,6 +46,7 @@ from apache_beam.utils.windowed_value import PaneInfo
 __all__ = [
     'assert_that',
     'equal_to',
+    'equal_to_approx',
     'equal_to_per_window',
     'has_at_least_one',
     'is_empty',
@@ -229,6 +232,33 @@ def row_namedtuple_equals_fn(expected, actual, fallback_equals_fn=None):
       return False
 
   return True
+
+
+def equal_to_approx(expected, rel_tol=1e-09, abs_tol=0.0):
+  """Matcher used by assert_that that compares numeric elements approximately.
+
+  Behaves like equal_to for ordering and membership, but real number elements,
+  including numbers nested in tuples or lists, are compared with math.isclose
+  using the given rel_tol and abs_tol rather than exact equality. All other
+  elements are compared with == (equal_to's Row and NamedTuple handling is not
+  applied). Useful for pipelines that produce floating point results.
+  """
+  def _approx_equals(expected_element, actual_element):
+    return _elements_approx_equal(
+        expected_element, actual_element, rel_tol, abs_tol)
+
+  return equal_to(expected, equals_fn=_approx_equals)
+
+
+def _elements_approx_equal(expected, actual, rel_tol, abs_tol):
+  if all(isinstance(x, numbers.Real) for x in (expected, actual)):
+    return math.isclose(expected, actual, rel_tol=rel_tol, abs_tol=abs_tol)
+  if (isinstance(expected, (list, tuple)) and type(actual) is type(expected) and
+      len(expected) == len(actual)):
+    return all(
+        _elements_approx_equal(e, a, rel_tol, abs_tol)
+        for e, a in zip(expected, actual))
+  return expected == actual
 
 
 def matches_all(expected):

--- a/sdks/python/apache_beam/testing/util_test.py
+++ b/sdks/python/apache_beam/testing/util_test.py
@@ -29,6 +29,7 @@ from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import TestWindowedValue
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
+from apache_beam.testing.util import equal_to_approx
 from apache_beam.testing.util import equal_to_per_window
 from apache_beam.testing.util import is_empty
 from apache_beam.testing.util import is_not_empty
@@ -92,6 +93,50 @@ class UtilTest(unittest.TestCase):
       assert_that(
           p | Create([1, 2, 3]),
           equal_to(['1', '2', '3'], equals_fn=lambda e, a: int(e) == int(a)))
+
+  def test_equal_to_approx(self):
+    with TestPipeline() as p:
+      assert_that(
+          p | Create([1.0, 2.0, 3.0]),
+          equal_to_approx([3.0000000001, 2.0, 1.0]))
+
+  def test_equal_to_approx_nested(self):
+    with TestPipeline() as p:
+      assert_that(
+          p | Create([('a', 1.0), ('b', 2.0)]),
+          equal_to_approx([('b', 2.0000000001), ('a', 1.0)]))
+
+  def test_equal_to_approx_with_abs_tol(self):
+    with TestPipeline() as p:
+      assert_that(p | Create([0.0]), equal_to_approx([1e-10], abs_tol=1e-9))
+
+  def test_equal_to_approx_fails_outside_tolerance(self):
+    with self.assertRaises(Exception):
+      with TestPipeline() as p:
+        assert_that(p | Create([1.0]), equal_to_approx([1.1]))
+
+  def test_equal_to_approx_nested_list(self):
+    with TestPipeline() as p:
+      assert_that(
+          p | Create([[1.0, 2.0]]), equal_to_approx([[1.0000000001, 2.0]]))
+
+  def test_equal_to_approx_non_numeric(self):
+    with TestPipeline() as p:
+      assert_that(p | Create(['a', 'b']), equal_to_approx(['b', 'a']))
+
+  def test_equal_to_approx_empty(self):
+    with TestPipeline() as p:
+      assert_that(p | Create([]), equal_to_approx([]))
+
+  def test_equal_to_approx_with_rel_tol(self):
+    with TestPipeline() as p:
+      assert_that(
+          p | Create([100.0]), equal_to_approx([100.00001], rel_tol=1e-6))
+
+  def test_equal_to_approx_nested_fails_outside_tolerance(self):
+    with self.assertRaises(Exception):
+      with TestPipeline() as p:
+        assert_that(p | Create([('a', 1.0)]), equal_to_approx([('a', 1.2)]))
 
   def test_reified_value_passes(self):
     expected = [

--- a/sdks/python/apache_beam/testing/util_test.py
+++ b/sdks/python/apache_beam/testing/util_test.py
@@ -97,14 +97,13 @@ class UtilTest(unittest.TestCase):
   def test_equal_to_approx(self):
     with TestPipeline() as p:
       assert_that(
-          p | Create([1.0, 2.0, 3.0]),
-          equal_to_approx([3.0000000001, 2.0, 1.0]))
+          p | Create([1.0, 2, 3.0]), equal_to_approx([3.0000000001, 2.0, 1.0]))
 
   def test_equal_to_approx_nested(self):
     with TestPipeline() as p:
       assert_that(
           p | Create([('a', 1.0), ('b', 2.0)]),
-          equal_to_approx([('b', 2.0000000001), ('a', 1.0)]))
+          equal_to_approx([('b', 2.0000000001), ('a', 1)]))
 
   def test_equal_to_approx_with_abs_tol(self):
     with TestPipeline() as p:


### PR DESCRIPTION
### Problem

The `assert_that` matchers only offer exact equality through `equal_to`.
Pipelines that produce floating point results are awkward to assert, because
callers have to hand write an `equals_fn` in every test. Issue #18028 asks to
expand the set of matchers.

### Solution

Add `equal_to_approx`, an `assert_that` matcher that behaves like `equal_to` for
ordering and membership but compares real number elements, including numbers
nested in tuples or lists, with `math.isclose` using configurable `rel_tol` and
`abs_tol`. All other elements are compared with `==`. It is a thin wrapper over
the existing `equal_to(equals_fn=...)` mechanism and adds no new dependency.

### Testing

Added unit tests in `util_test.py` covering values within and outside tolerance
(including a nested value outside tolerance), nested tuples and lists, `rel_tol`
and `abs_tol`, non numeric passthrough, and an empty PCollection.

Fixes #18028

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).
