### PR TITLE
Override default fadvise to fix regression from gcs-connector v3 upgrade

### DIFF
--- a/sdks/java/extensions/google-cloud-platform-core/build.gradle
+++ b/sdks/java/extensions/google-cloud-platform-core/build.gradle
@@ -56,6 +56,7 @@ dependencies {
   implementation library.java.http_core
   implementation library.java.http_client
   implementation library.java.jackson_annotations
+  implementation library.java.jackson_core
   implementation library.java.jackson_databind
   permitUnusedDeclared library.java.jackson_databind // BEAM-11761
   testImplementation project(path: ":sdks:java:core", configuration: "shadowTest")

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/options/GcsOptions.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/options/GcsOptions.java
@@ -61,10 +61,7 @@ public interface GcsOptions extends ApplicationNameOptions, GcpOptions, Pipeline
       // In gcs-connector v3, GoogleCloudStorageReadOptions.DEFAULT changed fadvise from SEQUENTIAL
       // to AUTO. Beam workloads default to SEQUENTIAL to preserve expected sequential read
       // throughput and caching behavior.
-      return GoogleCloudStorageReadOptions.DEFAULT
-          .toBuilder()
-          .setFadvise(GoogleCloudStorageReadOptions.Fadvise.SEQUENTIAL)
-          .build();
+      return GcsReadOptionsSerializer.DEFAULT_OPTIONS;
     }
   }
 
@@ -304,7 +301,7 @@ public interface GcsOptions extends ApplicationNameOptions, GcpOptions, Pipeline
 }
 
 class GcsReadOptionsSerializer extends JsonSerializer<GoogleCloudStorageReadOptions> {
-  private static final GoogleCloudStorageReadOptions DEFAULT_OPTIONS =
+  static final GoogleCloudStorageReadOptions DEFAULT_OPTIONS =
       GoogleCloudStorageReadOptions.DEFAULT
           .toBuilder()
           .setFadvise(GoogleCloudStorageReadOptions.Fadvise.SEQUENTIAL)
@@ -345,9 +342,7 @@ class GcsReadOptionsDeserializer extends JsonDeserializer<GoogleCloudStorageRead
       throws java.io.IOException {
     JsonNode root = p.readValueAsTree();
     GoogleCloudStorageReadOptions.Builder builder =
-        GoogleCloudStorageReadOptions.DEFAULT
-            .toBuilder()
-            .setFadvise(GoogleCloudStorageReadOptions.Fadvise.SEQUENTIAL);
+        GcsReadOptionsSerializer.DEFAULT_OPTIONS.toBuilder();
 
     if (root != null && root.isObject()) {
       if (root.hasNonNull("fadvise")) {

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/options/GcsOptions.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/options/GcsOptions.java
@@ -18,8 +18,19 @@
 package org.apache.beam.sdk.extensions.gcp.options;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions;
 import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.concurrent.ExecutorService;
 import org.apache.beam.sdk.extensions.gcp.storage.GcsPathValidator;
@@ -53,8 +64,48 @@ public interface GcsOptions extends ApplicationNameOptions, GcpOptions, Pipeline
     }
   }
 
+  class GcsReadOptionsSerializer extends JsonSerializer<GoogleCloudStorageReadOptions> {
+    @Override
+    public void serialize(
+        GoogleCloudStorageReadOptions value, JsonGenerator gen, SerializerProvider serializers)
+        throws java.io.IOException {
+      serializers.defaultSerializeValue(value, gen);
+    }
+  }
+
+  class GcsReadOptionsDeserializer extends JsonDeserializer<GoogleCloudStorageReadOptions> {
+    @Override
+    public GoogleCloudStorageReadOptions deserialize(JsonParser p, DeserializationContext ctxt)
+        throws java.io.IOException {
+      ObjectMapper mapper = (ObjectMapper) p.getCodec();
+      JsonNode root = mapper.readTree(p);
+      GoogleCloudStorageReadOptions.Builder builder = GoogleCloudStorageReadOptions.builder();
+
+      for (Method method : GoogleCloudStorageReadOptions.Builder.class.getMethods()) {
+        if (method.getName().startsWith("set") && method.getParameterCount() == 1) {
+          String propName =
+              Character.toLowerCase(method.getName().charAt(3)) + method.getName().substring(4);
+          JsonNode node = root.get(propName);
+          if (node != null && !node.isNull()) {
+            try {
+              Class<?> paramType = method.getParameterTypes()[0];
+              Object val = mapper.treeToValue(node, paramType);
+              if (val != null) {
+                method.invoke(builder, java.util.Objects.requireNonNull(val));
+              }
+            } catch (Exception ignored) {
+              // Ignore incompatible or unmappable properties
+            }
+          }
+        }
+      }
+      return builder.build();
+    }
+  }
+
   /** @deprecated This option will be removed in a future release. */
-  @JsonIgnore
+  @JsonSerialize(using = GcsReadOptionsSerializer.class)
+  @JsonDeserialize(using = GcsReadOptionsDeserializer.class)
   @Description(
       "The GoogleCloudStorageReadOptions instance that should be used to read from Google Cloud Storage.")
   @Default.InstanceFactory(GcsReadOptionsFactory.class)

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/options/GcsOptions.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/options/GcsOptions.java
@@ -60,7 +60,13 @@ public interface GcsOptions extends ApplicationNameOptions, GcpOptions, Pipeline
   class GcsReadOptionsFactory implements DefaultValueFactory<GoogleCloudStorageReadOptions> {
     @Override
     public GoogleCloudStorageReadOptions create(PipelineOptions options) {
-      return GoogleCloudStorageReadOptions.DEFAULT;
+      // In gcs-connector v3, GoogleCloudStorageReadOptions.DEFAULT changed fadvise from SEQUENTIAL
+      // to AUTO. Beam workloads default to SEQUENTIAL to preserve expected sequential read
+      // throughput and caching behavior.
+      return GoogleCloudStorageReadOptions.DEFAULT
+          .toBuilder()
+          .setFadvise(GoogleCloudStorageReadOptions.Fadvise.SEQUENTIAL)
+          .build();
     }
   }
 

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/options/GcsOptions.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/options/GcsOptions.java
@@ -24,13 +24,11 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions;
 import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
-import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.concurrent.ExecutorService;
 import org.apache.beam.sdk.extensions.gcp.storage.GcsPathValidator;
@@ -67,45 +65,6 @@ public interface GcsOptions extends ApplicationNameOptions, GcpOptions, Pipeline
           .toBuilder()
           .setFadvise(GoogleCloudStorageReadOptions.Fadvise.SEQUENTIAL)
           .build();
-    }
-  }
-
-  class GcsReadOptionsSerializer extends JsonSerializer<GoogleCloudStorageReadOptions> {
-    @Override
-    public void serialize(
-        GoogleCloudStorageReadOptions value, JsonGenerator gen, SerializerProvider serializers)
-        throws java.io.IOException {
-      serializers.defaultSerializeValue(value, gen);
-    }
-  }
-
-  class GcsReadOptionsDeserializer extends JsonDeserializer<GoogleCloudStorageReadOptions> {
-    @Override
-    public GoogleCloudStorageReadOptions deserialize(JsonParser p, DeserializationContext ctxt)
-        throws java.io.IOException {
-      ObjectMapper mapper = (ObjectMapper) p.getCodec();
-      JsonNode root = mapper.readTree(p);
-      GoogleCloudStorageReadOptions.Builder builder = GoogleCloudStorageReadOptions.builder();
-
-      for (Method method : GoogleCloudStorageReadOptions.Builder.class.getMethods()) {
-        if (method.getName().startsWith("set") && method.getParameterCount() == 1) {
-          String propName =
-              Character.toLowerCase(method.getName().charAt(3)) + method.getName().substring(4);
-          JsonNode node = root.get(propName);
-          if (node != null && !node.isNull()) {
-            try {
-              Class<?> paramType = method.getParameterTypes()[0];
-              Object val = mapper.treeToValue(node, paramType);
-              if (val != null) {
-                method.invoke(builder, java.util.Objects.requireNonNull(val));
-              }
-            } catch (Exception ignored) {
-              // Ignore incompatible or unmappable properties
-            }
-          }
-        }
-      }
-      return builder.build();
     }
   }
 
@@ -341,5 +300,75 @@ public interface GcsOptions extends ApplicationNameOptions, GcpOptions, Pipeline
 
       return oldValue;
     }
+  }
+}
+
+class GcsReadOptionsSerializer extends JsonSerializer<GoogleCloudStorageReadOptions> {
+  private static final GoogleCloudStorageReadOptions DEFAULT_OPTIONS =
+      GoogleCloudStorageReadOptions.DEFAULT
+          .toBuilder()
+          .setFadvise(GoogleCloudStorageReadOptions.Fadvise.SEQUENTIAL)
+          .build();
+
+  @Override
+  public void serialize(
+      GoogleCloudStorageReadOptions value, JsonGenerator gen, SerializerProvider serializers)
+      throws java.io.IOException {
+    // Note: We only support a partial set of options to propagate to remote
+    // workers. Setting the unsupported ones will not have any effect and will fall
+    // back to default in remote workers. Support for additional options can be
+    // added on a need basis. The full list of options can be seen in
+    // com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.
+    gen.writeStartObject();
+    if (value.getFadvise() != null && value.getFadvise() != DEFAULT_OPTIONS.getFadvise()) {
+      gen.writeStringField("fadvise", value.getFadvise().name());
+    }
+    if (value.isFastFailOnNotFoundEnabled() != DEFAULT_OPTIONS.isFastFailOnNotFoundEnabled()) {
+      gen.writeBooleanField("fastFailOnNotFoundEnabled", value.isFastFailOnNotFoundEnabled());
+    }
+    if (value.getMinRangeRequestSize() != DEFAULT_OPTIONS.getMinRangeRequestSize()) {
+      gen.writeNumberField("minRangeRequestSize", value.getMinRangeRequestSize());
+    }
+    if (value.getInplaceSeekLimit() != DEFAULT_OPTIONS.getInplaceSeekLimit()) {
+      gen.writeNumberField("inplaceSeekLimit", value.getInplaceSeekLimit());
+    }
+    if (value.isGrpcReadZeroCopyEnabled() != DEFAULT_OPTIONS.isGrpcReadZeroCopyEnabled()) {
+      gen.writeBooleanField("grpcReadZeroCopyEnabled", value.isGrpcReadZeroCopyEnabled());
+    }
+    gen.writeEndObject();
+  }
+}
+
+class GcsReadOptionsDeserializer extends JsonDeserializer<GoogleCloudStorageReadOptions> {
+  @Override
+  public GoogleCloudStorageReadOptions deserialize(JsonParser p, DeserializationContext ctxt)
+      throws java.io.IOException {
+    JsonNode root = p.readValueAsTree();
+    GoogleCloudStorageReadOptions.Builder builder =
+        GoogleCloudStorageReadOptions.DEFAULT
+            .toBuilder()
+            .setFadvise(GoogleCloudStorageReadOptions.Fadvise.SEQUENTIAL);
+
+    if (root != null && root.isObject()) {
+      if (root.hasNonNull("fadvise")) {
+        builder.setFadvise(
+            GoogleCloudStorageReadOptions.Fadvise.valueOf(root.get("fadvise").asText()));
+      }
+      if (root.hasNonNull("fastFailOnNotFoundEnabled")) {
+        builder.setFastFailOnNotFoundEnabled(root.get("fastFailOnNotFoundEnabled").asBoolean());
+      } else if (root.hasNonNull("fastFailOnNotFound")) {
+        builder.setFastFailOnNotFoundEnabled(root.get("fastFailOnNotFound").asBoolean());
+      }
+      if (root.hasNonNull("minRangeRequestSize")) {
+        builder.setMinRangeRequestSize(root.get("minRangeRequestSize").asLong());
+      }
+      if (root.hasNonNull("inplaceSeekLimit")) {
+        builder.setInplaceSeekLimit(root.get("inplaceSeekLimit").asLong());
+      }
+      if (root.hasNonNull("grpcReadZeroCopyEnabled")) {
+        builder.setGrpcReadZeroCopyEnabled(root.get("grpcReadZeroCopyEnabled").asBoolean());
+      }
+    }
+    return builder.build();
   }
 }

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/GcpCoreApiSurfaceTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/GcpCoreApiSurfaceTest.java
@@ -51,6 +51,8 @@ public class GcpCoreApiSurfaceTest {
     final Set<Matcher<Class<?>>> allowedClasses =
         ImmutableSet.of(
             classesInPackage("com.fasterxml.jackson.annotation"),
+            classesInPackage("com.fasterxml.jackson.core"),
+            classesInPackage("com.fasterxml.jackson.databind"),
             classesInPackage("com.google.api.client.googleapis"),
             classesInPackage("com.google.api.client.http"),
             classesInPackage("com.google.api.client.json"),

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/options/GcsOptionsTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/options/GcsOptionsTest.java
@@ -18,11 +18,16 @@
 package org.apache.beam.sdk.extensions.gcp.options;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -74,5 +79,31 @@ public class GcsOptionsTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> PipelineOptionsFactory.fromArgs(TOO_MANY_ENTRIES_WITH_JOB).as(GcsOptions.class));
+  }
+
+  @Test
+  public void testGoogleCloudStorageReadOptionsSerialization() throws Exception {
+    GcsOptions options = PipelineOptionsFactory.as(GcsOptions.class);
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder()
+            .setFadvise(GoogleCloudStorageReadOptions.Fadvise.SEQUENTIAL)
+            .setFastFailOnNotFoundEnabled(false)
+            .setMinRangeRequestSize(12345L)
+            .build();
+    options.setGoogleCloudStorageReadOptions(readOptions);
+
+    ObjectMapper mapper = new ObjectMapper();
+    String serialized = mapper.writeValueAsString(options);
+    GcsOptions deserialized =
+        mapper.readValue(serialized, PipelineOptions.class).as(GcsOptions.class);
+
+    GoogleCloudStorageReadOptions deserializedReadOptions =
+        deserialized.getGoogleCloudStorageReadOptions();
+
+    assertNotNull(deserializedReadOptions);
+    assertEquals(
+        GoogleCloudStorageReadOptions.Fadvise.SEQUENTIAL, deserializedReadOptions.getFadvise());
+    assertFalse(deserializedReadOptions.isFastFailOnNotFoundEnabled());
+    assertEquals(12345L, deserializedReadOptions.getMinRangeRequestSize());
   }
 }

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/options/GcsOptionsTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/options/GcsOptionsTest.java
@@ -106,4 +106,20 @@ public class GcsOptionsTest {
     assertFalse(deserializedReadOptions.isFastFailOnNotFoundEnabled());
     assertEquals(12345L, deserializedReadOptions.getMinRangeRequestSize());
   }
+
+  @Test
+  public void testDefaultGoogleCloudStorageReadOptionsSerialization() throws Exception {
+    GcsOptions options = PipelineOptionsFactory.as(GcsOptions.class);
+    ObjectMapper mapper = new ObjectMapper();
+    String serialized = mapper.writeValueAsString(options);
+    GcsOptions deserialized =
+        mapper.readValue(serialized, PipelineOptions.class).as(GcsOptions.class);
+
+    GoogleCloudStorageReadOptions deserializedReadOptions =
+        deserialized.getGoogleCloudStorageReadOptions();
+
+    assertNotNull(deserializedReadOptions);
+    assertEquals(
+        GoogleCloudStorageReadOptions.Fadvise.SEQUENTIAL, deserializedReadOptions.getFadvise());
+  }
 }

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/options/GcsOptionsTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/options/GcsOptionsTest.java
@@ -86,7 +86,7 @@ public class GcsOptionsTest {
     GcsOptions options = PipelineOptionsFactory.as(GcsOptions.class);
     GoogleCloudStorageReadOptions readOptions =
         GoogleCloudStorageReadOptions.builder()
-            .setFadvise(GoogleCloudStorageReadOptions.Fadvise.SEQUENTIAL)
+            .setFadvise(GoogleCloudStorageReadOptions.Fadvise.RANDOM)
             .setFastFailOnNotFoundEnabled(false)
             .setMinRangeRequestSize(12345L)
             .build();
@@ -102,7 +102,7 @@ public class GcsOptionsTest {
 
     assertNotNull(deserializedReadOptions);
     assertEquals(
-        GoogleCloudStorageReadOptions.Fadvise.SEQUENTIAL, deserializedReadOptions.getFadvise());
+        GoogleCloudStorageReadOptions.Fadvise.RANDOM, deserializedReadOptions.getFadvise());
     assertFalse(deserializedReadOptions.isFastFailOnNotFoundEnabled());
     assertEquals(12345L, deserializedReadOptions.getMinRangeRequestSize());
   }


### PR DESCRIPTION
This PR fixes the performance regression introduced by upgrading gcs-connector from v2 to v3 (#38419).

In `gcs-connector` v3, `GoogleCloudStorageReadOptions.DEFAULT` changed its default `fadvise` from `SEQUENTIAL` to `AUTO`, which leads to performance degradation or even stuck jobs (internal bug id: 535194786; the issue of `AUTO` mode for gcs-connector v3 has been reported in https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1762). 
- v.2.2.33: https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/v2.2.33/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptions.java#L47
- v3.1.16: https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/v3.1.16/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptions.java#L50

With this PR change, Beam workloads default to `SEQUENTIAL` in `GcsReadOptionsFactory` to preserve expected sequential read throughput and caching behavior.

--- 

Meanwhile, we also found a bug where setting `GoogleCloudStorageReadOptions` in `GcsOptions` is not effective on remote workers. The root cause is that annotating `GoogleCloudStorageReadOptions` with `@JsonIgnore` caused custom GCS read options (such as `fadvise`) to be dropped during JSON serialization, forcing remote workers to fall back to default settings.

We implement a fix here so that users can configure `GoogleCloudStorageReadOptions` and they will successfully take effect on workers using a code snippet like the following:

```java
        // Configure GCS Read Options with AUTO fadvise
        GoogleCloudStorageReadOptions gcsReadOpt = GoogleCloudStorageReadOptions.DEFAULT.toBuilder()
                .setFadvise(GoogleCloudStorageReadOptions.Fadvise.AUTO)
                .build();
        options.as(GcsOptions.class).setGoogleCloudStorageReadOptions(gcsReadOpt);
```

fixes #39548 