### PR TITLE
Fix ThreadSanitizer data races between bundle processing and async background writer closing in FileBasedSink and WriteFiles

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
@@ -913,7 +914,7 @@ public abstract class FileBasedSink<UserT, DestinationT, OutputT>
     private @Nullable ResourceId outputFile;
 
     /** The channel to write to. */
-    private @Nullable WritableByteChannel channel;
+    private volatile @Nullable WritableByteChannel channel;
 
     /**
      * The MIME type used in the creation of the output channel (if the file system supports it).
@@ -925,11 +926,17 @@ public abstract class FileBasedSink<UserT, DestinationT, OutputT>
      */
     private final @Nullable String mimeType;
 
+    private final AtomicBoolean readyToClose = new AtomicBoolean(false);
+
     /** Construct a new {@link Writer} that will produce files of the given MIME type. */
     public Writer(WriteOperation<DestinationT, OutputT> writeOperation, String mimeType) {
       checkNotNull(writeOperation);
       this.writeOperation = writeOperation;
       this.mimeType = mimeType;
+    }
+
+    void releaseForBackgroundClose() {
+      readyToClose.set(true);
     }
 
     /**
@@ -1037,6 +1044,7 @@ public abstract class FileBasedSink<UserT, DestinationT, OutputT>
     }
 
     public final void cleanup() throws Exception {
+      readyToClose.get();
       if (outputFile != null) {
         LOG.info("Deleting temporary file {}", outputFile);
         // outputFile may be null if open() was not called or failed.
@@ -1047,28 +1055,30 @@ public abstract class FileBasedSink<UserT, DestinationT, OutputT>
 
     /** Closes the channel and returns the bundle result. */
     public final void close() throws Exception {
+      readyToClose.get();
+      WritableByteChannel channelToClose = channel;
       checkState(outputFile != null, "FileResult.close cannot be called with a null outputFile");
       LOG.debug("Closing {}", outputFile);
 
       try {
         writeFooter();
       } catch (Exception e) {
-        closeChannelAndThrow(channel, outputFile, e);
+        closeChannelAndThrow(channelToClose, outputFile, e);
       }
 
       try {
         finishWrite();
       } catch (Exception e) {
-        closeChannelAndThrow(channel, outputFile, e);
+        closeChannelAndThrow(channelToClose, outputFile, e);
       }
 
       // It is valid for a subclass to either close the channel or not.
       // They would typically close the channel e.g. if they are wrapping it in another channel
       // and the wrapper needs to be closed.
-      if (channel.isOpen()) {
+      if (channelToClose.isOpen()) {
         LOG.debug("Closing channel to {}.", outputFile);
         try {
-          channel.close();
+          channelToClose.close();
         } catch (Exception e) {
           throw new IOException(String.format("Failed closing channel to %s", outputFile), e);
         }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WriteFiles.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WriteFiles.java
@@ -1272,6 +1272,9 @@ public abstract class WriteFiles<UserT, DestinationT, OutputT>
     }
 
     private void closeWriterInBackground(Writer<DestinationT, OutputT> writer) {
+      // Release memory barrier so background thread acquires all prior writes on Writer and
+      // channels.
+      writer.releaseForBackgroundClose();
       // Close in parallel so flushing of buffered writes to files for many windows happens in
       // parallel.
       closeFutures.add(

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TFRecordSchemaTransformProviderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TFRecordSchemaTransformProviderTest.java
@@ -434,9 +434,10 @@ public class TFRecordSchemaTransformProviderTest {
     assertTrue("File should exist", tmpFile.exists());
     assertTrue("File should have content", tmpFile.length() > 0);
 
-    FileInputStream fis = new FileInputStream(tmpFile);
-    String written = BaseEncoding.base64().encode(ByteStreams.toByteArray(fis));
-    assertThat(written, is(in(base64)));
+    try (FileInputStream fis = new FileInputStream(tmpFile)) {
+      String written = BaseEncoding.base64().encode(ByteStreams.toByteArray(fis));
+      assertThat(written, is(in(base64)));
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary
  
  Fixes ThreadSanitizer data races during asynchronous file closing in `WriteFiles` / `FileBasedSink` and an OS file-descriptor race in `TFRecordSchemaTransformProviderTest`.
  
  ### Root Cause
  - **Async Writer Close (`FileBasedSink` / `WriteFiles`):** `FileBasedSink.Writer` instances are written to on the bundle processing thread and closed asynchronously via `MoreFutures.runAsync`. Lacking a release-acquire memory barrier between threads, TSAN reported cross-thread data races on:
    1. `FileBasedSink.Writer.close()V` (`FileBasedSink.java:1066` reading `channel.isOpen()` vs. `Writer.open()` at `FileBasedSink.java:993` writing `channel = factory.create(...)`).
    2. `CRC32.getValue()J` (reading GZIP checksums during `close()` vs. `crc.update(...)` during `write(value)`).
  - **Test Resource Leak (`TFRecordSchemaTransformProviderTest`):** An unclosed `FileInputStream` caused a syscall race when the JDK background Cleaner thread closed the unreferenced file descriptor during test execution.
  
  ### Solution
  - **Release-Acquire Handoff (`readyToClose`):** Added an `AtomicBoolean readyToClose` handoff to `FileBasedSink.Writer`. Calling `releaseForBackgroundClose()` (`readyToClose.set(true)`) before spawning the async task and calling `readyToClose.get()` at the start of `close()`/`cleanup()` ensures that `open()`, `write()`, and all stream mutations happen-before background closing.
  - **Try-With-Resources:** Wrapped `FileInputStream` in `TFRecordSchemaTransformProviderTest.runTestWrite` in a try-with-resources block for deterministic closure.
  
  ### Testing
  - All TSAN runs of `TFRecordSchemaTransformProviderTest` (`--config=tsan-chlor`) pass cleanly with zero data race reports.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
