### PR TITLE
Support Python's --files_to_stage option in Java xlang.

### DIFF
--- a/sdks/java/extensions/python/src/main/java/org/apache/beam/sdk/extensions/python/PythonExternalTransform.java
+++ b/sdks/java/extensions/python/src/main/java/org/apache/beam/sdk/extensions/python/PythonExternalTransform.java
@@ -81,6 +81,7 @@ public class PythonExternalTransform<InputT extends PInput, OutputT extends POut
 
   private String expansionService;
   private List<String> extraPackages;
+  private List<String> filesToStage;
 
   // We preseve the order here since Schema's care about order of fields but the order will not
   // matter when applying kwargs at the Python side.
@@ -98,6 +99,7 @@ public class PythonExternalTransform<InputT extends PInput, OutputT extends POut
     this.fullyQualifiedName = fullyQualifiedName;
     this.expansionService = expansionService;
     this.extraPackages = new ArrayList<>();
+    this.filesToStage = new ArrayList<>();
     this.kwargsMap = new TreeMap<>();
     this.typeHints = new HashMap<>();
     // TODO(https://github.com/apache/beam/issues/21567): remove a default type hint for
@@ -302,6 +304,28 @@ public class PythonExternalTransform<InputT extends PInput, OutputT extends POut
         "Extra packages only apply to auto-started expansion service.");
     this.extraPackages = extraPackages;
     return this;
+  }
+
+  /**
+   * Specifies that the given Python files should be staged for the Python worker.
+   *
+   * @param filesToStage a list of local paths to Python files or data files.
+   * @return updated wrapper for the cross-language transform.
+   */
+  public PythonExternalTransform<InputT, OutputT> withFilesToStage(List<String> filesToStage) {
+    if (filesToStage.isEmpty()) {
+      return this;
+    }
+    Preconditions.checkState(
+        Strings.isNullOrEmpty(expansionService),
+        "Files to stage only apply to auto-started expansion service.");
+    this.filesToStage = filesToStage;
+    return this;
+  }
+
+  @VisibleForTesting
+  List<String> getFilesToStage() {
+    return filesToStage;
   }
 
   @VisibleForTesting
@@ -510,6 +534,11 @@ public class PythonExternalTransform<InputT extends PInput, OutputT extends POut
         // * It was explicitly requested.
         // * Python executable is not available in the system but Docker is available.
         if (useTransformService || (!pythonAvailable && dockerAvailable)) {
+          if (!filesToStage.isEmpty()) {
+            throw new UnsupportedOperationException(
+                "Staging local files is not supported when using the Docker-based transform service. "
+                    + "Please use the default local Python-based expansion service instead.");
+          }
           // A unique project name ensures that this expansion gets a dedicated instance of the
           // transform service.
           String projectName = UUID.randomUUID().toString();
@@ -549,6 +578,11 @@ public class PythonExternalTransform<InputT extends PInput, OutputT extends POut
               "--port=" + port, "--fully_qualified_name_glob=*", "--pickle_library=cloudpickle");
           if (requirementsFile != null) {
             args.add("--requirements_file=" + requirementsFile.getAbsolutePath());
+          }
+          if (!filesToStage.isEmpty()) {
+            for (String file : filesToStage) {
+              args.add("--files_to_stage=" + file);
+            }
           }
           PythonService service =
               new PythonService(

--- a/sdks/java/extensions/python/src/test/java/org/apache/beam/sdk/extensions/python/PythonExternalTransformTest.java
+++ b/sdks/java/extensions/python/src/test/java/org/apache/beam/sdk/extensions/python/PythonExternalTransformTest.java
@@ -85,6 +85,17 @@ public class PythonExternalTransformTest implements Serializable {
   }
 
   @Test
+  public void testFilesToStage() {
+    PythonExternalTransform<?, ?> transform =
+        PythonExternalTransform
+            .<PCollection<KV<String, String>>, PCollection<KV<String, Iterable<String>>>>from(
+                "DummyTransform")
+            .withFilesToStage(ImmutableList.of("file1.py", "file2.py"));
+
+    assertEquals(ImmutableList.of("file1.py", "file2.py"), transform.getFilesToStage());
+  }
+
+  @Test
   public void generateArgsEmpty() {
     PythonExternalTransform<?, ?> transform =
         PythonExternalTransform
@@ -392,5 +403,30 @@ public class PythonExternalTransformTest implements Serializable {
                         from("apache_beam.GroupByKey"))
             .apply(Keys.create());
     PAssert.that(output).containsInAnyOrder("A", "B");
+  }
+
+  @Test
+  public void testFilesToStageWithTransformServiceThrows() {
+    PythonExternalTransformOptions options =
+        PipelineOptionsFactory.create().as(PythonExternalTransformOptions.class);
+    options.setUseTransformService(true);
+
+    Pipeline p = Pipeline.create(options);
+
+    PythonExternalTransform<PCollection<String>, PCollection<String>> transform =
+        PythonExternalTransform.<PCollection<String>, PCollection<String>>from("DummyTransform")
+            .withFilesToStage(ImmutableList.of("file1.py"));
+
+    PCollection<String> input = p.apply(Create.of("a"));
+
+    try {
+      input.apply(transform);
+      org.junit.Assert.fail("Expected UnsupportedOperationException");
+    } catch (UnsupportedOperationException e) {
+      assertTrue(
+          e.getMessage()
+              .contains(
+                  "Staging local files is not supported when using the Docker-based transform service"));
+    }
   }
 }


### PR DESCRIPTION
Note: this flag is not supported in docker-based expansion since the file needs to be staged into the container first, and existing mechanism by using requirements.txt might not be appropriate, so it would need more work. 


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
