### PR TITLE
Fix scheduled Iceberg performance test checkout

### DIFF
--- a/.github/workflows/beam_PostCommit_Java_IO_Performance_Tests.yml
+++ b/.github/workflows/beam_PostCommit_Java_IO_Performance_Tests.yml
@@ -76,12 +76,12 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }} ${{ matrix.test_case }})
     - name: Get Beam latest release
-      if: github.event_name == 'schedule' #This has scheduled runs run against the latest release
+      if: github.event_name == 'schedule' && matrix.test_case != 'IcebergPerformanceTest'
       run: |
         BEAM_VERSION=$(curl -s https://api.github.com/repos/apache/beam/releases/latest | jq -r '.tag_name')
         echo "BEAM_VERSION=${BEAM_VERSION}" >> $GITHUB_ENV
     - name: Checkout release branch
-      if: github.event_name == 'schedule' #This has scheduled runs run against the latest release
+      if: github.event_name == 'schedule' && matrix.test_case != 'IcebergPerformanceTest'
       uses: actions/checkout@v7
       with:
         ref: ${{ env.BEAM_VERSION }}


### PR DESCRIPTION
Fixes #38694

Scheduled Java IO performance runs build their matrix from `master`, then check out latest release before running each Gradle task. `IcebergPerformanceTest` was added after v2.75.0, so scheduled runs consistently fail because that release does not contain `:it:IcebergPerformanceTest`.

Keep Iceberg performance job on initial `master` checkout. Existing scheduled performance jobs continue testing latest release, and manually triggered runs remain unchanged.

Validation:

- `./gradlew --no-daemon :beam-test-gha:preCommit`
- `git diff --check`
- Verified `IcebergPerformanceTest` exists on `master` and is absent from v2.75.0

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Link appropriate issue.
- [x] `CHANGES.md` is not needed for this workflow-only fix.
- [x] ICLA is not needed for this small change.

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [making the reviewer's job easier](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check build health, visit [.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md).

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for GitHub workflow details.
