### PR TITLE
feat: add MongoDB driver handshake metadata for Java-based client connections

### DIFF
--- a/it/mongodb/build.gradle
+++ b/it/mongodb/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation library.java.google_code_gson
     implementation library.java.mongo_java_driver
     implementation library.java.mongo_bson
+    implementation library.java.mongodb_driver_core
     implementation library.java.vendored_guava_32_1_2_jre
 
     testImplementation library.java.mockito_core

--- a/it/mongodb/src/main/java/org/apache/beam/it/mongodb/MongoDBResourceManager.java
+++ b/it/mongodb/src/main/java/org/apache/beam/it/mongodb/MongoDBResourceManager.java
@@ -20,6 +20,8 @@ package org.apache.beam.it.mongodb;
 import static org.apache.beam.it.mongodb.MongoDBResourceManagerUtils.checkValidCollectionName;
 import static org.apache.beam.it.mongodb.MongoDBResourceManagerUtils.generateDatabaseName;
 
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoDriverInformation;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
@@ -57,6 +59,10 @@ public class MongoDBResourceManager extends TestContainerResourceManager<MongoDB
 
   private static final String DEFAULT_MONGODB_CONTAINER_NAME = "mongo";
 
+  @VisibleForTesting
+  static final MongoDriverInformation DRIVER_INFO =
+      MongoDriverInformation.builder().driverName("Apache Beam").build();
+
   // A list of available MongoDB Docker image tags can be found at
   // https://hub.docker.com/_/mongo/tags
   private static final String DEFAULT_MONGODB_CONTAINER_TAG = "4.0.18";
@@ -88,7 +94,10 @@ public class MongoDBResourceManager extends TestContainerResourceManager<MongoDB
         usingStaticDatabase ? builder.databaseName : generateDatabaseName(builder.testId);
     this.connectionString =
         String.format("mongodb://%s:%d", this.getHost(), this.getPort(MONGODB_INTERNAL_PORT));
-    this.mongoClient = mongoClient == null ? MongoClients.create(connectionString) : mongoClient;
+    this.mongoClient =
+        mongoClient == null
+            ? MongoClients.create(new ConnectionString(connectionString), DRIVER_INFO)
+            : mongoClient;
   }
 
   public static Builder builder(String testId) {

--- a/it/mongodb/src/test/java/org/apache/beam/it/mongodb/MongoDBResourceManagerTest.java
+++ b/it/mongodb/src/test/java/org/apache/beam/it/mongodb/MongoDBResourceManagerTest.java
@@ -72,6 +72,11 @@ public class MongoDBResourceManagerTest {
   }
 
   @Test
+  public void testDriverInfoHasExpectedName() {
+    assertThat(MongoDBResourceManager.DRIVER_INFO.getDriverNames()).contains("Apache Beam");
+  }
+
+  @Test
   public void testCreateResourceManagerBuilderReturnsMongoDBResourceManager() {
     assertThat(
             MongoDBResourceManager.builder(TEST_ID)

--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbGridFSIO.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbGridFSIO.java
@@ -23,6 +23,7 @@ import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Pr
 import com.google.auto.value.AutoValue;
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoDriverInformation;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCursor;
@@ -119,6 +120,9 @@ import org.joda.time.Instant;
  */
 public class MongoDbGridFSIO {
 
+  private static final MongoDriverInformation DRIVER_INFO =
+      MongoDriverInformation.builder().driverName("Apache Beam").build();
+
   /** Callback for the parser to use to submit data. */
   public interface ParserCallback<T> extends Serializable {
     /** Output the object. The default timestamp will be the GridFSFile creation timestamp. */
@@ -203,13 +207,13 @@ public class MongoDbGridFSIO {
 
     MongoClient setupMongo() {
       if (uri() == null) {
-        return MongoClients.create();
+        return MongoClients.create(MongoClientSettings.builder().build(), DRIVER_INFO);
       }
       MongoClientSettings settings =
           MongoClientSettings.builder()
               .applyConnectionString(new ConnectionString(Preconditions.checkStateNotNull(uri())))
               .build();
-      return MongoClients.create(settings);
+      return MongoClients.create(settings, DRIVER_INFO);
     }
 
     GridFSBucket setupGridFS(MongoClient mongo) {

--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbIO.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbIO.java
@@ -27,6 +27,7 @@ import com.mongodb.MongoBulkWriteException;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoClientSettings.Builder;
 import com.mongodb.MongoCommandException;
+import com.mongodb.MongoDriverInformation;
 import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
@@ -144,6 +145,9 @@ import org.slf4j.LoggerFactory;
 public class MongoDbIO {
 
   private static final Logger LOG = LoggerFactory.getLogger(MongoDbIO.class);
+
+  private static final MongoDriverInformation DRIVER_INFO =
+      MongoDriverInformation.builder().driverName("Apache Beam").build();
 
   public static final String ERROR_MSG_QUERY_FN =
       " class is not supported. "
@@ -427,7 +431,7 @@ public class MongoDbIO {
                   spec.ignoreSSLCertificate())
               .applyConnectionString(new ConnectionString(uri))
               .build();
-      try (MongoClient mongoClient = MongoClients.create(settings)) {
+      try (MongoClient mongoClient = MongoClients.create(settings, DRIVER_INFO)) {
         return getDocumentCount(mongoClient, database, collection);
       } catch (Exception e) {
         return -1;
@@ -459,7 +463,7 @@ public class MongoDbIO {
                   spec.ignoreSSLCertificate())
               .applyConnectionString(new ConnectionString(uri))
               .build();
-      try (MongoClient mongoClient = MongoClients.create(settings)) {
+      try (MongoClient mongoClient = MongoClients.create(settings, DRIVER_INFO)) {
         try {
           return getEstimatedSizeBytes(mongoClient, database, collection);
         } catch (MongoCommandException exception) {
@@ -496,7 +500,7 @@ public class MongoDbIO {
                   spec.ignoreSSLCertificate())
               .applyConnectionString(new ConnectionString(uri))
               .build();
-      try (MongoClient mongoClient = MongoClients.create(settings)) {
+      try (MongoClient mongoClient = MongoClients.create(settings, DRIVER_INFO)) {
         MongoDatabase mongoDatabase = mongoClient.getDatabase(database);
 
         List<Document> splitKeys;
@@ -812,7 +816,7 @@ public class MongoDbIO {
                   spec.ignoreSSLCertificate())
               .applyConnectionString(new ConnectionString(uri))
               .build();
-      return MongoClients.create(settings);
+      return MongoClients.create(settings, DRIVER_INFO);
     }
   }
 
@@ -1012,7 +1016,7 @@ public class MongoDbIO {
                     spec.ignoreSSLCertificate())
                 .applyConnectionString(new ConnectionString(uri))
                 .build();
-        client = MongoClients.create(settings);
+        client = MongoClients.create(settings, DRIVER_INFO);
       }
 
       @StartBundle


### PR DESCRIPTION
Passes `MongoDriverInformation` to `MongoClients.create()` in `MongoDBResourceManager` so that MongoDB server-side telemetry can identify traffic originating from Apache Beam.

## What changes

**`it/mongodb/src/main/java/.../MongoDBResourceManager.java`**

- Adds a package-visible `DRIVER_INFO` constant (`@VisibleForTesting`) built with `MongoDriverInformation.builder().driverName("Apache Beam").build()`.
- Passes it as the second argument to `MongoClients.create(connectionString, DRIVER_INFO)` when no external `MongoClient` is provided. When a client is injected via the `@VisibleForTesting` constructor (e.g. in unit tests), the external client is used unchanged.

This will appear in mongos/d logs similar to:
>`
{"t":{"$date":"..."},"s":"I","c":"NETWORK","id":51800,"ctx":"conn1","msg":"client metadata","attr":{"doc":{"driver":{"name":"mongo-java-driver|Apache Beam","version":"5.5.0"},"os":{"type":"Linux"},"platform":"Java/..."}}}`

See the [MongoDB handshake specification](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.md) for more info.