### PR TITLE
Fix flaky AsyncWrapper reset_state test on Python 3.14

### DIFF
--- a/sdks/python/apache_beam/transforms/async_dofn_test.py
+++ b/sdks/python/apache_beam/transforms/async_dofn_test.py
@@ -489,7 +489,7 @@ class AsyncTest(unittest.TestCase):
       self.assertEqual(bag_states['key' + str(i)].items, [])
 
   @staticmethod
-  def _run_reset_state_concurrent_teardown(use_asyncio):
+  def _run_reset_state_concurrent_teardown(use_asyncio, reset_started):
     dofn = BasicDofn(sleep_time=0.5)
     async_dofn = async_lib.AsyncWrapper(dofn, use_asyncio=use_asyncio)
     async_dofn.setup()
@@ -502,15 +502,26 @@ class AsyncTest(unittest.TestCase):
 
     # Verify that calling reset_state() while background tasks are actively running
     # completes cleanly without causing lock-ordering deadlocks.
+    reset_started.set()
     async_lib.AsyncWrapper.reset_state()
 
   def test_reset_state_concurrent_teardown(self):
     # Verify concurrent teardown safety in a separate process to prevent any potential
     # regressions from freezing the main pytest process at exit.
+    reset_started = multiprocessing.Event()
     p = multiprocessing.Process(
         target=AsyncTest._run_reset_state_concurrent_teardown,
-        args=(self.use_asyncio, ))
+        args=(self.use_asyncio, reset_started))
     p.start()
+
+    # Python 3.14 uses forkserver by default on POSIX. Wait for child startup
+    # before measuring reset_state() so import and process startup time cannot
+    # be mistaken for a teardown deadlock.
+    if not reset_started.wait(timeout=30.0):
+      p.terminate()
+      p.join()
+      self.fail("child process did not reach reset_state() before timeout")
+
     p.join(timeout=10.0)
 
     if p.is_alive():


### PR DESCRIPTION
Fixes #39456.

## Summary

The deadlock regression test currently starts its 10-second timeout at process creation. That timeout includes child startup and imports, even though failure is reported as a reset_state() deadlock. Python 3.14 uses forkserver by default on POSIX, making this distinction more relevant.

This change adds a readiness signal immediately before reset_state(). Parent uses a separate startup timeout, then applies existing 10-second limit only to teardown. This preserves real deadlock detection and gives distinct failures for startup and teardown. Production code is unchanged.

## Validation

- Python 3.14 cloud tox target: 2 passed
- Python 3.13 tox target: 2 passed
- Python 3.14 cloud stress: 100/100 passes for each asyncio and thread-pool variant
- Negative control: injected 11-second stall after readiness signal; test failed at original 10-second deadlock assertion
- YAPF 0.43.0 and Ruff 0.15.7 passed on changed file