### PR TITLE
Replace non-PEP 585 types in watch.py

### DIFF
--- a/sdks/python/apache_beam/io/watch.py
+++ b/sdks/python/apache_beam/io/watch.py
@@ -59,10 +59,10 @@ import hashlib
 import inspect
 import time
 import typing
+from collections.abc import Iterable
 from typing import Any
 from typing import Callable
 from typing import Generic
-from typing import Iterable
 from typing import Optional
 from typing import TypeVar
 

--- a/sdks/python/apache_beam/io/watch.py
+++ b/sdks/python/apache_beam/io/watch.py
@@ -64,7 +64,6 @@ from typing import Callable
 from typing import Generic
 from typing import Iterable
 from typing import Optional
-from typing import Tuple
 from typing import TypeVar
 
 from apache_beam import coders
@@ -111,7 +110,7 @@ class PollResult(Generic[OutputT]):
   The ``OutputT`` type parameter can annotate a poll function's return type,
   as in ``-> PollResult[str]``; the transform infers the output coder from it.
   """
-  outputs: Tuple[TimestampedValue, ...]
+  outputs: tuple[TimestampedValue, ...]
   watermark: Optional[Timestamp] = None
 
   @property
@@ -119,7 +118,7 @@ class PollResult(Generic[OutputT]):
     return self.watermark == MAX_TIMESTAMP
 
   @staticmethod
-  def _normalize(outputs, timestamp) -> Tuple[TimestampedValue, ...]:
+  def _normalize(outputs, timestamp) -> tuple[TimestampedValue, ...]:
     if timestamp is None:
       default_ts = Timestamp.now()
     else:
@@ -428,7 +427,7 @@ class _GrowthRestrictionTracker(iobase.RestrictionTracker):
   def current_restriction(self) -> _GrowthState:
     return self._restriction
 
-  def try_claim(self, position: Tuple[PollResult, Any]) -> bool:
+  def try_claim(self, position: tuple[PollResult, Any]) -> bool:
     """Claims one poll round; at most one claim succeeds per ``process()``.
 
     The claim is rejected after a checkpoint already stopped this invocation,
@@ -723,7 +722,7 @@ class Watch(PTransform):
             output_coder,
             key_fn,
             key_coder,
-            self._now)).with_output_types(Tuple[input_type, value_type])
+            self._now)).with_output_types(tuple[input_type, value_type])
 
 
 def _as_duration(value) -> Duration:


### PR DESCRIPTION
`typing.Tuple` and `typing.Iterable` usages in watch.py are incorrect, this updates to the modern hint format.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
