### PR TITLE
Fix Update Python Dependencies

### DIFF
--- a/.github/actions/setup-environment-action/action.yml
+++ b/.github/actions/setup-environment-action/action.yml
@@ -56,6 +56,24 @@ runs:
           sdks/python/setup.py
           sdks/python/tox.ini
 
+    # Multiline python-version (e.g. 3.10\n3.11\n...) must not be embedded raw
+    # in cache keys: actions/cache treats each newline-separated line as a
+    # separate key and fails when there are more than 10 ("Keys are limited to
+    # a maximum of 10"). Collapse whitespace into a single key fragment.
+    - name: Sanitize Python version for tox cache key
+      if: ${{ inputs.python-version != '' && inputs.tox-cache == 'true' }}
+      id: py-cache-key
+      shell: bash
+      env:
+        PYTHON_VERSION_INPUT: ${{ inputs.python-version }}
+      run: |
+        if [[ "$PYTHON_VERSION_INPUT" == "default" ]]; then
+          sanitized="310"
+        else
+          sanitized=$(printf '%s' "$PYTHON_VERSION_INPUT" | tr -s '[:space:]' '-' | sed 's/^-//;s/-$//')
+        fi
+        echo "sanitized=$sanitized" >> "$GITHUB_OUTPUT"
+
     - name: Cache tox environments
       if: ${{ inputs.python-version != '' && inputs.tox-cache == 'true' }}
       uses: actions/cache@v6
@@ -64,10 +82,10 @@ runs:
           sdks/python/target/.tox
           !sdks/python/target/.tox/**/log
           !sdks/python/target/.tox/.package_cache
-        key: tox-${{ runner.os }}-py${{ inputs.python-version == 'default' && '310' || inputs.python-version }}-${{ hashFiles('sdks/python/tox.ini') }}-${{ hashFiles('sdks/python/setup.py') }}
+        key: tox-${{ runner.os }}-py${{ steps.py-cache-key.outputs.sanitized }}-${{ hashFiles('sdks/python/tox.ini') }}-${{ hashFiles('sdks/python/setup.py') }}
         restore-keys: |
-          tox-${{ runner.os }}-py${{ inputs.python-version == 'default' && '310' || inputs.python-version }}-${{ hashFiles('sdks/python/tox.ini') }}-
-          tox-${{ runner.os }}-py${{ inputs.python-version == 'default' && '310' || inputs.python-version }}-
+          tox-${{ runner.os }}-py${{ steps.py-cache-key.outputs.sanitized }}-${{ hashFiles('sdks/python/tox.ini') }}-
+          tox-${{ runner.os }}-py${{ steps.py-cache-key.outputs.sanitized }}-
 
     - name: Install Java
       if: ${{ inputs.java-version != '' }}

--- a/.github/workflows/update_python_dependencies.yml
+++ b/.github/workflows/update_python_dependencies.yml
@@ -69,9 +69,7 @@ jobs:
           java-version: default
           go-version: default
           disable-cache: true
-          # generatePythonRequirementsAll does not use tox; also avoids
-          # actions/cache failing when multiline python-version expands into
-          # more than 10 restore-keys (limit since 3.14 was added).
+          # generatePythonRequirementsAll does not use tox.
           tox-cache: false
       - name: Update Python Dependencies
         uses: ./.github/actions/gradle-command-self-hosted-action

--- a/.github/workflows/update_python_dependencies.yml
+++ b/.github/workflows/update_python_dependencies.yml
@@ -69,6 +69,10 @@ jobs:
           java-version: default
           go-version: default
           disable-cache: true
+          # generatePythonRequirementsAll does not use tox; also avoids
+          # actions/cache failing when multiline python-version expands into
+          # more than 10 restore-keys (limit since 3.14 was added).
+          tox-cache: false
       - name: Update Python Dependencies
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:


### PR DESCRIPTION
Update Python Dependencies has been flaky after Python 3.14 was added, multiline python-version was embedded in the tox cache key. actions/cache treats each line as a separate key and fails with Keys are limited to a maximum of 10. (disable-cache: true only disables the Gradle cache; tox cache stayed enabled.)

- Disable tox cache in Update Python Dependencies (job only runs generatePythonRequirementsAll)

- Sanitize multiline python-version in setup-environment-action so tox cache keys stay under the actions/cache 10-key limit (regression after adding 3.14)
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
