### PR TITLE
[GSoC-273] Feat: new cleaning rule to orphaned subscriptions

### DIFF
--- a/.test-infra/tools/stale_cleaner.py
+++ b/.test-infra/tools/stale_cleaner.py
@@ -331,18 +331,19 @@ class PubSubSubscriptionCleaner(StaleCleaner):
     def _active_resources(self) -> dict:
         d = {}
         self.client = pubsub_v1.SubscriberClient()
+        taxi_prefix = f"{self.project_path}/subscriptions/taxirides-realtime_beam_"
 
         with self.client:
             for subscription in self.client.list_subscriptions(request={"project": self.project_path}):
                 subscription_name = subscription.name
                 # Apply prefix filtering if prefixes are defined
-                if not self.prefixes or any(subscription_name.startswith(f"{self.project_path}/subscriptions/{prefix}") for prefix in self.prefixes):
-                    # Safe orphan detection:
-                    # - Standard rule: detached subscriptions are eligible.
-                    # - Taxi exception: subscriptions containing the NYC taxi prefix are eligible even if attached.
-                    es_taxi = "taxirides-realtime_beam_" in subscription_name
-                    if subscription.detached or es_taxi:
+                if subscription.detached:
                         d[subscription_name] = GoogleCloudResource(resource_name=subscription_name, clock=self.clock)
+                #Only attached subscriptions with the NYC taxi prefix are eligible.
+                elif any(
+                    subscription_name.startswith(f"{self.project_path}/subscriptions/{prefix}") for prefix in self.prefixes
+                ) and subscription_name.startswith(taxi_prefix):
+                    d[subscription_name] = GoogleCloudResource(resource_name=subscription_name, clock=self.clock)
 
         return d
 

--- a/.test-infra/tools/stale_cleaner.py
+++ b/.test-infra/tools/stale_cleaner.py
@@ -331,7 +331,6 @@ class PubSubSubscriptionCleaner(StaleCleaner):
     def _active_resources(self) -> dict:
         d = {}
         self.client = pubsub_v1.SubscriberClient()
-        taxi_prefix = f"{self.project_path}/subscriptions/taxirides-realtime_beam_"
 
         with self.client:
             for subscription in self.client.list_subscriptions(request={"project": self.project_path}):
@@ -342,7 +341,7 @@ class PubSubSubscriptionCleaner(StaleCleaner):
                 #Only attached subscriptions with the NYC taxi prefix are eligible.
                 elif any(
                     subscription_name.startswith(f"{self.project_path}/subscriptions/{prefix}") for prefix in self.prefixes
-                ) and subscription_name.startswith(taxi_prefix):
+                ):
                     d[subscription_name] = GoogleCloudResource(resource_name=subscription_name, clock=self.clock)
 
         return d

--- a/.test-infra/tools/stale_cleaner.py
+++ b/.test-infra/tools/stale_cleaner.py
@@ -337,8 +337,11 @@ class PubSubSubscriptionCleaner(StaleCleaner):
                 subscription_name = subscription.name
                 # Apply prefix filtering if prefixes are defined
                 if not self.prefixes or any(subscription_name.startswith(f"{self.project_path}/subscriptions/{prefix}") for prefix in self.prefixes):
-                    # Check if the subscription has a topic associated with it
-                    if subscription.detached:
+                    # Safe orphan detection:
+                    # - Standard rule: detached subscriptions are eligible.
+                    # - Taxi exception: subscriptions containing the NYC taxi prefix are eligible even if attached.
+                    es_taxi = "taxirides-realtime_beam_" in subscription_name
+                    if subscription.detached or es_taxi:
                         d[subscription_name] = GoogleCloudResource(resource_name=subscription_name, clock=self.clock)
 
         return d
@@ -416,8 +419,10 @@ def clean_pubsub_subscriptions():
     project_id = DEFAULT_PROJECT_ID
     bucket_name = DEFAULT_BUCKET_NAME
 
-    # No prefixes are defined for subscriptions so we will delete all stale subscriptions
-    prefixes = []
+    # Restrict subscription cleanup to the NYC taxi prefix only.
+    prefixes = [
+        "taxirides-realtime_beam_",
+    ]
 
     # Create a PubSubSubscriptionCleaner instance
     cleaner = PubSubSubscriptionCleaner(project_id=project_id, bucket_name=bucket_name,

--- a/.test-infra/tools/test_stale_cleaner.py
+++ b/.test-infra/tools/test_stale_cleaner.py
@@ -432,16 +432,16 @@ class PubSubSubscriptionCleanerTest(unittest.TestCase):
         self.assertIsInstance(self.cleaner.clock, FakeClock)
 
     def test_active_resources_active_subscriptions(self):
-        """Valida que las suscripciones activas con el prefijo de taxirides sean identificadas."""
+        """Verify that active subscriptions with the 'taxirides' prefix are identified."""
         self.cleaner.prefixes = ["taxirides-realtime_beam_"]
 
-        # Suscripción activa con el prefijo correcto de taxis
+        # Active suscription with the correct taxi prefix
         sub_taxi_active = mock.Mock()
         sub_taxi_active.name = f"projects/{self.project_id}/subscriptions/taxirides-realtime_beam_-12345"
         sub_taxi_active.topic = "projects/pubsub-public-data/topics/taxirides-realtime"
         sub_taxi_active.detached = False
 
-        # Suscripción activa con un prefijo distinto
+        # Active subscription with a different prefix
         sub_other_active = mock.Mock()
         sub_other_active.name = f"projects/{self.project_id}/subscriptions/other-prefix-sub"
         sub_other_active.topic = f"projects/{self.project_id}/topics/another-topic"
@@ -452,7 +452,7 @@ class PubSubSubscriptionCleanerTest(unittest.TestCase):
         with SilencePrint():
             active = self.cleaner._active_resources()
 
-        # Verificamos que solo capture la suscripción de taxi, descartando la otra
+        # Verify that only the taxi subscription is captured, discarding the other one
         self.assertIn(sub_taxi_active.name, active)
         self.assertNotIn(sub_other_active.name, active)
         self.assertEqual(len(active), 1)
@@ -462,13 +462,13 @@ class PubSubSubscriptionCleanerTest(unittest.TestCase):
             independientemente de los prefijos específicos de taxis."""
             self.cleaner.prefixes = ["test-prefix"]
 
-            # Suscripción desconectada (debería incluirse en la recolección)
+            # Standar suscription with a detached topic (should be included)
             sub_detached = mock.Mock()
             sub_detached.name = f"projects/{self.project_id}/subscriptions/test-prefix-detached"
             sub_detached.topic = "_deleted-topic_"
             sub_detached.detached = True
 
-            # Suscripción conectada normal (debería ignorarse)
+            # Standard connected subscription (should ignore)
             sub_attached = mock.Mock()
             sub_attached.name = f"projects/{self.project_id}/subscriptions/test-prefix-attached"
             sub_attached.topic = f"projects/{self.project_id}/topics/some-topic"
@@ -479,7 +479,7 @@ class PubSubSubscriptionCleanerTest(unittest.TestCase):
             with SilencePrint():
                 active = self.cleaner._active_resources()
 
-            # Verificamos que solo se registre la suscripción huérfana
+            # Only the detached subscription should be included in the active resources
             self.assertIn(sub_detached.name, active)
             self.assertNotIn(sub_attached.name, active)
             self.assertEqual(len(active), 1)

--- a/.test-infra/tools/test_stale_cleaner.py
+++ b/.test-infra/tools/test_stale_cleaner.py
@@ -431,42 +431,58 @@ class PubSubSubscriptionCleanerTest(unittest.TestCase):
         self.assertEqual(self.cleaner.time_threshold, self.time_threshold)
         self.assertIsInstance(self.cleaner.clock, FakeClock)
 
-    def test_active_resources(self):
-        """Test _active_resources method."""
-        # Keep the existing standard prefix coverage and add the taxi-only cleanup prefix.
-        self.cleaner.prefixes = ["test-prefix", "taxirides-realtime_beam_"]
+    def test_active_resources_active_subscriptions(self):
+        """Valida que las suscripciones activas con el prefijo de taxirides sean identificadas."""
+        self.cleaner.prefixes = ["taxirides-realtime_beam_"]
 
-        # Mock subscriptions
-        sub1 = mock.Mock()
-        sub1.name = "projects/test-project/subscriptions/test-prefix-sub1"
-        sub1.topic = "projects/test-project/topics/some-topic"
-        sub1.detached = False
+        # Suscripción activa con el prefijo correcto de taxis
+        sub_taxi_active = mock.Mock()
+        sub_taxi_active.name = f"projects/{self.project_id}/subscriptions/taxirides-realtime_beam_-12345"
+        sub_taxi_active.topic = "projects/pubsub-public-data/topics/taxirides-realtime"
+        sub_taxi_active.detached = False
 
-        sub2 = mock.Mock()
-        sub2.name = "projects/test-project/subscriptions/test-prefix-sub2-detached"
-        sub2.topic = "_deleted-topic_"
-        sub2.detached = True
+        # Suscripción activa con un prefijo distinto
+        sub_other_active = mock.Mock()
+        sub_other_active.name = f"projects/{self.project_id}/subscriptions/other-prefix-sub"
+        sub_other_active.topic = f"projects/{self.project_id}/topics/another-topic"
+        sub_other_active.detached = False
 
-        sub3 = mock.Mock()
-        sub3.name = "projects/test-project/subscriptions/taxirides-realtime_beam_-102875"
-        sub3.topic = "projects/pubsub-public-data/topics/taxirides-realtime"
-        sub3.detached = False
-
-        sub4 = mock.Mock()
-        sub4.name = "projects/test-project/subscriptions/other-prefix-sub3"
-        sub4.topic = "projects/test-project/topics/another-topic"
-        sub4.detached = False
-
-        self.mock_subscriber_client.list_subscriptions.return_value = [sub1, sub2, sub3, sub4]
+        self.mock_subscriber_client.list_subscriptions.return_value = [sub_taxi_active, sub_other_active]
 
         with SilencePrint():
             active = self.cleaner._active_resources()
 
-        self.assertNotIn("projects/test-project/subscriptions/test-prefix-sub1", active)
-        self.assertIn("projects/test-project/subscriptions/test-prefix-sub2-detached", active)
-        self.assertIn("projects/test-project/subscriptions/taxirides-realtime_beam_-102875", active)
-        self.assertNotIn("projects/test-project/subscriptions/other-prefix-sub3", active)
-        self.assertEqual(len(active), 2)
+        # Verificamos que solo capture la suscripción de taxi, descartando la otra
+        self.assertIn(sub_taxi_active.name, active)
+        self.assertNotIn(sub_other_active.name, active)
+        self.assertEqual(len(active), 1)
+
+    def test_active_resources_detached_subscriptions(self):
+            """Valida que las suscripciones desconectadas se mantengan en la lista de activos a limpiar,
+            independientemente de los prefijos específicos de taxis."""
+            self.cleaner.prefixes = ["test-prefix"]
+
+            # Suscripción desconectada (debería incluirse en la recolección)
+            sub_detached = mock.Mock()
+            sub_detached.name = f"projects/{self.project_id}/subscriptions/test-prefix-detached"
+            sub_detached.topic = "_deleted-topic_"
+            sub_detached.detached = True
+
+            # Suscripción conectada normal (debería ignorarse)
+            sub_attached = mock.Mock()
+            sub_attached.name = f"projects/{self.project_id}/subscriptions/test-prefix-attached"
+            sub_attached.topic = f"projects/{self.project_id}/topics/some-topic"
+            sub_attached.detached = False
+
+            self.mock_subscriber_client.list_subscriptions.return_value = [sub_detached, sub_attached]
+
+            with SilencePrint():
+                active = self.cleaner._active_resources()
+
+            # Verificamos que solo se registre la suscripción huérfana
+            self.assertIn(sub_detached.name, active)
+            self.assertNotIn(sub_attached.name, active)
+            self.assertEqual(len(active), 1)
 
     def test_delete_resource(self):
         """Test _delete_resource method."""

--- a/.test-infra/tools/test_stale_cleaner.py
+++ b/.test-infra/tools/test_stale_cleaner.py
@@ -458,8 +458,7 @@ class PubSubSubscriptionCleanerTest(unittest.TestCase):
         self.assertEqual(len(active), 1)
 
     def test_active_resources_detached_subscriptions(self):
-            """Valida que las suscripciones desconectadas se mantengan en la lista de activos a limpiar,
-            independientemente de los prefijos específicos de taxis."""
+            """Verify that detached subscriptions with the 'test-prefix' prefix are identified."""
             self.cleaner.prefixes = ["test-prefix"]
 
             # Standar suscription with a detached topic (should be included)
@@ -470,7 +469,7 @@ class PubSubSubscriptionCleanerTest(unittest.TestCase):
 
             # Standard connected subscription (should ignore)
             sub_attached = mock.Mock()
-            sub_attached.name = f"projects/{self.project_id}/subscriptions/test-prefix-attached"
+            sub_attached.name = f"projects/{self.project_id}/subscriptions/other-prefix-attached"
             sub_attached.topic = f"projects/{self.project_id}/topics/some-topic"
             sub_attached.detached = False
 

--- a/.test-infra/tools/test_stale_cleaner.py
+++ b/.test-infra/tools/test_stale_cleaner.py
@@ -433,26 +433,38 @@ class PubSubSubscriptionCleanerTest(unittest.TestCase):
 
     def test_active_resources(self):
         """Test _active_resources method."""
+        # Keep the existing standard prefix coverage and add the taxi-only cleanup prefix.
+        self.cleaner.prefixes = ["test-prefix", "taxirides-realtime_beam_"]
+
         # Mock subscriptions
         sub1 = mock.Mock()
         sub1.name = "projects/test-project/subscriptions/test-prefix-sub1"
         sub1.topic = "projects/test-project/topics/some-topic"
+        sub1.detached = False
 
         sub2 = mock.Mock()
         sub2.name = "projects/test-project/subscriptions/test-prefix-sub2-detached"
         sub2.topic = "_deleted-topic_"
+        sub2.detached = True
 
         sub3 = mock.Mock()
-        sub3.name = "projects/test-project/subscriptions/other-prefix-sub3"
-        sub3.topic = "projects/test-project/topics/another-topic"
+        sub3.name = "projects/test-project/subscriptions/taxirides-realtime_beam_-102875"
+        sub3.topic = "projects/pubsub-public-data/topics/taxirides-realtime"
+        sub3.detached = False
 
-        self.mock_subscriber_client.list_subscriptions.return_value = [sub1, sub2, sub3]
+        sub4 = mock.Mock()
+        sub4.name = "projects/test-project/subscriptions/other-prefix-sub3"
+        sub4.topic = "projects/test-project/topics/another-topic"
+        sub4.detached = False
+
+        self.mock_subscriber_client.list_subscriptions.return_value = [sub1, sub2, sub3, sub4]
 
         with SilencePrint():
             active = self.cleaner._active_resources()
 
-        self.assertIn("projects/test-project/subscriptions/test-prefix-sub1", active)
+        self.assertNotIn("projects/test-project/subscriptions/test-prefix-sub1", active)
         self.assertIn("projects/test-project/subscriptions/test-prefix-sub2-detached", active)
+        self.assertIn("projects/test-project/subscriptions/taxirides-realtime_beam_-102875", active)
         self.assertNotIn("projects/test-project/subscriptions/other-prefix-sub3", active)
         self.assertEqual(len(active), 2)
 


### PR DESCRIPTION
This pull request introduces a new cleanup rule that identifies orphaned subscriptions for the topic related to taxirides.

## Problem detected

- An accumulation of over 500 orphaned subscriptions with random names like `taxirides-realtime_beam_-...` was identified, connected to the public, continuous New York taxi topic.

## Solution

- **`stale_cleaner.py`**: `PubSubSubscriptionCleaner` was modified to evaluate and mark for deletion subscriptions with the prefix `taxirides-realtime_beam_` that are older than 24 hours, even if they are not in the `detached` state (since the NY taxi topic is permanent and public).
- **`test_stale_cleaner.py`**: Unit tests were added to validate this specific taxi-related criterion in isolation, ensuring that other subscriptions remain intact and safe.

The document describing the justification for cleaning this resource can be found at the following link: https://gist.github.com/HansMarcus01/101c53d0e9fa6179a5f631b59324df96

## Test results

The tests were executed successfully and without errors.

## Output obtained on August 3, 2026

<details>
<summary><b>View test script and execution output</b></summary>

**Command used:**
```bash
python - <<'PY'
from stale_cleaner import PubSubSubscriptionCleaner, DEFAULT_PROJECT_ID, DEFAULT_BUCKET_NAME

cleaner = PubSubSubscriptionCleaner(
    project_id=DEFAULT_PROJECT_ID,
    bucket_name=DEFAULT_BUCKET_NAME,
    prefixes=["test-prefix", "taxirides-realtime_beam_"],
)

active = cleaner._active_resources()

print(f"Detected {len(active)} eligible subscriptions")
for name in sorted(active):
    print(name)
PY

Detected 528 eligible subscriptions
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-104501432975026265
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-1083229462436046322
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-1231831954451637316
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-1280782917901264638
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-1342985657417227580
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-1348897846101343984
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-1355840445738820915
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-1356700333400819105
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-1447354549597907655
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-1480556353078066562
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-1512014450128300646
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-1578655018652207355
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-160116504745805619
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-1626717673529364943
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-1639205523505747733
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-1744926633347371663
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-1817453314071652751
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-193260678072343496
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-1941176997380385011
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-1986076720428762224
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2003729379232283381
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2013115058358878837
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2018211048312254378
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2094970954255987003
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-212047083062887494
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2170218104930920345
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2176342192506686093
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2220526022938192009
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2231009776765852551
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2252439724900264908
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2281719184623772257
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2306432347353435608
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2408729873949375010
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2413403854638681882
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2451619691332572811
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2550360465678427812
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2575585040689871155
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2595658215629439339
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2599307024895235535
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-260747961889072320
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2640288325075411324
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2653937578462833128
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2714136528683662096
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2774470417358858153
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2816749904549838504
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-2961217161924126888
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3007490855619724419
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3072594078955757242
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-308410698061252006
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3128554194593821878
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-313061129341542861
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3172371003103727297
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3182725178516009056
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3185421233645889732
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3196289738618651788
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3204937474486132806
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3258757308609425193
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3271234097107942108
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3285723471762081652
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3348477512981028211
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3416644058372877325
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3468644604029937914
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3481615393312378586
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3565479293746510037
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3573001365509930265
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3627187342532679862
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3674346455250222369
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3747286355894565171
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3759892938894288574
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3905940804441485188
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3929916236502901637
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-393876946332596378
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3944491656245000386
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-3987923564667292672
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4013939367329938832
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4130077812598753357
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4161382324702903014
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4200445100597745773
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4241607331982031270
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4245372596112408031
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4315230102209641004
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-432622762480246607
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4356508455860247416
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4367083944622684891
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4420514873659070424
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4423625533521479776
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4435158728317196772
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4441698004097851868
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4446352541511832188
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4532366442417825460
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4539288515991481687
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4559741054053901902
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4575958118134499951
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4615447007834539346
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4624991840868169244
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4632240818026736478
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4655424108662424363
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4667902888073010012
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4678543712006627112
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-470496608656034988
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4751931928838031036
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4757786437290444463
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4775792066777232836
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4828360950902903501
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4873061198878227950
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4890523284127904142
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4948133052363104278
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4955423484056730090
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4994434506109365970
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-4995615813745266073
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-508509483055699518
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5157781406401418244
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5158975908928725559
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5159870351964895607
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5213933441042050948
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-522456114259082288
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-522799322437398197
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5249052260041612564
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5278381100260079699
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5280697544211016952
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5284899393317295668
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5324587053495845680
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5353365981121370193
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5382874045166486541
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5434245365650875374
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5469024085022356304
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5494278917583215557
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5535964721187397901
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-555667447232538574
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5579359453781592510
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5602453891900669683
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5620392373290159898
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5648446812255648152
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5653359919141210842
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5665088127142997030
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5677652135395927478
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5766516080537367627
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5771829498913152785
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5821893149834321758
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5837148851853910179
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-586915809147930223
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5874091382441155923
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-5887607194533032223
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6007236996286408769
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6031533438209145733
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6079035918375742990
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6092241866742323809
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6092871248779035064
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6122776904265245228
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-614650965181893678
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6168332070094919094
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6174914210054876211
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6196063234647863630
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6247990086587944280
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6263877816161987842
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6269365706148142680
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6312758496292799459
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6348543144431074239
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6357620773214621826
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6361998872001137066
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6413074580631200911
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6415531272491694461
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-672121719258758148
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6748533086800207382
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-680245254042927012
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6832829163444673860
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6868232023272795063
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6940665886685743561
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6966634109083274461
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-6975628789059183621
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7011878847439142008
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7061013420730689556
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-71255564480589959
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7126406502009525044
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7141243711031728909
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7237102844228189561
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7389225708885398886
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7403932232872631526
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7408448173613835862
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7411190262768325460
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7441290478396260675
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-748654897331995718
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7497922517526046710
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7526373179125543299
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7571297165156638526
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7587146178627937652
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7615668057225326551
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7650300064799139182
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7683633689786646712
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7694320537498961058
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7731759194534867690
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7816809092506682212
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7822203291818435413
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7859937640893458276
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7873615292882921825
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7879910838361387252
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7885706533418703421
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7888906100989515192
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7894346250825812392
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7904752095822301856
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7988268965047337559
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-7993797551070672316
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8009808600728753448
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8028261713741305256
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8052803035839999695
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8063474064293669045
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8175294454610063984
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8184832769531031187
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8186295742207888833
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8210972182067842910
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8270767771114217051
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8282160746359807300
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8298471733770139399
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8335814824307601424
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-837412779792861129
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8400234907317974283
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8412451303904678274
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8420994367743472064
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8488746555103520210
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8535287492156072447
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8537739794049893065
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8542147060696712949
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8633674866838142113
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8644766115781514249
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8675425099587385131
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8717749670448203246
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8739304979252073140
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8801679256223016408
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8803205238082775827
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8811723439094484714
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8851020038360448853
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-8964068259064007006
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-897889253998490114
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-9032691186697185899
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-9078077779633921171
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-9107293735960197917
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-9169496533205133270
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-9196317380229692077
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-938012649355368632
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-948675744561688260
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-968392120856435228
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_-97842860534873503
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1021035091581276111
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1023502499618061194
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1056926481991335547
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1067573937773350224
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1068171509118561610
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1107263606758930741
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1201576864727598612
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1247949865872884009
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1278796857832053780
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1296296375601392376
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1297124727561251467
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1316205247540430874
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1476018618188041553
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1476568386231585420
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1510287235470284893
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1534133474366603672
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1545118460531054761
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1571139083252484323
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1581776803910891244
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1583391433702281672
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1585006081679900541
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1617297082103003654
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1631281472512207719
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1634633394570075826
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1635889747414343488
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1723492927641820175
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1733897766724724005
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1773460013985346511
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1785692480924186296
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1794986714574995068
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1800082216021149791
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1805946875050344607
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1809385234399487344
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1888231203337141151
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1890169966410479213
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_1980150942119076346
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2043574156920526175
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2079155803328080759
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2085986685048861559
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2098362239347174948
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2137284030339325314
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2165312030254226698
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2172005533781897555
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_225035550455259472
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2251660109666344738
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2279275712666075503
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2298996468809632964
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2322150930247112079
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2381015695152425777
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2388833038952443982
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2418083963528102294
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2443277078886738437
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2462446255427432466
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2462648597049624659
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_247092327281670287
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2472131934460679562
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2497319944662735717
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2503914392892012644
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2507383312985552918
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2530555398394472089
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2537219723049109671
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2562320672850634924
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2565829213145585238
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2587470964768838353
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2611683881789385224
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2635642042805366619
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2655254447662121037
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2702154945826227798
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2749616124815930269
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2811459690903703427
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2938340287419713899
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2950750623606030333
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_2974463047323661706
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3038939999586415082
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3041474437575503730
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3069589615061491539
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3073293329223680797
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3078927113985455953
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3115060398657537626
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3142856213379508286
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3157444714693279274
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3175934154466117546
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_317775118192797996
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3182069248056019548
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3188495720729771551
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3219185544429938364
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3257948398150323393
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3284692588227761832
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_328887015625429039
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3295831742131871505
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3312358861637868676
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3409025011898404541
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3420800557772094432
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3426647454764887251
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3427040535099535285
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3434414600806861470
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3483364906362231274
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3516027543390222548
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3541289867348592855
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3544395135665802216
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3645702361893696268
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3703778320643313009
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3718336641795784945
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3719512441818712806
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_372409910845818126
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3734241316243715116
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3742871669254186122
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3771241846039916110
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3785737537351670031
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_380282374780223185
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3813856220524690924
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3858484106805878348
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3882002621840652235
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3897108021986535993
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_3902418585384491489
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_393509683858517956
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_400065210065179381
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_401455295168106018
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_410407646217245056
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4113646521427624885
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4128788584316942835
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4130016374021386306
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4133573899454017830
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_420825240984201303
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4213560474468172122
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4220253535263249858
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4233522345010639846
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4319505034021129751
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4320613164730674293
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4323977413110941412
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4359038219580741406
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_43810819775320145
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4401017658569822991
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4417626494139145816
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4446215177039578015
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_447543982915745998
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4560953349311236433
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4574657439786399637
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4602689297065005677
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_464214549507304549
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4646538538284898370
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4647383515845430953
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4653650517483786351
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_468536576987072804
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4839612886863387668
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4840708298622661669
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4887279594587074022
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4921234338255116948
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_49223652393145791
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4933446960353750666
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_4969744237800622886
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_5068161190276858023
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_509934098764918899
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_5108626533987653746
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_5121668038840073871
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_5128042785667446857
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_5159816209332692060
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_522104223668961680
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_5257656772707316917
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_5263525985576419972
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_5335179205572918991
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_543821823588817260
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_5484860736757058441
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_5501171339028062577
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_5519993501278528711
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_5542091237435430153
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_5669306824361506886
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_5684863610480275130
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_5685974008678170380
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_5828157930331248508
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_5851105887662325342
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_5853807018463682952
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_5858771210805443936
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_5867638976699577018
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_587501222815179393
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_5923557726698760381
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_5972880904514863559
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6034045623478542236
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6058207028107516215
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6073749255452020743
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_609388194353853416
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6116696821174380337
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6128985940796749166
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6180466371195666898
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6197655418346195920
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6215700173141363398
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6303276551684139167
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6306831768223991190
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6311924675425049489
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_632855973252397142
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6380262961293651481
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6470039392016177668
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6470298280160207501
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6566032999103345624
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6594640330193390242
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6602953209476231053
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6637464328823529595
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6639124915714329271
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6645260565835318115
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6646824243566044273
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6649546441585037743
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6678396741612032684
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6805243567968467722
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6811829195786735670
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6861166766832358924
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6929022602707943767
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6956528717557526312
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_6991441891091885004
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7073659241600126235
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7078244138241147541
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7079534052338689190
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7084961342203699574
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7182255183949315524
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7214489607935842036
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7243734644689794689
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7247755691809351340
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7272838137517986272
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7284302815285459374
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7337771735910691243
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7340917467527524438
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7344036196917075580
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7364658546125508706
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7386030947113882787
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7427116976934566471
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7428008175075973275
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7428435930365967933
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_745792391717135500
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7463785860414065560
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7468548462553587784
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7475738458041945109
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7492354674581350713
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7528950419262681565
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7561169881486361509
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7567953505091765328
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7581776815673038160
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7633379533197143250
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_767042633369115379
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7678119667680309365
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7702015055787790512
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7754686039517446334
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7787384694762043608
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7831032932649994331
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7832977545946765971
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7849084210168475975
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7864291957111492364
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7917078563931401215
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7955969749010690818
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7962435485120794148
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_7999366451215854534
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_8018548687244515985
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_8025618513134711582
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_8197498730981350824
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_8216569369119054710
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_824338433735625251
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_825387018703597999
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_8295321950102532026
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_8342635548186561721
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_8351592721315184116
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_8351855172953492341
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_840101922102510982
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_8465812075178826083
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_852492562232724008
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_8554493813217843952
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_8568658590452146219
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_8574707981141282907
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_8663009272709974902
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_8676522532687035818
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_868869139298376135
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_8734367183251447431
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_8744864392078370300
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_8851132286530233399
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_8882354742000498328
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_898329325372854790
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_9001863853633698642
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_9061434640018514110
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_9089121512533187252
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_9101450224113096978
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_9180410699266369323
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_9212660600126371313
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_9261082381434352
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_936138070133271187
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_945295656461636606
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_94574500586254274
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_948999970926339337
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_956565410050105324
projects/apache-beam-testing/subscriptions/taxirides-realtime_beam_977150222616420097
```
