### PR TITLE
Fix flaky BigQuery persistent retry test

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_test.py
@@ -1524,8 +1524,10 @@ class BigQueryStreamingInsertsErrorHandling(unittest.TestCase):
     # Expecting 1 initial call plus maximum number of retries
     expected_call_count = 1 + bigquery_tools.MAX_RETRIES
 
+    # This relies on runner-specific mocking behavior which can be
+    # inconsistent on Prism.
     with self.assertRaises(Exception) as exc:
-      with beam.Pipeline() as p:
+      with beam.Pipeline('FnApiRunner') as p:
         _ = (
             p
             | beam.Create([{


### PR DESCRIPTION
Fixes #39526.

## Summary

The persistent retry test asserts one initial BigQuery call plus three retries. Its default pipeline can select Prism, where runner-dependent execution sometimes invokes the mocked retry path twice. The reported failure saw 8 calls instead of 4.

Pin this runner-specific mocking test to FnApiRunner, matching the adjacent intermittent retry test. Production code is unchanged.

## Validation

- Confirmed failing CI trace contained two four-attempt retry sequences
- Unchanged test: 50/50 local passes, consistent with a rare scheduling flake
- Python 3.12 cloud tox target after fix: 2 passed
- Patched timeout case stress: 50/50 passes
- YAPF 0.43.0 and Ruff 0.15.7 passed on changed file