### PR TITLE
Fix TSAN bug by swapping ForkJoinPool with ScheduledExecutorService

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WriteFiles.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WriteFiles.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
@@ -46,6 +47,7 @@ import org.apache.beam.sdk.io.FileBasedSink.FileResultCoder;
 import org.apache.beam.sdk.io.FileBasedSink.WriteOperation;
 import org.apache.beam.sdk.io.FileBasedSink.Writer;
 import org.apache.beam.sdk.io.fs.ResourceId;
+import org.apache.beam.sdk.options.ExecutorOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
@@ -1199,6 +1201,7 @@ public abstract class WriteFiles<UserT, DestinationT, OutputT>
     private transient List<CompletionStage<Void>> closeFutures = new ArrayList<>();
     private transient List<KV<Instant, FileResult<DestinationT>>> deferredOutput =
         new ArrayList<>();
+    private transient ScheduledExecutorService executorService;
 
     // Ensure that transient fields are initialized.
     private void readObject(java.io.ObjectInputStream in)
@@ -1206,6 +1209,11 @@ public abstract class WriteFiles<UserT, DestinationT, OutputT>
       in.defaultReadObject();
       closeFutures = new ArrayList<>();
       deferredOutput = new ArrayList<>();
+    }
+
+    @Setup
+    public void setup(PipelineOptions options) {
+      executorService = options.as(ExecutorOptions.class).getScheduledExecutorService();
     }
 
     @ProcessElement
@@ -1285,7 +1293,8 @@ public abstract class WriteFiles<UserT, DestinationT, OutputT>
                   writer.cleanup();
                   throw e;
                 }
-              }));
+              },
+              executorService));
     }
 
     @FinishBundle


### PR DESCRIPTION
This fixes the same issue as #39458 by having the `ScheduledExecutorService` establish a happens-before relationship between the submitting thread and executing thread, which appears to be missing for the common `ForkJoinPool` executor used by `MoreFutures.runAsync(ThrowingRunnable)` based on testing `TFRecordSchemaTransformProviderTest` with TSAN enabled. TSAN reports data races between the processing thread's write(s) to the `Writer` and the background thread's closing and/or cleanup of the `Writer` in [`CRC32`](https://docs.oracle.com/javase/8/docs/api/java/util/zip/CRC32.html) calls made by a gzip compressor.

`Writer` can be patched to establish acquire/release barriers between open and close/cleanup (e.g., by marking `channel` as `volatile` and adjusting reads/writes accordingly), but since `write` is `abstract` and the underlying `WritableByteChannel` is passed to implementations in `prepareWrite` instead of being accessed through its member field on the super class there's no point between any call to `write` and `close` which would insert the required memory barriers.

I can't think of any other tricks to make `Writer` inherently thread safe without modifying its public API as is already proposed in #39458. It is thread compatible at least, so it just needs external synchronization to play nice. Replacing the common `ForkJoinPool` with the harness `ScheduledExecutorService` as the executor for closing writers should be enough to take care of that.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
