### PR TITLE
[Python] Set a Beam user agent on the boto3 S3 client

### DIFF
--- a/sdks/python/apache_beam/io/aws/clients/s3/boto3_client.py
+++ b/sdks/python/apache_beam/io/aws/clients/s3/boto3_client.py
@@ -17,6 +17,7 @@
 
 # pytype: skip-file
 
+from apache_beam import version as beam_version
 from apache_beam.io.aws.clients.s3 import messages
 from apache_beam.options import pipeline_options
 from apache_beam.utils import retry
@@ -25,6 +26,7 @@ try:
   # pylint: disable=wrong-import-order, wrong-import-position
   # pylint: disable=ungrouped-imports
   import boto3
+  from botocore.config import Config
 
 except ImportError:
   boto3 = None
@@ -72,7 +74,9 @@ class Client(object):
         endpoint_url=endpoint_url,
         aws_access_key_id=access_key_id,
         aws_secret_access_key=secret_access_key,
-        aws_session_token=session_token)
+        aws_session_token=session_token,
+        config=Config(
+            user_agent_extra='apache-beam/%s' % beam_version.__version__))
 
     self._download_request = None
     self._download_stream = None

--- a/sdks/python/apache_beam/io/aws/clients/s3/client_test.py
+++ b/sdks/python/apache_beam/io/aws/clients/s3/client_test.py
@@ -20,10 +20,19 @@ import logging
 import os
 import unittest
 
+from apache_beam import version as beam_version
 from apache_beam.io.aws import s3io
 from apache_beam.io.aws.clients.s3 import fake_client
 from apache_beam.io.aws.clients.s3 import messages
 from apache_beam.options import pipeline_options
+
+# Protect against environments where boto3 library is not available.
+# pylint: disable=wrong-import-order, wrong-import-position
+try:
+  from apache_beam.io.aws.clients.s3 import boto3_client
+except ImportError:
+  boto3_client = None  # type: ignore[assignment]
+# pylint: enable=wrong-import-order, wrong-import-position
 
 
 class ClientErrorTest(unittest.TestCase):
@@ -220,6 +229,15 @@ class ClientErrorTest(unittest.TestCase):
     except Exception as e:
       self.assertIsInstance(e, messages.S3ClientError)
       self.assertEqual(e.code, 400)
+
+
+@unittest.skipIf(boto3_client is None, 'AWS dependencies are not installed')
+class ClientUserAgentTest(unittest.TestCase):
+  def test_user_agent_contains_beam_version(self):
+    client = boto3_client.Client(pipeline_options.S3Options())
+    self.assertIn(
+        'apache-beam/%s' % beam_version.__version__,
+        client.client.meta.config.user_agent)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Addresses #39573

`apache_beam.io.aws.clients.s3.boto3_client.Client` builds its boto3 client without a botocore `Config`, so every S3 request Beam makes goes out with the stock boto3 user agent and carries nothing identifying the caller as Beam. The other cloud clients in the Python SDK all tag themselves already: `gcsio.py` sends `apache-beam/<version> (GPN:Beam)`, `bigquery_tools.py` sends `apache-beam-<version>`, and the Datastore helper sends `beam-python-sdk/<version>`. The S3 client is the odd one out.

This passes `Config(user_agent_extra='apache-beam/%s' % beam_version.__version__)` when constructing the client. botocore appends `user_agent_extra` to the end of the composed user agent, so the boto3, botocore, platform, and language segments are all preserved and only a suffix is added. The version comes from `apache_beam.version.__version__`, the same source `gcsio.py` uses. The practical benefit is that Beam's S3 traffic becomes identifiable in server access logs, which helps when diagnosing throttling or endpoint problems against Amazon S3 and against any other S3-compatible endpoint reached through `--s3_endpoint_url`.

Tests: a new `ClientUserAgentTest` in `client_test.py` constructs the client from a default `S3Options()` and asserts the composed `client.client.meta.config.user_agent` contains `apache-beam/<version>`. It is guarded with `@unittest.skipIf(boto3_client is None, ...)` following the pattern already used in `s3filesystem_test.py`, and client construction needs no credentials and no region, so it runs offline. yapf and ruff are clean on both files.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).