### PR TITLE
fix(dataframe): claim remaining restriction range on empty/header-only CSV reads

### DIFF
--- a/sdks/python/apache_beam/dataframe/io.py
+++ b/sdks/python/apache_beam/dataframe/io.py
@@ -565,6 +565,7 @@ class _TruncatingFileHandle(object):
       self._buffer = self._underlying.read(size)
 
     if not self._buffer:
+      self._tracker.try_claim(self._tracker.current_restriction().stop)
       self._done = True
       return self._empty
 

--- a/sdks/python/apache_beam/dataframe/io_test.py
+++ b/sdks/python/apache_beam/dataframe/io_test.py
@@ -126,6 +126,12 @@ A     B
       pcoll = p | beam.io.ReadFromCsv(f'{input}tmp.csv', dtype=str)
       assert_that(pcoll | beam.Map(max), equal_to(['99']))
 
+  def test_empty_csv_read(self):
+    input = self.temp_dir({'empty.csv': 'col1,col2,col3\n'})
+    with beam.Pipeline() as p:
+      pcoll = p | beam.io.ReadFromCsv(input + 'empty.csv')
+      assert_that(pcoll, equal_to([]))
+
   def test_sharding_parameters(self):
     data = pd.DataFrame({'label': ['11a', '37a', '389a'], 'rank': [0, 1, 2]})
     output = self.temp_dir()


### PR DESCRIPTION
This is my first contribution to Apache Beam — happy to adjust the approach if there's a preferred pattern I'm missing.

### What broke?

When reading an empty or header-only CSV file using `beam.io.ReadFromCsv`, the pipeline fails with:

ValueError: OffsetRestrictionTracker is not done since work in range [0, 16) has not been claimed.


### Root Cause

In `sdks/python/apache_beam/dataframe/io.py`, `_TruncatingFileHandle._read()` returns early on an empty buffer without claiming the remaining restriction range, causing `check_done()` to fail.

### Fix

```python
if not self._buffer:
  self._tracker.try_claim(self._tracker.current_restriction().stop)
  self._done = True
  return self._empty
```

### Verification

Added `test_empty_csv_read` to `IOTest`. Full suite (36 tests) passes with the fix; fails without it. Pre-existing Windows-only failures are unrelated (#20642).