### PR TITLE
Fix Row.toString NPE on a null nested inside an array, map or row

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaUtils.java
@@ -238,6 +238,13 @@ public class SchemaUtils {
   }
 
   static String toPrettyFieldValueString(Schema.FieldType fieldType, Object value, String prefix) {
+    if (value == null) {
+      // toPrettyRowString drops a row's own null fields, but a null nested inside an array, an
+      // iterable, a map or a row has a position and has to be rendered. The numeric and boolean
+      // branches below already render one as "null" via Objects.toString, so do the same for the
+      // remaining types rather than dereferencing the value.
+      return "null";
+    }
     String nextPrefix = prefix + INDENT;
     switch (fieldType.getTypeName()) {
       case BYTE:

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaUtilsTest.java
@@ -18,8 +18,13 @@
 package org.apache.beam.sdk.schemas;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.values.Row;
 import org.junit.Test;
 
 /** Tests for {@link org.apache.beam.sdk.schemas.SchemaUtils}. */
@@ -103,5 +108,43 @@ public class SchemaUtilsTest {
                 "field1", FieldType.INT32.withNullable(true), FieldType.INT32.withNullable(true))
             .build();
     assertEquals(expected, SchemaUtils.mergeWideningNullable(schema1, schema2));
+  }
+
+  @Test
+  public void testToPrettyStringRendersNullInsideArray() {
+    Schema schema =
+        Schema.builder().addArrayField("a", FieldType.STRING.withNullable(true)).build();
+    Row row = Row.withSchema(schema).addValue(Arrays.asList("x", null)).build();
+    assertTrue(row.toString(), row.toString().contains("null"));
+  }
+
+  @Test
+  public void testToPrettyStringRendersNullMapValue() {
+    Schema schema =
+        Schema.builder()
+            .addMapField("m", FieldType.STRING, FieldType.STRING.withNullable(true))
+            .build();
+    Map<String, String> map = new HashMap<>();
+    map.put("k", null);
+    Row row = Row.withSchema(schema).addValue(map).build();
+    assertTrue(row.toString(), row.toString().contains("null"));
+  }
+
+  @Test
+  public void testToPrettyStringRendersNullRowInsideArray() {
+    Schema inner = Schema.builder().addStringField("s").build();
+    Schema schema =
+        Schema.builder().addArrayField("a", FieldType.row(inner).withNullable(true)).build();
+    Row row = Row.withSchema(schema).addValue(Arrays.asList((Row) null)).build();
+    assertTrue(row.toString(), row.toString().contains("null"));
+  }
+
+  @Test
+  public void testToPrettyStringRendersNullInsideArrayOfInts() {
+    Schema schema = Schema.builder().addArrayField("a", FieldType.INT32.withNullable(true)).build();
+    Row row = Row.withSchema(schema).addValue(Arrays.asList(1, null)).build();
+    String rendered = row.toString();
+    assertTrue(rendered, rendered.contains("1"));
+    assertTrue(rendered, rendered.contains("null"));
   }
 }


### PR DESCRIPTION
`Row.toString()` throws `NullPointerException` whenever a null sits inside an array, an iterable, a map or a nested row.

```java
Schema schema = Schema.builder().addArrayField("a", FieldType.STRING.withNullable(true)).build();
Row.withSchema(schema).addValue(Arrays.asList("x", null)).build().toString();
// java.lang.NullPointerException: Cannot invoke "String.replace(...)" because "string" is null
//     at SchemaUtils.toPrettyFieldValueString(SchemaUtils.java:256)
```

`toPrettyRowString` skips a row's own null fields, but every recursive call hands the raw element to `toPrettyFieldValueString`, which has no null check and dereferences it — `string.replace` for `STRING`, `row.getValues()` for `ROW`, `value.getClass()` for `ARRAY`/`MAP`. Only the numeric and boolean branches survive, and only because `Objects.toString` already renders a null as `"null"`.

These values are legal: `RowUtils` explicitly accepts null array elements and null map values when the element type is nullable.

## The fix

Return `"null"` for a null value at the top of `toPrettyFieldValueString`. That is not a new rendering — it is exactly what the numeric branches have always produced, so this makes the remaining types consistent with the ones that already worked. Seven lines, one file, no API or wire-format change.

`toPrettyRowString`'s deliberate skipping of top-level null fields is left alone; that is the printer's intended terse style.

## Why this regressed

`Row.toString()` used to call `toString(true)`, whose private helper opens with `if (value == null) { return "<null>"; }` and is therefore null-safe at every depth. That method is still present. `Row.toString()` was rerouted to `SchemaUtils.toPrettyString(this)` in #35150, and `SchemaUtils.toPrettyString(this)` first appears in `Row.java` at `v2.69.0` — it is absent from `v2.67.0` and `v2.68.0` — so every release from 2.69.0 on has it.

`toString()` is called from logging, `PAssert` failure messages, exception messages and debugger inspection, so in practice the NPE fires while a pipeline is already reporting a different problem, and hides it.

`SchemaUtilsTest` is 107 lines and does not reference the pretty-printer at all, which is why the 279 lines added in #35150 went unnoticed.

## Testing

Four tests added to `SchemaUtilsTest`: null inside an array of strings, a null map value, a null row inside an array, and — as a control that pins the existing behaviour — null inside an array of ints. The first three fail on current `master` with the NPEs above and pass with this change; the control passes both before and after, which is what makes the `"null"` rendering a consistency fix rather than a new choice.

- `:sdks:java:core:test --tests "org.apache.beam.sdk.schemas.*Test"` with `--rerun-tasks` — 522 tests, 0 failures, 0 errors
- `:sdks:java:core:spotlessJavaCheck` — passes

Fixes #21063
