### PR TITLE
Fix OpenTelemetry dependencies in published POMs

### DIFF
--- a/sdks/java/io/google-cloud-platform/build.gradle
+++ b/sdks/java/io/google-cloud-platform/build.gradle
@@ -37,6 +37,7 @@ tasks.withType(Test).configureEach {
 
 dependencies {
   implementation(enforcedPlatform(library.java.google_cloud_platform_libraries_bom))
+  implementation platform(library.java.opentelemetry_bom)
   implementation project(path: ":model:pipeline", configuration: "shadow")
   implementation project(":runners:core-java")
   implementation project(path: ":sdks:java:core", configuration: "shadow")

--- a/sdks/java/io/kafka/build.gradle
+++ b/sdks/java/io/kafka/build.gradle
@@ -42,6 +42,7 @@ def kafkaVersions = [
 kafkaVersions.each{k,v -> configurations.create("kafkaVersion$k")}
 
 dependencies {
+  implementation platform(library.java.opentelemetry_bom)
   implementation library.java.vendored_guava_32_1_2_jre
   provided library.java.jackson_dataformat_csv
   permitUnusedDeclared library.java.jackson_dataformat_csv


### PR DESCRIPTION
Recent OpenTelemetry tracing changes added versionless `opentelemetry-api` dependencies to GCP and Kafka IO without importing the corresponding BOM. Their published snapshot POMs became invalid, so Maven discarded transitive dependencies and the PostRelease examples archetype failed to compile with missing Avro and GCP classes.

Import the OpenTelemetry BOM in both modules so generated POMs provide the required dependency management.

Addresses #38714.

Testing:

- Confirmed both baseline generated POMs fail `mvn validate` because `opentelemetry-api` has no version.
- Confirmed both patched generated POMs pass `mvn validate` and import `opentelemetry-bom-alpha`.
- Built GCP IO and Kafka IO jars and passed their Spotless checks.
- Deployed patched snapshots locally and confirmed the generated examples archetype compiles all 71 sources from a clean target with `-Pspark-runner`, matching the failing PostRelease profile.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)
