### PR TITLE
[GSoC 2026] Kafka Streams runner: CombineTest coverage and two review follow-ups

### DIFF
--- a/runners/kafka-streams/build.gradle
+++ b/runners/kafka-streams/build.gradle
@@ -113,8 +113,9 @@ def sickbayTests = [
   // Merging (session) windows are not supported yet: ReduceFnRunner drives them through a merging
   // window set that moves per-window state as windows merge, which this first windowing pass does
   // not implement. Non-merging windows (fixed, sliding), the default trigger and timestamp
-  // combiners do work. Lands with the follow-up windowing PR.
+  // combiners do work, for both GroupByKey and Combine. Lands with the follow-up windowing PR.
   'org.apache.beam.sdk.transforms.GroupByKeyTest$WindowTests.testGroupByKeyMergingWindows',
+  'org.apache.beam.sdk.transforms.CombineTest$WindowingTests.testSessionsCombine',
   // A DoFn whose @StartBundle throws never gets to report its error: SdkHarnessClient.newBundle
   // sends the ProcessBundleRequest and then blocks in GrpcDataService.createOutboundAggregator
   // waiting for the SDK harness to open its data stream, which a bundle that failed during setup
@@ -177,6 +178,7 @@ tasks.register("validatesRunner", Test) {
     includeTestsMatching 'org.apache.beam.sdk.transforms.FlattenTest'
     includeTestsMatching 'org.apache.beam.sdk.transforms.GroupByKeyTest*'
     includeTestsMatching 'org.apache.beam.sdk.transforms.ParDoTest*'
+    includeTestsMatching 'org.apache.beam.sdk.transforms.CombineTest*'
     for (String test : sickbayTests) {
       excludeTestsMatching test
     }

--- a/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/FlattenTranslator.java
+++ b/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/FlattenTranslator.java
@@ -57,8 +57,14 @@ class FlattenTranslator implements PTransformTranslator {
     Set<String> seenInputs = new HashSet<>();
     List<String> parentProcessors = new ArrayList<>();
     Set<String> upstreamTransformIds = new HashSet<>();
-    // Kafka Streams puts a processor and the parents it is wired to in one subtopology, so the
-    // inputs are co-partitioned and this Flatten runs at their partition count.
+    // How many instances this Flatten runs as. Kafka Streams merges the subtopologies of every
+    // parent a processor is wired to and gives the merged subtopology as many tasks as its largest
+    // source topic has partitions, so the max is what that comes to. In practice the inputs agree:
+    // a Flatten whose branches could disagree — one through a GroupByKey, one straight from a
+    // source — is fused into the harness stage instead of becoming a node here, and the runner
+    // Flattens that do reach this translator come from the fuser deduplicating partial outputs of
+    // one PCollection. The max is kept as the cheap conservative choice rather than asserting that
+    // agreement, which is not enforced anywhere.
     int partitionCount = 1;
     for (String inputPCollectionId : transform.getInputsMap().values()) {
       if (!seenInputs.add(inputPCollectionId)) {

--- a/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/GroupByKeyBroadcastPartitioner.java
+++ b/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/GroupByKeyBroadcastPartitioner.java
@@ -56,10 +56,15 @@ class GroupByKeyBroadcastPartitioner<T> implements StreamPartitioner<byte[], KSt
       }
       return Optional.of(all);
     }
-    // A keyless record — a stateless stage carries no key — has nowhere in particular to go, so
-    // send it to partition 0 rather than hashing a null. This is the method Kafka Streams calls,
-    // so the guard has to be here and not only on partition() above.
-    int partition = key == null ? 0 : Utils.toPositive(Utils.murmur2(key)) % numPartitions;
+    if (key == null) {
+      // A keyless record has no partition it must go to, so leave the choice to Kafka rather than
+      // hashing a null or pinning one partition: an empty Optional tells Kafka Streams no explicit
+      // partition was chosen, and the producer's default partitioner spreads keyless records over
+      // the topic instead of piling them onto one. This is the method Kafka Streams calls, so the
+      // null has to be handled here and not only in partition() above.
+      return Optional.empty();
+    }
+    int partition = Utils.toPositive(Utils.murmur2(key)) % numPartitions;
     return Optional.of(Collections.singleton(partition));
   }
 }

--- a/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/GroupByKeyBroadcastPartitioner.java
+++ b/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/GroupByKeyBroadcastPartitioner.java
@@ -56,7 +56,10 @@ class GroupByKeyBroadcastPartitioner<T> implements StreamPartitioner<byte[], KSt
       }
       return Optional.of(all);
     }
-    int partition = Utils.toPositive(Utils.murmur2(key)) % numPartitions;
+    // A keyless record — a stateless stage carries no key — has nowhere in particular to go, so
+    // send it to partition 0 rather than hashing a null. This is the method Kafka Streams calls,
+    // so the guard has to be here and not only on partition() above.
+    int partition = key == null ? 0 : Utils.toPositive(Utils.murmur2(key)) % numPartitions;
     return Optional.of(Collections.singleton(partition));
   }
 }

--- a/runners/kafka-streams/src/test/java/org/apache/beam/runners/kafka/streams/translation/FlattenParallelismTest.java
+++ b/runners/kafka-streams/src/test/java/org/apache/beam/runners/kafka/streams/translation/FlattenParallelismTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.kafka.streams.translation;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.apache.beam.runners.kafka.streams.KafkaStreamsPipelineOptions;
+import org.apache.beam.runners.kafka.streams.KafkaStreamsTestRunner;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.Flatten;
+import org.apache.beam.sdk.transforms.GroupByKey;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionList;
+import org.junit.Test;
+
+/**
+ * Pins down what happens to a Flatten whose branches would run at different parallelisms — one
+ * through a GroupByKey and so at the shuffle's parallelism, one straight from a source and so a
+ * single instance.
+ *
+ * <p>This matters because a Flatten runs as one set of tasks over all of its inputs. Kafka Streams
+ * merges the subtopologies of every parent a processor is wired to and gives the result as many
+ * tasks as its largest source topic has partitions, so a parent with fewer partitions would only
+ * produce on some of those tasks and the rest would wait forever for a watermark report from it.
+ *
+ * <p>That does not arise, and this test is here to record why: the fuser folds such a Flatten into
+ * the SDK harness stage rather than leaving a node for the runner to translate. The Flattens that
+ * do reach {@link FlattenTranslator} come from the fuser deduplicating partial outputs of a single
+ * PCollection. If a change ever makes the mismatched shape reach the translator, this test starts
+ * failing and the partition-count handling there needs revisiting.
+ */
+public class FlattenParallelismTest {
+
+  private static class ToKvFn extends DoFn<Integer, KV<String, Integer>> {
+    @ProcessElement
+    public void processElement(@Element Integer input, OutputReceiver<KV<String, Integer>> out) {
+      out.output(KV.of("k", input));
+    }
+  }
+
+  private static class UngroupFn extends DoFn<KV<String, Iterable<Integer>>, Integer> {
+    @ProcessElement
+    public void processElement(
+        @Element KV<String, Iterable<Integer>> group, OutputReceiver<Integer> out) {
+      for (int value : group.getValue()) {
+        out.output(value);
+      }
+    }
+  }
+
+  private static Pipeline mixedParallelismFlatten(int internalParallelism) {
+    KafkaStreamsPipelineOptions options =
+        KafkaStreamsTestRunner.testOptions().as(KafkaStreamsPipelineOptions.class);
+    options.setInternalParallelism(internalParallelism);
+    Pipeline pipeline = Pipeline.create(options);
+
+    // Through a GroupByKey, so this branch runs at the shuffle's parallelism.
+    PCollection<Integer> shuffled =
+        pipeline
+            .apply("createGrouped", Create.of(1, 2, 3))
+            .apply("toKv", ParDo.of(new ToKvFn()))
+            .apply("group", GroupByKey.create())
+            .apply("ungroup", ParDo.of(new UngroupFn()));
+
+    // Straight from a source, so this branch is a single instance.
+    PCollection<Integer> direct = pipeline.apply("createDirect", Create.of(4, 5, 6));
+
+    PCollectionList.of(shuffled).and(direct).apply("merge", Flatten.pCollections());
+    return pipeline;
+  }
+
+  @Test
+  public void branchesAtDifferentParallelismsAreFusedRatherThanLeftToTheRunner() {
+    // Translating is the assertion: the mismatched shape does not reach FlattenTranslator, because
+    // the fuser absorbs this Flatten into the harness stage. Were it to arrive there, the runner
+    // would build one Flatten node over branches of differing parallelism and stall.
+    KafkaStreamsTranslationContext context =
+        KafkaStreamsTestRunner.translate(mixedParallelismFlatten(4));
+
+    assertThat(context.getTopology().describe().subtopologies().isEmpty(), is(false));
+  }
+
+  @Test
+  public void theSameShapeTranslatesAtASingleParallelism() {
+    KafkaStreamsTranslationContext context =
+        KafkaStreamsTestRunner.translate(mixedParallelismFlatten(1));
+
+    assertThat(context.getTopology().describe().subtopologies().isEmpty(), is(false));
+  }
+}

--- a/runners/kafka-streams/src/test/java/org/apache/beam/runners/kafka/streams/translation/FlattenParallelismTest.java
+++ b/runners/kafka-streams/src/test/java/org/apache/beam/runners/kafka/streams/translation/FlattenParallelismTest.java
@@ -20,6 +20,8 @@ package org.apache.beam.runners.kafka.streams.translation;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.beam.runners.kafka.streams.KafkaStreamsPipelineOptions;
 import org.apache.beam.runners.kafka.streams.KafkaStreamsTestRunner;
 import org.apache.beam.sdk.Pipeline;
@@ -31,6 +33,7 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionList;
+import org.apache.kafka.streams.TopologyDescription;
 import org.junit.Test;
 
 /**
@@ -43,13 +46,17 @@ import org.junit.Test;
  * tasks as its largest source topic has partitions, so a parent with fewer partitions would only
  * produce on some of those tasks and the rest would wait forever for a watermark report from it.
  *
- * <p>That does not arise, and this test is here to record why: the fuser folds such a Flatten into
- * the SDK harness stage rather than leaving a node for the runner to translate. The Flattens that
+ * <p>That does not arise, and these tests record why: the fuser folds such a Flatten into the SDK
+ * harness stages rather than leaving a node for the runner to translate, so the branches never
+ * share a subtopology and no Flatten node exists to run at a single parallelism. The Flattens that
  * do reach {@link FlattenTranslator} come from the fuser deduplicating partial outputs of a single
- * PCollection. If a change ever makes the mismatched shape reach the translator, this test starts
+ * PCollection. If a change ever makes the mismatched shape reach the translator, these tests start
  * failing and the partition-count handling there needs revisiting.
  */
 public class FlattenParallelismTest {
+
+  /** The name given to the Flatten below, which no topology node should be derived from. */
+  private static final String FLATTEN_NAME = "merge";
 
   private static class ToKvFn extends DoFn<Integer, KV<String, Integer>> {
     @ProcessElement
@@ -89,22 +96,46 @@ public class FlattenParallelismTest {
     return pipeline;
   }
 
-  @Test
-  public void branchesAtDifferentParallelismsAreFusedRatherThanLeftToTheRunner() {
-    // Translating is the assertion: the mismatched shape does not reach FlattenTranslator, because
-    // the fuser absorbs this Flatten into the harness stage. Were it to arrive there, the runner
-    // would build one Flatten node over branches of differing parallelism and stall.
-    KafkaStreamsTranslationContext context =
-        KafkaStreamsTestRunner.translate(mixedParallelismFlatten(4));
+  /** Every processor node in the topology, across all subtopologies. */
+  private static List<String> processorNames(TopologyDescription description) {
+    List<String> names = new ArrayList<>();
+    for (TopologyDescription.Subtopology subtopology : description.subtopologies()) {
+      for (TopologyDescription.Node node : subtopology.nodes()) {
+        if (node instanceof TopologyDescription.Processor) {
+          names.add(node.name());
+        }
+      }
+    }
+    return names;
+  }
 
-    assertThat(context.getTopology().describe().subtopologies().isEmpty(), is(false));
+  private static void assertFlattenWasFusedAway(TopologyDescription description) {
+    // No node stands for the Flatten. If one did, it would be wired to both branches and so would
+    // run over a merged subtopology whose smaller-parallelism parent could not reach all of its
+    // instances.
+    for (String name : processorNames(description)) {
+      assertThat(
+          "no processor node should stand for the Flatten, but found " + name,
+          name.contains(FLATTEN_NAME),
+          is(false));
+    }
+    // The branches stay in separate subtopologies for the same reason: the source-fed branch, the
+    // one behind the shuffle, and the second source-fed branch.
+    assertThat(description.subtopologies().size(), is(3));
   }
 
   @Test
-  public void theSameShapeTranslatesAtASingleParallelism() {
-    KafkaStreamsTranslationContext context =
-        KafkaStreamsTestRunner.translate(mixedParallelismFlatten(1));
+  public void branchesAtDifferentParallelismsAreFusedRatherThanLeftToTheRunner() {
+    assertFlattenWasFusedAway(
+        KafkaStreamsTestRunner.translate(mixedParallelismFlatten(4)).getTopology().describe());
+  }
 
-    assertThat(context.getTopology().describe().subtopologies().isEmpty(), is(false));
+  @Test
+  public void theSameHoldsAtASingleParallelism() {
+    // Whether the Flatten is fused is a property of the fused graph, not of the parallelism, so
+    // the shape is the same either way — which is why raising the parallelism cannot introduce a
+    // Flatten node over mismatched branches.
+    assertFlattenWasFusedAway(
+        KafkaStreamsTestRunner.translate(mixedParallelismFlatten(1)).getTopology().describe());
   }
 }


### PR DESCRIPTION
## Summary

Part of #18479. Enables `CombineTest` in the ValidatesRunner suite, and picks up two review follow-ups from #39546 and #39578.

## Combine coverage

Combine has always been expected to work here without a translator of its own: the fuser expands `Combine.perKey` into a GroupByKey with the combining logic running as ordinary ParDos in the SDK harness, all of which the runner already executes. That was an assumption though — nothing exercised it. Enabling `CombineTest` takes the suite from 49 to 59 tests and makes it a tested claim.

| Suite | Tests |
| --- | --- |
| `CombineTest$BasicTests` | 8 |
| `CombineTest$WindowingTests` | 2 |

`BasicTests` passes in full, including hot-key fanout and the accumulation-mode variant; `WindowingTests` contributes the fixed-window and empty-window cases. The rest falls out on category excludes the task already declares — `CombineWithContextTests` and `AccumulationTests` need side inputs, and most of `WindowingTests` needs side inputs, triggers or `TestStream`.

`CombineTest$WindowingTests.testSessionsCombine` is sickbayed. Session windows are merging windows, which the first windowing pass did not implement, so it joins the existing `testGroupByKeyMergingWindows` entry under a comment now worded to cover Combine too. That is the *only* Combine failure, and it is the known windowing gap rather than anything specific to Combine.

## Flatten: what the `Math.max` is actually doing

The review question on #39546 was whether the `Math.max` over the inputs' partition counts is redundant, since the comment above it asserted the inputs are co-partitioned.

Neither half of that was quite right, so both are now fixed. The max is not a no-op in principle: Kafka Streams merges the subtopologies of every parent a processor is wired to and gives the merged subtopology as many tasks as its largest source topic has partitions, so the max is what that task count comes to. But the mismatched case does not reach this translator at all. A Flatten whose branches would disagree — one through a GroupByKey, one straight from a source — is folded into the SDK harness stage by the fuser rather than becoming a node here, and the runner Flattens that do arrive come from the fuser deduplicating partial outputs of a single PCollection.

I tried to build the mismatched shape to see what the runner does with it, and could not: it never becomes a runner Flatten. `FlattenParallelismTest` records that, so if a change ever lets that shape through, it starts failing and the partition-count handling gets revisited. The comment now describes the situation instead of asserting an invariant nothing enforces.

Worth stating why this is not just tidying. If such a Flatten ever did reach the translator, the branch with fewer partitions would only produce on that many of the merged subtopology's tasks, and the remaining Flatten instances would wait forever for a watermark report from it. A stalled pipeline is a bad failure mode to leave undetected, which is what the test is guarding.

## Partitioner: guard the null key

`GroupByKeyBroadcastPartitioner.partition()` guarded against a null record key, but `partitions()` — the method Kafka Streams actually calls when it is present — hashed it unguarded. Nothing reaches that today, because data arriving at a repartition sink has been re-keyed by `ShuffleByKeyProcessor` first, but the guard belongs on the method that runs.

That is the groundwork for the other half of the review point: that a stateless stage should carry a null key rather than the empty-array placeholder Impulse and Read emit. That change is more invasive than it looks — every processor is declared `Processor<byte[], …, byte[], …>`, so emitting a null key means moving all of them, plus the payload serde and the partitioner generics, to `byte @Nullable []`, or adding nullness suppressions in several places. It is worth doing, but as its own change rather than folded in here.

## Testing

```
./gradlew :runners:kafka-streams:validatesRunner   # 59 tests, 0 failures
./gradlew :runners:kafka-streams:build            # 82 unit tests, spotless + checker + errorprone
```
