### PR TITLE
Fix Dataflow ValueProvider serialization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,6 +112,7 @@
 
 ## Bugfixes
 
+* Fixed unresolved runtime `ValueProvider` options being stringified in Python Dataflow Flex Templates ([#39499](https://github.com/apache/beam/issues/39499)).
 * Fixed unbounded checkpoint state growth for splittable DoFns that self-checkpoint on the portable Flink runner (Java) ([#27648](https://github.com/apache/beam/issues/27648)).
 * Improved Java pipeline performance by avoiding repeated `DoFn` type descriptor resolution when creating cached invokers ([#39309](https://github.com/apache/beam/issues/39309)).
 * (Python) Fixed a memory leak in Python SDK caused by storing exceptions with potentially large stack frames in a cache ([#39406](https://github.com/apache/beam/issues/39406)).

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
@@ -280,8 +280,10 @@ class Environment(object):
       for k, v in sdk_pipeline_options.items():
         if v is None:
           continue
-        options_dict[k] = str(v) if isinstance(
-            v, value_provider.ValueProvider) else v
+        if isinstance(v, value_provider.ValueProvider):
+          options_dict[k] = v.get() if v.is_accessible() else None
+        else:
+          options_dict[k] = v
       options_dict["pipelineUrl"] = proto_pipeline_staged_url
       if pipeline_proto_hash:
         options_dict["pipelineProtoHash"] = pipeline_proto_hash

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
@@ -113,6 +113,25 @@ class UtilTest(unittest.TestCase):
 
     self.assertEqual(pipeline_url, FAKE_PIPELINE_URL)
 
+  def test_value_provider_options_serialization(self):
+    class UserOptions(PipelineOptions):
+      @classmethod
+      def _add_argparse_args(cls, parser):
+        parser.add_value_provider_argument('--at_vp_arg1')
+        parser.add_value_provider_argument('--at_vp_arg2')
+
+    pipeline_options = UserOptions([
+        '--at_vp_arg2', 'provided', '--temp_location', 'gs://any-location/temp'
+    ])
+    env = apiclient.Environment([],
+                                pipeline_options,
+                                '2.0.0',
+                                FAKE_PIPELINE_URL)
+
+    recovered_options = env.proto.sdk_pipeline_options['options']
+    self.assertIsNone(recovered_options['at_vp_arg1'])
+    self.assertEqual(recovered_options['at_vp_arg2'], 'provided')
+
   def test_pipeline_proto_hash(self):
     pipeline_options = PipelineOptions(
         ['--temp_location', 'gs://any-location/temp'])


### PR DESCRIPTION
Fixes #39499.

Python Dataflow client migration changed `ValueProvider` serialization to `str(v)`. Unset runtime providers were consequently sent in `sdk_pipeline_options` as their object representation, which Flex Template workers treated as the runtime value.

This restores previous JSON behavior:

- accessible providers serialize their resolved value
- inaccessible providers serialize as `null`
- focused coverage checks both static and unresolved runtime providers
- `CHANGES.md` documents the 2.76.0 bug fix

## Reproduction

Before the fix, the new test fails with:

```
AssertionError: 'RuntimeValueProvider(option: at_vp_arg1, type: str, default_value: None)' is not None
```

The same test passes after restoring value-aware serialization.

## Testing

- `uvx tox -e py311-cloud -- apache_beam/runners/dataflow/internal/apiclient_test.py -k test_value_provider_options_serialization`
- `target/.tox/py311-cloud/bin/pytest -q apache_beam/runners/dataflow/internal/apiclient_test.py apache_beam/internal/gcp/json_value_test.py` (78 passed, 1 skipped)
- `uvx pre-commit run --files CHANGES.md sdks/python/apache_beam/runners/dataflow/internal/apiclient.py sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py`

------------------------

- [x] Linked relevant issue.
- [x] Updated `CHANGES.md`.
- [x] Small contribution; ICLA not applicable.
