### PR TITLE
[Java] Avoid RowCoder bytecode generation

### DIFF
--- a/sdks/java/core/jmh/src/main/java/org/apache/beam/sdk/jmh/coders/RowCoderBenchmark.java
+++ b/sdks/java/core/jmh/src/main/java/org/apache/beam/sdk/jmh/coders/RowCoderBenchmark.java
@@ -46,6 +46,12 @@ public class RowCoderBenchmark {
     @Param({"false", "true"})
     boolean staticEncoding;
 
+    @Param({"2", "1024"})
+    int fieldCount;
+
+    @Param({"false", "true"})
+    boolean nested;
+
     RowCoder coder;
     Row row;
     ByteArrayOutputStream output;
@@ -53,21 +59,59 @@ public class RowCoderBenchmark {
 
     @Setup(Level.Trial)
     public void setup() throws Exception {
-      Schema.Builder builder =
-          Schema.builder().addByteField("_pythonsdk_any_type_byte").addByteArrayField("payload");
-      if (staticEncoding) {
-        builder.setOptions(
-            Schema.Options.builder()
-                .setOption("beam:option:row:static_encoding", FieldType.BOOLEAN, true)
-                .build());
-      }
-      Schema schema = builder.build();
+      Schema schema = newSchema(fieldCount, nested, staticEncoding);
       coder = RowCoder.of(schema);
-      row = Row.withSchema(schema).addValues((byte) 5, new byte[] {1, 2, 3, 4}).build();
+      row = newRow(schema);
       output = new ByteArrayOutputStream(64);
       coder.encode(row, output);
       input = new ByteArrayInputStream(output.toByteArray());
+      if (!row.equals(coder.decode(input))) {
+        throw new IllegalStateException("Benchmark row did not round trip");
+      }
+      input.reset();
     }
+  }
+
+  // A nested case has fieldCount top-level fields, each containing a two-field row.
+  static Schema newSchema(int fieldCount, boolean nested, boolean staticEncoding) {
+    Schema.Builder builder = Schema.builder();
+    Schema nestedSchema = nested ? newSchema(2, false, staticEncoding) : null;
+    for (int i = 0; i < fieldCount; ++i) {
+      if (nested) {
+        builder.addRowField("field" + i, nestedSchema);
+      } else if (i % 2 == 0) {
+        builder.addByteField("field" + i);
+      } else {
+        builder.addByteArrayField("field" + i);
+      }
+    }
+    if (staticEncoding) {
+      builder.setOptions(
+          Schema.Options.builder()
+              .setOption("beam:option:row:static_encoding", FieldType.BOOLEAN, true)
+              .build());
+    }
+    return builder.build();
+  }
+
+  private static Row newRow(Schema schema) {
+    Row.Builder builder = Row.withSchema(schema);
+    for (Schema.Field field : schema.getFields()) {
+      switch (field.getType().getTypeName()) {
+        case ROW:
+          builder.addValue(newRow(field.getType().getRowSchema()));
+          break;
+        case BYTE:
+          builder.addValue((byte) 5);
+          break;
+        case BYTES:
+          builder.addValue(new byte[] {1, 2, 3, 4});
+          break;
+        default:
+          throw new IllegalArgumentException("Unexpected benchmark field: " + field);
+      }
+    }
+    return builder.build();
   }
 
   @Benchmark

--- a/sdks/java/core/jmh/src/main/java/org/apache/beam/sdk/jmh/coders/RowCoderBenchmark.java
+++ b/sdks/java/core/jmh/src/main/java/org/apache/beam/sdk/jmh/coders/RowCoderBenchmark.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.jmh.coders;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.concurrent.TimeUnit;
+import org.apache.beam.sdk.coders.RowCoder;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.values.Row;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+public class RowCoderBenchmark {
+  @State(Scope.Thread)
+  public static class CoderState {
+    @Param({"false", "true"})
+    boolean staticEncoding;
+
+    RowCoder coder;
+    Row row;
+    ByteArrayOutputStream output;
+    ByteArrayInputStream input;
+
+    @Setup(Level.Trial)
+    public void setup() throws Exception {
+      Schema.Builder builder =
+          Schema.builder().addByteField("_pythonsdk_any_type_byte").addByteArrayField("payload");
+      if (staticEncoding) {
+        builder.setOptions(
+            Schema.Options.builder()
+                .setOption("beam:option:row:static_encoding", FieldType.BOOLEAN, true)
+                .build());
+      }
+      Schema schema = builder.build();
+      coder = RowCoder.of(schema);
+      row = Row.withSchema(schema).addValues((byte) 5, new byte[] {1, 2, 3, 4}).build();
+      output = new ByteArrayOutputStream(64);
+      coder.encode(row, output);
+      input = new ByteArrayInputStream(output.toByteArray());
+    }
+  }
+
+  @Benchmark
+  public int encode(CoderState state) throws Exception {
+    state.output.reset();
+    state.coder.encode(state.row, state.output);
+    return state.output.size();
+  }
+
+  @Benchmark
+  public Row decode(CoderState state) throws Exception {
+    state.input.reset();
+    return state.coder.decode(state.input);
+  }
+}

--- a/sdks/java/core/jmh/src/main/java/org/apache/beam/sdk/jmh/coders/RowCoderGenerationBenchmark.java
+++ b/sdks/java/core/jmh/src/main/java/org/apache/beam/sdk/jmh/coders/RowCoderGenerationBenchmark.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.jmh.coders;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.RowCoderGenerator;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.values.Row;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+public class RowCoderGenerationBenchmark {
+  @Benchmark
+  public Schema buildSchema() {
+    return newSchema();
+  }
+
+  @Benchmark
+  public Coder<Row> generate() {
+    return RowCoderGenerator.generate(newSchema());
+  }
+
+  private static Schema newSchema() {
+    return Schema.builder()
+        .addByteField("_pythonsdk_any_type_byte")
+        .addByteArrayField("payload")
+        .build();
+  }
+}

--- a/sdks/java/core/jmh/src/main/java/org/apache/beam/sdk/jmh/coders/RowCoderGenerationBenchmark.java
+++ b/sdks/java/core/jmh/src/main/java/org/apache/beam/sdk/jmh/coders/RowCoderGenerationBenchmark.java
@@ -27,6 +27,9 @@ import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.SingleShotTime)
@@ -34,20 +37,27 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 5)
 @Measurement(iterations = 10)
 public class RowCoderGenerationBenchmark {
-  @Benchmark
-  public Schema buildSchema() {
-    return newSchema();
+  @State(Scope.Thread)
+  public static class SchemaState {
+    @Param({"2", "1024"})
+    int fieldCount;
+
+    @Param({"false", "true"})
+    boolean nested;
+
+    Schema newSchema() {
+      // Each invocation creates fresh schema UUIDs so generation cannot hit the coder cache.
+      return RowCoderBenchmark.newSchema(fieldCount, nested, false);
+    }
   }
 
   @Benchmark
-  public Coder<Row> generate() {
-    return RowCoderGenerator.generate(newSchema());
+  public Schema buildSchema(SchemaState state) {
+    return state.newSchema();
   }
 
-  private static Schema newSchema() {
-    return Schema.builder()
-        .addByteField("_pythonsdk_any_type_byte")
-        .addByteArrayField("payload")
-        .build();
+  @Benchmark
+  public Coder<Row> generate(SchemaState state) {
+    return RowCoderGenerator.generate(state.newSchema());
   }
 }

--- a/sdks/java/core/jmh/src/main/java/org/apache/beam/sdk/jmh/coders/package-info.java
+++ b/sdks/java/core/jmh/src/main/java/org/apache/beam/sdk/jmh/coders/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Benchmarks for coders. */
+package org.apache.beam.sdk.jmh.coders;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoderGenerator.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoderGenerator.java
@@ -17,45 +17,22 @@
  */
 package org.apache.beam.sdk.coders;
 
-import static org.apache.beam.sdk.util.ByteBuddyUtils.getClassLoadingStrategy;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Map;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
-import net.bytebuddy.ByteBuddy;
-import net.bytebuddy.description.modifier.FieldManifestation;
-import net.bytebuddy.description.modifier.Ownership;
-import net.bytebuddy.description.modifier.Visibility;
-import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.description.type.TypeDescription.ForLoadedType;
-import net.bytebuddy.dynamic.DynamicType;
-import net.bytebuddy.dynamic.scaffold.InstrumentedType;
-import net.bytebuddy.implementation.FixedValue;
-import net.bytebuddy.implementation.Implementation;
-import net.bytebuddy.implementation.bytecode.ByteCodeAppender;
-import net.bytebuddy.implementation.bytecode.ByteCodeAppender.Size;
-import net.bytebuddy.implementation.bytecode.Duplication;
-import net.bytebuddy.implementation.bytecode.StackManipulation;
-import net.bytebuddy.implementation.bytecode.member.FieldAccess;
-import net.bytebuddy.implementation.bytecode.member.MethodInvocation;
-import net.bytebuddy.implementation.bytecode.member.MethodReturn;
-import net.bytebuddy.implementation.bytecode.member.MethodVariableAccess;
-import net.bytebuddy.matcher.ElementMatchers;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.SchemaCoder;
 import org.apache.beam.sdk.util.StringUtils;
-import org.apache.beam.sdk.util.common.ReflectHelpers;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
@@ -63,56 +40,18 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * A utility for automatically generating a {@link Coder} for {@link Row} objects corresponding to a
- * specific schema. The resulting coder is loaded into the default ClassLoader and returned.
- *
- * <p>When {@link RowCoderGenerator#generate(Schema)} is called, a new subclass of {@literal
- * Coder<Row>} is generated for the specified schema. This class is generated using low-level
- * bytecode generation, and hardcodes encodings for all fields of the Schema. Empirically, this is
- * 30-40% faster than a coder that introspects the schema.
- *
- * <p>The generated class corresponds to the following Java class:
- *
- * <pre><code>
- * class SchemaRowCoder extends{@literal Coder<Row>} {
- *   // Generated array containing a coder for each field in the Schema.
- *   private static final Coder[] FIELD_CODERS;
- *
- *   // Generated method to return the schema this class corresponds to. Used during code
- *   // generation.
- *   private static getSchema() {
- *     return schema;
- *   }
- *
- *  {@literal @}Override
- *   public void encode(T value, OutputStream outStream) {
- *     // Delegate to a method that evaluates each coder in the static array.
- *     encodeDelegate(FIELD_CODERS, value, outStream);
- *   }
- *
- *  {@literal @}Override
- *   public abstract T decode(InputStream inStream) {
- *     // Delegate to a method that evaluates each coder in the static array.
- *     return decodeDelegate(FIELD_CODERS, inStream);
- *   }
- * }
- * </code></pre>
- */
+/** Creates and caches a {@link Coder} for {@link Row} objects corresponding to a schema. */
 @SuppressWarnings({
   "nullness", // TODO(https://github.com/apache/beam/issues/20497)
   "rawtypes"
 })
 public abstract class RowCoderGenerator {
-  private static final ByteBuddy BYTE_BUDDY = new ByteBuddy();
   private static final BitSetCoder NULL_LIST_CODER = BitSetCoder.of();
   private static final VarIntCoder VAR_INT_CODER = VarIntCoder.of();
   // BitSet.get(n) will return false for any n >= nbits, so a BitSet with 0 bits will return false
   // for all calls to get.
   private static final BitSet EMPTY_BIT_SET = new BitSet(0);
 
-  private static final String CODERS_FIELD_NAME = "FIELD_CODERS";
-  private static final String POSITIONS_FIELD_NAME = "FIELD_ENCODING_POSITIONS";
   private static final String SCHEMA_OPTION_STATIC_ENCODING = "beam:option:row:static_encoding";
 
   static class WithStackTrace<T> {
@@ -133,7 +72,7 @@ public abstract class RowCoderGenerator {
     }
   }
 
-  // Cache for Coder class that are already generated.
+  // Cache for coders that are already created.
   @GuardedBy("cacheLock")
   private static final Map<UUID, WithStackTrace<Coder<Row>>> GENERATED_CODERS = Maps.newHashMap();
 
@@ -198,7 +137,6 @@ public abstract class RowCoderGenerator {
     }
   }
 
-  @SuppressWarnings("unchecked")
   public static Coder<Row> generate(Schema schema) {
     UUID uuid = Preconditions.checkNotNull(schema.getUUID());
     // Avoid using computeIfAbsent which may cause issues with nested schemas.
@@ -207,12 +145,6 @@ public abstract class RowCoderGenerator {
       if (existingRowCoder != null) {
         return existingRowCoder.getValue();
       }
-      TypeDescription.Generic coderType =
-          TypeDescription.Generic.Builder.parameterizedType(Coder.class, Row.class).build();
-      DynamicType.Builder<Coder> builder =
-          (DynamicType.Builder<Coder>) BYTE_BUDDY.subclass(coderType);
-      builder = implementMethods(schema, builder);
-
       int[] encodingPosToRowIndex = new int[schema.getFieldCount()];
       @Nullable
       WithStackTrace<Map<String, Integer>> existingEncodingPositions =
@@ -241,33 +173,12 @@ public abstract class RowCoderGenerator {
             SchemaCoder.coderForFieldType(schema.getField(rowIndex).getType().withNullable(false));
       }
 
-      builder =
-          builder
-              .defineField(
-                  CODERS_FIELD_NAME, Coder[].class, Visibility.PRIVATE, FieldManifestation.FINAL)
-              .defineField(
-                  POSITIONS_FIELD_NAME, int[].class, Visibility.PRIVATE, FieldManifestation.FINAL)
-              .defineConstructor(Modifier.PUBLIC)
-              .withParameters(Coder[].class, int[].class)
-              .intercept(new GeneratedCoderConstructor());
-
-      Coder<Row> rowCoder;
-      try {
-        rowCoder =
-            builder
-                .make()
-                .load(
-                    ReflectHelpers.findClassLoader(Coder.class.getClassLoader()),
-                    getClassLoadingStrategy(Coder.class))
-                .getLoaded()
-                .getDeclaredConstructor(Coder[].class, int[].class)
-                .newInstance((Object) componentCoders, (Object) encodingPosToRowIndex);
-      } catch (InstantiationException
-          | IllegalAccessException
-          | NoSuchMethodException
-          | InvocationTargetException e) {
-        throw new RuntimeException("Unable to generate coder for schema " + schema, e);
-      }
+      Coder<Row> rowCoder =
+          new RowCoderImpl(
+              schema,
+              componentCoders,
+              encodingPosToRowIndex,
+              schema.getFields().stream().map(Field::getType).anyMatch(FieldType::getNullable));
       String stackTrace = getStackTrace();
       GENERATED_CODERS.put(uuid, new WithStackTrace<>(rowCoder, stackTrace));
       LOG.debug(
@@ -279,126 +190,32 @@ public abstract class RowCoderGenerator {
     }
   }
 
-  private static class GeneratedCoderConstructor implements Implementation {
-    @Override
-    public InstrumentedType prepare(InstrumentedType instrumentedType) {
-      return instrumentedType;
+  private static final class RowCoderImpl extends CustomCoder<Row> {
+    private final Schema schema;
+    private final Coder[] coders;
+    private final int[] encodingPosToIndex;
+    private final boolean hasNullableFields;
+
+    private RowCoderImpl(
+        Schema schema, Coder[] coders, int[] encodingPosToIndex, boolean hasNullableFields) {
+      this.schema = schema;
+      this.coders = coders;
+      this.encodingPosToIndex = encodingPosToIndex;
+      this.hasNullableFields = hasNullableFields;
     }
 
     @Override
-    public ByteCodeAppender appender(final Target implementationTarget) {
-      return (methodVisitor, implementationContext, instrumentedMethod) -> {
-        int numLocals = 1 + instrumentedMethod.getParameters().size();
-        StackManipulation stackManipulation =
-            new StackManipulation.Compound(
-                // Call the base constructor.
-                MethodVariableAccess.loadThis(),
-                Duplication.SINGLE,
-                MethodInvocation.invoke(
-                    new ForLoadedType(Coder.class)
-                        .getDeclaredMethods()
-                        .filter(
-                            ElementMatchers.isConstructor().and(ElementMatchers.takesArguments(0)))
-                        .getOnly()),
-                Duplication.SINGLE,
-                // Store the list of Coders as a member variable.
-                MethodVariableAccess.REFERENCE.loadFrom(1),
-                FieldAccess.forField(
-                        implementationTarget
-                            .getInstrumentedType()
-                            .getDeclaredFields()
-                            .filter(ElementMatchers.named(CODERS_FIELD_NAME))
-                            .getOnly())
-                    .write(),
-                // Store the list of encoding offsets as a member variable.
-                MethodVariableAccess.REFERENCE.loadFrom(2),
-                FieldAccess.forField(
-                        implementationTarget
-                            .getInstrumentedType()
-                            .getDeclaredFields()
-                            .filter(ElementMatchers.named(POSITIONS_FIELD_NAME))
-                            .getOnly())
-                    .write(),
-                MethodReturn.VOID);
-        StackManipulation.Size size = stackManipulation.apply(methodVisitor, implementationContext);
-        return new Size(size.getMaximalSize(), numLocals);
-      };
-    }
-  }
-
-  private static DynamicType.Builder<Coder> implementMethods(
-      Schema schema, DynamicType.Builder<Coder> builder) {
-    boolean hasNullableFields =
-        schema.getFields().stream().map(Field::getType).anyMatch(FieldType::getNullable);
-    return builder
-        .defineMethod("getSchema", Schema.class, Visibility.PRIVATE, Ownership.STATIC)
-        .intercept(FixedValue.reference(schema))
-        .defineMethod("hasNullableFields", boolean.class, Visibility.PRIVATE, Ownership.STATIC)
-        .intercept(FixedValue.reference(hasNullableFields))
-        .method(ElementMatchers.named("encode"))
-        .intercept(new EncodeInstruction())
-        .method(ElementMatchers.named("decode"))
-        .intercept(new DecodeInstruction());
-  }
-
-  private static class EncodeInstruction implements Implementation {
-    static final ForLoadedType LOADED_TYPE = new ForLoadedType(EncodeInstruction.class);
-
-    @Override
-    public ByteCodeAppender appender(Target implementationTarget) {
-      return (methodVisitor, implementationContext, instrumentedMethod) -> {
-        StackManipulation manipulation =
-            new StackManipulation.Compound(
-                // Array of coders.
-                MethodVariableAccess.loadThis(),
-                FieldAccess.forField(
-                        implementationContext
-                            .getInstrumentedType()
-                            .getDeclaredFields()
-                            .filter(ElementMatchers.named(CODERS_FIELD_NAME))
-                            .getOnly())
-                    .read(),
-                MethodVariableAccess.loadThis(),
-                FieldAccess.forField(
-                        implementationContext
-                            .getInstrumentedType()
-                            .getDeclaredFields()
-                            .filter(ElementMatchers.named(POSITIONS_FIELD_NAME))
-                            .getOnly())
-                    .read(),
-                // Element to encode. (offset 1, as offset 0 is always "this").
-                MethodVariableAccess.REFERENCE.loadFrom(1),
-                // OutputStream.
-                MethodVariableAccess.REFERENCE.loadFrom(2),
-                // hasNullableFields
-                MethodInvocation.invoke(
-                    implementationContext
-                        .getInstrumentedType()
-                        .getDeclaredMethods()
-                        .filter(ElementMatchers.named("hasNullableFields"))
-                        .getOnly()),
-                // Call EncodeInstruction.encodeDelegate
-                MethodInvocation.invoke(
-                    LOADED_TYPE
-                        .getDeclaredMethods()
-                        .filter(
-                            ElementMatchers.isStatic().and(ElementMatchers.named("encodeDelegate")))
-                        .getOnly()),
-                MethodReturn.VOID);
-        StackManipulation.Size size = manipulation.apply(methodVisitor, implementationContext);
-        return new ByteCodeAppender.Size(size.getMaximalSize(), instrumentedMethod.getStackSize());
-      };
+    public void encode(Row value, OutputStream outputStream) throws IOException {
+      encodeDelegate(coders, encodingPosToIndex, value, outputStream, hasNullableFields);
     }
 
     @Override
-    public InstrumentedType prepare(InstrumentedType instrumentedType) {
-      return instrumentedType;
+    public Row decode(InputStream inputStream) throws IOException {
+      return decodeDelegate(schema, coders, encodingPosToIndex, inputStream);
     }
 
-    // The encode method of the generated Coder delegates to this method to evaluate all of the
-    // per-field Coders.
     @SuppressWarnings("unchecked")
-    static void encodeDelegate(
+    private static void encodeDelegate(
         Coder[] coders,
         int[] encodingPosToIndex,
         Row value,
@@ -463,62 +280,8 @@ public abstract class RowCoderGenerator {
       }
       return nullFields;
     }
-  }
 
-  private static class DecodeInstruction implements Implementation {
-    static final ForLoadedType LOADED_TYPE = new ForLoadedType(DecodeInstruction.class);
-
-    @Override
-    public ByteCodeAppender appender(Target implementationTarget) {
-      return (methodVisitor, implementationContext, instrumentedMethod) -> {
-        StackManipulation manipulation =
-            new StackManipulation.Compound(
-                // Schema. Used in generation of DecodeInstruction.
-                MethodInvocation.invoke(
-                    implementationContext
-                        .getInstrumentedType()
-                        .getDeclaredMethods()
-                        .filter(ElementMatchers.named("getSchema"))
-                        .getOnly()),
-                // Array of coders.
-                MethodVariableAccess.loadThis(),
-                FieldAccess.forField(
-                        implementationContext
-                            .getInstrumentedType()
-                            .getDeclaredFields()
-                            .filter(ElementMatchers.named(CODERS_FIELD_NAME))
-                            .getOnly())
-                    .read(),
-                MethodVariableAccess.loadThis(),
-                FieldAccess.forField(
-                        implementationContext
-                            .getInstrumentedType()
-                            .getDeclaredFields()
-                            .filter(ElementMatchers.named(POSITIONS_FIELD_NAME))
-                            .getOnly())
-                    .read(),
-                // read the InputStream. (offset 1, as offset 0 is always "this").
-                MethodVariableAccess.REFERENCE.loadFrom(1),
-                MethodInvocation.invoke(
-                    LOADED_TYPE
-                        .getDeclaredMethods()
-                        .filter(
-                            ElementMatchers.isStatic().and(ElementMatchers.named("decodeDelegate")))
-                        .getOnly()),
-                MethodReturn.REFERENCE);
-        StackManipulation.Size size = manipulation.apply(methodVisitor, implementationContext);
-        return new ByteCodeAppender.Size(size.getMaximalSize(), instrumentedMethod.getStackSize());
-      };
-    }
-
-    @Override
-    public InstrumentedType prepare(InstrumentedType instrumentedType) {
-      return instrumentedType;
-    }
-
-    // The decode method of the generated Coder delegates to this method to evaluate all of the
-    // per-field Coders.
-    static Row decodeDelegate(
+    private static Row decodeDelegate(
         Schema schema, Coder[] coders, int[] encodingPosToIndex, InputStream inputStream)
         throws IOException {
       int fieldCount;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaCoder.java
@@ -110,7 +110,7 @@ public class SchemaCoder<T> extends CustomCoder<T> {
   private Coder<Row> getDelegateCoder() {
     if (delegateCoder == null) {
       // RowCoderGenerator caches based on id, so if a new instance of this RowCoder is
-      // deserialized, we don't need to run ByteBuddy again to construct the class.
+      // deserialized, we don't need to construct the delegate again.
       delegateCoder = RowCoderGenerator.generate(schema);
     }
     return delegateCoder;


### PR DESCRIPTION
`RowCoderGenerator` creates and loads a ByteBuddy class for each uncached schema. This replaces those generated forwarding classes with one immutable `CustomCoder<Row>`, retaining the schema UUID cache, encoding-position overrides, precomputed component coders, null handling, and encode/decode algorithms.

The measured benefit is cheaper uncached coder creation and less class-generation machinery. These microbenchmarks do not establish an improvement in total worker startup or pipeline runtime. Generated classes can also affect JVM optimization, even when their source-level delegates are the same: the expanded benchmarks below show a small nested-decoding cost in this run. This PR remains draft while that tradeoff is reviewed.

## Large and nested schema benchmarks

The benchmarks cover 2 and 1,024 top-level fields, flat and nested rows, and both static and dynamic encoding. Each nested field contains a two-scalar-field row, so the largest nested case has 2,048 scalar leaves. Fields are non-null; nullable correctness remains covered by the unit tests. Benchmark setup verifies an encode/decode round trip.

JDK 21.0.11, JMH 1.34, one thread, two fresh JVM forks per case, and a fixed 256 MiB heap. Steady-state runs use three one-second warmup iterations and five one-second measurements per fork. Generation uses five warmups and ten single-shot measurements per fork, with a fresh schema UUID per invocation and a schema-construction control. Both versions use the same benchmark and dependency classpath; the baseline substitutes the pre-PR `RowCoderGenerator` from merge base `77a11347746d702040035bf673ae5596b8c0deba`.

In the full matrix, uncached generation takes 48% to 97% less time. Nested dynamic decoding takes about 1.4% to 1.5% more time, while large dynamic encoding takes about 1% less time. Those differences have non-overlapping JMH intervals in this run. The other steady-state intervals overlap, which does not prove equivalent performance.

### Steady-state encoding and decoding

| Operation | Fields | Nested | Static | Baseline | PR | Delta | CI overlap |
| --- | ---: | --- | --- | ---: | ---: | ---: | --- |
| decode | 2 | false | false | 143.856 ± 3.059 | 141.786 ± 0.339 | -1.4% | yes |
| decode | 2 | false | true | 105.379 ± 3.448 | 102.956 ± 0.295 | -2.3% | yes |
| decode | 2 | true | false | 349.284 ± 1.492 | 354.303 ± 0.677 | +1.4% | NO |
| decode | 2 | true | true | 232.926 ± 6.921 | 239.637 ± 0.999 | +2.9% | yes |
| decode | 1024 | false | false | 32239.912 ± 137.486 | 32055.925 ± 413.399 | -0.6% | yes |
| decode | 1024 | false | true | 31941.739 ± 124.761 | 31788.384 ± 152.501 | -0.5% | yes |
| decode | 1024 | true | false | 141062.867 ± 193.572 | 143162.173 ± 220.386 | +1.5% | NO |
| decode | 1024 | true | true | 96388.643 ± 876.604 | 99638.545 ± 3447.966 | +3.4% | yes |
| encode | 2 | false | false | 122.752 ± 0.444 | 122.256 ± 1.654 | -0.4% | yes |
| encode | 2 | false | true | 84.958 ± 0.249 | 84.943 ± 0.782 | -0.0% | yes |
| encode | 2 | true | false | 267.772 ± 1.780 | 266.938 ± 1.528 | -0.3% | yes |
| encode | 2 | true | true | 153.798 ± 2.809 | 151.681 ± 0.761 | -1.4% | yes |
| encode | 1024 | false | false | 33896.642 ± 99.083 | 33518.694 ± 133.647 | -1.1% | NO |
| encode | 1024 | false | true | 22265.421 ± 44.222 | 22350.275 ± 157.844 | +0.4% | yes |
| encode | 1024 | true | false | 136650.399 ± 472.765 | 135283.834 ± 369.174 | -1.0% | NO |
| encode | 1024 | true | true | 60128.121 ± 836.998 | 59904.478 ± 3979.238 | -0.4% | yes |

Units: ns/op; ± is JMH 99.9% confidence interval half-width.

### Uncached generation and schema construction

| Operation | Fields | Nested | Static | Baseline | PR | Delta | CI overlap |
| --- | ---: | --- | --- | ---: | ---: | ---: | --- |
| buildSchema | 2 | false | n/a | 42.265 ± 15.750 | 37.605 ± 14.873 | -11.0% | yes |
| buildSchema | 2 | true | n/a | 81.910 ± 21.225 | 71.099 ± 15.305 | -13.2% | yes |
| buildSchema | 1024 | false | n/a | 989.413 ± 150.391 | 968.540 ± 151.825 | -2.1% | yes |
| buildSchema | 1024 | true | n/a | 1170.750 ± 395.736 | 1076.936 ± 194.098 | -8.0% | yes |
| generate | 2 | false | n/a | 3999.797 ± 850.965 | 108.903 ± 23.316 | -97.3% | NO |
| generate | 2 | true | n/a | 3821.793 ± 568.833 | 184.776 ± 32.288 | -95.2% | NO |
| generate | 1024 | false | n/a | 4782.310 ± 668.789 | 1344.075 ± 249.599 | -71.9% | NO |
| generate | 1024 | true | n/a | 7906.075 ± 1640.051 | 4091.236 ± 654.041 | -48.3% | NO |

Units: us/op; ± is JMH 99.9% confidence interval half-width.

### Reverse-order nested decode confirmation

A second run, with the PR measured before the baseline, reproduces the dynamic nested decode cost at about 1.5% to 1.6%. It also measures a 4.6% cost for the small nested static case; the first pass measured 2.9% with overlapping intervals. The large nested static intervals still overlap.


| Fields | Static | Baseline ns/op | PR ns/op | Delta | CI overlap |
| ---: | --- | ---: | ---: | ---: | --- |
| 2 | false | 349.678 ± 0.590 | 354.777 ± 0.465 | +1.5% | NO |
| 2 | true | 228.309 ± 1.692 | 238.845 ± 1.783 | +4.6% | NO |
| 1024 | false | 140966.673 ± 138.393 | 143235.672 ± 265.550 | +1.6% | NO |
| 1024 | true | 96649.567 ± 939.941 | 97825.333 ± 2540.487 | +1.2% | yes |

Same protocol; PR ran before baseline. Intervals are 99.9%.

Reproduce the matrix on each implementation with:

```sh
./gradlew :sdks:java:core:jmh:jmh --args='RowCoderBenchmark -f 2 -wi 3 -i 5 -w 1s -r 1s -jvmArgs "-Xms256m -Xmx256m" -foe true'
./gradlew :sdks:java:core:jmh:jmh --args='RowCoderGenerationBenchmark -f 2 -jvmArgs "-Xms256m -Xmx256m" -foe true'
```

## Validation

- `RowCoderTest`: 28 passed.
- `SchemaCoderTest`: 19 passed.
- Both benchmark classes compile; all 16 steady-state cases and 8 generation/control cases run on both implementations.
- Spotless and `git diff --check` pass.

No API or wire-format change is intended. End-to-end worker performance and additional schema shapes remain unmeasured.
