### PR TITLE
fix PostCommit Python Dependency

### DIFF
--- a/.github/trigger_files/beam_PostCommit_Python_Dependency.json
+++ b/.github/trigger_files/beam_PostCommit_Python_Dependency.json
@@ -1,4 +1,4 @@
 {
     "comment": "Modify this file in a trivial way to cause this test suite to run",
-    "modification": 3
+    "modification": 4
   }

--- a/sdks/python/test-suites/tox/py310/build.gradle
+++ b/sdks/python/test-suites/tox/py310/build.gradle
@@ -44,22 +44,9 @@ project.tasks.register("preCommitPyCoverage") {
 // e.g. pyarrow and pandas also run on PreCommit Dataframe and Coverage
 project.tasks.register("postCommitPyDep") {}
 
-// Create a test task for supported major versions of pyarrow
-// We should have a test for the lowest supported version and
-// For versions that we would like to prioritize for testing,
-// for example versions released in a timeframe of last 1-2 years.
-
-toxTask "testPy310pyarrow-6", "py310-pyarrow-6", "${posargs}"
-test.dependsOn "testPy310pyarrow-6"
-postCommitPyDep.dependsOn "testPy310pyarrow-6"
-
-toxTask "testPy310pyarrow-15", "py310-pyarrow-15", "${posargs}"
-test.dependsOn "testPy310pyarrow-15"
-postCommitPyDep.dependsOn "testPy310pyarrow-15"
-
-toxTask "testPy310pyarrow-16", "py310-pyarrow-16", "${posargs}"
-test.dependsOn "testPy310pyarrow-16"
-postCommitPyDep.dependsOn "testPy310pyarrow-16"
+// Create a test task for supported major versions of pyarrow.
+// Keep in sync with [testenv:py{310,311}-pyarrow-...] in tox.ini
+// (versions released in roughly the last 1-2 years).
 
 toxTask "testPy310pyarrow-17", "py310-pyarrow-17", "${posargs}"
 test.dependsOn "testPy310pyarrow-17"
@@ -88,6 +75,14 @@ postCommitPyDep.dependsOn "testPy310pyarrow-22"
 toxTask "testPy310pyarrow-23", "py310-pyarrow-23", "${posargs}"
 test.dependsOn "testPy310pyarrow-23"
 postCommitPyDep.dependsOn "testPy310pyarrow-23"
+
+toxTask "testPy310pyarrow-24", "py310-pyarrow-24", "${posargs}"
+test.dependsOn "testPy310pyarrow-24"
+postCommitPyDep.dependsOn "testPy310pyarrow-24"
+
+toxTask "testPy310pyarrow-25", "py310-pyarrow-25", "${posargs}"
+test.dependsOn "testPy310pyarrow-25"
+postCommitPyDep.dependsOn "testPy310pyarrow-25"
 
 // Create a test task for each supported minor version of pandas
 toxTask "testPy310pandas-14", "py310-pandas-14", "${posargs}"


### PR DESCRIPTION
Fixes: #30799

After #39530 tox.ini removed pyarrow 6/15/16 and added 24/25 but py310/build.gradle still ran the old tox envs and that made python 3.10 fail with environments not found so I updated the Gradle tasks to match tox.ini: drop 6/15/16 and add 24/25
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
