### PR TITLE
Enable Apache Iceberg REST Metrics Reporting for Lakehouse

### DIFF
--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/AddFilesIT.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/AddFilesIT.java
@@ -126,8 +126,7 @@ public class AddFilesIT {
           "warehouse", WAREHOUSE,
           "header.x-goog-user-project", PROJECT,
           "rest.auth.type", "google",
-          "io-impl", "org.apache.iceberg.gcp.gcs.GCSFileIO",
-          "rest-metrics-reporting-enabled", "false");
+          "io-impl", "org.apache.iceberg.gcp.gcs.GCSFileIO");
   private Storage storage;
   private PubsubClient pubsub;
   private Notification notification;

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/catalog/RESTCatalogBLMSIT.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/catalog/RESTCatalogBLMSIT.java
@@ -41,7 +41,6 @@ public class RESTCatalogBLMSIT extends IcebergCatalogBaseIT {
             .put("uri", "https://biglake.googleapis.com/iceberg/v1/restcatalog")
             .put("warehouse", BIGLAKE_WAREHOUSE)
             .put("header.x-goog-user-project", OPTIONS.getProject())
-            .put("rest-metrics-reporting-enabled", "false")
             .put("io-impl", "org.apache.iceberg.gcp.gcs.GCSFileIO")
             .put("rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager")
             .build();

--- a/sdks/python/apache_beam/transforms/managed_iceberg_it_test.py
+++ b/sdks/python/apache_beam/transforms/managed_iceberg_it_test.py
@@ -63,8 +63,7 @@ class ManagedIcebergIT(unittest.TestCase):
         'header.x-goog-user-project': 'apache-beam-testing',
         'rest.auth.type': 'google',
         'io-impl': 'org.apache.iceberg.gcp.gcs.GCSFileIO',
-        'header.X-Iceberg-Access-Delegation': 'vended-credentials',
-        'rest-metrics-reporting-enabled': 'false'
+        'header.X-Iceberg-Access-Delegation': 'vended-credentials'
     }
     iceberg_config = {
         "table": "test_iceberg_write_read.test_" + uuid.uuid4().hex,


### PR DESCRIPTION
According to https://docs.cloud.google.com/lakehouse/docs/release-notes#May_07_2026, we no longer need to override `rest-metrics-reporting-enabled` to `false`.