### PR TITLE
Fix GRPC channel leak

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/fn/data/BeamFnDataGrpcMultiplexer.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/fn/data/BeamFnDataGrpcMultiplexer.java
@@ -28,6 +28,7 @@ import java.util.function.Consumer;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
 import org.apache.beam.model.pipeline.v1.Endpoints;
 import org.apache.beam.sdk.fn.stream.OutboundObserverFactory;
+import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.ManagedChannel;
 import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.Status;
 import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.stub.StreamObserver;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
@@ -57,6 +58,7 @@ public class BeamFnDataGrpcMultiplexer implements AutoCloseable {
   private final Endpoints.@Nullable ApiServiceDescriptor apiServiceDescriptor;
   private final StreamObserver<BeamFnApi.Elements> inboundObserver;
   private final StreamObserver<BeamFnApi.Elements> outboundObserver;
+  private final @Nullable ManagedChannel channel;
   private final ConcurrentHashMap<
           /*instructionId=*/ String, CompletableFuture<CloseableFnDataReceiver<BeamFnApi.Elements>>>
       receivers;
@@ -73,7 +75,17 @@ public class BeamFnDataGrpcMultiplexer implements AutoCloseable {
       OutboundObserverFactory outboundObserverFactory,
       OutboundObserverFactory.BasicFactory<BeamFnApi.Elements, BeamFnApi.Elements>
           baseOutboundObserverFactory) {
+    this(apiServiceDescriptor, outboundObserverFactory, baseOutboundObserverFactory, null);
+  }
+
+  public BeamFnDataGrpcMultiplexer(
+      Endpoints.@Nullable ApiServiceDescriptor apiServiceDescriptor,
+      OutboundObserverFactory outboundObserverFactory,
+      OutboundObserverFactory.BasicFactory<BeamFnApi.Elements, BeamFnApi.Elements>
+          baseOutboundObserverFactory,
+      @Nullable ManagedChannel channel) {
     this.apiServiceDescriptor = apiServiceDescriptor;
+    this.channel = channel;
     this.receivers = new ConcurrentHashMap<>();
     this.poisonedInstructionIds =
         CacheBuilder.newBuilder().expireAfterWrite(POISONED_INSTRUCTION_ID_CACHE_TIMEOUT).build();
@@ -194,6 +206,9 @@ public class BeamFnDataGrpcMultiplexer implements AutoCloseable {
     outboundObserver.onError(
         Status.CANCELLED.withDescription("Multiplexer hanging up").asException());
     inboundObserver.onCompleted();
+    if (channel != null) {
+      channel.shutdown();
+    }
     if (exception != null) {
       throw exception;
     }

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/ExternalWorkerService.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/ExternalWorkerService.java
@@ -39,6 +39,7 @@ import org.apache.beam.sdk.options.PortablePipelineOptions;
 import org.apache.beam.sdk.util.Sleeper;
 import org.apache.beam.sdk.util.construction.Environments;
 import org.apache.beam.sdk.util.construction.PipelineOptionsTranslation;
+import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.ManagedChannel;
 import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.stub.StreamObserver;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Sets;
@@ -78,13 +79,18 @@ public class ExternalWorkerService extends BeamFnExternalWorkerPoolImplBase impl
               .withInterceptors(
                   ImmutableList.of(AddHarnessIdInterceptor.create(request.getWorkerId())));
 
-      ProvisionServiceGrpc.ProvisionServiceBlockingStub provisionStub =
-          ProvisionServiceGrpc.newBlockingStub(
-              channelFactory.forDescriptor(request.getProvisionEndpoint()));
-      ProvisionApi.ProvisionInfo provisionInfo =
-          provisionStub
-              .getProvisionInfo(ProvisionApi.GetProvisionInfoRequest.newBuilder().build())
-              .getInfo();
+      ManagedChannel channel = channelFactory.forDescriptor(request.getProvisionEndpoint());
+      ProvisionApi.ProvisionInfo provisionInfo;
+      try {
+        ProvisionServiceGrpc.ProvisionServiceBlockingStub provisionStub =
+            ProvisionServiceGrpc.newBlockingStub(channel);
+        provisionInfo =
+            provisionStub
+                .getProvisionInfo(ProvisionApi.GetProvisionInfoRequest.newBuilder().build())
+                .getInfo();
+      } finally {
+        channel.shutdown();
+      }
 
       runnerCapabilites = Sets.newHashSet(provisionInfo.getRunnerCapabilitiesList());
       if (provisionInfo.hasControlEndpoint()) {

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnHarness.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnHarness.java
@@ -453,6 +453,9 @@ public class FnHarness {
         beamFnStatusClient.close();
       }
       processBundleHandler.shutdown();
+      if (channel != null) {
+        channel.shutdown();
+      }
     } catch (Exception e) {
       LOG.error("Shutting down harness due to exception", e);
       e.printStackTrace();

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/data/BeamFnDataGrpcClient.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/data/BeamFnDataGrpcClient.java
@@ -142,10 +142,10 @@ public class BeamFnDataGrpcClient implements BeamFnDataClient {
     return multiplexerCache.computeIfAbsent(
         key,
         k -> {
+          ManagedChannel channel = channelFactory.apply(apiServiceDescriptor);
           OutboundObserverFactory.BasicFactory<Elements, Elements> baseOutboundObserverFactory =
               inboundObserver -> {
-                BeamFnDataGrpc.BeamFnDataStub stub =
-                    BeamFnDataGrpc.newStub(channelFactory.apply(apiServiceDescriptor));
+                BeamFnDataGrpc.BeamFnDataStub stub = BeamFnDataGrpc.newStub(channel);
                 if (dataStreamId != null && !dataStreamId.isEmpty()) {
                   Metadata headers = new Metadata();
                   headers.put(
@@ -156,7 +156,7 @@ public class BeamFnDataGrpcClient implements BeamFnDataClient {
                 return stub.data(inboundObserver);
               };
           return new BeamFnDataGrpcMultiplexer(
-              apiServiceDescriptor, outboundObserverFactory, baseOutboundObserverFactory);
+              apiServiceDescriptor, outboundObserverFactory, baseOutboundObserverFactory, channel);
         });
   }
 }


### PR DESCRIPTION
### Description
#### Problem
When running Portable/YAML pipelines, gRPC outputs severe error logs indicating that ManagedChannel instances were garbage collected without being shut down:

```
SEVERE: *~*~*~ Previous channel ManagedChannelImpl{logId=..., target=...} was garbage collected without being shut down! ~*~*~*
    Make sure to call shutdown()/shutdownNow()
java.lang.Throwable: java.lang.RuntimeException: ManagedChannel allocation site
    at org.apache.beam.vendor.grpc.v1p69p0.io.grpc.internal.ManagedChannelOrphanWrapper$ManagedChannelReference.<init>(...)
```

#### Cause
Three places in the Java Fn Harness allocated gRPC ManagedChannel instances without shutting them down upon task completion or harness shutdown:

- ExternalWorkerService: A ManagedChannel was created to query the provision service for worker options, but was left unclosed after obtaining provisionInfo.
- BeamFnDataGrpcClient & BeamFnDataGrpcMultiplexer: BeamFnDataGrpcClient created a ManagedChannel per BeamFnDataGrpcMultiplexer, but neither stored nor shut down the channel when close() was called.
- FnHarness: The control service ManagedChannel was created during harness startup but was never shut down when FnHarness.main() finished.