### PR TITLE
[Python] Deflake TextIO footer test

### DIFF
--- a/sdks/python/apache_beam/io/textio_test.py
+++ b/sdks/python/apache_beam/io/textio_test.py
@@ -1677,9 +1677,10 @@ class TextSinkTest(unittest.TestCase):
     with TestPipeline() as pipeline:
       footer_text = 'footer'
       pcoll = pipeline | beam.core.Create(self.lines)
-      pcoll | 'Write' >> WriteToText(   # pylint: disable=expression-not-assigned
-        self.path,
-        footer=footer_text)
+      pcoll | 'Write' >> WriteToText(  # pylint: disable=expression-not-assigned
+          self.path,
+          shard_name_template='',
+          footer=footer_text)
 
     read_result = []
     for file_name in glob.glob(self.path + '*'):


### PR DESCRIPTION
Fixes #39639.

`TextSinkTest.test_write_pipeline_footer` let the runner choose its output shard count even though its assertions expect one trailing footer. Text sinks add the footer to every shard, so a multi-shard run leaves extra footer lines in the combined output.

Use one output shard for this test, matching the adjacent header test. Per-shard header and footer behavior remains covered by `test_write_max_bytes_per_shard`.

## Reproduction

Setting `num_shards=5` on current `master` reproduces the failure deterministically: four footer lines remain after the assertion removes the final footer.

## Testing

- Python 3.13 Gradle/tox targeted test
- 20 consecutive targeted test runs
- Related footer, header, max-records-per-shard, and max-bytes-per-shard tests

------------------------

- [x] Linked the issue with `Fixes #39639`.
- [x] No `CHANGES.md` entry needed for a test-only change.
- [x] Change is small and does not require an ICLA.
