### PR TITLE
[Python] Deflake anomaly transform tests

### DIFF
--- a/sdks/python/apache_beam/ml/anomaly/transforms_test.py
+++ b/sdks/python/apache_beam/ml/anomaly/transforms_test.py
@@ -310,6 +310,35 @@ class TestAnomalyDetection(unittest.TestCase):
       else:
         assert_that(result, equal_to(expected, _unkeyed_result_is_equal_to))
 
+  @parameterized.expand([(False, ), (True, )])
+  def test_ensemble_preserves_model_state(self, keyed):
+    # Constant values make the scores independent of processing order. Each
+    # model must produce exactly two warmup predictions per key.
+    input = [beam.Row(x1=1, x2=4)] * 6
+    counts_by_key = [(0, 6)]
+    if keyed:
+      input = [(1, row) for row in input] + [(2, beam.Row(x1=100, x2=50))] * 3
+      counts_by_key = [(1, 6), (2, 3)]
+
+    detectors = [
+        ZScore(features=[feature], model_id=feature)
+        for feature in ('x1', 'x2')
+    ]
+    expected = [(key, model_id, label) for key, count in counts_by_key
+                for model_id in ('x1', 'x2')
+                for label in [-2, -2] + [0] * (count - 2)]
+
+    with TestPipeline() as p:
+      result = (
+          p | beam.Create(input)
+          | AnomalyDetection(EnsembleAnomalyDetector(detectors)))
+      if not keyed:
+        result = result | beam.WithKeys(0)
+      labels = result | beam.FlatMap(
+          lambda item: [(item[0], prediction.model_id, prediction.label)
+                        for prediction in item[1].predictions])
+      assert_that(labels, equal_to(expected))
+
 
 class FakeNumpyModel():
   def __init__(self):

--- a/sdks/python/apache_beam/ml/anomaly/transforms_test.py
+++ b/sdks/python/apache_beam/ml/anomaly/transforms_test.py
@@ -32,6 +32,7 @@ from parameterized import parameterized
 
 import apache_beam as beam
 from apache_beam.ml.anomaly.aggregations import AnyVote
+from apache_beam.ml.anomaly.base import AnomalyDetector
 from apache_beam.ml.anomaly.base import AnomalyPrediction
 from apache_beam.ml.anomaly.base import AnomalyResult
 from apache_beam.ml.anomaly.base import EnsembleAnomalyDetector
@@ -116,18 +117,33 @@ def _keyed_result_is_equal_to(
   return a[0] == b[0] and _unkeyed_result_is_equal_to(a[1], b[1])
 
 
+@specifiable
+class _ValueDetector(AnomalyDetector):
+  def learn_one(self, unused_x: beam.Row) -> None:
+    pass
+
+  def score_one(self, x: beam.Row) -> float:
+    value = float(next(iter(x)))
+    return float('NaN') if value == -1 else value
+
+
 class TestAnomalyDetection(unittest.TestCase):
   class TestData:
     unkeyed_input = [
-        beam.Row(x1=1, x2=4),
-        beam.Row(x1=2, x2=4),
-        beam.Row(x1=3, x2=5),
-        beam.Row(x1=10, x2=4),  # outlier in key=1, with respect to x1
-        beam.Row(x1=2, x2=10),  # outlier in key=1, with respect to x2
-        beam.Row(x1=3, x2=4),
+        beam.Row(x1=1, x2=4, score_x1=-1.0, score_x2=-1.0),
+        beam.Row(x1=2, x2=4, score_x1=-1.0, score_x2=-1.0),
+        beam.Row(x1=3, x2=5, score_x1=2.1213203435596424, score_x2=0.0),
+        beam.Row(x1=10, x2=4, score_x1=8.0, score_x2=0.5773502691896252),
+        beam.Row(x1=2, x2=10, score_x1=0.4898979485566356, score_x2=11.5),
+        beam.Row(
+            x1=3,
+            x2=4,
+            score_x1=0.16452254913212455,
+            score_x2=0.5368754921931594),
     ]
-    keyed_input = list(zip(itertools.repeat(1),
-                           unkeyed_input)) + [(2, beam.Row(x1=100, x2=5))]
+    keyed_input = list(zip(itertools.repeat(1), unkeyed_input)) + [
+        (2, beam.Row(x1=100, x2=5, score_x1=-1.0, score_x2=-1.0))
+    ]
 
     zscore_x1_expected_predictions = [
         AnomalyPrediction(
@@ -244,10 +260,14 @@ class TestAnomalyDetection(unittest.TestCase):
   ])
   def test_multiple_detectors_without_aggregation(self, input, expected):
     sub_detectors = []
-    sub_detectors.append(ZScore(features=["x1"], model_id="zscore_x1"))
     sub_detectors.append(
-        ZScore(
-            features=["x2"],
+        _ValueDetector(
+            features=["score_x1"],
+            threshold_criterion=FixedThreshold(3),
+            model_id="zscore_x1"))
+    sub_detectors.append(
+        _ValueDetector(
+            features=["score_x2"],
             threshold_criterion=FixedThreshold(2),
             model_id="zscore_x2"))
 
@@ -267,10 +287,14 @@ class TestAnomalyDetection(unittest.TestCase):
   ])
   def test_multiple_sub_detectors_with_aggregation(self, input, expected):
     sub_detectors = []
-    sub_detectors.append(ZScore(features=["x1"], model_id="zscore_x1"))
     sub_detectors.append(
-        ZScore(
-            features=["x2"],
+        _ValueDetector(
+            features=["score_x1"],
+            threshold_criterion=FixedThreshold(3),
+            model_id="zscore_x1"))
+    sub_detectors.append(
+        _ValueDetector(
+            features=["score_x2"],
             threshold_criterion=FixedThreshold(2),
             model_id="zscore_x2"))
 


### PR DESCRIPTION
Related to #37779.

The ensemble tests compare each row with an online Z-score calculated in input order, but each detector branch reshuffles independently. Use explicit score fields for grouping and aggregation assertions so valid reordering does not change the expected outputs. These tests still check features, thresholds, keys, examples, model IDs, scores, prediction counts, and `AnyVote` aggregation.

Keep the existing single-detector Z-score tests and add keyed and unkeyed ensemble tests using real Z-score models on constant observations. The new tests assert exactly two warmup predictions per model and key, regardless of processing order, so lost model state still fails the suite.

The extra state coverage matters because #37779 shows repeated warmup predictions that reordering alone does not explain. This PR removes an invalid ordering assumption and preserves checks for lost model state; it does not establish the cause of that historical runner failure.

Validation:

- 16 targeted tests pass in `transforms_test.py` and `detectors/zscore_test.py`.
- Reversing the input fails all four original ensemble cases and passes their updated versions.
- Both new state tests fail when model state is deliberately discarded.
- YAPF, Ruff, and `git diff --check` pass.

No changelog entry is needed for this test-only change.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes. Not applicable because this is a test-only change.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf). Not applicable because this is a focused test-only change.

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
