### PR TITLE
fix ensurepip bundled pip cleanup for Python 3.12+ containers

### DIFF
--- a/sdks/python/container/Dockerfile
+++ b/sdks/python/container/Dockerfile
@@ -91,11 +91,13 @@ RUN  \
         pip install upgrade_ensurepip; \
         python3 -m upgrade_ensurepip; \
         find /usr/local/lib/python${py_version}/ensurepip/_bundled/setuptools-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/setuptools-*-py3-none-any.whl | tail -n 1)) -delete; \
+        find /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-*-py3-none-any.whl | tail -n 1)) -delete; \
         pip uninstall upgrade_ensurepip -y; \
     else \
         python3 /tmp/upgrade_bundled_pip.py; \
     fi; \
-    find /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-* -type f ! -name $(basename $(ls -v /usr/local/lib/python${py_version}/ensurepip/_bundled/pip-*-py3-none-any.whl | tail -n 1)) -delete;
+    # Verify ensurepip can bootstrap pip. Required by boot.go worker venv creation.
+    python3 -m ensurepip;
 
 ENTRYPOINT ["/opt/apache/beam/boot"]
 

--- a/sdks/python/container/license_scripts/upgrade_bundled_pip.py
+++ b/sdks/python/container/license_scripts/upgrade_bundled_pip.py
@@ -21,6 +21,10 @@ Upgrade the pip wheel bundled in ensurepip for Python 3.12+.
 The script is executed within Docker after the image pip has been upgraded.
 upgrade_ensurepip expects setuptools to be bundled as well, but Python 3.12+
 only ships pip in ensurepip/_bundled.
+
+After downloading, removes other pip-* files from _bundled so only the wheel
+matching the installed pip version remains. Worker harness startup (boot.go)
+creates a venv via ensurepip, so that wheel must be present.
 """
 
 import subprocess
@@ -34,8 +38,8 @@ def main():
   ep_path = Path(ensurepip.__file__)
   wheel_dir = ep_path.parent / '_bundled'
   pip_version = subprocess.check_output(
-      [sys.executable, '-m', 'pip', '--version'],
-      text=True).split()[1]
+      [sys.executable, '-m', 'pip', '--version'], text=True).split()[1]
+  expected_wheel_name = 'pip-{}-py3-none-any.whl'.format(pip_version)
   subprocess.check_call([
       sys.executable,
       '-m',
@@ -46,6 +50,13 @@ def main():
       str(wheel_dir),
       '--no-deps',
   ])
+  for path in wheel_dir.glob('pip-*'):
+    if path.name != expected_wheel_name:
+      path.unlink()
+  if not (wheel_dir / expected_wheel_name).is_file():
+    sys.exit(
+        'ensurepip bundled pip wheel missing after install: {}'.format(
+            wheel_dir / expected_wheel_name))
   lines = ep_path.read_text().splitlines()
   pip_line = None
   for idx, line in enumerate(lines):


### PR DESCRIPTION
fixes: #38791
python 3.14 Dataflow ARM workers were hanging because the container could lose the ensurepip pip wheel so the worker venv creation failed so this change makes the helper download the pip wheel into ensurepip _bundled, remove other pip-* files and keep the matching one and the Dockerfile also runs python3 -m ensurepip again after that step so a broken image fails during the build instead of later on the worker

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
