### PR TITLE
Fix Windows paths for Dataflow job files

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -1592,7 +1592,7 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
       String fileLocation =
           firstNonNull(options.getTemplateLocation(), options.getDataflowJobFile());
       checkArgument(
-          fileLocation.startsWith("/") || fileLocation.startsWith("gs://"),
+          new File(fileLocation).isAbsolute() || fileLocation.startsWith("gs://"),
           "Location must be local or on Cloud Storage, got %s.",
           fileLocation);
 


### PR DESCRIPTION
Addresses #18734

## Description

Allow `--dataflowJobFile` and `--templateLocation` to accept absolute local paths on every supported platform. The previous string-prefix check only recognized Unix paths beginning with `/`, so valid Windows paths such as `C:\\Users\\...\\job.json` were rejected before the file was written.

## Testing

- `git diff --check`
- Not run locally: the environment does not have a Java runtime.
- The existing `DataflowRunnerTest.testTemplateRunnerFullCompletion` covers successful local template creation; hosted CI should exercise the updated runner test suite.

## Checklist

- [x] Mentioned the related issue.
- [ ] Updated `CHANGES.md`; this is a focused bug fix without a user-facing release note.
- [ ] Apache ICLA is not required for this small contribution.
