### PR TITLE
Document required Go SDK initialization

### DIFF
--- a/sdks/go/pkg/beam/forward.go
+++ b/sdks/go/pkg/beam/forward.go
@@ -147,7 +147,7 @@ type ElementEncoder = coder.ElementEncoder
 type ElementDecoder = coder.ElementDecoder
 
 // Init is the hook that all user code must call after flags processing and
-// other static initialization, for now.
+// other static initialization, and before pipeline construction.
 func Init() {
 	runtime.Init()
 }

--- a/website/www/site/content/en/documentation/sdks/go.md
+++ b/website/www/site/content/en/documentation/sdks/go.md
@@ -30,6 +30,23 @@ Get started with the [Beam Go SDK quickstart](/get-started/quickstart-go) to set
 
 See the [godoc](https://pkg.go.dev/github.com/apache/beam/sdks/v2/go/pkg/beam) for more detailed information.
 
+## Initialize the Go SDK
+
+Call [`beam.Init()`](https://pkg.go.dev/github.com/apache/beam/sdks/v2/go/pkg/beam#Init)
+after parsing flags and completing other static initialization, and before
+constructing the pipeline. This initializes the SDK runtime used by Beam
+runners; omitting the call can prevent a pipeline from executing or produce a
+runner error.
+
+```go
+func main() {
+    flag.Parse()
+    beam.Init()
+
+    // Construct and run the pipeline here.
+}
+```
+
 ## Status
 
 Version 2.32.0 is the last experimental release of the Go SDK. The Go SDK supports most Batch oriented features, and cross language transforms.

--- a/website/www/site/content/en/get-started/quickstart-go.md
+++ b/website/www/site/content/en/get-started/quickstart-go.md
@@ -33,6 +33,19 @@ go version
 
 If you are unfamiliar with Go, see the [Get Started With Go Tutorial](https://go.dev/doc/tutorial/getting-started).
 
+## Initialize the SDK
+
+Before creating a pipeline, parse the command-line flags and call
+`beam.Init()`:
+
+```go
+flag.Parse()
+beam.Init()
+```
+
+Call `beam.Init()` before constructing the pipeline. This step initializes the
+Beam Go SDK runtime required by the runners.
+
 ## Run wordcount
 
 The Apache Beam


### PR DESCRIPTION
Addresses #19226

## Description

Document the required `beam.Init()` call in the Go SDK documentation and
quickstart, including when it must be called relative to flag parsing and
pipeline construction. The public API comment now states the same ordering so
the requirement is visible in generated Go documentation.

This is the short-term documentation portion of the issue; it does not change
runtime behavior.

## Testing

- `git diff --check`
- Go tests not run because this change only updates documentation and a public API comment.

