### PR TITLE
Update base_image_requirements_manual.txt

### DIFF
--- a/sdks/python/container/base_image_requirements_manual.txt
+++ b/sdks/python/container/base_image_requirements_manual.txt
@@ -36,7 +36,7 @@ google-cloud-profiler;python_version<="3.12"
 # Without google-cloud-profiler at python 3.13+, we need to manually add its
 # transitive dependency google-api-python-client as it is required by internal
 # tests
-google-api-python-client;python_version>="3.13"
+google-api-python-client
 guppy3
 # Explicitly pin memray to use a version compatible with postprocessing logic in Beam.
 memray==1.19.3


### PR DESCRIPTION
### What changes were proposed in this pull request? Remove the `python_version<="3.13"` constraint for `google-api-python-client` in `base_image_requirements_manual.txt`.

### Why are the changes needed?
`google-cloud-profiler` is capped at `<= 3.12` and does not support Python 3.13+. Because `google-cloud-profiler` pulled in `google-api-python-client` transitively for Python <= 3.12, `google-api-python-client` was manually added to `base_image_requirements_manual.txt` for Python 3.13+. However, the constraint was written as `python_version<="3.13"`, which (possibly unintentionally?) excluded `google-api-python-client` from the Python 3.14 container image, causing `ModuleNotFoundError: No module named 'googleapiclient'` during test execution on Python 3.14 workers.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
