### PR TITLE
fix: run all HBaseIO cleanup steps even if an earlier close() throws [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/sdks/java/io/hbase/src/main/java/org/apache/beam/sdk/io/hbase/HBaseIO.java
+++ b/sdks/java/io/hbase/src/main/java/org/apache/beam/sdk/io/hbase/HBaseIO.java
@@ -549,14 +549,36 @@ public class HBaseIO {
     @Override
     public void close() throws IOException {
       LOG.debug("Closing reader after reading {} records.", recordsReturned);
+      IOException thrown = null;
       if (scanner != null) {
-        scanner.close();
-        scanner = null;
+        try {
+          scanner.close();
+        } catch (IOException e) {
+          thrown = e;
+        } finally {
+          scanner = null;
+        }
       }
       if (connection != null) {
-        connection.close();
-        connection = null;
+        try {
+          connection.close();
+        } catch (IOException e) {
+          thrown = addSuppressed(thrown, e);
+        } finally {
+          connection = null;
+        }
       }
+      if (thrown != null) {
+        throw thrown;
+      }
+    }
+
+    private static IOException addSuppressed(IOException first, IOException next) {
+      if (first != null) {
+        first.addSuppressed(next);
+        return first;
+      }
+      return next;
     }
 
     @Override
@@ -765,13 +787,34 @@ public class HBaseIO {
 
       @Teardown
       public void tearDown() throws Exception {
+        Exception thrown = null;
         if (mutator != null) {
-          mutator.close();
-          mutator = null;
+          try {
+            mutator.close();
+          } catch (Exception e) {
+            thrown = e;
+          } finally {
+            mutator = null;
+          }
         }
         if (connection != null) {
-          connection.close();
-          connection = null;
+          try {
+            connection.close();
+          } catch (Exception e) {
+            if (thrown != null) {
+              thrown.addSuppressed(e);
+            } else {
+              thrown = e;
+            }
+          } finally {
+            connection = null;
+          }
+        }
+        if (thrown != null) {
+          if (thrown instanceof IOException) {
+            throw (IOException) thrown;
+          }
+          throw thrown;
         }
       }
 
@@ -930,13 +973,31 @@ public class HBaseIO {
 
       @Teardown
       public void tearDown() throws Exception {
-
+        Exception thrown = null;
         if (table != null) {
-          table.close();
-          table = null;
+          try {
+            table.close();
+          } catch (Exception e) {
+            thrown = e;
+          } finally {
+            table = null;
+          }
         }
-
-        HBaseSharedConnection.close(configuration);
+        try {
+          HBaseSharedConnection.close(configuration);
+        } catch (Exception e) {
+          if (thrown != null) {
+            thrown.addSuppressed(e);
+          } else {
+            thrown = e;
+          }
+        }
+        if (thrown != null) {
+          if (thrown instanceof IOException) {
+            throw (IOException) thrown;
+          }
+          throw thrown;
+        }
       }
 
       @ProcessElement


### PR DESCRIPTION
Fixes #39710

## What

`HBaseIO` releases its resources as consecutive, unguarded statements in three teardown paths. If an earlier `close()` throws, everything after it is skipped:

1. **`HBaseReader.close()`** — a throwing `scanner.close()` leaks the `Connection`.
2. **`HBaseWriterFn.tearDown()`** — `BufferedMutator.close()` is documented to throw on a final flush failure (down region server, network blip), so a failed flush skips `connection.close()`, leaking the whole per-`@Setup` Connection.
3. **`HBaseRowMutationWriterFn.tearDown()`** — worst case: a throwing `table.close()` skips `HBaseSharedConnection.close(configuration)`, which is a reference-count decrement. Because the pool is a `static HashMap`, the leaked entry (and its ZooKeeper session / RPC threads) survives for the JVM lifetime and every later `getOrCreate` hands back the same permanently-unreleasable connection.

## Fix

Wrap each cleanup step in `try/finally` so every step runs unconditionally, while preserving the **first** failure and attaching later ones with `addSuppressed`, so callers still see the error that actually broke the job rather than a teardown symptom.

- `HBaseReader.close()`: connection is now always closed even if `scanner.close()` throws.
- `HBaseWriterFn.tearDown()`: `connection.close()` always runs even if `mutator.close()` throws.
- `HBaseRowMutationWriterFn.tearDown()`: `HBaseSharedConnection.close(configuration)` (the refcount decrement) always runs even if `table.close()` throws.

## Testing

Existing tests in `sdks/java/io/hbase/src/test/java/org/apache/beam/sdk/io/hbase/` cover the read and write paths; the change is purely control-flow (guarding cleanup), so no new behavior is introduced when nothing throws.
