### PR TITLE
fix: poll publish results from all producers in SolaceIO writer

### DIFF
--- a/sdks/java/io/solace/src/main/java/org/apache/beam/sdk/io/solace/write/UnboundedSolaceWriter.java
+++ b/sdks/java/io/solace/src/main/java/org/apache/beam/sdk/io/solace/write/UnboundedSolaceWriter.java
@@ -143,57 +143,61 @@ public abstract class UnboundedSolaceWriter
     long minFailed = Long.MAX_VALUE;
     long maxFailed = 0;
 
-    Queue<PublishResult> publishResultsQueue =
-        solaceSessionServiceWithProducer().getPublishedResultsQueue();
-    Solace.PublishResult result = publishResultsQueue.poll();
+    for (int producerIndex = 0; producerIndex < producersMapCardinality; producerIndex++) {
+      SessionService session =
+          SolaceWriteSessionsHandler.getSessionServiceWithProducer(
+              producerIndex, sessionServiceFactory, writerTransformUuid);
+      Queue<PublishResult> publishResultsQueue = session.getPublishedResultsQueue();
+      Solace.PublishResult result = publishResultsQueue.poll();
 
-    if (result != null) {
-      if (getCurrentBundleTimestamp() == null) {
-        setCurrentBundleTimestamp(Instant.now());
-      }
-    }
-
-    while (result != null) {
-      Long latency = result.getLatencyNanos();
-
-      if (latency == null && shouldPublishLatencyMetrics()) {
-        LOG.error(
-            "SolaceIO.Write: Latency is null but user asked for latency metrics."
-                + " This may be a bug.");
+      if (result != null) {
+        if (getCurrentBundleTimestamp() == null) {
+          setCurrentBundleTimestamp(Instant.now());
+        }
       }
 
-      if (latency != null) {
+      while (result != null) {
+        Long latency = result.getLatencyNanos();
+
+        if (latency == null && shouldPublishLatencyMetrics()) {
+          LOG.error(
+              "SolaceIO.Write: Latency is null but user asked for latency metrics."
+                  + " This may be a bug.");
+        }
+
+        if (latency != null) {
+          if (result.getPublished()) {
+            sumPublish += latency;
+            countPublish++;
+            minPublish = Math.min(minPublish, latency);
+            maxPublish = Math.max(maxPublish, latency);
+          } else {
+            sumFailed += latency;
+            countFailed++;
+            minFailed = Math.min(minFailed, latency);
+            maxFailed = Math.max(maxFailed, latency);
+          }
+        }
         if (result.getPublished()) {
-          sumPublish += latency;
-          countPublish++;
-          minPublish = Math.min(minPublish, latency);
-          maxPublish = Math.max(maxPublish, latency);
+          context.output(
+              SUCCESSFUL_PUBLISH_TAG, result, getCurrentBundleTimestamp(), GlobalWindow.INSTANCE);
         } else {
-          sumFailed += latency;
-          countFailed++;
-          minFailed = Math.min(minFailed, latency);
-          maxFailed = Math.max(maxFailed, latency);
+          try {
+            BadRecord b =
+                BadRecord.fromExceptionInformation(
+                    result,
+                    null,
+                    null,
+                    Optional.ofNullable(result.getError()).orElse("SolaceIO.Write: unknown error."));
+            context.output(FAILED_PUBLISH_TAG, b, getCurrentBundleTimestamp(), GlobalWindow.INSTANCE);
+          } catch (IOException e) {
+            // ignore, the exception is thrown when the exception argument in the
+            // `BadRecord.fromExceptionInformation` is not null.
+          }
         }
-      }
-      if (result.getPublished()) {
-        context.output(
-            SUCCESSFUL_PUBLISH_TAG, result, getCurrentBundleTimestamp(), GlobalWindow.INSTANCE);
-      } else {
-        try {
-          BadRecord b =
-              BadRecord.fromExceptionInformation(
-                  result,
-                  null,
-                  null,
-                  Optional.ofNullable(result.getError()).orElse("SolaceIO.Write: unknown error."));
-          context.output(FAILED_PUBLISH_TAG, b, getCurrentBundleTimestamp(), GlobalWindow.INSTANCE);
-        } catch (IOException e) {
-          // ignore, the exception is thrown when the exception argument in the
-          // `BadRecord.fromExceptionInformation` is not null.
-        }
-      }
 
-      result = publishResultsQueue.poll();
+        result = publishResultsQueue.poll();
+      }
     }
 
     if (shouldPublishLatencyMetrics()) {


### PR DESCRIPTION
## Description

The `UnboundedSolaceWriter.publishResults()` method only polls the publish results queue for the **current bundle's producer**. When multiple producers are configured (`producersMapCardinality > 1`), messages published by other producers have their publish results left in their respective queues, never drained or output. This causes downstream transforms attached to the `SolaceIO.Write` output to receive only a subset of publish results.

### Root Cause

In `publishResults()`:
```java
Queue<PublishResult> publishResultsQueue =
    solaceSessionServiceWithProducer().getPublishedResultsQueue();
```

`solaceSessionServiceWithProducer()` returns the session for `currentBundleProducerIndex` (set at `@StartBundle` time). Other producers' queues are never polled.

### Fix

Iterate over all producers (0 to `producersMapCardinality - 1`) and poll each one's publish results queue. This ensures all publish results are drained and output, regardless of which producer published the message.

### Related Issues

Fixes #39588
Also related to #39589 (batch pipeline output loss in SolaceIO writer).

CC @stankiewicz @iht