### PR TITLE
Encode DynamoDB empty list and empty map attributes

### DIFF
--- a/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/dynamodb/AttributeValueCoder.java
+++ b/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/dynamodb/AttributeValueCoder.java
@@ -89,10 +89,13 @@ public class AttributeValueCoder extends AtomicCoder<AttributeValue> {
     } else if (value.bs() != null && value.bs().size() > 0) {
       StringUtf8Coder.of().encode(AttributeValueType.bs.toString(), outStream);
       LIST_BYTE_CODER.encode(convertToListByteArray(value.bs()), outStream);
-    } else if (value.l() != null && value.l().size() > 0) {
+    } else if (value.hasL()) {
+      // hasL/hasM rather than a size check: DynamoDB allows an empty L or M, and the size guard
+      // sent those to the terminal else. The ss/ns/bs guards below keep their size check on
+      // purpose -- DynamoDB rejects empty sets, so an empty one there is not a value to preserve.
       StringUtf8Coder.of().encode(AttributeValueType.l.toString(), outStream);
       LIST_ATTRIBUTE_CODER.encode(value.l(), outStream);
-    } else if (value.m() != null && value.m().size() > 0) {
+    } else if (value.hasM()) {
       StringUtf8Coder.of().encode(AttributeValueType.m.toString(), outStream);
       MAP_ATTRIBUTE_CODER.encode(value.m(), outStream);
     } else if (value.nul() != null) {

--- a/sdks/java/io/amazon-web-services2/src/test/java/org/apache/beam/sdk/io/aws2/dynamodb/AttributeValueCoderTest.java
+++ b/sdks/java/io/amazon-web-services2/src/test/java/org/apache/beam/sdk/io/aws2/dynamodb/AttributeValueCoderTest.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.junit.Assert;
 import org.junit.Test;
@@ -204,5 +205,69 @@ public class AttributeValueCoderTest {
     AttributeValue actual = coder.decode(in);
 
     Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void shouldPassForEmptyListType() throws IOException {
+    AttributeValue expected = AttributeValue.builder().l(new ArrayList<>()).build();
+
+    AttributeValue actual = roundTrip(expected);
+
+    Assert.assertEquals(expected, actual);
+    Assert.assertTrue("an empty L must decode back as a set-but-empty list", actual.hasL());
+  }
+
+  @Test
+  public void shouldPassForEmptyMapType() throws IOException {
+    AttributeValue expected = AttributeValue.builder().m(new HashMap<>()).build();
+
+    AttributeValue actual = roundTrip(expected);
+
+    Assert.assertEquals(expected, actual);
+    Assert.assertTrue("an empty M must decode back as a set-but-empty map", actual.hasM());
+  }
+
+  @Test
+  public void shouldPassForEmptyListNestedInMap() throws IOException {
+    // The realistic trigger: one empty list anywhere inside an item makes the whole item
+    // unencodable, not just that attribute.
+    Map<String, AttributeValue> item = new HashMap<>();
+    item.put("name", AttributeValue.builder().s("widget").build());
+    item.put("tags", AttributeValue.builder().l(new ArrayList<>()).build());
+    AttributeValue expected = AttributeValue.builder().m(item).build();
+
+    AttributeValue actual = roundTrip(expected);
+
+    Assert.assertEquals(expected, actual);
+    Assert.assertTrue(actual.m().get("tags").hasL());
+  }
+
+  @Test
+  public void shouldPassForEmptyMapNestedInList() throws IOException {
+    AttributeValue expected =
+        AttributeValue.builder()
+            .l(ImmutableList.of(AttributeValue.builder().m(new HashMap<>()).build()))
+            .build();
+
+    AttributeValue actual = roundTrip(expected);
+
+    Assert.assertEquals(expected, actual);
+    Assert.assertTrue(actual.l().get(0).hasM());
+  }
+
+  @Test
+  public void shouldStillRejectAnAttributeValueWithNoTypeSet() throws IOException {
+    // Control: the terminal else must keep rejecting a genuinely typeless value, so the fix does
+    // not turn "Unknown Type" into silently encoding nothing.
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    Assert.assertThrows(
+        CoderException.class,
+        () -> AttributeValueCoder.of().encode(AttributeValue.builder().build(), out));
+  }
+
+  private static AttributeValue roundTrip(AttributeValue value) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    AttributeValueCoder.of().encode(value, out);
+    return AttributeValueCoder.of().decode(new ByteArrayInputStream(out.toByteArray()));
   }
 }


### PR DESCRIPTION
Fixes #39730.

`AttributeValueCoder.encode` selected the L and M branches with a size check, so a DynamoDB attribute holding an **empty list** or **empty map** fell through to the terminal `else` and threw `CoderException("Unknown Type")`.

`hasL()`/`hasM()` are the SDK's way of separating "unset" from "set but empty", which is exactly the distinction the size check lost.

**The `ss`/`ns`/`bs` guards look identical and are deliberately left alone.** DynamoDB rejects empty sets, so an empty one there is not a value worth preserving — relaxing those would be wrong.

**Blast radius.** `MAP_ATTRIBUTE_CODER` re-enters this coder for every child, so one empty list nested anywhere inside an item makes the whole item unencodable, not just that attribute. That is the realistic production trigger and it is what two of the new tests cover.

The decode side already handles both: `case l:` and `case m:` delegate to `ListCoder`/`MapCoder`, which round-trip empties.

### Compatibility

Wire-compatible **for every value the service can produce**. I want to be precise rather than overclaim: the change is *not* a no-op for a malformed `AttributeValue` that sets two types at once — `AttributeValue.builder().l(new ArrayList<>()).nul(true).build()` currently encodes as `nul` and would now encode as `l`. An `AttributeValue` carries exactly one type, DynamoDB never emits such a value, and no ordinary builder usage produces one, but the claim is "every value the service can produce", not "every possible value".

### Tests

Five cases added to the existing `AttributeValueCoderTest`, which is a plain in-process encode/decode round trip — no cluster, no AWS account, no localstack.

| case | on master |
|---|---|
| empty `L` round trip | **fails**, `CoderException: Unknown Type` |
| empty `M` round trip | **fails** |
| empty `L` nested in a map | **fails** — shows the parent item is lost |
| empty `M` nested in a list | **fails** |
| `AttributeValue.builder().build()` still rejected | passes **before and after** — the control |

```
15 tests completed, 4 failed      <- on master
BUILD SUCCESSFUL                  <- with the fix, 15/15
```

The fifth is there so the fix cannot quietly turn "Unknown Type" into encoding nothing, and because it passes on both versions it also shows the other four are not trivially red.

Each round trip asserts `hasL()`/`hasM()` on the decoded value in addition to equality, so a "decoded back as unset" regression would still be caught.

`spotlessCheck`, `checkstyleMain` and `checkstyleTest` pass, as does the rest of the `dynamodb` package.
