### PR TITLE
fix: allow empty DynamoDB list and map in AttributeValueCoder

### DIFF
--- a/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/dynamodb/AttributeValueCoder.java
+++ b/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/dynamodb/AttributeValueCoder.java
@@ -89,10 +89,10 @@ public class AttributeValueCoder extends AtomicCoder<AttributeValue> {
     } else if (value.bs() != null && value.bs().size() > 0) {
       StringUtf8Coder.of().encode(AttributeValueType.bs.toString(), outStream);
       LIST_BYTE_CODER.encode(convertToListByteArray(value.bs()), outStream);
-    } else if (value.l() != null && value.l().size() > 0) {
+    } else if (value.l() != null) {
       StringUtf8Coder.of().encode(AttributeValueType.l.toString(), outStream);
       LIST_ATTRIBUTE_CODER.encode(value.l(), outStream);
-    } else if (value.m() != null && value.m().size() > 0) {
+    } else if (value.m() != null) {
       StringUtf8Coder.of().encode(AttributeValueType.m.toString(), outStream);
       MAP_ATTRIBUTE_CODER.encode(value.m(), outStream);
     } else if (value.nul() != null) {


### PR DESCRIPTION
### Problem

`AttributeValueCoder.encode` cannot encode a DynamoDB attribute whose value is an **empty list** or an **empty map** — it throws `CoderException("Unknown Type")`.

The `L` and `M` branches are guarded with `size() > 0`:

```java
} else if (value.l() != null && value.l().size() > 0) {     // wrong: DynamoDB allows an empty L
} else if (value.m() != null && value.m().size() > 0) {     // wrong: DynamoDB allows an empty M
```

### Fix

Remove the `size() > 0` guard for `L` and `M` branches. The `decode` side already handles empty lists and maps correctly via `ListCoder`/`MapCoder` — only `encode` rejects them.

### Blast radius

A single empty list nested anywhere inside an item makes the whole item unencodable, because `MAP_ATTRIBUTE_CODER` re-enters this coder for every child.

Fixes #39730