### PR TITLE
[KafkaIO] Remove beam_fn_api requirement for dynamic reads

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -81,6 +81,7 @@
 ## Bugfixes
 
 * (Python) Fixed incorrect profiler options handling on portable runners ([#39613](https://github.com/apache/beam/issues/39613)).
+* (Java) KafkaIO dynamic reads no longer require the obsolete `beam_fn_api` experiment ([#29998](https://github.com/apache/beam/issues/29998)).
 
 ## Security Fixes
 

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -1651,18 +1651,13 @@ public class KafkaIO {
       checkArgument(
           getConsumerConfig().get(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG) != null,
           "withBootstrapServers() is required");
-      // With dynamic read, we no longer require providing topic/partition during pipeline
-      // construction time. But it requires enabling beam_fn_api.
+      // With dynamic read, topics and partitions are discovered during pipeline execution.
       if (!isDynamicRead()) {
         checkArgument(
             (getTopics() != null && getTopics().size() > 0)
                 || (getTopicPartitions() != null && getTopicPartitions().size() > 0)
                 || getTopicPattern() != null,
             "Either withTopic(), withTopics(), withTopicPartitions() or withTopicPattern() is required");
-      } else {
-        checkArgument(
-            ExperimentalOptions.hasExperiment(input.getPipeline().getOptions(), "beam_fn_api"),
-            "Kafka Dynamic Read requires enabling experiment beam_fn_api.");
       }
       checkArgument(getKeyDeserializerProvider() != null, "withKeyDeserializer() is required");
       checkArgument(getValueDeserializerProvider() != null, "withValueDeserializer() is required");

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOReadImplementationCompatibilityTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOReadImplementationCompatibilityTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.io.kafka;
 
+import static org.apache.beam.sdk.io.kafka.KafkaIOReadImplementationCompatibility.KafkaIOReadImplementation.SDF;
 import static org.apache.beam.sdk.io.kafka.KafkaIOTest.mkKafkaReadTransformWithOffsetDedup;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -30,6 +31,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.kafka.KafkaIOReadImplementationCompatibility.KafkaIOReadProperties;
 import org.apache.beam.sdk.io.kafka.KafkaIOTest.ValueAsTimestampFn;
@@ -160,6 +162,26 @@ public class KafkaIOReadImplementationCompatibilityTest {
             .map(topic -> String.format("kafka:`%s`.%s", KafkaIOTest.mkKafkaServers, topic))
             .toArray(String[]::new);
     assertThat(Lineage.query(r.metrics(), Lineage.Type.SOURCE), containsInAnyOrder(expect));
+  }
+
+  @Test
+  public void testDynamicReadUsesSdfWithoutBeamFnApiExperiment() {
+    KafkaIO.Read<Integer, Long> read =
+        KafkaIOTest.mkKafkaReadTransform(
+                1000,
+                null,
+                new ValueAsTimestampFn(),
+                false, /* redistribute */
+                false, /* allowDuplicates */
+                0, /* numKeys */
+                null, /* offsetDeduplication */
+                null, /* topics */
+                null /* redistributeByRecordKey */)
+            .withDynamicRead(Duration.standardMinutes(1));
+
+    assertThat(
+        KafkaIOReadImplementationCompatibility.getCompatibility(read).supportsOnly(SDF), is(true));
+    Pipeline.create().apply(read);
   }
 
   @Test


### PR DESCRIPTION
Fixes #29998.

KafkaIO dynamic reads currently fail during pipeline expansion unless the obsolete `beam_fn_api` experiment is enabled.

This change removes that expansion-time requirement. Dynamic reads remain SDF-only through the existing `KafkaIOReadImplementationCompatibility` selection, so runner fallback and compatibility behavior are unchanged.

The regression test verifies that:

- dynamic read is still classified as SDF-only
- the transform expands without enabling `beam_fn_api`

The change also updates the 2.77.0 release notes.

### Testing

- `./gradlew :sdks:java:io:kafka:test :sdks:java:io:kafka:kafkaVersion392Test :sdks:java:io:kafka:spotlessCheck --no-daemon`
- `./gradlew :sdks:java:io:kafka:test --tests org.apache.beam.sdk.io.kafka.KafkaIOReadImplementationCompatibilityTest.testDynamicReadUsesSdfWithoutBeamFnApiExperiment :sdks:java:io:kafka:check --no-build-cache --rerun-tasks --no-daemon`

The full KafkaIO check includes Checkstyle, SpotBugs, Javadocs, dependency analysis, formatting, and unit tests.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).