### PR TITLE
[GSoC 2026] Kafka Streams runner: separate source poll size from bundle size, expose the session timeout

### DIFF
--- a/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/KafkaStreamsPipelineOptions.java
+++ b/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/KafkaStreamsPipelineOptions.java
@@ -50,6 +50,27 @@ public interface KafkaStreamsPipelineOptions extends PortablePipelineOptions {
   void setMaxBundleSize(int maxBundleSize);
 
   @Description(
+      "How many elements an unbounded source may yield per poll. Separate from --maxBundleSize:"
+          + " a small bundle is how you get output promptly, while how much a source reads at a"
+          + " time is about throughput, and tying them together means a pipeline cannot have both.")
+  @Default.Integer(1000)
+  int getReadMaxElementsPerPoll();
+
+  void setReadMaxElementsPerPoll(int readMaxElementsPerPoll);
+
+  @Description(
+      "How long the consumer group waits before deciding an instance has gone, in milliseconds."
+          + " This is the floor on how quickly work moves to another instance after one is lost,"
+          + " since a departed instance is not noticed any sooner. Kafka's default of 45s is kept,"
+          + " but a pipeline that values recovery over tolerance of a slow or briefly paused"
+          + " instance can lower it — a broker will not accept a value below its"
+          + " group.min.session.timeout.ms, which itself defaults to 6s.")
+  @Default.Integer(45_000)
+  int getSessionTimeoutMs();
+
+  void setSessionTimeoutMs(int sessionTimeoutMs);
+
+  @Description(
       "Intended cap on how long a bundle may stay open, in milliseconds. NOT APPLIED YET: closing a"
           + " bundle from a wall-clock punctuator made a pipeline with two chained GroupByKeys"
           + " across several partitions emit its groups repeatedly against a real broker, so only"

--- a/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/KafkaStreamsPipelineRunner.java
+++ b/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/KafkaStreamsPipelineRunner.java
@@ -26,6 +26,7 @@ import org.apache.beam.runners.jobsubmission.PortablePipelineResult;
 import org.apache.beam.runners.jobsubmission.PortablePipelineRunner;
 import org.apache.beam.runners.kafka.streams.translation.KafkaStreamsPipelineTranslator;
 import org.apache.beam.runners.kafka.streams.translation.KafkaStreamsTranslationContext;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
@@ -162,7 +163,8 @@ public class KafkaStreamsPipelineRunner implements PortablePipelineRunner {
     }
   }
 
-  private Properties streamsConfig(JobInfo jobInfo) {
+  // Visible for testing: the session timeout and the heartbeat derived from it.
+  Properties streamsConfig(JobInfo jobInfo) {
     Properties props = new Properties();
     props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, pipelineOptions.getBootstrapServers());
     props.put(StreamsConfig.APPLICATION_ID_CONFIG, pipelineOptions.getApplicationId());
@@ -177,6 +179,16 @@ public class KafkaStreamsPipelineRunner implements PortablePipelineRunner {
     // is
     // what Kafka Streams does by default when no client id is set.
     props.put(StreamsConfig.CLIENT_ID_CONFIG, jobInfo.jobId() + "-" + UUID.randomUUID());
+    // How quickly a lost instance is noticed, which is the floor on how quickly its work moves
+    // elsewhere. The heartbeat must be shorter than the timeout, or a healthy instance would be
+    // declared dead between beats; a third is the ratio Kafka's own defaults use. Deriving it
+    // rather than exposing it keeps the pair consistent whatever the timeout is set to.
+    int sessionTimeoutMs = pipelineOptions.getSessionTimeoutMs();
+    props.put(
+        StreamsConfig.consumerPrefix(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG), sessionTimeoutMs);
+    props.put(
+        StreamsConfig.consumerPrefix(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG),
+        Math.max(1, sessionTimeoutMs / 3));
     return props;
   }
 }

--- a/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/ReadTranslator.java
+++ b/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/ReadTranslator.java
@@ -136,7 +136,7 @@ class ReadTranslator implements PTransformTranslator {
     // splitting a source that has already been split.
     UnboundedSource<T, CheckpointT> readableSource = singleSplitOf(source, context);
     Coder<CheckpointT> checkpointCoder = readableSource.getCheckpointMarkCoder();
-    int maxElementsPerPoll = context.getPipelineOptions().getMaxBundleSize();
+    int maxElementsPerPoll = context.getPipelineOptions().getReadMaxElementsPerPoll();
     int checkpointEveryNPolls = context.getPipelineOptions().getReadCheckpointNumBundles();
 
     topology.addSource(

--- a/runners/kafka-streams/src/test/java/org/apache/beam/runners/kafka/streams/KafkaStreamsPipelineRunnerConfigTest.java
+++ b/runners/kafka-streams/src/test/java/org/apache/beam/runners/kafka/streams/KafkaStreamsPipelineRunnerConfigTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.kafka.streams;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+
+import java.util.Properties;
+import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.util.construction.PipelineOptionsTranslation;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.streams.StreamsConfig;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for the Kafka Streams configuration the runner builds from its pipeline options. */
+@RunWith(JUnit4.class)
+public class KafkaStreamsPipelineRunnerConfigTest {
+
+  private static final String SESSION_TIMEOUT =
+      StreamsConfig.consumerPrefix(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG);
+  private static final String HEARTBEAT =
+      StreamsConfig.consumerPrefix(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG);
+
+  private static Properties configFor(Integer sessionTimeoutMs) {
+    KafkaStreamsPipelineOptions options =
+        PipelineOptionsFactory.create().as(KafkaStreamsPipelineOptions.class);
+    options.setApplicationId("an-application");
+    options.setBootstrapServers("localhost:9092");
+    if (sessionTimeoutMs != null) {
+      options.setSessionTimeoutMs(sessionTimeoutMs);
+    }
+    JobInfo jobInfo =
+        JobInfo.create("a-job", "a-job", "", PipelineOptionsTranslation.toProto(options));
+    return new KafkaStreamsPipelineRunner(options).streamsConfig(jobInfo);
+  }
+
+  @Test
+  public void theSessionTimeoutDefaultsToKafkasOwn() {
+    // Changing this would change how long a lost instance goes unnoticed, so it is deliberate that
+    // the runner keeps Kafka's default rather than choosing its own.
+    assertThat(configFor(null).get(SESSION_TIMEOUT), is(45_000));
+  }
+
+  @Test
+  public void theSessionTimeoutIsWhateverThePipelineAskedFor() {
+    assertThat(configFor(6_000).get(SESSION_TIMEOUT), is(6_000));
+  }
+
+  @Test
+  public void theHeartbeatIsAThirdOfTheSessionTimeout() {
+    assertThat(configFor(6_000).get(HEARTBEAT), is(2_000));
+  }
+
+  @Test
+  public void theHeartbeatStaysShorterThanEvenATinySessionTimeout() {
+    // Kafka rejects a heartbeat that is not shorter than the session timeout, so deriving it has
+    // to hold for small values too — a fixed floor would not. One millisecond is excluded because
+    // no positive heartbeat is shorter than it, and a broker would refuse such a timeout anyway.
+    for (int sessionTimeoutMs : new int[] {2, 10, 100, 200, 1_000, 6_000, 45_000}) {
+      Properties config = configFor(sessionTimeoutMs);
+      assertThat(
+          "heartbeat must stay under the session timeout for " + sessionTimeoutMs + "ms",
+          (Integer) config.get(HEARTBEAT),
+          lessThan((Integer) config.get(SESSION_TIMEOUT)));
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Part of #18479. Two pipeline options that came out of trying to measure how the runner behaves under load, and that are worth having whatever the measurement ends up looking like.

## How much a source reads is not how big a bundle is

`ReadTranslator` took the unbounded source's per-poll limit from `--maxBundleSize`. They are different concerns: a small bundle is how output arrives promptly, while how much a source reads at a time is about throughput. Sharing one setting means a pipeline cannot ask for both — lowering the bundle size to get prompt output also throttles the source to a couple of elements per poll.

`--readMaxElementsPerPoll` (default 1000, what the source effectively had before) separates them.

## The recovery knob was unreachable

How quickly work moves to another instance after one is lost is bounded by how quickly the consumer group notices, which is `session.timeout.ms`. The runner never set it, so it was Kafka's default of 45 seconds and a pipeline had no way to ask for anything else.

`--sessionTimeoutMs` exposes it, keeping Kafka's 45s default so nothing changes for an existing pipeline. Lowering it trades tolerance of a slow or briefly paused instance for quicker recovery, and a broker will refuse a value below its own `group.min.session.timeout.ms`, which itself defaults to 6s — so this is not a knob that can be turned arbitrarily far.

The heartbeat is derived as a third of the timeout rather than exposed separately. Kafka rejects a heartbeat that is not shorter than the session timeout, so deriving it keeps the pair consistent however the timeout is set; a third is the ratio Kafka's own defaults use.

## Testing

```
./gradlew :runners:kafka-streams:build              # 103 unit tests, spotless + checker + errorprone
./gradlew :runners:kafka-streams:validatesRunner    # 59 tests
```

`KafkaStreamsPipelineRunnerConfigTest` covers the default, the override, the ratio, and that the heartbeat stays shorter than the timeout across a range of values. That last one is not decoration: the derivation first had a fixed 200ms floor, which produces a heartbeat equal to the timeout at 200ms and would be rejected by Kafka. The test fails if that floor is put back.
