### PR TITLE
Render ARRAY and ITERABLE fields that are not backed by a List

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaUtils.java
@@ -18,13 +18,11 @@
 package org.apache.beam.sdk.schemas;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.Schema.LogicalType;
 import org.apache.beam.sdk.values.Row;
-import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
 
 /** A set of utility functions for schemas. */
 @SuppressWarnings({
@@ -284,24 +282,26 @@ public class SchemaUtils {
           FieldType elementType = Objects.requireNonNull(fieldType.getCollectionElementType());
 
           @SuppressWarnings("unchecked")
-          List<Object> list = Lists.newArrayList((Iterable<Object>) value);
-          if (list.isEmpty()) {
-            return "[]";
-          }
+          Iterable<Object> elements = (Iterable<Object>) value;
+
+          // Rendered in a single pass. The previous shape asked the collection for isEmpty(),
+          // then size(), then iterated it -- three traversals, which a List absorbs for free but
+          // which an Iterable that can only be read once would not survive.
           StringBuilder sb = new StringBuilder();
           sb.append("[\n");
-          int size = list.size();
-          int index = 0;
-          for (Object element : list) {
+          boolean empty = true;
+          for (Object element : elements) {
+            if (!empty) {
+              sb.append(",\n");
+            }
             sb.append(nextPrefix)
                 .append(toPrettyFieldValueString(elementType, element, nextPrefix));
-            if (index++ < size - 1) {
-              sb.append(",\n");
-            } else {
-              sb.append("\n");
-            }
+            empty = false;
           }
-          sb.append(prefix).append("]");
+          if (empty) {
+            return "[]";
+          }
+          sb.append("\n").append(prefix).append("]");
           return sb.toString();
         }
       case MAP:

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaUtils.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.Schema.LogicalType;
 import org.apache.beam.sdk.values.Row;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
 
 /** A set of utility functions for schemas. */
 @SuppressWarnings({
@@ -270,7 +271,11 @@ public class SchemaUtils {
       case ARRAY:
       case ITERABLE:
         {
-          if (!(value instanceof List)) {
+          // An ITERABLE field declares an Iterable, and an ARRAY value need not be a List
+          // either, so require only what is actually iterated below. This is reached from
+          // Row#toString, where refusing to render one field takes out logging and debugger
+          // output for the entire row.
+          if (!(value instanceof Iterable)) {
             throw new IllegalArgumentException(
                 String.format(
                     "value type is '%s' for field type '%s'",
@@ -279,7 +284,7 @@ public class SchemaUtils {
           FieldType elementType = Objects.requireNonNull(fieldType.getCollectionElementType());
 
           @SuppressWarnings("unchecked")
-          List<Object> list = (List<Object>) value;
+          List<Object> list = Lists.newArrayList((Iterable<Object>) value);
           if (list.isEmpty()) {
             return "[]";
           }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaUtilsTest.java
@@ -21,7 +21,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.values.Row;
@@ -174,5 +176,42 @@ public class SchemaUtilsTest {
     String rendered = row.toString();
     assertTrue(rendered, rendered.contains("p"));
     assertTrue(rendered, rendered.contains("q"));
+  }
+
+  @Test
+  public void testToPrettyStringRendersAnIterableThatCanOnlyBeReadOnce() {
+    Schema schema =
+        Schema.builder().addStringField("k").addIterableField("vals", FieldType.STRING).build();
+    // Hands out its iterator exactly once and fails loudly on a second attempt. Rendering asks
+    // the collection for one traversal now; asking for isEmpty(), then size(), then iterating
+    // would trip the guard below.
+    Iterable<String> onceOnly =
+        new Iterable<String>() {
+          private boolean taken = false;
+
+          @Override
+          public Iterator<String> iterator() {
+            if (taken) {
+              throw new IllegalStateException("iterated more than once");
+            }
+            taken = true;
+            return Arrays.asList("p", "q").iterator();
+          }
+        };
+    Row row = Row.withSchema(schema).attachValues("k1", onceOnly);
+
+    String rendered = row.toString();
+    assertTrue(rendered, rendered.contains("p"));
+    assertTrue(rendered, rendered.contains("q"));
+  }
+
+  @Test
+  public void testToPrettyStringRendersAnEmptyIterableAsEmptyBrackets() {
+    Schema schema = Schema.builder().addIterableField("vals", FieldType.STRING).build();
+    Iterable<String> empty = Collections::emptyIterator;
+    Row row = Row.withSchema(schema).attachValues((Object) empty);
+
+    String rendered = row.toString();
+    assertTrue(rendered, rendered.contains("[]"));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaUtilsTest.java
@@ -147,4 +147,32 @@ public class SchemaUtilsTest {
     assertTrue(rendered, rendered.contains("1"));
     assertTrue(rendered, rendered.contains("null"));
   }
+
+  @Test
+  public void testToPrettyStringRendersIterableThatIsNotAList() {
+    Schema schema =
+        Schema.builder().addStringField("k").addIterableField("vals", FieldType.STRING).build();
+    // A bare Iterable, which is exactly what an ITERABLE field declares.
+    Iterable<String> bare = () -> Arrays.asList("p", "q").iterator();
+    Row row = Row.withSchema(schema).attachValues("k1", bare);
+
+    // The precondition that makes this test meaningful: if the value ever starts arriving as a
+    // List, the assertion below would pass for the wrong reason.
+    assertTrue(!(row.getValue("vals") instanceof java.util.List));
+
+    String rendered = row.toString();
+    assertTrue(rendered, rendered.contains("p"));
+    assertTrue(rendered, rendered.contains("q"));
+  }
+
+  @Test
+  public void testToPrettyStringStillRendersAListArray() {
+    // Control: the ordinary List case must be unchanged.
+    Schema schema = Schema.builder().addArrayField("vals", FieldType.STRING).build();
+    Row row = Row.withSchema(schema).attachValues((Object) Arrays.asList("p", "q"));
+
+    String rendered = row.toString();
+    assertTrue(rendered, rendered.contains("p"));
+    assertTrue(rendered, rendered.contains("q"));
+  }
 }


### PR DESCRIPTION
Fixes #39749.

`Row#toString` throws for an `ITERABLE` field holding a plain `Iterable`:

```java
Schema s = Schema.builder().addStringField("k").addIterableField("vals", FieldType.STRING).build();
Row.withSchema(s).attachValues("k1", () -> list.iterator()).toString();
// IllegalArgumentException: value type is '...' for field type 'ITERABLE'
```

`toPrettyFieldValueString` demanded a `List` before iterating. An `ITERABLE` field declares an `Iterable`, so the guard was stricter than the type it guards, and the branch below only ever iterates and counts — both fine from an `Iterable` once materialised.

This is reached from `Row#toString`, so refusing to render one field takes out logging and debugger output for every field beside it. That is a poor trade for a stricter check in a renderer.

The guard now requires `Iterable`; a value that is neither still throws the same exception.

### On where this belongs

A reviewer could reasonably hold that a materialised `Row` should always store a `List` for `ARRAY`/`ITERABLE`, and that a non-`List` reaching here means a producer is at fault — `ByteBuddyUtils.transformContainer` hands back a `Collections2.TransformedCollection` for a `Set`-typed POJO field, for instance. I think that is worth looking at separately and have not touched it.

What makes this worth fixing on its own is that the reproducer needs only `Schema.builder`, `attachValues` and `toString()` — no POJO, no registry, no pipeline — so the renderer is reachable with a merely-`Iterable` value through plain public API. And a `toString()` that throws is difficult to justify whatever produced the value.

I should be straight about the blast radius rather than inflate it: I could **not** construct a case where a non-`List` reaches user code inside a running pipeline. Coder round-trips materialise, and `Convert.toRows()` / `@Element Row` both yield `List`s. The demonstrated exposure is direct API use.

### Tests

| case | on master |
|---|---|
| bare `Iterable` on an `ITERABLE` field | **fails** with the `IllegalArgumentException` above |
| ordinary `List` on an `ARRAY` field | passes — the control |

The first also asserts `!(row.getValue("vals") instanceof List)` **before** rendering, so if the value ever starts arriving materialised the test fails loudly rather than going green for the wrong reason.

11/11 in `SchemaUtilsTest`, and the wider `*schemas*` / `*RowTest*` suites pass. `spotlessCheck`, `checkstyleMain`, `checkstyleTest` clean.
