### PR TITLE
Tag the TFRecord write error output with the schema it actually emits

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TFRecordWriteSchemaTransformProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TFRecordWriteSchemaTransformProvider.java
@@ -184,8 +184,7 @@ public class TFRecordWriteSchemaTransformProvider
           output = "";
         }
       }
-      PCollection<Row> errorOutput =
-          byteArrays.get(ERROR_TAG).setRowSchema(ErrorHandling.errorSchema(errorSchema));
+      PCollection<Row> errorOutput = byteArrays.get(ERROR_TAG).setRowSchema(errorSchema);
       return PCollectionRowTuple.of(handleErrors ? output : "errors", errorOutput);
     }
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TFRecordSchemaTransformProviderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TFRecordSchemaTransformProviderTest.java
@@ -49,6 +49,7 @@ import org.apache.beam.sdk.io.TFRecordWriteSchemaTransformProvider.TFRecordWrite
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.transforms.SchemaTransform;
 import org.apache.beam.sdk.schemas.transforms.SchemaTransformProvider;
+import org.apache.beam.sdk.schemas.transforms.providers.ErrorHandling;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
@@ -236,6 +237,34 @@ public class TFRecordSchemaTransformProviderTest {
             .setCompression("UNCOMPRESSED")
             .setNoSpilling(true)
             .build());
+  }
+
+  @Test
+  public void testWriteErrorSchemaMatchesTheRowsErrorFnEmits() throws Exception {
+    // The schema is fixed when the graph is built, so this needs no runner.
+    writePipeline.enableAbandonedNodeEnforcement(false);
+
+    Schema schema = Schema.of(Schema.Field.of("record", Schema.FieldType.BYTES));
+
+    TFRecordWriteSchemaTransformProvider provider = new TFRecordWriteSchemaTransformProvider();
+    TFRecordWriteSchemaTransform transform =
+        (TFRecordWriteSchemaTransform)
+            provider.from(
+                TFRecordWriteSchemaTransformConfiguration.builder()
+                    .setOutputPrefix(tempFolder.getRoot().toPath().resolve("errors").toString())
+                    .setCompression("UNCOMPRESSED")
+                    .setNumShards(0)
+                    .setNoSpilling(true)
+                    .build());
+
+    Row row = Row.withSchema(schema).addValue("foo".getBytes(StandardCharsets.UTF_8)).build();
+    PCollection<Row> input =
+        writePipeline.apply(Create.of(Collections.singletonList(row)).withRowSchema(schema));
+    PCollectionRowTuple result = PCollectionRowTuple.of("input", input).apply(transform);
+
+    // ErrorFn emits ErrorHandling.errorRecord(errorSchema, ..), so the collection has to carry
+    // that schema. Wrapping it a second time declares a shape no element it emits can match.
+    assertEquals(ErrorHandling.errorSchema(schema), result.get("errors").getSchema());
   }
 
   @Test


### PR DESCRIPTION
**Please add a meaningful description for your change here**

`ErrorFn` is constructed with `errorSchema = ErrorHandling.errorSchema(inputSchema)` and emits `ErrorHandling.errorRecord(errorSchema, row, e)`, so every row on `ERROR_TAG` carries that schema. The collection was then tagged with the wrapper applied a **second** time:

```java
Schema errorSchema = ErrorHandling.errorSchema(inputSchema);          // :162
...
new ErrorFn("TFRecord-write-error-counter", rowToBytesFn, errorSchema, handleErrors)
...
byteArrays.get(ERROR_TAG).setRowSchema(ErrorHandling.errorSchema(errorSchema));   // :188
```

`errorSchema(x)` is `{failed_row: Row(x), error_message: STRING}`, so the declared shape becomes `{failed_row: {failed_row: …, error_message: …}, error_message: …}` — which no element the transform produces can match.

The sibling in the same package gets it right, five lines after an identical `ErrorFn` construction:

```java
// TFRecordReadSchemaTransformProvider.java:140
PCollection<Row> errorOutput = outputTuple.get(ERROR_TAG).setRowSchema(errorSchema);
```

`JavaFilterTransformProvider`, `JavaMapToFieldsTransformProvider`, `PubsubRowToMessage`, `PubsubWriteSchemaTransformProvider` and `BigQueryStorageWriteApiSchemaTransformProvider` all do the same.

### Test

One, and it needs no runner — the schema is fixed when the graph is built, so it runs in the ordinary `:sdks:java:core:test` task rather than under `NeedsRunner`.

Restoring the second wrap fails it and nothing else:

```
tests: 8, failures: 1
  FAILED: testWriteErrorSchemaMatchesTheRowsErrorFnEmits
```

`spotlessJavaCheck`, `checkstyleMain` and `checkstyleTest` on `:sdks:java:core` are clean.

### Not in this PR

`KafkaWriteSchemaTransformProvider.java:301` has the identical double wrap. It is in a different module with its own CI, so I have kept it separate rather than folding it in.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
