### PR TITLE
Tag the Kafka write error output with the schema it actually emits

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriteSchemaTransformProvider.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriteSchemaTransformProvider.java
@@ -297,8 +297,7 @@ public class KafkaWriteSchemaTransformProvider
       }
 
       // TODO: include output from KafkaIO Write once updated from PDone
-      PCollection<Row> errorOutput =
-          outputTuple.get(ERROR_TAG).setRowSchema(ErrorHandling.errorSchema(errorSchema));
+      PCollection<Row> errorOutput = outputTuple.get(ERROR_TAG).setRowSchema(errorSchema);
       return PCollectionRowTuple.of(
           handleErrors ? configuration.getErrorHandling().getOutput() : "errors", errorOutput);
     }

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaWriteSchemaTransformProviderTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaWriteSchemaTransformProviderTest.java
@@ -49,6 +49,7 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionRowTuple;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TupleTag;
@@ -269,6 +270,29 @@ public class KafkaWriteSchemaTransformProviderTest {
               Pipeline.create()
                   .apply(Create.empty(Schema.builder().addByteArrayField("bytes").build())));
     }
+  }
+
+  @Test
+  public void testErrorOutputCarriesTheSchemaErrorCounterFnEmits() {
+    // The output schema is fixed while the graph is built, so this needs no runner.
+    p.enableAbandonedNodeEnforcement(false);
+
+    Schema inputSchema = Schema.builder().addByteArrayField("bytes").build();
+    KafkaWriteSchemaTransformProvider.KafkaWriteSchemaTransformConfiguration configuration =
+        KafkaWriteSchemaTransformProvider.KafkaWriteSchemaTransformConfiguration.builder()
+            .setFormat("RAW")
+            .setTopic("test-topic")
+            .setBootstrapServers("host:9092")
+            .setErrorHandling(ErrorHandling.builder().setOutput("errors").build())
+            .build();
+
+    PCollectionRowTuple output =
+        PCollectionRowTuple.of("input", p.apply(Create.empty(inputSchema)))
+            .apply(new KafkaWriteSchemaTransformProvider().from(configuration));
+
+    // ErrorCounterFn emits ErrorHandling.errorRecord(errorSchema, ...), where errorSchema is
+    // already ErrorHandling.errorSchema(inputSchema).
+    assertEquals(ErrorHandling.errorSchema(inputSchema), output.get("errors").getSchema());
   }
 
   @Test


### PR DESCRIPTION
**Please add a meaningful description for your change here**

Follow-up to #39759, which fixed the identical defect in `TFRecordWriteSchemaTransformProvider`. Same bug, different module, so it is a separate PR.

`ErrorCounterFn` (and `GenericRecordErrorCounterFn`) are handed `errorSchema = ErrorHandling.errorSchema(inputSchema)` and emit `ErrorHandling.errorRecord(errorSchema, row, e)`, so every row on `ERROR_TAG` carries exactly that schema. The collection was then tagged with the wrapper applied a **second** time:

```java
Schema errorSchema = ErrorHandling.errorSchema(inputSchema);                    // :246
...
new ErrorCounterFn("Kafka-write-error-counter", toBytesFn, errorSchema, handleErrors)
...
receiver.get(ERROR_TAG).output(ErrorHandling.errorRecord(errorSchema, row, e)); // :161
...
outputTuple.get(ERROR_TAG).setRowSchema(ErrorHandling.errorSchema(errorSchema)); // :301
```

`errorSchema(x)` is `{failed_row: Row(x), error_message: STRING}`, so the declared shape becomes `{failed_row: {failed_row: …, error_message: …}, error_message: …}` — which no element this transform produces can match.

`KafkaReadSchemaTransformProvider` gets it right in the same package, and so do `JavaFilterTransformProvider`, `JavaMapToFieldsTransformProvider`, `PubsubRowToMessage`, `PubsubWriteSchemaTransformProvider` and `BigQueryStorageWriteApiSchemaTransformProvider`.

### Why the existing tests did not catch it

`KafkaWriteSchemaTransformProviderTest` exercises `ErrorCounterFn` by applying the `ParDo` directly and then calling `setRowSchema(errorSchema)` itself:

```java
PCollectionTuple output = input.apply(ParDo.of(new ErrorCounterFn(...)).withOutputTags(...));
output.get(ERROR_TAG).setRowSchema(errorSchema);        // the test's own, correct, tagging
```

So the four `ErrorFn` tests never reach line 301. The one test that does build the whole transform, `testBuildTransformWithManaged`, does not look at the output schema.

### Test

One, and it needs no runner — the schema is fixed while the graph is built, so it runs in the ordinary `:sdks:java:io:kafka:test` task. It goes through `expand()`, which is the gap above.

Restoring the second wrap fails it and nothing else:

```
7 tests completed, 1 failed

KafkaWriteSchemaTransformProviderTest > testErrorOutputCarriesTheSchemaErrorCounterFnEmits FAILED
    java.lang.AssertionError:
    expected:<{ failed_row: ROW { bytes: BYTES }, error_message: STRING }>
     but was:<{ failed_row: ROW { failed_row: ROW { bytes: BYTES }, error_message: STRING }, error_message: STRING }>
```

Note this needs a clean recompile to reproduce — running it incrementally on top of a previous build makes `KafkaIO.writeRecords` throw `NullPointerException: Null eosTriggerTimeout` in both this test and `testBuildTransformWithManaged`, from stale AutoValue output rather than from the change. With `--rerun-tasks` only the one test fails.

`spotlessJavaCheck`, `checkstyleMain` and `checkstyleTest` on `:sdks:java:io:kafka` are clean.

### Are there user-facing changes?

Yes, for anyone reading the `errors` output of the Kafka write `SchemaTransform`: it is now tagged with the schema its rows actually have. Code that hardcoded the doubly-nested shape to work around this would need updating, but such code could not have been reading real rows successfully.
