### PR TITLE
fix: increase AVG MathContext precision from 10 to 34 to prevent BIGINT overflow and silent precision loss

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamBuiltinAggregations.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamBuiltinAggregations.java
@@ -90,7 +90,7 @@ public class BeamBuiltinAggregations {
               .put("COUNTIF", typeName -> CountIf.combineFn())
               .build();
 
-  private static MathContext mc = new MathContext(10, RoundingMode.HALF_UP);
+  private static MathContext mc = new MathContext(34, RoundingMode.HALF_UP);
 
   public static CombineFn<?, ?, ?> create(String functionName, Schema.FieldType fieldType) {
 


### PR DESCRIPTION
## Problem

[#39751](https://github.com/apache/beam/issues/39751) — SQL `AVG` rounds every result to 10 significant digits via the fixed `MathContext(10, RoundingMode.HALF_UP)` at `BeamBuiltinAggregations.java:93`. All AVG subtypes (`INT32`, `INT64`, `INT16`, `INT8`, `FLOAT`, `DOUBLE`, `DECIMAL`) go through `prepareOutput` which divides the accumulator with this precision.

Consequences:
- `AVG` over a single `BIGINT` value `9223372036854775807` returns `-9223372036709551616` — **sign flipped** due to 10-digit rounding then `.longValue()` truncation
- Values above 10 significant digits (ids, epoch-millis, cent-denominated amounts) are silently rounded (e.g. `AVG(1786500000123)` → `1786500000000`)
- `DECIMAL(18,2)` values lose precision (`123456789.99` → `123456790.0`)

## Fix

Increase the `MathContext` precision from 10 to 34 significant digits (`MathContext.DECIMAL128` precision, with the same `HALF_UP` rounding mode). This keeps all values representable in any of the supported input types exact through the division:
- `INT64`/`BIGINT` values need up to 19 significant digits — 34 is sufficient, so the sign flip and truncation disappear
- `DECIMAL(38,10)` can need up to 49 digits, but 34 covers the overwhelmingly common `DECIMAL(p,s)` ranges and matches `MathContext.DECIMAL128` semantics (sum/count where the division terminates is exact; non-terminating divisions are rounded to 34 digits instead of 10)

The alternative of dropping the MathContext would turn non-terminating divisions into `ArithmeticException`; threading the declared output `RelDataType` precision/scale from `AggregateCall` is a larger design change touching `VAR_*`, `STDDEV_*`, `COVAR_*` coders — a follow-up for the component owners. This fix addresses the reported correctness bugs with a minimal, targeted change.

Fixes #39751