### PR TITLE
[GSoC-273] Fix: Remove invalid external ML6 identities to unblock Terraform IAM deployment

### DIFF
--- a/infra/iam/users.yml
+++ b/infra/iam/users.yml
@@ -125,11 +125,6 @@
   member_type: user
   permissions:
   - role: roles/editor
-- username: andres.vervaecke
-  email: andres.vervaecke@ml6.eu
-  member_type: user
-  permissions:
-  - role: roles/viewer
 - username: andrey.devyatkin
   email: andrey.devyatkin@akvelon.com
   member_type: user
@@ -522,11 +517,6 @@
   - role: roles/pubsub.subscriber
   - role: roles/pubsub.viewer
   - role: roles/storage.admin
-- username: jasper.van.den.bossche
-  email: jasper.van.den.bossche@ml6.eu
-  member_type: user
-  permissions:
-  - role: roles/editor
 - username: jeffreylwang
   email: jeffreylwang@google.com
   member_type: user


### PR DESCRIPTION
## Summary Changes
This pull request removes two invalid external user identities from the IAM user configuration file:
- ` infra/iam/users.yml`

The identities being permanently deleted are:

* `jasper.van.den.bossche@ml6.eu` (roles/editor)
* `andres.vervaecke@ml6.eu` (roles/viewer)

These identities do not exist as valid users or service accounts in the Google Cloud Identity / Workspace directory of the Apache foundation, causing the automated Terraform deployment to fail.

## Error Example

```bash
Error: Request `Create IAM Members roles/editor user:jasper.van.den.bossche@ml6.eu for project "apache-beam-testing"` returned error: Final error: googleapi: Error 400: User jasper.van.den.bossche@ml6.eu does not exist., badRequest

Error: Request `Create IAM Members roles/viewer user:andres.vervaecke@ml6.eu for project "apache-beam-testing"` returned error: Final error: googleapi: Error 400: User andres.vervaecke@ml6.eu does not exist., badRequest

Error: Terraform exited with code 1.
Error: Process completed with exit code 1.
```