### PR TITLE
Fix PubSub subscription path double-prefix in stale_cleaner (#39772)

### DIFF
--- a/.test-infra/tools/stale_cleaner.py
+++ b/.test-infra/tools/stale_cleaner.py
@@ -350,8 +350,10 @@ class PubSubSubscriptionCleaner(StaleCleaner):
         self.client = pubsub_v1.SubscriberClient()
         print(f"{self.clock()} - Deleting PubSub subscription {resource_name}")
         with self.client:
-            subscription_path = self.client.subscription_path(self.project_id, resource_name)
-            self.client.delete_subscription(request={"subscription": subscription_path})
+            # resource_name from list_subscriptions() is already a fully-qualified
+            # path (e.g. "projects/<project>/subscriptions/<sub-id>"). Passing it
+            # to subscription_path() would double-prefix and cause a 400 error.
+            self.client.delete_subscription(request={"subscription": resource_name})
 
 def clean_pubsub_topics():
     """ Clean up stale PubSub topics in the specified GCP project.

--- a/.test-infra/tools/test_stale_cleaner.py
+++ b/.test-infra/tools/test_stale_cleaner.py
@@ -484,17 +484,22 @@ class PubSubSubscriptionCleanerTest(unittest.TestCase):
             self.assertEqual(len(active), 1)
 
     def test_delete_resource(self):
-        """Test _delete_resource method."""
-        sub_name = "test-sub-to-delete"
-        subscription_path = f"projects/{self.project_id}/subscriptions/{sub_name}"
-        self.mock_subscriber_client.subscription_path.return_value = subscription_path
+        """Test _delete_resource method.
+
+        list_subscriptions() returns subscription names as fully-qualified
+        paths (e.g. "projects/<project>/subscriptions/<sub-id>"), so
+        _delete_resource must pass them directly to delete_subscription
+        without re-prefixing via subscription_path(). Double-prefixing
+        causes InvalidArgument 400 and is the cause of issue #39772.
+        """
+        sub_path = f"projects/{self.project_id}/subscriptions/test-sub-to-delete"
 
         with SilencePrint():
-            self.cleaner._delete_resource(sub_name)
+            self.cleaner._delete_resource(sub_path)
 
-        self.mock_subscriber_client.subscription_path.assert_called_once_with(self.project_id, sub_name)
+        self.mock_subscriber_client.subscription_path.assert_not_called()
         self.mock_subscriber_client.delete_subscription.assert_called_once_with(
-            request={'subscription': subscription_path}
+            request={'subscription': sub_path}
         )
 
 


### PR DESCRIPTION
The Clean Up GCP Resources workflow (`beam_CleanUpGCPResources.yml`) fails
over 80% of the time. Root cause:

**`PubSubSubscriptionCleaner._delete_resource()`** calls
`subscription_path(project_id, resource_name)` on a resource name that is
**already a fully-qualified path** from `list_subscriptions()`. This produces
`projects/<project>/subscriptions/projects/<project>/subscriptions/<sub-id>`
which GCP rejects with `InvalidArgument: 400 Invalid resource name given`.

`PubSubTopicCleaner._delete_resource()` correctly passes the full path
directly to `delete_topic()`. This fix mirrors that pattern.

Fixes #39772