### PR TITLE
fix: preserve duplicate same-timestamp elements in FlinkOrderedListState

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
@@ -20,8 +20,11 @@ package org.apache.beam.runners.flink.translation.wrappers.streaming.state;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
@@ -620,18 +623,21 @@ public class FlinkStateInternals<K> implements StateInternals {
 
     @Override
     public Iterable<TimestampedValue<T>> readRange(Instant minTimestamp, Instant limitTimestamp) {
-      return readAsMap().subMap(minTimestamp, limitTimestamp).values();
+      return readAsMultimap().subMap(minTimestamp, limitTimestamp).values().stream()
+          .flatMap(List::stream)
+          .collect(Collectors.toList());
     }
 
     @Override
     public void clearRange(Instant minTimestamp, Instant limitTimestamp) {
-      SortedMap<Instant, TimestampedValue<T>> sortedMap = readAsMap();
+      SortedMap<Instant, List<TimestampedValue<T>>> sortedMap = readAsMultimap();
       sortedMap.subMap(minTimestamp, limitTimestamp).clear();
       try {
         ListState<TimestampedValue<T>> partitionedState =
             flinkStateBackend.getPartitionedState(
                 namespace, namespaceSerializer, flinkStateDescriptor);
-        partitionedState.update(Lists.newArrayList(sortedMap.values()));
+        partitionedState.update(
+            sortedMap.values().stream().flatMap(List::stream).collect(Collectors.toList()));
       } catch (Exception e) {
         throw new RuntimeException("Error adding to bag state.", e);
       }
@@ -680,10 +686,12 @@ public class FlinkStateInternals<K> implements StateInternals {
     @Override
     @Nullable
     public Iterable<TimestampedValue<T>> read() {
-      return readAsMap().values();
+      return readAsMultimap().values().stream()
+          .flatMap(List::stream)
+          .collect(Collectors.toList());
     }
 
-    private SortedMap<Instant, TimestampedValue<T>> readAsMap() {
+    private SortedMap<Instant, List<TimestampedValue<T>>> readAsMultimap() {
       Iterable<TimestampedValue<T>> listValues;
       try {
         ListState<TimestampedValue<T>> partitionedState =
@@ -694,9 +702,9 @@ public class FlinkStateInternals<K> implements StateInternals {
         throw new RuntimeException("Error reading state.", e);
       }
 
-      SortedMap<Instant, TimestampedValue<T>> sortedMap = Maps.newTreeMap();
+      SortedMap<Instant, List<TimestampedValue<T>>> sortedMap = Maps.newTreeMap();
       for (TimestampedValue<T> value : listValues) {
-        sortedMap.put(value.getTimestamp(), value);
+        sortedMap.computeIfAbsent(value.getTimestamp(), k -> new ArrayList<>()).add(value);
       }
       return sortedMap;
     }


### PR DESCRIPTION
**Issue:** #39782

**Problem:** `FlinkOrderedListState.readAsMap()` builds a `SortedMap<Instant, TimestampedValue<T>>` using `Map.put()` keyed by timestamp. When multiple elements share the same timestamp, the second element overwrites the first — causing silent data loss when reading the state.

**Fix:** Changed to a multimap structure (`SortedMap<Instant, List<TimestampedValue<T>>>`). Uses `Map.computeIfAbsent()` to accumulate all values per timestamp bucket, preserving every element. Updated `read()`, `readRange()`, and `clearRange()` to flatten the multimap values.

**Root cause (code):**
```java
// Before (bug): duplicates lost
SortedMap<Instant, TimestampedValue<T>> sortedMap = Maps.newTreeMap();
for (TimestampedValue<T> value : listValues) {
    sortedMap.put(value.getTimestamp(), value);  // overwrites same-ts elements
}

// After: all values preserved
SortedMap<Instant, List<TimestampedValue<T>>> sortedMap = Maps.newTreeMap();
for (TimestampedValue<T> value : listValues) {
    sortedMap.computeIfAbsent(value.getTimestamp(), k -> new ArrayList<>()).add(value);
}
```

**Testing:** `FlinkStateInternalsTest` — existing ordered-list tests cover ordering semantics; they pass unchanged since the multimap flattens back to the same sorted order. The scoped PR change is behavior-preserving for unique timestamps and fixes duplicate-timestamp data loss.

**Docs / changelog:** This is a bug fix; no user-facing API change.