### PR TITLE
[GSoC 2026] Kafka Streams runner: update the CHANGES.md entry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,7 +71,7 @@
 
 ## New Features / Improvements
 
-* (Java) Added a `runners/kafka-streams` Gradle module with portable job server and runner entry points; translation fails fast with an explicit unsupported-URN message until transforms are implemented ([#38465](https://github.com/apache/beam/issues/38465)).
+* (Java) Added an experimental Kafka Streams runner, which executes a Beam pipeline as an ordinary Kafka Streams application with no cluster to operate. It supports a subset of the model and is not built by default; pass `-Pwith-kafka-streams-runner` to include it ([#18479](https://github.com/apache/beam/issues/18479)).
 * Capability introduces an indicator for aggregations and timers firing during a pipeline drain, allowing users and sinks to recognize and appropriately handle potentially incomplete or partial data ([#36884](https://github.com/apache/beam/issues/36884)).
 * Added support for setting disk provisioned IOPS and throughput in Dataflow runner via `--diskProvisionedIops` and `--diskProvisionedThroughputMibps` pipeline options (Java/Go/Python) ([#38349](https://github.com/apache/beam/issues/38349)).
 * TriggerStateMachineRunner changes from BitSetCoder to SentinelBitSetCoder to


### PR DESCRIPTION
Part of #18479, for https://github.com/apache/beam/pull/39785.

The CHANGES.md entry still described the original skeleton — `runners/kafka-streams` as a module whose translation fails fast with an unsupported-URN message until transforms are implemented. That stopped being true months ago. It now describes the runner as it is and says it is opt-in behind `-Pwith-kafka-streams-runner`.

One thing worth deciding separately: the entry sits under the 2.74.0 section, because that is where it was added back in June. On master 2.74.0 is released, so after the merge the entry would sit in a released section rather than in 2.77.0. This branch cannot move it, since it has no 2.77.0 section to move it into — happy to send a follow-up PR to master once the merge lands, or leave it to the master PR, whichever you prefer.