### PR TITLE
Fix stale broken cluster connection in CassandraIO

### DIFF
--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/ConnectionManager.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/ConnectionManager.java
@@ -62,16 +62,17 @@ public class ConnectionManager {
     String clusterHash = readToClusterHash(read);
     String sessionHash = readToSessionHash(read);
 
-    Cluster cluster = clusterMap.get(clusterHash);
+    Cluster cachedCluster = clusterMap.get(clusterHash);
 
-    if(cluster != null && cluster.isClosed()) {
+    if (cachedCluster != null && cachedCluster.isClosed()) {
       Session brokenSession = sessionMap.get(sessionHash);
       if (brokenSession != null) {
-        sessionMap.remove(sessionHash,brokenSession);
+        sessionMap.remove(sessionHash, brokenSession);
       }
-      clusterMap.remove(clusterHash,cluster);
+      // Removing broken cluster object
+      clusterMap.remove(clusterHash, cachedCluster);
     }
-    cluster =
+    Cluster cluster =
         clusterMap.computeIfAbsent(
             clusterHash,
             k ->

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/ConnectionManager.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/ConnectionManager.java
@@ -59,9 +59,21 @@ public class ConnectionManager {
   }
 
   static Session getSession(Read<?> read) {
-    Cluster cluster =
+    String clusterHash = readToClusterHash(read);
+    String sessionHash = readToSessionHash(read);
+
+    Cluster cluster = clusterMap.get(clusterHash);
+
+    if(cluster != null && cluster.isClosed()) {
+      Session brokenSession = sessionMap.get(sessionHash);
+      if (brokenSession != null) {
+        sessionMap.remove(sessionHash,brokenSession);
+      }
+      clusterMap.remove(clusterHash,cluster);
+    }
+    cluster =
         clusterMap.computeIfAbsent(
-            readToClusterHash(read),
+            clusterHash,
             k ->
                 CassandraIO.getCluster(
                     Objects.requireNonNull(read.hosts()),

--- a/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOTest.java
+++ b/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOTest.java
@@ -19,6 +19,9 @@ package org.apache.beam.sdk.io.cassandra;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 
 import com.datastax.driver.core.Cluster;
@@ -1217,5 +1220,32 @@ public class CassandraIOTest implements Serializable {
     public int hashCode() {
       return Objects.hashCode(tableColumn, indexColumn, valueColumn, data);
     }
+  }
+
+  @Test
+  public void testSessionEvictionOnClosedCluster() {
+    CassandraIO.Read<String> readConfig =
+        CassandraIO.<String>read()
+            .withHosts(Collections.singletonList(CASSANDRA_HOST))
+            .withPort(cassandraPort)
+            .withKeyspace(CASSANDRA_KEYSPACE)
+            .withTable(CASSANDRA_TABLE);
+
+    Session initialSession = ConnectionManager.getSession(readConfig);
+    Cluster initialCluster = initialSession.getCluster();
+
+    initialCluster.close();
+    assertTrue("Cluster should be closed", initialCluster.isClosed());
+
+    Session newSession = ConnectionManager.getSession(readConfig);
+    Cluster newCluster = newSession.getCluster();
+
+    assertNotNull("New session should not be null", newSession);
+    assertFalse("New cluster should be open", newCluster.isClosed());
+
+    assertNotSame(
+        "ConnectionManager should create a new Session instance", initialSession, newSession);
+    assertNotSame(
+        "ConnectionManager should create a new Cluster instance", initialCluster, newCluster);
   }
 }


### PR DESCRIPTION

fixes #39780 

This PR fixes an issue in `CassandraIO` where read operations can fail if the underlying Cassandra Cluster connection is broken due to a transient issue avoiding subsequent work failures.

Previously, `ConnectionManager` would cache the `Cluster` and `Session` and continue to return them even if the cluster was in a broken state, leading to subsequent operation failures.

This change adds a validation step in `ConnectionManager.getSession()`. If the cached Cluster is found to be closed, the stale references are proactively removed from `sessionMap` and `clusterMap`. This ensures that a new, healthy Cluster and Session are transparently recreated via computeIfAbsent.