### PR TITLE
fix: pin httpclient5 to 5.4.3 in expansion service to fix OAUTHBEARER auth regression

### DIFF
--- a/sdks/java/io/expansion-service/build.gradle
+++ b/sdks/java/io/expansion-service/build.gradle
@@ -35,6 +35,13 @@ applyJavaNature(
 configurations.runtimeClasspath {
   // Pin kafka-clients version due to <3.4.0 missing auth callback classes.
   resolutionStrategy.force 'org.apache.kafka:kafka-clients:3.9.0'
+  // Pin httpclient5 to 5.4.3 to fix OAUTHBEARER auth regression (#39789)
+  // httpclient5 5.5 breaks google-auth-library-oauth2-http transport layer
+  resolutionStrategy.force 'org.apache.httpcomponents.client5:httpclient5:5.4.3'
+  resolutionStrategy.force 'org.apache.httpcomponents.client5:httpclient5-fluent:5.4.3'
+  resolutionStrategy.force 'org.apache.httpcomponents.core5:httpcore5:5.2.5'
+  resolutionStrategy.force 'org.apache.httpcomponents.core5:httpcore5-h2:5.2.5'
+
   // force parquet-avro:1.15.2 to fix CVE-2025-46762
   resolutionStrategy.force 'org.apache.parquet:parquet-avro:1.15.2'
 


### PR DESCRIPTION
Fixes #39789

The httpclient5 5.4.3→5.5 upgrade broke OAUTHBEARER auth against GCP Managed Service for Apache Kafka. The google-auth-library-oauth2-http (1.37.1) is compiled against httpclient5 5.4.x and the 5.5 upgrade introduces binary incompatibility at runtime.

This pins httpclient5 (and its transitive httpcore5) to the versions that were in use at Beam 2.68.0, which was the last known-good release.

See #39789 for full bisection details.