### PR TITLE
bigtable: Set Apache Beam user agent for Python BigtableIO write client

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigtableio.py
+++ b/sdks/python/apache_beam/io/gcp/bigtableio.py
@@ -43,6 +43,7 @@ from typing import Dict
 from typing import List
 
 import apache_beam as beam
+from apache_beam import version as beam_version
 from apache_beam.internal.metrics.metric import ServiceCallMetric
 from apache_beam.io.gcp import resource_identifiers
 from apache_beam.metrics import Metrics
@@ -59,6 +60,7 @@ FLUSH_COUNT = 1000
 MAX_ROW_BYTES = 5242880  # 5MB
 
 try:
+  from google.api_core.gapic_v1 import client_info as client_info_lib
   from google.cloud.bigtable import Client
   from google.cloud.bigtable.batcher import MutationsBatcher
   from google.cloud.bigtable.row import Cell
@@ -141,7 +143,11 @@ class _BigTableWriteFn(beam.DoFn):
 
   def start_bundle(self):
     if self.table is None:
-      client = Client(project=self.beam_options['project_id'])
+      client = Client(
+          project=self.beam_options['project_id'],
+          client_info=client_info_lib.ClientInfo(
+              user_agent="apache-beam/%s (GPN:Beam)" %
+              beam_version.__version__))
       instance = client.instance(self.beam_options['instance_id'])
       self.table = instance.table(self.beam_options['table_id'])
     self.service_call_metric = self.start_service_call_metrics(


### PR DESCRIPTION
Configure the native Python Bigtable write client with a Beam user agent (apache-beam/<version> (GPN:Beam)), matching the Java BigtableIO behavior and the convention used by gcsio.py and the Datastore connector.