### PR TITLE
Portable Time type (Java + model changes)

### DIFF
--- a/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/schema.proto
+++ b/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/schema.proto
@@ -247,6 +247,13 @@ message LogicalTypes {
     //     e.g. -1.5s at precision 6 is {seconds: -2, subseconds: 500000}.
     TIMESTAMP = 9 [(org.apache.beam.model.pipeline.v1.beam_urn) =
       "beam:logical_type:timestamp:v1"];
+
+    // A URN for Time type
+    //   - Representation type: INT64
+    //   - A time without a timezone, represented by the number of
+    //     nanoseconds since midnight.
+    TIME = 10 [(org.apache.beam.model.pipeline.v1.beam_urn) =
+      "beam:logical_type:time:v1"];
   }
 }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java
@@ -50,6 +50,7 @@ import org.apache.beam.sdk.schemas.logicaltypes.FixedString;
 import org.apache.beam.sdk.schemas.logicaltypes.MicrosInstant;
 import org.apache.beam.sdk.schemas.logicaltypes.PythonCallable;
 import org.apache.beam.sdk.schemas.logicaltypes.SchemaLogicalType;
+import org.apache.beam.sdk.schemas.logicaltypes.Time;
 import org.apache.beam.sdk.schemas.logicaltypes.Timestamp;
 import org.apache.beam.sdk.schemas.logicaltypes.UnknownLogicalType;
 import org.apache.beam.sdk.schemas.logicaltypes.VariableBytes;
@@ -116,6 +117,7 @@ public class SchemaTranslation {
           .put(FixedString.IDENTIFIER, FixedString.class)
           .put(VariableString.IDENTIFIER, VariableString.class)
           .put(Date.IDENTIFIER, Date.class)
+          .put(Time.IDENTIFIER, Time.class)
           .put(Timestamp.IDENTIFIER, Timestamp.class)
           .build();
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/Time.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/Time.java
@@ -18,7 +18,10 @@
 package org.apache.beam.sdk.schemas.logicaltypes;
 
 import java.time.LocalTime;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.model.pipeline.v1.SchemaApi;
 import org.apache.beam.sdk.schemas.Schema;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A time without a time-zone.
@@ -30,23 +33,20 @@ import org.apache.beam.sdk.schemas.Schema;
  * of time in nanoseconds.
  */
 public class Time implements Schema.LogicalType<LocalTime, Long> {
-  public static final String IDENTIFIER = "beam:logical_type:time:v1";
+  public static final String IDENTIFIER =
+      SchemaApi.LogicalTypes.Enum.TIME
+          .getValueDescriptor()
+          .getOptions()
+          .getExtension(RunnerApi.beamUrn);
 
   @Override
   public String getIdentifier() {
     return IDENTIFIER;
   }
 
-  // unused
   @Override
-  public Schema.FieldType getArgumentType() {
-    return Schema.FieldType.STRING;
-  }
-
-  // unused
-  @Override
-  public String getArgument() {
-    return "";
+  public Schema.@Nullable FieldType getArgumentType() {
+    return null;
   }
 
   @Override

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaTranslationTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaTranslationTest.java
@@ -27,6 +27,7 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -41,6 +42,7 @@ import org.apache.beam.model.pipeline.v1.SchemaApi.FieldValue;
 import org.apache.beam.model.pipeline.v1.SchemaApi.LogicalType;
 import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.schemas.logicaltypes.Date;
 import org.apache.beam.sdk.schemas.logicaltypes.DateTime;
 import org.apache.beam.sdk.schemas.logicaltypes.FixedBytes;
 import org.apache.beam.sdk.schemas.logicaltypes.FixedPrecisionNumeric;
@@ -51,6 +53,7 @@ import org.apache.beam.sdk.schemas.logicaltypes.NanosInstant;
 import org.apache.beam.sdk.schemas.logicaltypes.PythonCallable;
 import org.apache.beam.sdk.schemas.logicaltypes.SchemaLogicalType;
 import org.apache.beam.sdk.schemas.logicaltypes.SqlTypes;
+import org.apache.beam.sdk.schemas.logicaltypes.Time;
 import org.apache.beam.sdk.schemas.logicaltypes.Timestamp;
 import org.apache.beam.sdk.schemas.logicaltypes.UnknownLogicalType;
 import org.apache.beam.sdk.schemas.logicaltypes.VariableBytes;
@@ -145,6 +148,7 @@ public class SchemaTranslationTest {
           .add(Schema.of(Field.of("fixed_bytes", FieldType.logicalType(FixedBytes.of(24)))))
           .add(Schema.of(Field.of("micros_instant", FieldType.logicalType(new MicrosInstant()))))
           .add(Schema.of(Field.of("date", FieldType.logicalType(SqlTypes.DATE))))
+          .add(Schema.of(Field.of("time", FieldType.logicalType(SqlTypes.TIME))))
           .add(Schema.of(Field.of("python_callable", FieldType.logicalType(new PythonCallable()))))
           .add(
               Schema.of(
@@ -392,6 +396,7 @@ public class SchemaTranslationTest {
           .add(simpleRow(FieldType.logicalType(new PortableNullArgLogicalType()), "str"))
           .add(simpleRow(FieldType.logicalType(new DateTime()), LocalDateTime.of(2000, 1, 3, 3, 1)))
           .add(simpleRow(FieldType.logicalType(SqlTypes.DATE), LocalDate.of(2000, 1, 3)))
+          .add(simpleRow(FieldType.logicalType(SqlTypes.TIME), LocalTime.of(3, 1, 2, 3000)))
           .add(simpleNullRow(FieldType.STRING))
           .add(simpleNullRow(FieldType.INT32))
           .add(simpleNullRow(FieldType.map(FieldType.STRING, FieldType.INT32)))
@@ -441,6 +446,41 @@ public class SchemaTranslationTest {
 
       assertThat(exception.getMessage(), containsString("field_no_typeInfo"));
       assertThat(exception.getCause().getMessage(), containsString("TYPEINFO_NOT_SET"));
+    }
+  }
+
+  /**
+   * A portable logical type has to be recoverable from its URN alone, because that is all a schema
+   * coming from another SDK carries. {@link LogicalTypesTest#testLogicalTypeFromToProtoCorrectly}
+   * cannot check this: it branches on {@code STANDARD_LOGICAL_TYPES} itself, so it passes whether
+   * or not the type is registered there.
+   */
+  @RunWith(JUnit4.class)
+  public static class PortableLogicalTypeFromUrnTest {
+
+    @Test
+    public void timeIsRecoveredFromItsUrnAlone() {
+      FieldType fieldType = FieldType.logicalType(SqlTypes.TIME);
+
+      // serializeLogicalType = false, so the proto carries the URN and no Java payload
+      SchemaApi.FieldType proto = SchemaTranslation.fieldTypeToProto(fieldType, false, false);
+      assertThat(proto.getLogicalType().getUrn(), equalTo("beam:logical_type:time:v1"));
+      assertThat(proto.getLogicalType().getPayload().size(), equalTo(0));
+
+      Schema.FieldType translated = SchemaTranslation.fieldTypeFromProto(proto);
+      assertThat(translated.getLogicalType().getClass(), equalTo(Time.class));
+      assertThat(translated.getLogicalType().getBaseType(), equalTo(FieldType.INT64));
+    }
+
+    @Test
+    public void dateIsRecoveredFromItsUrnAlone() {
+      FieldType fieldType = FieldType.logicalType(SqlTypes.DATE);
+
+      SchemaApi.FieldType proto = SchemaTranslation.fieldTypeToProto(fieldType, false, false);
+      assertThat(proto.getLogicalType().getUrn(), equalTo("beam:logical_type:date:v1"));
+
+      Schema.FieldType translated = SchemaTranslation.fieldTypeFromProto(proto);
+      assertThat(translated.getLogicalType().getClass(), equalTo(Date.class));
     }
   }
 


### PR DESCRIPTION
Adds the portable `Time` logical type, so a `LocalTime` field can cross an SDK boundary the way `Date` can since #38077.

`Time` already exists in the Java SDK but is not portable: its identifier is a hardcoded string that no entry in `LogicalTypes.Enum` backs, and it is absent from `SchemaTranslation.STANDARD_LOGICAL_TYPES`. A schema arriving from another SDK carrying `beam:logical_type:time:v1` therefore comes back as `UnknownLogicalType` rather than as `Time`.

This is a direct mirror of #38077:

* `schema.proto` — `TIME = 10`, representation `INT64`, nanoseconds since midnight, matching what `Time.toBaseType` already produces;
* `SchemaTranslation` — register `Time.IDENTIFIER -> Time.class`;
* `Time.java` — take `IDENTIFIER` from the enum, and return `null` from `getArgumentType()` instead of the `STRING`/`""` pair that was marked `// unused`.

Following the same split @Abacn suggested on #37830, the Python changes go in a separate PR so the new URN is in a snapshot container before the cross-language tests need it. `JdbcUtil` is deliberately left out too: the `Date` PR added a `Date.valueOf(LocalDate)` setter, but the `Time` equivalent, `Time.valueOf(LocalTime)`, silently truncates sub-second precision, and this type's whole base representation is nanoseconds. That deserves its own change rather than a copy of the `Date` line.

### Testing

`SchemaTranslationTest` — 89 tests, 0 failures. `spotlessJavaCheck`, `checkstyleMain` and `checkstyleTest` are clean.

The two entries added to the existing parameterised lists are not on their own enough, and it is worth saying why. `LogicalTypesTest.testLogicalTypeFromToProtoCorrectly` branches on the registry it is meant to be exercising:

```java
if (STANDARD_LOGICAL_TYPES.containsKey(translated.getLogicalType().getIdentifier())) {
  assertThat(translated.getLogicalType().getClass(), equalTo(fieldType.getLogicalType().getClass()));
} else {
  assertThat(translated.getLogicalType().getClass(), equalTo(UnknownLogicalType.class));
}
```

Drop the `SchemaTranslation` registration and the `else` branch simply takes over — the suite stays green. I checked: with that one line removed, all 87 pre-existing tests still passed.

So this adds `PortableLogicalTypeFromUrnTest`, which asserts the recovery directly and consults nothing:

```java
SchemaApi.FieldType proto = SchemaTranslation.fieldTypeToProto(fieldType, false, false);
assertThat(proto.getLogicalType().getUrn(), equalTo("beam:logical_type:time:v1"));
assertThat(proto.getLogicalType().getPayload().size(), equalTo(0));

Schema.FieldType translated = SchemaTranslation.fieldTypeFromProto(proto);
assertThat(translated.getLogicalType().getClass(), equalTo(Time.class));
```

With the registration removed this fails as it should —

```
timeIsRecoveredFromItsUrnAlone
Expected: <class org.apache.beam.sdk.schemas.logicaltypes.Time>
     but: was <class org.apache.beam.sdk.schemas.logicaltypes.UnknownLogicalType>
```

— while its `Date` sibling stays green, so the failure is the missing registration and not the test class itself.

Addresses part of #25946. @ahmedabu98 you offered to review this one back in March — PTAL.
