### PR TITLE
Set getSession to synchronized to avoid race conditions

### DIFF
--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/ConnectionManager.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/ConnectionManager.java
@@ -58,7 +58,7 @@ public class ConnectionManager {
     return readToClusterHash(read) + read.keyspace().get();
   }
 
-  static Session getSession(Read<?> read) {
+  static synchronized Session getSession(Read<?> read) {
     String clusterHash = readToClusterHash(read);
     String sessionHash = readToSessionHash(read);
 


### PR DESCRIPTION
Synchronized `getSession()` to fix race condition suggested in - https://github.com/apache/beam/pull/39803