### PR TITLE
AddFiles: regenerate name mapping, read footers once, error helper

### DIFF
--- a/.github/trigger_files/IO_Iceberg_Integration_Tests.json
+++ b/.github/trigger_files/IO_Iceberg_Integration_Tests.json
@@ -1,4 +1,4 @@
 {
     "comment": "Modify this file in a trivial way to cause this test suite to run.",
-    "modification": 3
+    "modification": 4
 }

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/AddFiles.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/AddFiles.java
@@ -446,8 +446,6 @@ public class AddFiles extends PTransform<PCollection<String>, PCollectionRowTupl
         }
 
         // ---- Per-file phase: every failure below is one error row, never a failed bundle.
-
-        // One footer read per file, shared by stats collection and partition resolution.
         @Nullable ParquetMetadata parquetFooter = null;
         if (format.equals(FileFormat.PARQUET)) {
           try {
@@ -589,7 +587,7 @@ public class AddFiles extends PTransform<PCollection<String>, PCollectionRowTupl
      */
     static String getPartitionFromMetrics(
         Metrics metrics, InputFile inputFile, Table table, @Nullable ParquetMetadata preReadFooter)
-        throws UnknownPartitionException, IOException, InterruptedException {
+        throws UnknownPartitionException {
       List<PartitionField> fields = table.spec().fields();
       List<Integer> sourceIds =
           fields.stream().map(PartitionField::sourceId).collect(Collectors.toList());
@@ -848,22 +846,17 @@ public class AddFiles extends PTransform<PCollection<String>, PCollectionRowTupl
     }
   }
 
-  /**
-   * {@code preReadFooter} reuses an already-read Parquet footer, avoiding a second remote read;
-   * null reads it here. Always null for ORC and Avro.
-   */
   @SuppressWarnings("argument")
   public static Metrics getFileMetrics(
       InputFile file,
       FileFormat format,
       MetricsConfig config,
       NameMapping mapping,
-      @Nullable ParquetMetadata preReadFooter)
-      throws IOException {
+      @Nullable ParquetMetadata preReadFooter) {
     switch (format) {
       case PARQUET:
         ParquetMetadata footer =
-            preReadFooter != null ? preReadFooter : readParquetFooter(file.location());
+            checkStateNotNull(preReadFooter, "Parquet metrics require the pre-read footer");
         MessageType originalMessageType = footer.getFileMetaData().getSchema();
         if (!ParquetSchemaUtil.hasIds(originalMessageType)) {
           footer = getFooterWithTypeIds(originalMessageType, footer, mapping);

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/AddFiles.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/AddFiles.java
@@ -743,12 +743,23 @@ public class AddFiles extends PTransform<PCollection<String>, PCollectionRowTupl
     }
 
     private static void ensureNameMappingPresent(Table table) {
-      if (table.properties().get(TableProperties.DEFAULT_NAME_MAPPING) == null) {
-        // Forces Name based resolution instead of position based resolution
-        NameMapping mapping = MappingUtil.create(table.schema());
-        String mappingJson = NameMappingParser.toJson(mapping);
-        table.updateProperties().set(TableProperties.DEFAULT_NAME_MAPPING, mappingJson).commit();
+      // Forces name-based resolution: zero-copy files carry no field ids, so any schema column
+      // missing from the mapping is unreadable in registered files.
+      @Nullable
+      NameMapping existing =
+          NameMappingUtils.parseOrNull(
+              table.properties().get(TableProperties.DEFAULT_NAME_MAPPING));
+      if (existing != null && NameMappingUtils.covers(existing, table.schema().asStruct())) {
+        return;
       }
+      if (existing != null) {
+        LOG.info(
+            "Name mapping of table {} does not cover its schema; regenerating it, preserving "
+                + "custom names where possible.",
+            table.name());
+      }
+      String mappingJson = NameMappingUtils.regenerate(table.schema(), existing);
+      table.updateProperties().set(TableProperties.DEFAULT_NAME_MAPPING, mappingJson).commit();
     }
 
     @ProcessElement

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/AddFiles.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/AddFiles.java
@@ -437,9 +437,7 @@ public class AddFiles extends PTransform<PCollection<String>, PCollectionRowTupl
               } catch (FileNotFoundException e) {
                 return new ProcessResult(
                     null,
-                    Row.withSchema(ERROR_SCHEMA)
-                        .addValues(filePath, checkStateNotNull(e.getMessage()))
-                        .build(),
+                    Row.withSchema(ERROR_SCHEMA).addValues(filePath, errorMessage(e)).build(),
                     timestamp,
                     window,
                     paneInfo);
@@ -473,9 +471,7 @@ public class AddFiles extends PTransform<PCollection<String>, PCollectionRowTupl
         } catch (Exception e) {
           return new ProcessResult(
               null,
-              Row.withSchema(ERROR_SCHEMA)
-                  .addValues(filePath, checkStateNotNull(e.getMessage()))
-                  .build(),
+              Row.withSchema(ERROR_SCHEMA).addValues(filePath, errorMessage(e)).build(),
               timestamp,
               window,
               paneInfo);
@@ -563,10 +559,8 @@ public class AddFiles extends PTransform<PCollection<String>, PCollectionRowTupl
         throws IOException {
       Preconditions.checkArgument(
           format.equals(FileFormat.PARQUET), "Table creation is only supported for Parquet files.");
-      try (ParquetFileReader reader = ParquetFileReader.open(getParquetInputFile(filePath))) {
-        MessageType messageType = reader.getFooter().getFileMetaData().getSchema();
-        return ParquetSchemaUtil.convert(messageType);
-      }
+      MessageType messageType = readParquetFooter(filePath).getFileMetaData().getSchema();
+      return ParquetSchemaUtil.convert(messageType);
     }
 
     private String getPartitionFromFilePath(String filePath) {
@@ -860,6 +854,20 @@ public class AddFiles extends PTransform<PCollection<String>, PCollectionRowTupl
       default:
         throw new UnsupportedOperationException("Unsupported format: " + format);
     }
+  }
+
+  static ParquetMetadata readParquetFooter(String filePath) throws IOException {
+    try (ParquetFileReader reader = ParquetFileReader.open(getParquetInputFile(filePath))) {
+      return reader.getFooter();
+    }
+  }
+
+  /**
+   * Some exceptions carry a null message (bare EOFException, NPE); the error-routing path must
+   * never throw on one.
+   */
+  static String errorMessage(Throwable e) {
+    return e.getMessage() != null ? e.getMessage() : e.toString();
   }
 
   /** Tries to infer other file formats. Defaults to Parquet. */

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/AddFiles.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/AddFiles.java
@@ -420,27 +420,19 @@ public class AddFiles extends PTransform<PCollection<String>, PCollectionRowTupl
         try {
           format = inferFormat(filePath);
         } catch (UnknownFormatException e) {
-          return new ProcessResult(
-              null,
-              Row.withSchema(ERROR_SCHEMA).addValues(filePath, UNKNOWN_FORMAT_ERROR).build(),
-              timestamp,
-              window,
-              paneInfo);
+          return errorResult(filePath, UNKNOWN_FORMAT_ERROR, timestamp, window, paneInfo);
         }
 
-        // Synchronize table initialization
+        // ---- Infrastructure phase. Failures propagate so the runner retries the bundle;
+        // per-file error rows here would silently drop in-flight files on a transient blip.
+        // Only conditions that are properties of the file go to the error output.
         if (table == null) {
           synchronized (this) {
             if (table == null) {
               try {
                 table = getOrCreateTable(filePath, format);
               } catch (FileNotFoundException e) {
-                return new ProcessResult(
-                    null,
-                    Row.withSchema(ERROR_SCHEMA).addValues(filePath, errorMessage(e)).build(),
-                    timestamp,
-                    window,
-                    paneInfo);
+                return errorResult(filePath, errorMessage(e), timestamp, window, paneInfo);
               }
             }
           }
@@ -450,12 +442,19 @@ public class AddFiles extends PTransform<PCollection<String>, PCollectionRowTupl
         if (table.spec().isPartitioned()
             && !Strings.isNullOrEmpty(prefix)
             && !filePath.startsWith(checkStateNotNull(prefix))) {
-          return new ProcessResult(
-              null,
-              Row.withSchema(ERROR_SCHEMA).addValues(filePath, PREFIX_ERROR).build(),
-              timestamp,
-              window,
-              paneInfo);
+          return errorResult(filePath, PREFIX_ERROR, timestamp, window, paneInfo);
+        }
+
+        // ---- Per-file phase: every failure below is one error row, never a failed bundle.
+
+        // One footer read per file, shared by stats collection and partition resolution.
+        @Nullable ParquetMetadata parquetFooter = null;
+        if (format.equals(FileFormat.PARQUET)) {
+          try {
+            parquetFooter = readParquetFooter(filePath);
+          } catch (Exception e) {
+            return errorResult(filePath, errorMessage(e), timestamp, window, paneInfo);
+          }
         }
 
         InputFile inputFile = table.io().newInputFile(filePath);
@@ -467,14 +466,10 @@ public class AddFiles extends PTransform<PCollection<String>, PCollectionRowTupl
                   inputFile,
                   format,
                   MetricsConfig.forTable(table),
-                  MappingUtil.create(table.schema()));
+                  MappingUtil.create(table.schema()),
+                  parquetFooter);
         } catch (Exception e) {
-          return new ProcessResult(
-              null,
-              Row.withSchema(ERROR_SCHEMA).addValues(filePath, errorMessage(e)).build(),
-              timestamp,
-              window,
-              paneInfo);
+          return errorResult(filePath, errorMessage(e), timestamp, window, paneInfo);
         }
 
         // Figure out which partition this DataFile should go to
@@ -488,30 +483,39 @@ public class AddFiles extends PTransform<PCollection<String>, PCollectionRowTupl
         } else {
           try {
             // option 2: examine DataFile min/max statistics to determine partition
-            partitionPath = getPartitionFromMetrics(metrics, inputFile, table);
+            partitionPath = getPartitionFromMetrics(metrics, inputFile, table, parquetFooter);
           } catch (UnknownPartitionException e) {
-            return new ProcessResult(
-                null,
-                Row.withSchema(ERROR_SCHEMA)
-                    .addValues(filePath, UNKNOWN_PARTITION_ERROR + e.getMessage())
-                    .build(),
-                timestamp,
-                window,
-                paneInfo);
+            return errorResult(
+                filePath, UNKNOWN_PARTITION_ERROR + e.getMessage(), timestamp, window, paneInfo);
           }
         }
 
-        DataFile df =
-            DataFiles.builder(table.spec())
-                .withPath(filePath)
-                .withFormat(format)
-                .withMetrics(metrics)
-                .withFileSizeInBytes(inputFile.getLength())
-                .withPartitionPath(partitionPath)
-                .build();
-        return new ProcessResult(
-            SerializableDataFile.from(df, table.spec()), null, timestamp, window, paneInfo);
+        try {
+          DataFile df =
+              DataFiles.builder(table.spec())
+                  .withPath(filePath)
+                  .withFormat(format)
+                  .withMetrics(metrics)
+                  .withFileSizeInBytes(inputFile.getLength())
+                  .withPartitionPath(partitionPath)
+                  .build();
+          return new ProcessResult(
+              SerializableDataFile.from(df, table.spec()), null, timestamp, window, paneInfo);
+        } catch (Exception e) {
+          // getLength is a per-file read (e.g. the file was deleted mid-flight).
+          return errorResult(filePath, errorMessage(e), timestamp, window, paneInfo);
+        }
       };
+    }
+
+    private static ProcessResult errorResult(
+        String filePath, String message, Instant timestamp, BoundedWindow window, PaneInfo pane) {
+      return new ProcessResult(
+          null,
+          Row.withSchema(ERROR_SCHEMA).addValues(filePath, message).build(),
+          timestamp,
+          window,
+          pane);
     }
 
     static <W, T> T transformValue(Transform<W, T> transform, Type type, ByteBuffer bytes) {
@@ -583,7 +587,8 @@ public class AddFiles extends PTransform<PCollection<String>, PCollectionRowTupl
      * <p>In these cases, we output the DataFile to the DLQ, because assigning an incorrect
      * partition may lead to it being incorrectly ignored by downstream queries.
      */
-    static String getPartitionFromMetrics(Metrics metrics, InputFile inputFile, Table table)
+    static String getPartitionFromMetrics(
+        Metrics metrics, InputFile inputFile, Table table, @Nullable ParquetMetadata preReadFooter)
         throws UnknownPartitionException, IOException, InterruptedException {
       List<PartitionField> fields = table.spec().fields();
       List<Integer> sourceIds =
@@ -611,7 +616,8 @@ public class AddFiles extends PTransform<PCollection<String>, PCollectionRowTupl
                 inputFile,
                 inferFormat(inputFile.location()),
                 configWithPartitionFields,
-                MappingUtil.create(table.schema()));
+                MappingUtil.create(table.schema()),
+                preReadFooter);
       }
 
       PartitionKey pk = new PartitionKey(table.spec(), table.schema());
@@ -842,22 +848,27 @@ public class AddFiles extends PTransform<PCollection<String>, PCollectionRowTupl
     }
   }
 
+  /**
+   * {@code preReadFooter} reuses an already-read Parquet footer, avoiding a second remote read;
+   * null reads it here. Always null for ORC and Avro.
+   */
   @SuppressWarnings("argument")
   public static Metrics getFileMetrics(
-      InputFile file, FileFormat format, MetricsConfig config, NameMapping mapping)
+      InputFile file,
+      FileFormat format,
+      MetricsConfig config,
+      NameMapping mapping,
+      @Nullable ParquetMetadata preReadFooter)
       throws IOException {
     switch (format) {
       case PARQUET:
-        try (ParquetFileReader reader =
-            ParquetFileReader.open(getParquetInputFile(file.location()))) {
-          ParquetMetadata footer = reader.getFooter();
-          MessageType originalMessageType = footer.getFileMetaData().getSchema();
-          if (!ParquetSchemaUtil.hasIds(originalMessageType)) {
-            footer = getFooterWithTypeIds(originalMessageType, footer, mapping);
-          }
-
-          return ParquetUtil.footerMetrics(footer, Stream.empty(), config, mapping);
+        ParquetMetadata footer =
+            preReadFooter != null ? preReadFooter : readParquetFooter(file.location());
+        MessageType originalMessageType = footer.getFileMetaData().getSchema();
+        if (!ParquetSchemaUtil.hasIds(originalMessageType)) {
+          footer = getFooterWithTypeIds(originalMessageType, footer, mapping);
         }
+        return ParquetUtil.footerMetrics(footer, Stream.empty(), config, mapping);
       case ORC:
         return OrcMetrics.fromInputFile(file, config, mapping);
       case AVRO:

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/AddFiles.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/AddFiles.java
@@ -747,8 +747,9 @@ public class AddFiles extends PTransform<PCollection<String>, PCollectionRowTupl
     }
 
     private static void ensureNameMappingPresent(Table table) {
-      // Forces name-based resolution: zero-copy files carry no field ids, so any schema column
-      // missing from the mapping is unreadable in registered files.
+      // Forces name-based resolution: zero-copy files typically don't carry
+      // field ids, so any schema column missing from the mapping is unreadable
+      // in registered files.
       @Nullable
       NameMapping existing =
           NameMappingUtils.parseOrNull(

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/NameMappingUtils.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/NameMappingUtils.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.iceberg;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.mapping.MappedField;
+import org.apache.iceberg.mapping.MappedFields;
+import org.apache.iceberg.mapping.MappingUtil;
+import org.apache.iceberg.mapping.NameMapping;
+import org.apache.iceberg.mapping.NameMappingParser;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helpers for the {@code schema.name-mapping.default} table property, which zero-copy registered
+ * files (no embedded field ids) depend on for column resolution.
+ */
+class NameMappingUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(NameMappingUtils.class);
+
+  private NameMappingUtils() {}
+
+  /** A damaged property must self-heal via regeneration, never poison the stage reading it. */
+  static @Nullable NameMapping parseOrNull(@Nullable String mappingJson) {
+    if (mappingJson == null) {
+      return null;
+    }
+    try {
+      return NameMappingParser.fromJson(mappingJson);
+    } catch (RuntimeException e) {
+      LOG.warn(
+          "Malformed {} property; it will be regenerated from the schema: {}",
+          TableProperties.DEFAULT_NAME_MAPPING,
+          AddFiles.errorMessage(e));
+      return null;
+    }
+  }
+
+  /**
+   * Whether the mapping resolves every schema column to its own field id. A null-id entry (reads
+   * resolve the column to nothing) or a wrong-id entry (reads bind it to the wrong field) counts as
+   * not covered. List and map contents are addressed via the synthetic {@code element}/{@code
+   * key}/{@code value} path components, matching how {@code MappingUtil.create} names them.
+   */
+  static boolean covers(NameMapping mapping, Types.StructType struct) {
+    return coversStruct(mapping, struct, new ArrayList<>());
+  }
+
+  private static boolean coversStruct(
+      NameMapping mapping, Types.StructType struct, List<String> path) {
+    for (Types.NestedField field : struct.fields()) {
+      if (!coversField(mapping, field.name(), field.fieldId(), field.type(), path)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean coversField(
+      NameMapping mapping, String name, int expectedId, Type type, List<String> path) {
+    path.add(name);
+    try {
+      @Nullable MappedField found = mapping.find(path);
+      @Nullable Integer foundId = found == null ? null : found.id();
+      if (foundId == null || foundId != expectedId) {
+        return false;
+      }
+      if (type.isStructType()) {
+        return coversStruct(mapping, type.asStructType(), path);
+      } else if (type.isListType()) {
+        Types.ListType list = type.asListType();
+        return coversField(mapping, "element", list.elementId(), list.elementType(), path);
+      } else if (type.isMapType()) {
+        Types.MapType map = type.asMapType();
+        return coversField(mapping, "key", map.keyId(), map.keyType(), path)
+            && coversField(mapping, "value", map.valueId(), map.valueType(), path);
+      }
+      return true;
+    } finally {
+      path.remove(path.size() - 1);
+    }
+  }
+
+  /**
+   * Schema-derived mapping, with custom names (user aliases, pre-rename file names) carried over
+   * from {@code existing} by field id. Schema names win: a carried name that collides with a name
+   * already present at its level is dropped, since Iceberg rejects ambiguous mappings. Entries for
+   * ids no longer in the schema (including null-id tombstones) are not carried; their file columns
+   * stay unmapped, which readers treat the same way. Merge failures fall back to the plain
+   * schema-derived mapping.
+   */
+  static String regenerate(Schema schema, @Nullable NameMapping existing) {
+    NameMapping generated = MappingUtil.create(schema);
+    if (existing == null) {
+      return NameMappingParser.toJson(generated);
+    }
+    try {
+      Map<Integer, Set<String>> existingNamesById = new HashMap<>();
+      indexNamesById(existing.asMappedFields(), existingNamesById);
+      return NameMappingParser.toJson(
+          NameMapping.of(mergeNames(generated.asMappedFields(), existingNamesById, "")));
+    } catch (RuntimeException e) {
+      LOG.warn(
+          "Could not carry custom name-mapping entries over; regenerating from the schema: {}",
+          AddFiles.errorMessage(e));
+      return NameMappingParser.toJson(generated);
+    }
+  }
+
+  // Duplicate ids cannot survive parsing (NameMapping rejects them); the name-set union is
+  // defensive.
+  private static void indexNamesById(MappedFields fields, Map<Integer, Set<String>> index) {
+    for (MappedField field : fields.fields()) {
+      if (field.id() != null) {
+        index.computeIfAbsent(field.id(), unused -> new LinkedHashSet<>()).addAll(field.names());
+      }
+      if (field.nestedMapping() != null) {
+        indexNamesById(field.nestedMapping(), index);
+      }
+    }
+  }
+
+  private static MappedFields mergeNames(
+      MappedFields generated, Map<Integer, Set<String>> existingNamesById, String parentPath) {
+    Set<String> schemaNames = new HashSet<>();
+    for (MappedField field : generated.fields()) {
+      schemaNames.addAll(field.names());
+    }
+    Set<String> claimed = new HashSet<>(schemaNames);
+    List<MappedField> merged = new ArrayList<>();
+    for (MappedField field : generated.fields()) {
+      Set<String> names = new LinkedHashSet<>(field.names());
+      String fieldPath =
+          parentPath.isEmpty()
+              ? names.iterator().next()
+              : parentPath + "." + names.iterator().next();
+      @Nullable Set<String> extras = field.id() == null ? null : existingNamesById.get(field.id());
+      if (extras != null) {
+        for (String extra : extras) {
+          if (names.contains(extra)) {
+            continue;
+          }
+          if (claimed.contains(extra)) {
+            LOG.warn(
+                "Dropping custom name '{}' of '{}': {}.",
+                extra,
+                fieldPath,
+                schemaNames.contains(extra)
+                    ? "a schema column at the same level has this name"
+                    : "it was already carried over for another field at this level");
+          } else {
+            names.add(extra);
+            claimed.add(extra);
+          }
+        }
+      }
+      @Nullable MappedFields generatedNested = field.nestedMapping();
+      if (generatedNested == null) {
+        merged.add(MappedField.of(field.id(), new ArrayList<>(names)));
+      } else {
+        merged.add(
+            MappedField.of(
+                field.id(),
+                new ArrayList<>(names),
+                mergeNames(generatedNested, existingNamesById, fieldPath)));
+      }
+    }
+    return MappedFields.of(merged);
+  }
+}

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/NameMappingUtils.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/NameMappingUtils.java
@@ -25,6 +25,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Ascii;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableProperties;
@@ -45,6 +46,7 @@ import org.slf4j.LoggerFactory;
  */
 class NameMappingUtils {
   private static final Logger LOG = LoggerFactory.getLogger(NameMappingUtils.class);
+  private static final int MAX_LOGGED_MAPPING_CHARS = 4000;
 
   private NameMappingUtils() {}
 
@@ -56,10 +58,12 @@ class NameMappingUtils {
     try {
       return NameMappingParser.fromJson(mappingJson);
     } catch (RuntimeException e) {
+      // Regeneration overwrites the property, so this is the only record of the bad value.
       LOG.warn(
-          "Malformed {} property; it will be regenerated from the schema: {}",
+          "Malformed {} property; it will be regenerated from the schema. Error: {}. Value: {}",
           TableProperties.DEFAULT_NAME_MAPPING,
-          AddFiles.errorMessage(e));
+          AddFiles.errorMessage(e),
+          Ascii.truncate(mappingJson, MAX_LOGGED_MAPPING_CHARS, "..."));
       return null;
     }
   }

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/NameMappingUtils.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/NameMappingUtils.java
@@ -18,12 +18,14 @@
 package org.apache.beam.sdk.io.iceberg;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.mapping.MappedField;
@@ -87,7 +89,10 @@ class NameMappingUtils {
     path.add(name);
     try {
       @Nullable MappedField found = mapping.find(path);
-      @Nullable Integer foundId = found == null ? null : found.id();
+      if (found == null) {
+        return false;
+      }
+      @Nullable Integer foundId = found.id();
       if (foundId == null || foundId != expectedId) {
         return false;
       }
@@ -98,8 +103,10 @@ class NameMappingUtils {
         return coversField(mapping, "element", list.elementId(), list.elementType(), path);
       } else if (type.isMapType()) {
         Types.MapType map = type.asMapType();
-        return coversField(mapping, "key", map.keyId(), map.keyType(), path)
-            && coversField(mapping, "value", map.valueId(), map.valueType(), path);
+        if (!coversField(mapping, "key", map.keyId(), map.keyType(), path)) {
+          return false;
+        }
+        return coversField(mapping, "value", map.valueId(), map.valueType(), path);
       }
       return true;
     } finally {
@@ -123,8 +130,8 @@ class NameMappingUtils {
     try {
       Map<Integer, Set<String>> existingNamesById = new HashMap<>();
       indexNamesById(existing.asMappedFields(), existingNamesById);
-      return NameMappingParser.toJson(
-          NameMapping.of(mergeNames(generated.asMappedFields(), existingNamesById, "")));
+      MappedFields mergedFields = mergeNames(generated.asMappedFields(), existingNamesById, "");
+      return NameMappingParser.toJson(NameMapping.of(mergedFields));
     } catch (RuntimeException e) {
       LOG.warn(
           "Could not carry custom name-mapping entries over; regenerating from the schema: {}",
@@ -137,11 +144,18 @@ class NameMappingUtils {
   // defensive.
   private static void indexNamesById(MappedFields fields, Map<Integer, Set<String>> index) {
     for (MappedField field : fields.fields()) {
-      if (field.id() != null) {
-        index.computeIfAbsent(field.id(), unused -> new LinkedHashSet<>()).addAll(field.names());
+      @Nullable Integer id = field.id();
+      if (id != null) {
+        @Nullable Set<String> names = index.get(id);
+        if (names == null) {
+          names = new LinkedHashSet<>();
+          index.put(id, names);
+        }
+        names.addAll(field.names());
       }
-      if (field.nestedMapping() != null) {
-        indexNamesById(field.nestedMapping(), index);
+      @Nullable MappedFields nested = field.nestedMapping();
+      if (nested != null) {
+        indexNamesById(nested, index);
       }
     }
   }
@@ -156,39 +170,40 @@ class NameMappingUtils {
     List<MappedField> merged = new ArrayList<>();
     for (MappedField field : generated.fields()) {
       Set<String> names = new LinkedHashSet<>(field.names());
-      String fieldPath =
-          parentPath.isEmpty()
-              ? names.iterator().next()
-              : parentPath + "." + names.iterator().next();
-      @Nullable Set<String> extras = field.id() == null ? null : existingNamesById.get(field.id());
-      if (extras != null) {
-        for (String extra : extras) {
-          if (names.contains(extra)) {
-            continue;
-          }
-          if (claimed.contains(extra)) {
-            LOG.warn(
-                "Dropping custom name '{}' of '{}': {}.",
-                extra,
-                fieldPath,
-                schemaNames.contains(extra)
-                    ? "a schema column at the same level has this name"
-                    : "it was already carried over for another field at this level");
-          } else {
-            names.add(extra);
-            claimed.add(extra);
-          }
-        }
+      String fieldPath = Iterables.get(field.names(), 0);
+      if (!parentPath.isEmpty()) {
+        fieldPath = parentPath + "." + fieldPath;
       }
+
+      Set<String> extras = Collections.emptySet();
+      @Nullable Integer id = field.id();
+      if (id != null) {
+        extras = existingNamesById.getOrDefault(id, Collections.emptySet());
+      }
+      for (String extra : extras) {
+        if (names.contains(extra)) {
+          continue;
+        }
+        if (!claimed.contains(extra)) {
+          names.add(extra);
+          claimed.add(extra);
+          continue;
+        }
+        String reason;
+        if (schemaNames.contains(extra)) {
+          reason = "a schema column at the same level has this name";
+        } else {
+          reason = "it was already carried over for another field at this level";
+        }
+        LOG.warn("Dropping custom name '{}' of '{}': {}.", extra, fieldPath, reason);
+      }
+      List<String> mergedNames = new ArrayList<>(names);
       @Nullable MappedFields generatedNested = field.nestedMapping();
       if (generatedNested == null) {
-        merged.add(MappedField.of(field.id(), new ArrayList<>(names)));
+        merged.add(MappedField.of(field.id(), mergedNames));
       } else {
-        merged.add(
-            MappedField.of(
-                field.id(),
-                new ArrayList<>(names),
-                mergeNames(generatedNested, existingNamesById, fieldPath)));
+        MappedFields mergedNested = mergeNames(generatedNested, existingNamesById, fieldPath);
+        merged.add(MappedField.of(field.id(), mergedNames, mergedNested));
       }
     }
     return MappedFields.of(merged);

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/AddFilesTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/AddFilesTest.java
@@ -81,6 +81,7 @@ import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.SerializableFunction;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.Duration;
 import org.junit.Before;
@@ -521,6 +522,76 @@ public class AddFilesTest {
     pipeline.run().waitUntilFinish();
   }
 
+  /** Infrastructure failures must fail the bundle, not become silently-dropped error rows. */
+  @Test
+  public void testCatalogOutageFailsBundleInsteadOfDlq() throws Exception {
+    String file1 = root + "data1.parquet";
+    DataWriter<Record> writer = createWriter(file1);
+    writer.write(record(1, "Mark", 20));
+    writer.close();
+
+    IcebergCatalogConfig unreachable =
+        IcebergCatalogConfig.builder()
+            .setCatalogProperties(ImmutableMap.of("type", "rest", "uri", "http://localhost:1"))
+            .build();
+    pipeline
+        .apply("Create Input", Create.of(file1))
+        .apply(new AddFiles(unreachable, tableId.toString(), null, null, null, null, null, null));
+    assertThrows(Exception.class, () -> pipeline.run().waitUntilFinish());
+  }
+
+  /** A file deleted between listing and registration is one error row, never a stuck bundle. */
+  @Test
+  public void testMissingFileWithExistingTableRoutesToDlq() {
+    catalog.createTable(tableId, icebergSchema);
+    String missing = root + "missing.parquet";
+
+    PCollectionRowTuple output =
+        pipeline
+            .apply("Create Input", Create.of(missing))
+            .apply(
+                new AddFiles(
+                    catalogConfig, tableId.toString(), null, null, null, null, null, null));
+    PAssert.that(output.get("errors"))
+        .satisfies(
+            rows -> {
+              Row row = Iterables.getOnlyElement(rows);
+              assertEquals(missing, row.getString("file"));
+              assertThat(row.getString("error"), containsString("No files found"));
+              return null;
+            });
+    pipeline.run().waitUntilFinish();
+
+    assertEquals(0, Iterables.size(catalog.loadTable(tableId).snapshots()));
+  }
+
+  @Test
+  public void testGarbageParquetWithExistingTableRoutesToDlq() throws Exception {
+    catalog.createTable(tableId, icebergSchema);
+    File garbage = temp.newFile("garbage.parquet");
+    java.nio.file.Files.write(
+        garbage.toPath(), "not parquet".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    String file = garbage.getAbsolutePath();
+
+    PCollectionRowTuple output =
+        pipeline
+            .apply("Create Input", Create.of(file))
+            .apply(
+                new AddFiles(
+                    catalogConfig, tableId.toString(), null, null, null, null, null, null));
+    PAssert.that(output.get("errors"))
+        .satisfies(
+            rows -> {
+              Row row = Iterables.getOnlyElement(rows);
+              assertEquals(file, row.getString("file"));
+              assertNotNull(row.getString("error"));
+              return null;
+            });
+    pipeline.run().waitUntilFinish();
+
+    assertEquals(0, Iterables.size(catalog.loadTable(tableId).snapshots()));
+  }
+
   @Test
   public void testStaleNameMappingRegeneratedAtCommit() throws Exception {
     Table table = catalog.createTable(tableId, icebergSchema);
@@ -734,9 +805,10 @@ public class AddFilesTest {
       writer.close();
       InputFile file = table.io().newInputFile(fileName);
 
+      ParquetMetadata footer = AddFiles.readParquetFooter(fileName);
       Metrics metrics =
           AddFiles.getFileMetrics(
-              file, FileFormat.PARQUET, metricsConfig, MappingUtil.create(icebergSchema));
+              file, FileFormat.PARQUET, metricsConfig, MappingUtil.create(icebergSchema), footer);
       for (int i = 0; i < partitionSpec.fields().size(); i++) {
         PartitionField partitionField = partitionSpec.fields().get(i);
         Types.NestedField field = icebergSchema.findField(partitionField.sourceId());
@@ -750,7 +822,7 @@ public class AddFilesTest {
         assertEquals(caze.expectedUpper.get(i), upper);
       }
 
-      String partitionPath = getPartitionFromMetrics(metrics, file, table);
+      String partitionPath = getPartitionFromMetrics(metrics, file, table, footer);
       assertEquals(caze.expectedPartition, partitionPath);
     }
   }
@@ -799,9 +871,10 @@ public class AddFilesTest {
       writer.close();
       InputFile file = table.io().newInputFile(fileName);
 
+      ParquetMetadata footer = AddFiles.readParquetFooter(fileName);
       Metrics metrics =
           AddFiles.getFileMetrics(
-              file, FileFormat.PARQUET, metricsConfig, MappingUtil.create(icebergSchema));
+              file, FileFormat.PARQUET, metricsConfig, MappingUtil.create(icebergSchema), footer);
       // check that lower/upper stats are still fetched correctly
       for (int i = 0; i < partitionSpec.fields().size(); i++) {
         PartitionField partitionField = partitionSpec.fields().get(i);
@@ -818,7 +891,7 @@ public class AddFilesTest {
 
       assertThrows(
           AddFiles.UnknownPartitionException.class,
-          () -> getPartitionFromMetrics(metrics, file, table));
+          () -> getPartitionFromMetrics(metrics, file, table, footer));
     }
   }
 

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/AddFilesTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/AddFilesTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -61,6 +62,7 @@ import org.apache.iceberg.PartitionData;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
@@ -73,6 +75,7 @@ import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.io.DataWriter;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.mapping.MappingUtil;
+import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.mapping.NameMappingParser;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.types.Conversions;
@@ -99,8 +102,8 @@ public class AddFilesTest {
 
   private HadoopCatalog catalog;
   private TableIdentifier tableId;
-  private final org.apache.iceberg.Schema icebergSchema =
-      new org.apache.iceberg.Schema(
+  private final Schema icebergSchema =
+      new Schema(
           Types.NestedField.required(1, "id", Types.IntegerType.get()),
           Types.NestedField.required(2, "name", Types.StringType.get()),
           Types.NestedField.required(3, "age", Types.IntegerType.get()));
@@ -516,6 +519,165 @@ public class AddFilesTest {
               return null;
             });
     pipeline.run().waitUntilFinish();
+  }
+
+  @Test
+  public void testStaleNameMappingRegeneratedAtCommit() throws Exception {
+    Table table = catalog.createTable(tableId, icebergSchema);
+    // A mapping generated against an older version of the schema (covers only "id"), carrying a
+    // user-added alias.
+    table
+        .updateProperties()
+        .set(
+            TableProperties.DEFAULT_NAME_MAPPING,
+            json("[ {'field-id': 1, 'names': ['id', 'ident']} ]"))
+        .commit();
+
+    String file1 = root + "data1.parquet";
+    DataWriter<Record> writer = createWriter(file1);
+    writer.write(record(1, "Mark", 20));
+    writer.close();
+
+    PCollectionRowTuple output =
+        pipeline
+            .apply("Create Input", Create.of(file1))
+            .apply(
+                new AddFiles(
+                    catalogConfig, tableId.toString(), null, null, null, null, null, null));
+    PAssert.that(output.get("errors")).empty();
+    pipeline.run().waitUntilFinish();
+
+    NameMapping mapping = currentMapping();
+    assertNotNull(mapping.find("name"));
+    assertNotNull(mapping.find("age"));
+    // The user's alias survived the regeneration.
+    assertNotNull(mapping.find("ident"));
+    assertEquals(1, mapping.find("ident").id().intValue());
+  }
+
+  /**
+   * The stale mapping resolves every top-level name but is missing a field nested inside a
+   * list&lt;struct&gt;; only the recursive coverage walk can detect it.
+   */
+  @Test
+  public void testStaleNestedNameMappingRegeneratedAtCommit() throws Exception {
+    Schema tableSchema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "name", Types.StringType.get()),
+            Types.NestedField.required(3, "age", Types.IntegerType.get()),
+            Types.NestedField.optional(
+                4,
+                "events",
+                Types.ListType.ofOptional(
+                    5,
+                    Types.StructType.of(
+                        Types.NestedField.optional(6, "a", Types.IntegerType.get()),
+                        Types.NestedField.optional(7, "b", Types.StringType.get())))));
+    Table table = catalog.createTable(tableId, tableSchema);
+    Schema staleView =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "name", Types.StringType.get()),
+            Types.NestedField.required(3, "age", Types.IntegerType.get()),
+            Types.NestedField.optional(
+                4,
+                "events",
+                Types.ListType.ofOptional(
+                    5,
+                    Types.StructType.of(
+                        Types.NestedField.optional(6, "a", Types.IntegerType.get())))));
+    table
+        .updateProperties()
+        .set(
+            TableProperties.DEFAULT_NAME_MAPPING,
+            NameMappingParser.toJson(MappingUtil.create(staleView)))
+        .commit();
+
+    String file1 = root + "data1.parquet";
+    DataWriter<Record> writer = createWriter(file1);
+    writer.write(record(1, "Mark", 20));
+    writer.close();
+
+    PCollectionRowTuple output =
+        pipeline
+            .apply("Create Input", Create.of(file1))
+            .apply(
+                new AddFiles(
+                    catalogConfig, tableId.toString(), null, null, null, null, null, null));
+    PAssert.that(output.get("errors")).empty();
+    pipeline.run().waitUntilFinish();
+
+    assertNotNull(currentMapping().find("events", "element", "b"));
+  }
+
+  @Test
+  public void testMalformedNameMappingRegeneratedAtCommit() throws Exception {
+    Table table = catalog.createTable(tableId, icebergSchema);
+    // Duplicate names make NameMappingParser.fromJson throw eagerly.
+    table
+        .updateProperties()
+        .set(
+            TableProperties.DEFAULT_NAME_MAPPING,
+            json("[ {'field-id': 1, 'names': ['dup']}, {'field-id': 2, 'names': ['dup']} ]"))
+        .commit();
+
+    String file1 = root + "data1.parquet";
+    DataWriter<Record> writer = createWriter(file1);
+    writer.write(record(1, "Mark", 20));
+    writer.close();
+
+    PCollectionRowTuple output =
+        pipeline
+            .apply("Create Input", Create.of(file1))
+            .apply(
+                new AddFiles(
+                    catalogConfig, tableId.toString(), null, null, null, null, null, null));
+    PAssert.that(output.get("errors")).empty();
+    pipeline.run().waitUntilFinish();
+
+    NameMapping mapping = currentMapping();
+    assertNotNull(mapping.find("id"));
+    assertNotNull(mapping.find("age"));
+  }
+
+  /** A mapping that already covers the schema is never rewritten, whatever custom names it has. */
+  @Test
+  public void testHealthyCustomizedMappingLeftUntouched() throws Exception {
+    Table table = catalog.createTable(tableId, icebergSchema);
+    String custom =
+        json(
+            "[ {'field-id': 1, 'names': ['id', 'ident']},"
+                + "  {'field-id': 2, 'names': ['name']},"
+                + "  {'field-id': 3, 'names': ['age']} ]");
+    table.updateProperties().set(TableProperties.DEFAULT_NAME_MAPPING, custom).commit();
+
+    String file1 = root + "data1.parquet";
+    DataWriter<Record> writer = createWriter(file1);
+    writer.write(record(1, "Mark", 20));
+    writer.close();
+
+    PCollectionRowTuple output =
+        pipeline
+            .apply("Create Input", Create.of(file1))
+            .apply(
+                new AddFiles(
+                    catalogConfig, tableId.toString(), null, null, null, null, null, null));
+    PAssert.that(output.get("errors")).empty();
+    pipeline.run().waitUntilFinish();
+
+    assertEquals(
+        custom, catalog.loadTable(tableId).properties().get(TableProperties.DEFAULT_NAME_MAPPING));
+  }
+
+  /** Single-quoted JSON keeps test literals free of escape noise. */
+  private static String json(String singleQuoted) {
+    return singleQuoted.replace('\'', '"');
+  }
+
+  private NameMapping currentMapping() {
+    return NameMappingParser.fromJson(
+        catalog.loadTable(tableId).properties().get(TableProperties.DEFAULT_NAME_MAPPING));
   }
 
   @Test

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/AddFilesTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/AddFilesTest.java
@@ -519,6 +519,12 @@ public class AddFilesTest {
   }
 
   @Test
+  public void testErrorMessageToleratesNullMessage() {
+    assertEquals("java.io.IOException", AddFiles.errorMessage(new IOException((String) null)));
+    assertEquals("boom", AddFiles.errorMessage(new IOException("boom")));
+  }
+
+  @Test
   public void testGetPartitionFromMetrics() throws IOException, InterruptedException {
     PartitionSpec partitionSpec =
         PartitionSpec.builderFor(icebergSchema)

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/AddFilesTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/AddFilesTest.java
@@ -618,12 +618,14 @@ public class AddFilesTest {
     PAssert.that(output.get("errors")).empty();
     pipeline.run().waitUntilFinish();
 
-    NameMapping mapping = currentMapping();
-    assertNotNull(mapping.find("name"));
-    assertNotNull(mapping.find("age"));
-    // The user's alias survived the regeneration.
-    assertNotNull(mapping.find("ident"));
-    assertEquals(1, mapping.find("ident").id().intValue());
+    // Regenerated from the schema, with the user's alias carried over.
+    NameMapping expected =
+        NameMappingParser.fromJson(
+            json(
+                "[ {'field-id': 1, 'names': ['id', 'ident']},"
+                    + "  {'field-id': 2, 'names': ['name']},"
+                    + "  {'field-id': 3, 'names': ['age']} ]"));
+    assertEquals(expected.asMappedFields(), currentMapping().asMappedFields());
   }
 
   /**
@@ -679,7 +681,8 @@ public class AddFilesTest {
     PAssert.that(output.get("errors")).empty();
     pipeline.run().waitUntilFinish();
 
-    assertNotNull(currentMapping().find("events", "element", "b"));
+    assertEquals(
+        MappingUtil.create(tableSchema).asMappedFields(), currentMapping().asMappedFields());
   }
 
   @Test
@@ -707,9 +710,8 @@ public class AddFilesTest {
     PAssert.that(output.get("errors")).empty();
     pipeline.run().waitUntilFinish();
 
-    NameMapping mapping = currentMapping();
-    assertNotNull(mapping.find("id"));
-    assertNotNull(mapping.find("age"));
+    assertEquals(
+        MappingUtil.create(icebergSchema).asMappedFields(), currentMapping().asMappedFields());
   }
 
   /** A mapping that already covers the schema is never rewritten, whatever custom names it has. */

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/AddFilesTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/AddFilesTest.java
@@ -627,8 +627,8 @@ public class AddFilesTest {
   }
 
   /**
-   * The stale mapping resolves every top-level name but is missing a field nested inside a
-   * list&lt;struct&gt;; only the recursive coverage walk can detect it.
+   * The stale mapping resolves every top-level name but is missing a field nested inside a {@code
+   * list<struct>}; only the recursive coverage walk can detect it.
    */
   @Test
   public void testStaleNestedNameMappingRegeneratedAtCommit() throws Exception {

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/NameMappingUtilsTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/NameMappingUtilsTest.java
@@ -86,6 +86,23 @@ public class NameMappingUtilsTest {
     assertTrue(NameMappingUtils.covers(MappingUtil.create(FULL_SCHEMA), FULL_SCHEMA.asStruct()));
   }
 
+  /** Pins the exact mapping shape MappingUtil.create generates, and that covers accepts it. */
+  @Test
+  public void testGeneratedMappingMatchesExpectedShape() {
+    NameMapping expected =
+        mapping(
+            "[ {'field-id': 1, 'names': ['id']},"
+                + "  {'field-id': 2, 'names': ['events'], 'fields': ["
+                + "    {'field-id': 3, 'names': ['element'], 'fields': ["
+                + "      {'field-id': 4, 'names': ['a']},"
+                + "      {'field-id': 5, 'names': ['b']} ]} ]},"
+                + "  {'field-id': 6, 'names': ['attrs'], 'fields': ["
+                + "    {'field-id': 7, 'names': ['key']},"
+                + "    {'field-id': 8, 'names': ['value']} ]} ]");
+    assertEquals(expected.asMappedFields(), MappingUtil.create(FULL_SCHEMA).asMappedFields());
+    assertTrue(NameMappingUtils.covers(expected, FULL_SCHEMA.asStruct()));
+  }
+
   @Test
   public void testCoversDetectsMissingTopLevelColumn() {
     Schema idOnly = new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
@@ -175,7 +192,12 @@ public class NameMappingUtilsTest {
                 1, "tags", Types.ListType.ofOptional(2, Types.IntegerType.get())));
     NameMapping withoutElement = mapping("[ {'field-id': 1, 'names': ['tags']} ]");
     assertFalse(NameMappingUtils.covers(withoutElement, listOfInts.asStruct()));
-    assertTrue(NameMappingUtils.covers(MappingUtil.create(listOfInts), listOfInts.asStruct()));
+
+    NameMapping withElement =
+        mapping(
+            "[ {'field-id': 1, 'names': ['tags'], 'fields': ["
+                + "  {'field-id': 2, 'names': ['element']} ]} ]");
+    assertTrue(NameMappingUtils.covers(withElement, listOfInts.asStruct()));
   }
 
   @Test

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/NameMappingUtilsTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/NameMappingUtilsTest.java
@@ -1,0 +1,403 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.iceberg;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.mapping.MappingUtil;
+import org.apache.iceberg.mapping.NameMapping;
+import org.apache.iceberg.mapping.NameMappingParser;
+import org.apache.iceberg.types.Types;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class NameMappingUtilsTest {
+
+  private static final Schema FULL_SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.IntegerType.get()),
+          Types.NestedField.optional(
+              2,
+              "events",
+              Types.ListType.ofOptional(
+                  3,
+                  Types.StructType.of(
+                      Types.NestedField.optional(4, "a", Types.IntegerType.get()),
+                      Types.NestedField.optional(5, "b", Types.StringType.get())))),
+          Types.NestedField.optional(
+              6,
+              "attrs",
+              Types.MapType.ofOptional(7, 8, Types.StringType.get(), Types.LongType.get())));
+
+  /** Single-quoted JSON keeps test literals free of escape noise. */
+  private static String json(String singleQuoted) {
+    return singleQuoted.replace('\'', '"');
+  }
+
+  private static NameMapping mapping(String singleQuotedJson) {
+    return NameMappingParser.fromJson(json(singleQuotedJson));
+  }
+
+  @Test
+  public void testParseOrNullValidMapping() {
+    String json = NameMappingParser.toJson(MappingUtil.create(FULL_SCHEMA));
+    NameMapping parsed = NameMappingUtils.parseOrNull(json);
+    assertNotNull(parsed);
+    assertNotNull(parsed.find("events", "element", "b"));
+  }
+
+  @Test
+  public void testParseOrNullAbsentAndGarbage() {
+    assertNull(NameMappingUtils.parseOrNull(null));
+    assertNull(NameMappingUtils.parseOrNull("not json at all"));
+  }
+
+  @Test
+  public void testParseOrNullAmbiguousNames() {
+    assertNull(
+        NameMappingUtils.parseOrNull(
+            json("[ {'field-id': 1, 'names': ['a']}, {'field-id': 2, 'names': ['a']} ]")));
+  }
+
+  @Test
+  public void testCoversFullMapping() {
+    assertTrue(NameMappingUtils.covers(MappingUtil.create(FULL_SCHEMA), FULL_SCHEMA.asStruct()));
+  }
+
+  @Test
+  public void testCoversDetectsMissingTopLevelColumn() {
+    Schema idOnly = new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
+    assertFalse(NameMappingUtils.covers(MappingUtil.create(idOnly), FULL_SCHEMA.asStruct()));
+  }
+
+  @Test
+  public void testCoversDescendsListsAndMaps() {
+    // FULL_SCHEMA minus the nested "b": every top-level name still resolves, so only the
+    // recursive walk can detect the gap.
+    Schema staleView =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(
+                2,
+                "events",
+                Types.ListType.ofOptional(
+                    3,
+                    Types.StructType.of(
+                        Types.NestedField.optional(4, "a", Types.IntegerType.get())))),
+            Types.NestedField.optional(
+                6,
+                "attrs",
+                Types.MapType.ofOptional(7, 8, Types.StringType.get(), Types.LongType.get())));
+    NameMapping stale = MappingUtil.create(staleView);
+    assertNotNull(stale.find("events"));
+    assertNotNull(stale.find("events", "element", "a"));
+    assertFalse(NameMappingUtils.covers(stale, FULL_SCHEMA.asStruct()));
+  }
+
+  @Test
+  public void testCoversDescendsMapValueStructs() {
+    Schema full =
+        new Schema(
+            Types.NestedField.optional(
+                1,
+                "attrs",
+                Types.MapType.ofOptional(
+                    2,
+                    3,
+                    Types.StringType.get(),
+                    Types.StructType.of(
+                        Types.NestedField.optional(4, "x", Types.IntegerType.get()),
+                        Types.NestedField.optional(5, "y", Types.StringType.get())))));
+    Schema staleView =
+        new Schema(
+            Types.NestedField.optional(
+                1,
+                "attrs",
+                Types.MapType.ofOptional(
+                    2,
+                    3,
+                    Types.StringType.get(),
+                    Types.StructType.of(
+                        Types.NestedField.optional(4, "x", Types.IntegerType.get())))));
+    NameMapping stale = MappingUtil.create(staleView);
+    assertNotNull(stale.find("attrs", "value", "x"));
+    assertFalse(NameMappingUtils.covers(stale, full.asStruct()));
+    assertTrue(NameMappingUtils.covers(MappingUtil.create(full), full.asStruct()));
+  }
+
+  @Test
+  public void testCoversDescendsPlainStructs() {
+    Schema full =
+        new Schema(
+            Types.NestedField.optional(
+                1,
+                "info",
+                Types.StructType.of(
+                    Types.NestedField.optional(2, "x", Types.IntegerType.get()),
+                    Types.NestedField.optional(3, "y", Types.StringType.get()))));
+    Schema staleView =
+        new Schema(
+            Types.NestedField.optional(
+                1,
+                "info",
+                Types.StructType.of(Types.NestedField.optional(2, "x", Types.IntegerType.get()))));
+    assertFalse(NameMappingUtils.covers(MappingUtil.create(staleView), full.asStruct()));
+  }
+
+  /** Even a list of primitives needs an "element" entry for its contents to resolve. */
+  @Test
+  public void testCoversRequiresElementForPrimitiveLists() {
+    Schema listOfInts =
+        new Schema(
+            Types.NestedField.optional(
+                1, "tags", Types.ListType.ofOptional(2, Types.IntegerType.get())));
+    NameMapping withoutElement = mapping("[ {'field-id': 1, 'names': ['tags']} ]");
+    assertFalse(NameMappingUtils.covers(withoutElement, listOfInts.asStruct()));
+    assertTrue(NameMappingUtils.covers(MappingUtil.create(listOfInts), listOfInts.asStruct()));
+  }
+
+  @Test
+  public void testCoversDeepComposition() {
+    // list<map<string, struct<x>>>
+    Schema deep =
+        new Schema(
+            Types.NestedField.optional(
+                1,
+                "rows",
+                Types.ListType.ofOptional(
+                    2,
+                    Types.MapType.ofOptional(
+                        3,
+                        4,
+                        Types.StringType.get(),
+                        Types.StructType.of(
+                            Types.NestedField.optional(5, "x", Types.IntegerType.get()))))));
+    Schema staleView =
+        new Schema(
+            Types.NestedField.optional(
+                1,
+                "rows",
+                Types.ListType.ofOptional(
+                    2,
+                    Types.MapType.ofOptional(
+                        3,
+                        4,
+                        Types.StringType.get(),
+                        Types.StructType.of(
+                            Types.NestedField.optional(6, "w", Types.IntegerType.get()))))));
+    assertTrue(NameMappingUtils.covers(MappingUtil.create(deep), deep.asStruct()));
+    assertFalse(NameMappingUtils.covers(MappingUtil.create(staleView), deep.asStruct()));
+  }
+
+  /** A null-id entry means "maps to nothing": readers project nulls, so it is not coverage. */
+  @Test
+  public void testCoversRejectsNullIdEntry() {
+    Schema schema = new Schema(Types.NestedField.required(7, "user_id", Types.IntegerType.get()));
+    NameMapping tombstoned = mapping("[ {'names': ['user_id']} ]");
+    assertFalse(NameMappingUtils.covers(tombstoned, schema.asStruct()));
+  }
+
+  /** A wrong-id binding silently reads the wrong column, worse than reading nulls. */
+  @Test
+  public void testCoversRejectsWrongIdBinding() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.optional(1, "a", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "b", Types.IntegerType.get()));
+    NameMapping swapped =
+        mapping("[ {'field-id': 2, 'names': ['a']}, {'field-id': 1, 'names': ['b']} ]");
+    assertFalse(NameMappingUtils.covers(swapped, schema.asStruct()));
+  }
+
+  @Test
+  public void testCoversRejectsWrongNestedIdBinding() {
+    NameMapping wrongNestedId =
+        mapping(
+            "[ {'field-id': 1, 'names': ['id']},"
+                + "  {'field-id': 2, 'names': ['events'], 'fields': ["
+                + "    {'field-id': 3, 'names': ['element'], 'fields': ["
+                + "      {'field-id': 9, 'names': ['a']},"
+                + "      {'field-id': 5, 'names': ['b']} ]} ]},"
+                + "  {'field-id': 6, 'names': ['attrs'], 'fields': ["
+                + "    {'field-id': 7, 'names': ['key']},"
+                + "    {'field-id': 8, 'names': ['value']} ]} ]");
+    assertNotNull(wrongNestedId.find("events", "element", "a"));
+    assertFalse(NameMappingUtils.covers(wrongNestedId, FULL_SCHEMA.asStruct()));
+  }
+
+  @Test
+  public void testCoversEmptySchema() {
+    Schema empty = new Schema();
+    assertTrue(NameMappingUtils.covers(MappingUtil.create(empty), empty.asStruct()));
+    NameMapping regenerated = NameMappingParser.fromJson(NameMappingUtils.regenerate(empty, null));
+    assertTrue(NameMappingUtils.covers(regenerated, empty.asStruct()));
+  }
+
+  @Test
+  public void testRegenerateWithoutExisting() {
+    assertEquals(
+        NameMappingParser.toJson(MappingUtil.create(FULL_SCHEMA)),
+        NameMappingUtils.regenerate(FULL_SCHEMA, null));
+  }
+
+  @Test
+  public void testRegeneratePreservesCustomNames() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "name", Types.StringType.get()));
+    NameMapping stale = mapping("[ {'field-id': 1, 'names': ['id', 'ident']} ]");
+
+    NameMapping merged = NameMappingParser.fromJson(NameMappingUtils.regenerate(schema, stale));
+
+    assertEquals(1, merged.find("ident").id().intValue());
+    assertEquals(2, merged.find("name").id().intValue());
+    assertTrue(NameMappingUtils.covers(merged, schema.asStruct()));
+  }
+
+  @Test
+  public void testRegeneratePreservesNestedCustomNames() {
+    NameMapping stale =
+        mapping(
+            "[ {'field-id': 1, 'names': ['id']},"
+                + "  {'field-id': 2, 'names': ['events'], 'fields': ["
+                + "    {'field-id': 3, 'names': ['element'], 'fields': ["
+                + "      {'field-id': 4, 'names': ['a', 'legacy_a']} ]} ]} ]");
+
+    NameMapping merged =
+        NameMappingParser.fromJson(NameMappingUtils.regenerate(FULL_SCHEMA, stale));
+
+    assertEquals(4, merged.find("events", "element", "legacy_a").id().intValue());
+    assertEquals(5, merged.find("events", "element", "b").id().intValue());
+    assertTrue(NameMappingUtils.covers(merged, FULL_SCHEMA.asStruct()));
+  }
+
+  /** A custom name colliding with a real column would make the mapping ambiguous; schema wins. */
+  @Test
+  public void testRegenerateDropsNameClaimedByRealColumn() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.optional(1, "amount", Types.DoubleType.get()),
+            Types.NestedField.optional(2, "amt", Types.IntegerType.get()));
+    NameMapping stale = mapping("[ {'field-id': 1, 'names': ['amount', 'amt']} ]");
+
+    NameMapping merged = NameMappingParser.fromJson(NameMappingUtils.regenerate(schema, stale));
+
+    assertEquals(2, merged.find("amt").id().intValue());
+    assertEquals(1, merged.find("amount").id().intValue());
+  }
+
+  @Test
+  public void testRegenerateDropsRemovedColumns() {
+    Schema idOnly = new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
+    NameMapping stale =
+        mapping("[ {'field-id': 1, 'names': ['id']}, {'field-id': 9, 'names': ['ghost']} ]");
+
+    NameMapping merged = NameMappingParser.fromJson(NameMappingUtils.regenerate(idOnly, stale));
+
+    assertNull(merged.find("ghost"));
+    assertEquals(1, merged.find("id").id().intValue());
+  }
+
+  /** The collision check applies per nesting level, not just at the top. */
+  @Test
+  public void testRegenerateDropsNestedCollidingName() {
+    // The old entry for field 4 carries "b" as a custom name; ambiguous once the real "b"
+    // (field 5) is generated alongside it.
+    NameMapping stale =
+        mapping(
+            "[ {'field-id': 1, 'names': ['id']},"
+                + "  {'field-id': 2, 'names': ['events'], 'fields': ["
+                + "    {'field-id': 3, 'names': ['element'], 'fields': ["
+                + "      {'field-id': 4, 'names': ['a', 'b']} ]} ]} ]");
+
+    NameMapping merged =
+        NameMappingParser.fromJson(NameMappingUtils.regenerate(FULL_SCHEMA, stale));
+
+    assertEquals(5, merged.find("events", "element", "b").id().intValue());
+    assertEquals(4, merged.find("events", "element", "a").id().intValue());
+  }
+
+  /**
+   * Two old entries (parseable because they sat at different levels) donating the same name to one
+   * level: first in field order wins, the other is dropped.
+   */
+  @Test
+  public void testRegenerateSameNameDonatedTwice() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.optional(4, "a", Types.IntegerType.get()),
+            Types.NestedField.optional(5, "b", Types.IntegerType.get()));
+    NameMapping old =
+        mapping(
+            "[ {'field-id': 4, 'names': ['a', 'zz']},"
+                + "  {'field-id': 9, 'names': ['wrap'], 'fields': ["
+                + "    {'field-id': 5, 'names': ['b', 'zz']} ]} ]");
+
+    NameMapping merged = NameMappingParser.fromJson(NameMappingUtils.regenerate(schema, old));
+
+    assertEquals(4, merged.find("zz").id().intValue());
+    assertEquals(5, merged.find("b").id().intValue());
+  }
+
+  /** The name-mapping spec allows entries without a field-id; they are skipped, not a crash. */
+  @Test
+  public void testRegenerateToleratesIdLessEntries() {
+    Schema schema = new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
+    NameMapping old =
+        mapping("[ {'names': ['ghost']}, {'field-id': 1, 'names': ['id', 'ident']} ]");
+
+    NameMapping merged = NameMappingParser.fromJson(NameMappingUtils.regenerate(schema, old));
+
+    assertEquals(1, merged.find("ident").id().intValue());
+    assertNull(merged.find("ghost"));
+  }
+
+  /**
+   * Iceberg's own parser rejects duplicate ids, so a duplicate-id mapping self-resolves to "absent"
+   * and can never reach {@code regenerate}.
+   */
+  @Test
+  public void testDuplicateIdMappingIsUnparseable() {
+    assertNull(
+        NameMappingUtils.parseOrNull(
+            json(
+                "[ {'field-id': 4, 'names': ['a', 'x']},"
+                    + "  {'field-id': 9, 'names': ['wrap'], 'fields': ["
+                    + "    {'field-id': 4, 'names': ['a', 'y']} ]} ]")));
+  }
+
+  /** Files written before a column rename resolve through the carried-over old name. */
+  @Test
+  public void testRegenerateKeepsPreRenameName() {
+    Schema renamed = new Schema(Types.NestedField.required(1, "new_name", Types.IntegerType.get()));
+    NameMapping old = mapping("[ {'field-id': 1, 'names': ['old_name']} ]");
+
+    NameMapping merged = NameMappingParser.fromJson(NameMappingUtils.regenerate(renamed, old));
+
+    assertEquals(1, merged.find("new_name").id().intValue());
+    assertEquals(1, merged.find("old_name").id().intValue());
+  }
+}


### PR DESCRIPTION
## AddFiles: heal stale or malformed name mappings at commit time


Files registered by AddFiles carry no Iceberg field ids, so readers resolve every column through the `schema.name-mapping.default` table property. A column missing from that mapping reads as null in every registered file. Before this change the commit stage only created the mapping when the property was absent. A mapping that was present but broken was trusted as is, and a malformed one threw inside the commit stage and blocked every manifest commit for the table.

### Changes

Before each manifest commit, `CommitManifestFilesDoFn` now parses the stored mapping, checks that it covers the current schema, and regenerates it when it does not. Regeneration preserves custom names from the old mapping where it safely can. Logic lives in the new `NameMappingUtils` class.

### Cases handled

**Absent mapping.** Generated from the schema, same as before.

**Malformed mapping.** Unparseable JSON, a name used by two fields at the same level, or a duplicate field id. Treated as absent and regenerated with a warning. Previously this threw on every commit, permanently.

**Stale mapping.** The schema gained a column but the mapping was never updated, typically a hand written mapping from the original file import.

```json
schema:  id (1), name (2), age (3)
mapping: [{"field-id": 1, "names": ["id", "ident"]}]
result:  [{"field-id": 1, "names": ["id", "ident"]},
          {"field-id": 2, "names": ["name"]},
          {"field-id": 3, "names": ["age"]}]
```

The custom alias `ident` survives.

**Stale nested mapping.** The coverage check walks into structs, lists and maps using the same `element`, `key` and `value` path segments Iceberg uses. A mapping that resolves `events` and `events.element.a` but is missing `events.element.b` is detected and regenerated. A top level only check would have passed it.

**Null id entry.** `{"names": ["user_id"]}` with no field id means the column maps to nothing and reads as null. Counted as not covered.

**Wrong id entry.** `user_id` mapped to id 3 while the schema says 7. Readers would bind the column to the wrong field. Counted as not covered.

**Healthy mapping with custom names.** Left byte for byte untouched. No property commit happens.

**Pre-rename file names.** A column renamed from `old_name` to `new_name` keeps the old name as an alias, so files written before the rename still resolve:

```json
[{"field-id": 1, "names": ["new_name", "old_name"]}]
```

**Name collisions during regeneration.** Schema names always win. If the old mapping carried `amt` as an alias of `amount` but the schema now has a real `amt` column, the alias is dropped with a warning naming the field path. If two carried aliases collide with each other at one level, the first in schema column order wins.

**Dropped columns.** Old entries whose id is no longer in the schema, including null id tombstones, are not carried over. Their file columns stay unmapped, which readers treat the same way.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
