### PR TITLE
[Bigtable] Fix Bigtable segment truncation when open end key is startKey + null byte (#39842)

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
@@ -481,6 +481,14 @@ class BigtableServiceImpl implements BigtableService {
           segment.addRowRanges(newRange.build());
         } else {
           // Row is split, remove all read rowKeys and split RowSet at last buffered Row
+          if (rowRange.getEndKeyCase() == RowRange.EndKeyCase.END_KEY_OPEN
+              && !rowRange.getEndKeyOpen().isEmpty()) {
+            ByteString lastKeyWithNull = lastKey.concat(ByteString.copyFrom(new byte[] {0}));
+            if (ByteStringComparator.INSTANCE.compare(lastKeyWithNull, rowRange.getEndKeyOpen())
+                >= 0) {
+              continue;
+            }
+          }
           segment.addRowRanges(newRange.setStartKeyOpen(lastKey).build());
         }
       }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImplTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImplTest.java
@@ -764,6 +764,87 @@ public class BigtableServiceImplTest {
   }
 
   /**
+   * This test ensures that when a range has an open end key that is equal to the start key plus a
+   * null byte (e.g. [k, k\0)), and the buffer hits the byte limit on key k, truncateRequest
+   * correctly detects that the range is exhausted and does not create an invalid range (k, k\0).
+   */
+  @Test
+  public void testReadRangeWithNullByteEndKeyAtByteLimit() throws IOException {
+    ByteString startKey = ByteString.copyFromUtf8("exact_key");
+    ByteString endKey = startKey.concat(ByteString.copyFrom(new byte[] {0}));
+    RowRange mockRowRange =
+        RowRange.newBuilder().setStartKeyClosed(startKey).setEndKeyOpen(endKey).build();
+
+    long segmentByteLimit = DEFAULT_ROW_SIZE / 2;
+
+    byte[] largeMemory = new byte[(int) DEFAULT_ROW_SIZE];
+    Row expectedRow =
+        Row.newBuilder()
+            .setKey(startKey)
+            .addFamilies(
+                Family.newBuilder()
+                    .setName("Family")
+                    .addColumns(
+                        Column.newBuilder()
+                            .setQualifier(ByteString.copyFromUtf8("LargeMemoryRow"))
+                            .addCells(
+                                Cell.newBuilder()
+                                    .setValue(ByteString.copyFrom(largeMemory))
+                                    .setTimestampMicros(System.currentTimeMillis())
+                                    .build())
+                            .build())
+                    .build())
+            .build();
+
+    List<List<Row>> expectedResults =
+        ImmutableList.of(ImmutableList.of(expectedRow), ImmutableList.of());
+
+    ServerStreamingCallable<Query, Row> mockCallable = Mockito.mock(ServerStreamingCallable.class);
+
+    StreamController mockController = Mockito.mock(StreamController.class);
+    doAnswer(
+            new Answer<Void>() {
+              @Override
+              public Void answer(InvocationOnMock invocation) throws Throwable {
+                cancelled.set(true);
+                return null;
+              }
+            })
+        .when(mockController)
+        .cancel();
+
+    doAnswer(new MultipleAnswer<Row>(expectedResults, mockController))
+        .when(mockCallable)
+        .call(any(Query.class), any(ResponseObserver.class), any(ApiCallContext.class));
+    when(mockStub.createReadRowsCallable(any(RowAdapter.class))).thenReturn(mockCallable);
+    ServerStreamingCallable<Query, Row> callable =
+        mockStub.createReadRowsCallable(new BigtableServiceImpl.BigtableRowProtoAdapter());
+    when(mockBigtableDataClient.readRowsCallable(any(RowAdapter.class))).thenReturn(callable);
+
+    BigtableService.Reader underTest =
+        new BigtableServiceImpl.BigtableSegmentReaderImpl(
+            mockBigtableDataClient,
+            bigtableDataSettings.getProjectId(),
+            bigtableDataSettings.getInstanceId(),
+            TABLE_ID,
+            RowSet.newBuilder().addRowRanges(mockRowRange).build(),
+            RowFilter.getDefaultInstance(),
+            SEGMENT_SIZE,
+            segmentByteLimit,
+            mockCallMetric);
+
+    List<Row> actualResults = new ArrayList<>();
+    Assert.assertTrue(underTest.start());
+    do {
+      actualResults.add(underTest.getCurrentRow());
+    } while (underTest.advance());
+
+    Assert.assertEquals(ImmutableList.of(expectedRow), actualResults);
+    Mockito.verify(mockCallable, Mockito.times(1))
+        .call(any(Query.class), any(ResponseObserver.class), any(ApiCallContext.class));
+  }
+
+  /**
    * This test ensures the Exception handling inside of the scanHandler. This test will check if a
    * StatusRuntimeException was thrown.
    *


### PR DESCRIPTION
Fixes #39842

### Problem
When reading from Cloud Bigtable using Apache Beam, reads are processed in buffered segments. When a segment hits buffer memory limits or row limits during a read, Beam pauses the stream and calls `truncateRequest` to construct a new `ReadRowsRequest` for the remainder of the key range starting from `(start_key_open: lastKey)`.
For key ranges where the open end key is the start key with an appended null byte (e.g., `[K, K\0)`, common in single-row scans, prefix scans, or dynamic work rebalancing splits), `EndPoint.compareTo` compares `"K\0"` to `"K"`, evaluating to `endCmp > 0`. Because `endCmp > 0`, `truncateRequest` did not skip the range after reading key `K`, and generated a request with `(start_key_open: K, end_key_open: K\0)`.
Cloud Bigtable server validates `start_key_open` as `K\0` and strictly enforces `start_key < end_key`. Because `K\0 < K\0` is false, Bigtable server rejects the request with:
io.grpc.StatusRuntimeException: INVALID_ARGUMENT: Error in field 'row_ranges' : Error in element #0 : start_key must be less than end_key

### Solution
In `BigtableServiceImpl.BigtableSegmentReaderImpl.truncateRequest`, check if `rowRange.getEndKeyCase() == END_KEY_OPEN` and skip the range if `lastKey + "\0" >= rowRange.getEndKeyOpen()`.
### Tests
- Added unit test `testReadRangeWithNullByteEndKeyAtByteLimit` in `BigtableServiceImplTest.java` verifying that ranges with an open null-byte suffix end key are properly recognized as exhausted during truncation without generating invalid requests.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
