### PR TITLE
Fix KafkaIO write SchemaTransform parallelism

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriteSchemaTransformProvider.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriteSchemaTransformProvider.java
@@ -63,10 +63,7 @@ import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Sets;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
-import org.checkerframework.checker.initialization.qual.Initialized;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.checker.nullness.qual.UnknownKeyFor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,14 +84,12 @@ public class KafkaWriteSchemaTransformProvider
       LoggerFactory.getLogger(KafkaWriteSchemaTransformProvider.class);
 
   @Override
-  protected @UnknownKeyFor @NonNull @Initialized Class<KafkaWriteSchemaTransformConfiguration>
-      configurationClass() {
+  protected Class<KafkaWriteSchemaTransformConfiguration> configurationClass() {
     return KafkaWriteSchemaTransformConfiguration.class;
   }
 
   @Override
-  protected @UnknownKeyFor @NonNull @Initialized SchemaTransform from(
-      KafkaWriteSchemaTransformConfiguration configuration) {
+  protected SchemaTransform from(KafkaWriteSchemaTransformConfiguration configuration) {
     if (!SUPPORTED_FORMATS.contains(configuration.getFormat())) {
       throw new IllegalArgumentException(
           "Format "
@@ -320,19 +315,17 @@ public class KafkaWriteSchemaTransformProvider
   }
 
   @Override
-  public @UnknownKeyFor @NonNull @Initialized String identifier() {
+  public String identifier() {
     return getUrn(ExternalTransforms.ManagedTransforms.Urns.KAFKA_WRITE);
   }
 
   @Override
-  public @UnknownKeyFor @NonNull @Initialized List<@UnknownKeyFor @NonNull @Initialized String>
-      inputCollectionNames() {
+  public List<String> inputCollectionNames() {
     return Collections.singletonList("input");
   }
 
   @Override
-  public @UnknownKeyFor @NonNull @Initialized List<@UnknownKeyFor @NonNull @Initialized String>
-      outputCollectionNames() {
+  public List<String> outputCollectionNames() {
     return Collections.emptyList();
   }
 

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriteSchemaTransformProvider.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriteSchemaTransformProvider.java
@@ -28,11 +28,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.model.pipeline.v1.ExternalTransforms;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.NullableCoder;
 import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
 import org.apache.beam.sdk.extensions.avro.schemas.utils.AvroUtils;
 import org.apache.beam.sdk.extensions.protobuf.ProtoByteUtils;
@@ -65,6 +65,7 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Sets;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.checkerframework.checker.initialization.qual.Initialized;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.nullness.qual.UnknownKeyFor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,10 +79,10 @@ public class KafkaWriteSchemaTransformProvider
   public static final Set<String> SUPPORTED_FORMATS =
       Sets.newHashSet(SUPPORTED_FORMATS_STR.split(","));
   public static final TupleTag<Row> ERROR_TAG = new TupleTag<Row>() {};
-  public static final TupleTag<KV<byte[], byte[]>> OUTPUT_TAG =
-      new TupleTag<KV<byte[], byte[]>>() {};
-  public static final TupleTag<KV<byte[], GenericRecord>> RECORD_OUTPUT_TAG =
-      new TupleTag<KV<byte[], GenericRecord>>() {};
+  public static final TupleTag<KV<byte @Nullable [], byte[]>> OUTPUT_TAG =
+      new TupleTag<KV<byte @Nullable [], byte[]>>() {};
+  public static final TupleTag<KV<byte @Nullable [], GenericRecord>> RECORD_OUTPUT_TAG =
+      new TupleTag<KV<byte @Nullable [], GenericRecord>>() {};
   private static final Logger LOG =
       LoggerFactory.getLogger(KafkaWriteSchemaTransformProvider.class);
 
@@ -126,20 +127,20 @@ public class KafkaWriteSchemaTransformProvider
       }
     }
 
-    public abstract static class BaseKafkaWriterFn<T> extends DoFn<Row, KV<byte[], T>> {
+    public abstract static class BaseKafkaWriterFn<T> extends DoFn<Row, KV<byte @Nullable [], T>> {
       private final SerializableFunction<Row, T> conversionFn;
       private final Counter errorCounter;
       private Long errorsInBundle = 0L;
       private final boolean handleErrors;
       private final Schema errorSchema;
-      private final TupleTag<KV<byte[], T>> successTag;
+      private final TupleTag<KV<byte @Nullable [], T>> successTag;
 
       public BaseKafkaWriterFn(
           String name,
           SerializableFunction<Row, T> conversionFn,
           Schema errorSchema,
           boolean handleErrors,
-          TupleTag<KV<byte[], T>> successTag) {
+          TupleTag<KV<byte @Nullable [], T>> successTag) {
         this.conversionFn = conversionFn;
         this.errorCounter = Metrics.counter(KafkaWriteSchemaTransformProvider.class, name);
         this.handleErrors = handleErrors;
@@ -149,9 +150,9 @@ public class KafkaWriteSchemaTransformProvider
 
       @ProcessElement
       public void process(@DoFn.Element Row row, MultiOutputReceiver receiver) {
-        KV<byte[], T> output = null;
+        KV<byte @Nullable [], T> output = null;
         try {
-          output = KV.of(new byte[1], conversionFn.apply(row));
+          output = KV.of(null, conversionFn.apply(row));
         } catch (Exception e) {
           if (!handleErrors) {
             throw new RuntimeException(e);
@@ -262,7 +263,7 @@ public class KafkaWriteSchemaTransformProvider
         HashMap<String, Object> producerConfig = new HashMap<>(configOverrides);
         outputTuple
             .get(RECORD_OUTPUT_TAG)
-            .setCoder(KvCoder.of(ByteArrayCoder.of(), AvroCoder.of(avroSchema)))
+            .setCoder(KvCoder.of(NullableCoder.of(ByteArrayCoder.of()), AvroCoder.of(avroSchema)))
             .apply(
                 "Map Rows to GenericRecords",
                 KafkaIO.<byte[], GenericRecord>write()
@@ -284,6 +285,7 @@ public class KafkaWriteSchemaTransformProvider
 
         outputTuple
             .get(OUTPUT_TAG)
+            .setCoder(KvCoder.of(NullableCoder.of(ByteArrayCoder.of()), ByteArrayCoder.of()))
             .apply(
                 KafkaIO.<byte[], byte[]>write()
                     .withTopic(configuration.getTopic())

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaWriteSchemaTransformProviderTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaWriteSchemaTransformProviderTest.java
@@ -30,6 +30,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.NullableCoder;
 import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
 import org.apache.beam.sdk.extensions.avro.schemas.utils.AvroUtils;
 import org.apache.beam.sdk.extensions.protobuf.ProtoByteUtils;
@@ -146,9 +147,9 @@ public class KafkaWriteSchemaTransformProviderTest {
   public void testKafkaErrorFnSuccess() throws Exception {
     List<KV<byte[], byte[]>> msg =
         Arrays.asList(
-            KV.of(new byte[1], "{\"name\":\"a\"}".getBytes(UTF_8)),
-            KV.of(new byte[1], "{\"name\":\"b\"}".getBytes(UTF_8)),
-            KV.of(new byte[1], "{\"name\":\"c\"}".getBytes(UTF_8)));
+            KV.of(null, "{\"name\":\"a\"}".getBytes(UTF_8)),
+            KV.of(null, "{\"name\":\"b\"}".getBytes(UTF_8)),
+            KV.of(null, "{\"name\":\"c\"}".getBytes(UTF_8)));
 
     PCollection<Row> input = p.apply(Create.of(ROWS));
     Schema errorSchema = ErrorHandling.errorSchema(BEAMSCHEMA);
@@ -159,6 +160,9 @@ public class KafkaWriteSchemaTransformProviderTest {
                 .withOutputTags(OUTPUT_TAG, TupleTagList.of(ERROR_TAG)));
 
     output.get(ERROR_TAG).setRowSchema(errorSchema);
+    output
+        .get(OUTPUT_TAG)
+        .setCoder(KvCoder.of(NullableCoder.of(ByteArrayCoder.of()), ByteArrayCoder.of()));
 
     PAssert.that(output.get(OUTPUT_TAG)).containsInAnyOrder(msg);
     p.run().waitUntilFinish();
@@ -168,9 +172,9 @@ public class KafkaWriteSchemaTransformProviderTest {
   public void testKafkaErrorFnRawSuccess() throws Exception {
     List<KV<byte[], byte[]>> msg =
         Arrays.asList(
-            KV.of(new byte[1], "a".getBytes(UTF_8)),
-            KV.of(new byte[1], "b".getBytes(UTF_8)),
-            KV.of(new byte[1], "c".getBytes(UTF_8)));
+            KV.of(null, "a".getBytes(UTF_8)),
+            KV.of(null, "b".getBytes(UTF_8)),
+            KV.of(null, "c".getBytes(UTF_8)));
 
     PCollection<Row> input = p.apply(Create.of(RAW_ROWS));
     Schema errorSchema = ErrorHandling.errorSchema(BEAM_RAW_SCHEMA);
@@ -182,6 +186,9 @@ public class KafkaWriteSchemaTransformProviderTest {
                 .withOutputTags(OUTPUT_TAG, TupleTagList.of(ERROR_TAG)));
 
     output.get(ERROR_TAG).setRowSchema(errorSchema);
+    output
+        .get(OUTPUT_TAG)
+        .setCoder(KvCoder.of(NullableCoder.of(ByteArrayCoder.of()), ByteArrayCoder.of()));
 
     PAssert.that(output.get(OUTPUT_TAG)).containsInAnyOrder(msg);
     p.run().waitUntilFinish();
@@ -199,6 +206,9 @@ public class KafkaWriteSchemaTransformProviderTest {
                 .withOutputTags(OUTPUT_TAG, TupleTagList.of(ERROR_TAG)));
 
     output.get(ERROR_TAG).setRowSchema(errorSchema);
+    output
+        .get(OUTPUT_TAG)
+        .setCoder(KvCoder.of(NullableCoder.of(ByteArrayCoder.of()), ByteArrayCoder.of()));
     p.run().waitUntilFinish();
   }
 
@@ -223,8 +233,7 @@ public class KafkaWriteSchemaTransformProviderTest {
     record3.put("name", "c");
 
     List<KV<byte[], GenericRecord>> msg =
-        Arrays.asList(
-            KV.of(new byte[1], record1), KV.of(new byte[1], record2), KV.of(new byte[1], record3));
+        Arrays.asList(KV.of(null, record1), KV.of(null, record2), KV.of(null, record3));
 
     PCollection<Row> input = p.apply(Create.of(ROWS));
     Schema errorSchema = ErrorHandling.errorSchema(BEAMSCHEMA);
@@ -238,7 +247,7 @@ public class KafkaWriteSchemaTransformProviderTest {
     output.get(ERROR_TAG).setRowSchema(errorSchema);
     output
         .get(RECORD_OUTPUT_TAG)
-        .setCoder(KvCoder.of(ByteArrayCoder.of(), AvroCoder.of(avroSchema)));
+        .setCoder(KvCoder.of(NullableCoder.of(ByteArrayCoder.of()), AvroCoder.of(avroSchema)));
     PAssert.that(output.get(RECORD_OUTPUT_TAG)).containsInAnyOrder(msg);
     p.run().waitUntilFinish();
   }


### PR DESCRIPTION
Fix #39841

Tested with a Kafka schematransform producer pipeline + consumer pipeline on Dataflow, confirm that records now written to different partitions

Before:

<img width="1314" height="262" alt="image" src="https://github.com/user-attachments/assets/2bfeca39-1615-4270-bf1e-d464ec0a00a2" />

Only partition 20 has data. Other partitions always have offset at 0.

After:

<img width="1260" height="195" alt="image" src="https://github.com/user-attachments/assets/56c74fa6-14cb-4035-b67d-66f068c14710" />

data are evenly distributed.

The coder change (byte array -> nullable(byte awway) should not affect upgrade compatibility because the whole schematransform is in a single fused stage

<img width="250" height="553" alt="image" src="https://github.com/user-attachments/assets/ddfa906b-1293-41ef-9672-bbbc7dbd31f8" />

and not involving materialized data.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
