### PR TITLE
[GSoC 2026] Kafka Streams runner: say what the Python side is, and is not

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -2167,6 +2167,13 @@ class FlinkRunnerOptions(PipelineOptions):
 
 
 class KafkaStreamsRunnerOptions(PipelineOptions):
+  """Options for the Kafka Streams runner.
+
+  The runner is experimental and is not production ready. It is not part of
+  any Apache Beam release: its job server is built only when the Beam build is
+  run with -Pwith-kafka-streams-runner, so using it means building that job
+  server from a Beam source tree.
+  """
   @classmethod
   def _add_argparse_args(cls, parser):
     parser.add_argument(

--- a/sdks/python/apache_beam/runners/portability/kafka_streams_java_job_server_test.py
+++ b/sdks/python/apache_beam/runners/portability/kafka_streams_java_job_server_test.py
@@ -25,6 +25,7 @@ import mock
 
 from apache_beam.options import pipeline_options
 from apache_beam.runners.portability.kafka_streams_runner import KafkaStreamsJarJobServer
+from apache_beam.utils import subprocess_server
 from apache_beam.runners.portability.kafka_streams_runner import KafkaStreamsRunner
 
 
@@ -88,16 +89,32 @@ class KafkaStreamsJavaJobServerTest(unittest.TestCase):
                      job_server.java_arguments(
                          8099, 8098, 8097, '/tmp/artifacts'))
 
-  def test_path_to_jar_defaults_to_the_job_server_module(self):
+  def test_path_to_jar_uses_a_jar_built_from_this_source_tree(self):
     job_server = KafkaStreamsJarJobServer(pipeline_options.PipelineOptions([]))
-    # Without an explicit jar the runner resolves the one built by the job
-    # server module, which is what lets a user run a pipeline without having
-    # built or started anything first. Resolving it for real would either
-    # download or demand a built jar, so only the target is checked here.
-    with mock.patch.object(job_server, 'path_to_beam_jar') as path_to_beam_jar:
-      job_server.path_to_jar()
-    path_to_beam_jar.assert_called_once_with(
-        ':runners:kafka-streams:job-server:shadowJar')
+    # Without an explicit jar the runner uses the one the job server module
+    # builds, which is what lets someone working in a Beam checkout run a
+    # pipeline without passing anything.
+    with tempfile.NamedTemporaryFile(suffix='.jar') as jar:
+      with mock.patch.object(subprocess_server.JavaJarServer,
+                             'path_to_dev_beam_jar',
+                             return_value=jar.name) as path_to_dev_beam_jar:
+        self.assertEqual(jar.name, job_server.path_to_jar())
+      path_to_dev_beam_jar.assert_called_once_with(
+          ':runners:kafka-streams:job-server:shadowJar')
+
+  def test_path_to_jar_explains_itself_when_nothing_is_built(self):
+    job_server = KafkaStreamsJarJobServer(pipeline_options.PipelineOptions([]))
+    # The job server is not published with any Beam release, so falling back to
+    # a download would fetch an artifact that does not exist and fail with a
+    # 404. Say what is actually wrong instead, and how to build one.
+    with mock.patch.object(subprocess_server.JavaJarServer,
+                           'path_to_dev_beam_jar',
+                           return_value='/no/such/built.jar'):
+      with self.assertRaises(RuntimeError) as context:
+        job_server.path_to_jar()
+    message = str(context.exception)
+    self.assertIn('not part of any Apache Beam release', message)
+    self.assertIn('-Pwith-kafka-streams-runner', message)
 
   def test_path_to_jar_uses_an_explicit_jar(self):
     with tempfile.NamedTemporaryFile(suffix='.jar') as jar:

--- a/sdks/python/apache_beam/runners/portability/kafka_streams_runner.py
+++ b/sdks/python/apache_beam/runners/portability/kafka_streams_runner.py
@@ -15,7 +15,16 @@
 # limitations under the License.
 #
 
-"""A runner for executing portable pipelines on Kafka Streams."""
+"""A runner for executing portable pipelines on Kafka Streams.
+
+The Kafka Streams runner is experimental and is not production ready. It is
+not part of any Apache Beam release: its job server is only built when the
+Beam build is run with -Pwith-kafka-streams-runner, and no released artifact
+contains it. Using it means building the job server from a Beam source tree.
+
+See https://beam.apache.org/documentation/runners/kafkastreams/ for what the
+runner supports and what it does not.
+"""
 
 # pytype: skip-file
 
@@ -25,6 +34,7 @@ import urllib
 from apache_beam.options import pipeline_options
 from apache_beam.runners.portability import job_server
 from apache_beam.runners.portability import portable_runner
+from apache_beam.utils import subprocess_server
 
 # A Java job server is a heavyweight external process, so reuse one across
 # pipelines configured the same way.
@@ -33,6 +43,10 @@ JOB_SERVER_CACHE = {}
 
 class KafkaStreamsRunner(portable_runner.PortableRunner):
   """A runner for executing pipelines on Kafka Streams.
+
+  Experimental and not production ready; see the module docstring. The job
+  server is not published with any Beam release, so it has to be built from
+  source or passed with --kafka_streams_job_server_jar.
 
   Starts a job server automatically, so a pipeline can be submitted without
   running one by hand:
@@ -86,10 +100,28 @@ class KafkaStreamsJarJobServer(job_server.JavaJarJobServer):
               'Unable to parse jar URL "%s". If using a full URL, make sure '
               'the scheme is specified. If using a local file path, make sure '
               'the file exists; you may have to first build the job server '
-              'using `./gradlew runners:kafka-streams:job-server:shadowJar`.' %
-              self._jar)
+              'using `./gradlew -Pwith-kafka-streams-runner '
+              'runners:kafka-streams:job-server:shadowJar`.' % self._jar)
       return self._jar
-    return self.path_to_beam_jar(':runners:kafka-streams:job-server:shadowJar')
+
+    # No jar was given, so look for one built from this source tree. The base
+    # class would fall back to Maven Central, but the job server is not
+    # published for any Beam release, so that download always fails and says
+    # nothing useful about why.
+    local_jar = subprocess_server.JavaJarServer.path_to_dev_beam_jar(
+        ':runners:kafka-streams:job-server:shadowJar')
+    if os.path.exists(local_jar):
+      return local_jar
+    raise RuntimeError(
+        'The Kafka Streams runner is experimental and is not part of any '
+        'Apache Beam release, so there is no published job server jar to '
+        'download. Build one from a Beam source tree with\n'
+        '  ./gradlew -Pwith-kafka-streams-runner '
+        ':runners:kafka-streams:job-server:shadowJar\n'
+        'and pass it as --kafka_streams_job_server_jar, or point that option '
+        'at a jar you already have. The runner is opt-in at build time, so '
+        'the -Pwith-kafka-streams-runner flag is required; without it the '
+        'runner is not part of the build at all.')
 
   def java_arguments(
       self, job_port, artifact_port, expansion_port, artifacts_dir):

--- a/website/www/site/content/en/documentation/runners/kafkastreams.md
+++ b/website/www/site/content/en/documentation/runners/kafkastreams.md
@@ -33,10 +33,11 @@ introducing a second distributed system to operate.
 
 ## The runner is experimental, and is not built by default
 
-**The Kafka Streams Runner is experimental.** It executes a meaningful subset of the Beam model
-correctly, and the parts it does support are covered by Beam's own `@ValidatesRunner` suite, but
-several capabilities that are core to the model are not implemented yet. Read [what is not
-supported](#what-is-not-supported-yet) before choosing it for anything real.
+**The Kafka Streams Runner is experimental and is not production ready.** It executes a meaningful
+subset of the Beam model correctly, and the parts it does support are covered by Beam's own
+`@ValidatesRunner` suite, but several capabilities that are core to the model are not implemented
+yet, and it has known bugs rather than only missing features. Do not run it on anything that
+matters. Read [what is not supported](#what-is-not-supported-yet) first.
 
 It is also aimed squarely at streaming. A pipeline over bounded data will run, but there are more
 efficient choices for batch work; this runner exists for pipelines that do not end.
@@ -55,6 +56,22 @@ it reaches nobody who has not asked for it. The intent is to give the runner som
 developed and maintained by whoever is interested in it. If it becomes stable enough the flag will
 be dropped and the runner built like any other; if it does not, it can be removed again without
 affecting anyone, since no release ever contained it.
+
+### If you installed Beam from a release
+
+The Python SDK ships `KafkaStreamsRunner` as a module, because the SDK is published as one package
+and individual modules cannot be held back from it. **The runner still does not work from a
+release**, because the job server it needs is not published with one. Selecting it will tell you so
+and point you here.
+
+To use the runner you need a Beam source tree, and you build the job server yourself:
+
+```
+./gradlew -Pwith-kafka-streams-runner :runners:kafka-streams:job-server:shadowJar
+```
+
+then pass the resulting jar as `--kafka_streams_job_server_jar`, or let the runner find it when you
+run from that same source tree.
 
 ## Building it
 
@@ -92,8 +109,9 @@ server you are already running.
 
 ### From Python
 
-Select `KafkaStreamsRunner` there too. The Python runner builds the job server jar if it has to,
-starts it, and stops it when the pipeline finishes:
+Select `KafkaStreamsRunner` there too. The Python runner finds the job server jar, starts it, and
+stops it when the pipeline finishes. Run this from a Beam source tree where you have already built
+the jar, or pass one with `--kafka_streams_job_server_jar`:
 
 ```
 python my_pipeline.py \
@@ -102,9 +120,9 @@ python my_pipeline.py \
     --application_id=my-beam-pipeline
 ```
 
-The SDK harness runs in `LOOPBACK` mode by default, so a local run needs no Docker. Building the jar
-takes a while the first time; `--kafka_streams_job_server_jar` points at a prebuilt one, which
-`./gradlew -Pwith-kafka-streams-runner :runners:kafka-streams:job-server:shadowJar` produces.
+The SDK harness runs in `LOOPBACK` mode by default, so a local run needs no Docker. If no jar is
+found the runner says so rather than trying to download one, because none is published; see [if you
+installed Beam from a release](#if-you-installed-beam-from-a-release).
 
 ### Against a job server you are already running
 

--- a/website/www/site/data/capability_matrix.yaml
+++ b/website/www/site/data/capability_matrix.yaml
@@ -27,7 +27,7 @@ capability-matrix:
     - class: jet
       name: Hazelcast Jet
     - class: kafka-streams
-      name: Kafka Streams
+      name: Kafka Streams (experimental, not released)
     - class: twister2
       name: Twister2
     - class: python direct


### PR DESCRIPTION
Part of #18479, before the merge to master.

The Python modules ship with the SDK because it is published as one package and individual modules cannot be held back. They are already inert without the job server jar, which is not published with any release, but the failure was unhelpful: `path_to_beam_jar` built a Maven Central URL for an artifact that does not exist, so the user got a 404.

`path_to_jar` now looks for a jar built from the source tree and, failing that, raises an explicit error: the runner is experimental, it is not part of any Beam release, and here is how to build the job server. The build commands it prints carry `-Pwith-kafka-streams-runner`; without it they fail with project not found, which was true of both the message in this file and the generic one in `subprocess_server.py`.

Documentation: the runner page now says experimental **and not production ready**, with a new section on what happens if you installed Beam from a release; the module, runner class and options class carry the same warning; and the capability matrix names it "Kafka Streams (experimental, not released)", which it did not before.

`ALL_KNOWN_RUNNERS` is unchanged, as discussed.

Tested: 6 Python tests pass, and the two new ones fail if the Maven fallback is restored.