### PR TITLE
Install Cloud Spanner emulator component in Go PreCommit CI

### DIFF
--- a/.github/workflows/beam_PreCommit_Go.yml
+++ b/.github/workflows/beam_PreCommit_Go.yml
@@ -85,6 +85,8 @@ jobs:
         with:
           java-version: default
           go-version: default
+      - name: Install Cloud Spanner emulator
+        run: gcloud components install cloud-spanner-emulator --quiet
       - name: run goPreCommit script
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:


### PR DESCRIPTION
Adds a step to `beam_PreCommit_Go.yml` that installs the `cloud-spanner-emulator` gcloud component before running the Go PreCommit tests. We've previously been unable to run the emulator in docker, however gcloud is available - this installs the spanner emulator so that we can use it for improving tests.

This is split out from a larger in-progress PR (#37991) that replaces the Docker-testcontainer-based Spanner emulator setup in the Go Spanner IO integration tests with a real emulator driven via `gcloud emulators spanner start`. That workflow is triggered via `pull_request_target`, which always runs the workflow file from `master` rather than the PR branch, so this CI change needs to land on `master` on its own before #37991's checks can pick it up.

------------------------

- [ ] Mention the appropriate issue in your description, if applicable.
- [ ] Update `CHANGES.md` with noteworthy changes.
- [ ] If this contribution is large, please file an Apache Individual Contributor License Agreement.