### PR TITLE
fix: Setup a writable gcloud SDK before installing Spanner emulator component

### DIFF
--- a/.github/workflows/beam_PreCommit_Go.yml
+++ b/.github/workflows/beam_PreCommit_Go.yml
@@ -85,6 +85,8 @@ jobs:
         with:
           java-version: default
           go-version: default
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
       - name: Install Cloud Spanner emulator
         run: gcloud components install cloud-spanner-emulator --quiet
       - name: run goPreCommit script


### PR DESCRIPTION
Follow-up to #39850.

That PR added a `gcloud components install cloud-spanner-emulator --quiet` step to `beam_PreCommit_Go.yml` for the Go Spanner change-streams IO integration tests. Once merged, the step ran but failed on the self-hosted runner with:

```
ERROR: (gcloud.components.install) You cannot perform this action because you do not have permission to modify the Google Cloud SDK installation directory [/usr/local/google-cloud-sdk].

Re-run the command with sudo: sudo /usr/local/google-cloud-sdk/bin/gcloud ...
```

The runner's pre-baked gcloud SDK at `/usr/local/google-cloud-sdk` isn't writable by the job's user, so any component install against it fails, not just this one. Other workflows in this repo (e.g. `beam_CleanUpGCPResources.yml`, which installs the `cbt` component) avoid this by running `google-github-actions/setup-gcloud` first, which provisions its own writable SDK copy instead of relying on the runner's baked-in install. This PR does the same for `beam_PreCommit_Go.yml`.

------------------------

 - [x] N/A: no user-facing change, CI workflow fix only.

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).