### PR TITLE
[GSoC 2026] Publish the Kafka Streams runner to nightly snapshots

### DIFF
--- a/.github/workflows/beam_Release_NightlySnapshot.yml
+++ b/.github/workflows/beam_Release_NightlySnapshot.yml
@@ -82,6 +82,7 @@ jobs:
       - name: run Publish script
         run: |
           ./gradlew publish --max-workers=8 -Ppublishing -PskipCheckerFramework \
+          -Pwith-kafka-streams-runner \
           -Pjava21Home=$JAVA_HOME_21_X64 \
           --continue -Dorg.gradle.jvmargs=-Xms2g -Dorg.gradle.jvmargs=-Xmx6g \
           -Dorg.gradle.vfs.watch=false -Pdocker-pull-licenses \


### PR DESCRIPTION
Part of #18479, following Kenn's suggestion on the lazy consensus thread that snapshots would give people something to point at for testing.

Adds `-Pwith-kafka-streams-runner` to the nightly publish. Without it the runner's projects are not in the build, so nothing was published.

Verified with `./gradlew publish --dry-run`:
- with the flag, `:runners:kafka-streams:publish` and `:runners:kafka-streams:job-server:publish` resolve to the Apache snapshots repository
- without it, no Kafka Streams tasks at all
- the measurement module stays out, since it is `publish: false`
- the proto module is shaded into the runner rather than being a POM dependency, so the published jar is self-contained

Snapshots are not releases, so this does not change the runner being absent from released artifacts.