### PR TITLE
Revert "Install Cloud Spanner emulator component in Go PreCommit CI"

### DIFF
--- a/.github/workflows/beam_PreCommit_Go.yml
+++ b/.github/workflows/beam_PreCommit_Go.yml
@@ -85,8 +85,6 @@ jobs:
         with:
           java-version: default
           go-version: default
-      - name: Install Cloud Spanner emulator
-        run: gcloud components install cloud-spanner-emulator --quiet
       - name: run goPreCommit script
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:


### PR DESCRIPTION
Reverts apache/beam#39850

Breaks PreCommit Go, in addition to https://github.com/apache/beam/pull/39852#issuecomment-5396276044