### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -67,7 +67,7 @@ jobs:
           repository: apache/beam
           persist-credentials: true
       - name: Install Java 11
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: |
@@ -126,7 +126,7 @@ jobs:
           GITHUB_EVENT_INPUTS_APACHE_ID: ${{ github.event.inputs.APACHE_ID }}
           GITHUB_EVENT_INPUTS_APACHE_PASSWORD: ${{ github.event.inputs.APACHE_PASSWORD }}
       - name: Install Java 11
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '11'
@@ -298,7 +298,7 @@ jobs:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1
       - name: Install Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: |
@@ -364,7 +364,7 @@ jobs:
         with:
           node-version: '16'
       - name: Install Java 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -607,7 +607,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install Java 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/code_completion_plugin_tests.yml
+++ b/.github/workflows/code_completion_plugin_tests.yml
@@ -72,7 +72,7 @@ jobs:
 
       # Setup Java environment for the next steps
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/.github/workflows/republish_released_docker_containers.yml
+++ b/.github/workflows/republish_released_docker_containers.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1
       - name: Install Java 11
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/typescript_tests.yml
+++ b/.github/workflows/typescript_tests.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -182,7 +182,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '17'


### PR DESCRIPTION
Upgrade every active workflow reference from `actions/setup-java@v5` to `actions/setup-java@v6`. This keeps Beam CI on the current setup-java major.

Fixes #39878

------------------------

- [x] Mention the appropriate issue in the description.
- [x] `CHANGES.md` does not need an update for this workflow-only maintenance change.
- [x] This is a small workflow-only contribution and does not require an ICLA.

Validation: verified all `.github/workflows/*.yml` and `*.yaml` files contain no setup-java references older than v6; `git diff --check` passes.