### PR TITLE
Fix ZeroDivisionError at initial invocation of monitoring_info when there is no work yet

### DIFF
--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -1716,15 +1716,19 @@ class RestrictionProgress(object):
   def fraction_completed(self) -> float:
     if self._fraction is not None:
       return self._fraction
-    else:
-      return float(self._completed) / self.total_work
+    total_work = self.total_work
+    if total_work == 0.:
+      return 1.0
+    return float(self._completed) / total_work
 
   @property
   def fraction_remaining(self) -> float:
     if self._fraction is not None:
       return 1 - self._fraction
-    else:
-      return float(self._remaining) / self.total_work
+    total_work = self.total_work
+    if total_work == 0.:
+      return 0.0
+    return float(self._remaining) / total_work
 
   def with_completed(self, completed: int) -> 'RestrictionProgress':
     return RestrictionProgress(

--- a/sdks/python/apache_beam/io/iobase_test.py
+++ b/sdks/python/apache_beam/io/iobase_test.py
@@ -261,5 +261,26 @@ class UseSdfUnboundedSourcesTests(unittest.TestCase):
     self.assertTrue(read_transforms[0].subtransforms)
 
 
+class RestrictionProgressTest(unittest.TestCase):
+  def test_restriction_progress(self):
+    # Total work == 0 edge cases (avoids ZeroDivisionError)
+    progress_zero_int = iobase.RestrictionProgress(completed=0, remaining=0)
+    self.assertEqual(progress_zero_int.fraction_completed, 1.0)
+    self.assertEqual(progress_zero_int.fraction_remaining, 0.0)
+
+    # Progress with completed and remaining
+    progress_work = iobase.RestrictionProgress(completed=25, remaining=75)
+    self.assertEqual(progress_work.completed_work, 25)
+    self.assertEqual(progress_work.remaining_work, 75)
+    self.assertEqual(progress_work.total_work, 100)
+    self.assertEqual(progress_work.fraction_completed, 0.25)
+    self.assertEqual(progress_work.fraction_remaining, 0.75)
+
+    # Progress with fraction
+    progress_frac = iobase.RestrictionProgress(fraction=0.4)
+    self.assertEqual(progress_frac.fraction_completed, 0.4)
+    self.assertAlmostEqual(progress_frac.fraction_remaining, 0.6)
+
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
It is found running a streaming pipeline in Python, there is an error at the beginning:

```
Traceback (most recent call last):
  File "...beam/sdks/python/apache_beam/runners/worker/sdk_worker.py", line 310, in _execute
    response = task()
  File "...beam/sdks/python/apache_beam/runners/worker/sdk_worker.py", line 347, in <lambda>
    lambda: self.create_worker().do_instruction(request), request)
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "...beam/sdks/python/apache_beam/runners/worker/sdk_worker.py", line 671, in do_instruction
    return getattr(self, request_type)(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        getattr(request, request_type), request.instruction_id)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "...beam/sdks/python/apache_beam/runners/worker/sdk_worker.py", line 762, in process_bundle_progress
    monitoring_infos = processor.monitoring_infos()
  File "...beam/sdks/python/apache_beam/runners/worker/bundle_processor.py", line 1441, in monitoring_infos
    op.monitoring_infos(transform_id, dict(tag_to_pcollection_id)))
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apache_beam/runners/worker/operations.py", line 1111, in apache_beam.runners.worker.operations.SdfProcessSizedElements.monitoring_infos
    def monitoring_infos(self, transform_id, tag_to_pcollection_id):
  File "apache_beam/runners/worker/operations.py", line 1116, in apache_beam.runners.worker.operations.SdfProcessSizedElements.monitoring_infos
    with self.lock:
  File "apache_beam/runners/worker/operations.py", line 1125, in apache_beam.runners.worker.operations.SdfProcessSizedElements.monitoring_infos
    completed = current_element_progress.fraction_completed
  File "...beam/sdks/python/apache_beam/io/iobase.py", line 1720, in fraction_completed
    return float(self._completed) / self.total_work
           ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
ZeroDivisionError: float division by zero
```

This is because a `RestrictionProgress {'fraction': None, 'remaining': 0.0, 'completed': 0}` is initialized at

```
  File "apache_beam/runners/worker/operations.py", line 1116, in apache_beam.runners.worker.operations.SdfProcessSizedElements.monitoring_infos
    with self.lock:
  File "apache_beam/runners/worker/operations.py", line 1119, in apache_beam.runners.worker.operations.SdfProcessSizedElements.monitoring_infos
    current_element_progress = self.current_element_progress()
  File "apache_beam/runners/worker/operations.py", line 1101, in apache_beam.runners.worker.operations.SdfProcessSizedElements.current_element_progress
    with self.lock:
  File "apache_beam/runners/worker/operations.py", line 1106, in apache_beam.runners.worker.operations.SdfProcessSizedElements.current_element_progress
    return progress.with_completed(
  File "...beam/sdks/python/apache_beam/io/iobase.py", line 1733, in with_completed
    return RestrictionProgress(
        fraction=self._fraction, remaining=self._remaining, completed=completed)
```

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
