### PR TITLE
[PubsubIO] Account for message metadata in bounded write batch size

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
@@ -1912,14 +1912,11 @@ public class PubsubIO {
         // TODO(sjvanrossum): https://github.com/apache/beam/issues/31800
         // - Size validation makes no distinction between JSON and Protobuf encoding
         // - Accounting for HTTP to gRPC transcoding is non-trivial
-        PreparePubsubWriteDoFn.validatePubsubMessage(message, maxPublishBatchByteSize);
+        final int messageSize =
+            PreparePubsubWriteDoFn.validatePubsubMessage(message, maxPublishBatchByteSize);
         // NOTE: The record id is always null since it will be assigned by Pub/Sub.
         final OutgoingMessage msg =
             OutgoingMessage.of(message, timestamp.getMillis(), null, message.getTopic());
-        // TODO(sjvanrossum): https://github.com/apache/beam/issues/31800
-        // - Size validation makes no distinction between JSON and Protobuf encoding
-        // - Accounting for HTTP to gRPC transcoding is non-trivial
-        final int messageSize = msg.getMessage().getData().size();
 
         final PubsubTopic pubsubTopic;
         ValueProvider<PubsubTopic> topicProvider = getTopicProvider();

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
@@ -67,6 +67,7 @@ import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFnTester;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.SimpleFunction;
 import org.apache.beam.sdk.transforms.display.DisplayData;
@@ -82,6 +83,7 @@ import org.apache.beam.sdk.values.TypeDescriptors;
 import org.apache.beam.sdk.values.ValueInSingleWindow;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.MoreObjects;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -919,6 +921,45 @@ public class PubsubIOTest {
       messages.apply(PubsubIO.writeMessagesDynamic().withClientFactory(factory));
       pipeline.run();
     }
+  }
+
+  @Test
+  public void testBoundedWriteBatchSizeIncludesAttributesAndOrderingKey() throws Exception {
+    PubsubClient mockClient = Mockito.mock(PubsubClient.class);
+    PubsubClient.PubsubClientFactory mockFactory =
+        Mockito.mock(PubsubClient.PubsubClientFactory.class);
+    Mockito.when(
+            mockFactory.newClient(
+                Mockito.isNull(), Mockito.isNull(), Mockito.any(), Mockito.isNull()))
+        .thenReturn(mockClient);
+
+    List<Integer> publishedBatchSizes = Lists.newArrayList();
+    Mockito.when(mockClient.publish(Mockito.any(), Mockito.anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<OutgoingMessage> messages = invocation.getArgument(1);
+              publishedBatchSizes.add(messages.size());
+              return messages.size();
+            });
+
+    PubsubIO.Write<PubsubMessage> write =
+        PubsubIO.writeMessages()
+            .to("projects/project/topics/topic")
+            .withClientFactory(mockFactory)
+            .withOrderingKey()
+            .withMaxBatchBytesSize(40);
+    PubsubMessage message =
+        new PubsubMessage(
+                "0123456789".getBytes(StandardCharsets.UTF_8), ImmutableMap.of("k", "value"))
+            .withOrderingKey("order");
+
+    try (DoFnTester<PubsubMessage, Void> tester =
+        DoFnTester.of(write.new PubsubBoundedWriter(100, 40))) {
+      tester.setCloningBehavior(DoFnTester.CloningBehavior.DO_NOT_CLONE);
+      tester.processBundle(ImmutableList.of(message, message));
+    }
+
+    assertEquals(ImmutableList.of(1, 1), publishedBatchSizes);
   }
 
   @Test


### PR DESCRIPTION
Bounded PubsubIO writes size each batch from the message payload alone. Attributes and ordering keys are omitted, so the writer can publish a batch larger than `maxPublishBatchByteSize`.

`validatePubsubMessage` already returns the validated size of the payload, ordering key, and attributes. The bounded writer now uses that value instead of discarding it and recalculating `messageSize` from the payload.

This does not address https://github.com/apache/beam/issues/31800. Its existing TODOs cover JSON versus Protobuf encoding and HTTP to gRPC transcoding.

Fixes #28011

------------------------

## Testing

The regression sends two 27-byte messages through the real bounded-writer lifecycle with a 40-byte batch limit and captures each publish call. To reproduce against base `13875fc6bd3d5ad534c89d33f2395176fbc485fc` while keeping the regression test from this branch:

```bash
git checkout 13875fc6bd3d5ad534c89d33f2395176fbc485fc -- \
  sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
export JAVA_HOME=$(/usr/libexec/java_home -v 21.0.6)
export PATH="$JAVA_HOME/bin:$PATH"
./gradlew :sdks:java:io:google-cloud-platform:test \
  --tests org.apache.beam.sdk.io.gcp.pubsub.PubsubIOTest.testBoundedWriteBatchSizeIncludesAttributesAndOrderingKey \
  --no-daemon --console=plain
git checkout HEAD -- \
  sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
```

Both messages were sent in one batch:

```text
java.lang.AssertionError: expected:<[1, 1]> but was:<[2]>
1 test completed, 1 failed
BUILD FAILED in 17s
```

After the fix:

```bash
export JAVA_HOME=$(/usr/libexec/java_home -v 21.0.6)
export PATH="$JAVA_HOME/bin:$PATH"
./gradlew :sdks:java:io:google-cloud-platform:test \
  --tests org.apache.beam.sdk.io.gcp.pubsub.PubsubIOTest.testBoundedWriteBatchSizeIncludesAttributesAndOrderingKey \
  --no-daemon --console=plain
```

```text
BUILD SUCCESSFUL in 33s
```

The captured batch sizes are now `[1, 1]`, so neither publish exceeds the configured limit. The full `PubsubIOTest` class also passes with the same Gradle task and the class-level test selector.

- [x] This PR fixes #28011.
- [x] `CHANGES.md` is unchanged for this small bug fix.
- [x] This is not a large contribution, so the ICLA checklist item does not apply.
