### PR TITLE
fix(beam): guard jinja_variable_flags collision with pipeline options

### DIFF
--- a/sdks/python/apache_beam/yaml/main.py
+++ b/sdks/python/apache_beam/yaml/main.py
@@ -61,7 +61,17 @@ def _preparse_jinja_flags(argv):
     return argv
 
   jinja_variable_parser = argparse.ArgumentParser(allow_abbrev=False)
+  # Guard against jinja_variable_flags colliding with pipeline options.
+  # If a flag collides with a known pipeline option, skip it and require
+  # the variable to be provided via --jinja_variables JSON instead.
+  try:
+    from apache_beam.options.pipeline_options import PipelineOptions
+    _pipeline_option_names = set(PipelineOptions([]).get_all_options().keys())
+  except Exception:
+    _pipeline_option_names = set()
   for flag_name in jinja_args.jinja_variable_flags:
+    if flag_name.replace('-', '_') in _pipeline_option_names:
+      continue
     jinja_variable_parser.add_argument('--' + flag_name)
   jinja_flag_variables, pipeline_args = jinja_variable_parser.parse_known_args(
       other_args)

--- a/sdks/python/apache_beam/yaml/main_test.py
+++ b/sdks/python/apache_beam/yaml/main_test.py
@@ -154,8 +154,7 @@ class MainTest(unittest.TestCase):
         '--var=my_line',
     ]
     self.assertCountEqual(
-        main._preparse_jinja_flags(argv),
-        [
+        main._preparse_jinja_flags(argv), [
             '--runner=DirectRunner',
             '--jinja_variables=' + '{"var": "my_line"}',
         ])

--- a/sdks/python/apache_beam/yaml/main_test.py
+++ b/sdks/python/apache_beam/yaml/main_test.py
@@ -145,6 +145,21 @@ class MainTest(unittest.TestCase):
             'pos_arg',
         ])
 
+  def test_preparse_jinja_flags_pipeline_option_collision(self):
+    # A jinja_variable_flags entry that collides with a known pipeline
+    # option (e.g. runner) must not swallow the pipeline flag.
+    argv = [
+        '--jinja_variable_flags=runner,var',
+        '--runner=DirectRunner',
+        '--var=my_line',
+    ]
+    self.assertCountEqual(
+        main._preparse_jinja_flags(argv),
+        [
+            '--runner=DirectRunner',
+            '--jinja_variables=' + '{"var": "my_line"}',
+        ])
+
   def test_jinja_datetime(self):
     with tempfile.TemporaryDirectory() as tmpdir:
       out_path = os.path.join(tmpdir, 'out.txt')


### PR DESCRIPTION
Fixes #37475

Bug: _preparse_jinja_flags adds every jinja_variable_flags entry as an argparse flag without checking against known pipeline options. A jinja variable named runner, project, temp_location, etc. captures the pipeline flag and converts it into jinja_variables, removing it from pipeline_args.

Fix: Guard the loop by checking flag_name against PipelineOptions.get_all_options(). If the name collides (dash normalized to underscore), skip adding it to the jinja parser and require the variable via --jinja_variables JSON instead.

Verification: RED->GREEN verified with mocked PipelineOptions. Before fix, --jinja_variable_flags=runner --runner=DirectRunner produces --jinja_variables={"runner": "DirectRunner"} and loses the pipeline flag. After fix, runner stays in pipeline_args and only non-colliding vars are promoted. Dash variant temp-location also guarded. Existing behavior for non-colliding vars unchanged.
