### PR TITLE
Allow referencing both issues and PRs in release notes.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -765,15 +765,15 @@ tasks.register("validateChanges") {
             println("  No bracketed language reference found")
           }
 
-          // Rule 2: Check if each entry has an issue link
-          val issueLinkPattern = "\\(\\[#[0-9a-zA-Z]+\\]\\(https://github\\.com/apache/beam/issues/[0-9a-zA-Z]+\\)\\)"
-          val issueLinkRegex = Regex(issueLinkPattern)
+          // Rule 2: Check if each entry links an issue or a PR
+          val linkPattern = "\\(\\[#[0-9a-zA-Z]+\\]\\(https://github\\.com/apache/beam/(?:issues|pull)/[0-9a-zA-Z]+\\)\\)"
+          val linkRegex = Regex(linkPattern)
 
-          val hasIssueLink = issueLinkRegex.containsMatchIn(line)
-          println("  Has issue link: $hasIssueLink")
+          val hasLink = linkRegex.containsMatchIn(line)
+          println("  Has issue link: $hasLink")
 
-          if (!hasIssueLink) {
-            val error = "Line ${i+1}: Missing or malformed issue link. Each entry should end with ([#X](https://github.com/apache/beam/issues/X)): $line"
+          if (!hasLink) {
+            val error = "Line ${i+1}: Missing or malformed issue link. Each entry must end with a reference to an Issue or a PR, for example: ([#X](https://github.com/apache/beam/issues/X)): $line"
             println("  Adding error: $error")
             errors.add(error)
           }


### PR DESCRIPTION
Allow referencing both issues and PRs in release notes.


We routinely substitute `/pul/Xl` with `/issues/X` just to appease the checker without changes to the content that we end up linking, and sometimes the PR actualy has a more relevant information.