### PR TITLE
ci: pin third-party GitHub Actions to commit SHA in IO_Iceberg_Unit_Tests.yml

### DIFF
--- a/.github/workflows/IO_Iceberg_Unit_Tests.yml
+++ b/.github/workflows/IO_Iceberg_Unit_Tests.yml
@@ -82,7 +82,7 @@ jobs:
       github.event.comment.body == 'Run IcebergIO Unit Tests'
     runs-on: [self-hosted, ubuntu-24.04, main]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
       - name: Setup repository
@@ -102,13 +102,13 @@ jobs:
             -PdisableCheckStyle=true \
             --info
       - name: Archive JUnit Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !success() }}
         with:
           name: JUnit Test Results
           path: "**/build/reports/tests/"
       - name: Publish JUnit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           commit: '${{ env.prsha || env.GITHUB_SHA }}'
@@ -116,13 +116,13 @@ jobs:
           files: '**/build/test-results/**/*.xml'
           large_files: true
       - name: Archive SpotBugs Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: SpotBugs Results
           path: '**/build/reports/spotbugs/*.html'
       - name: Publish SpotBugs Results
-        uses: jwgmeligmeyling/spotbugs-github-action@v1.2
+        uses: jwgmeligmeyling/spotbugs-github-action@b8e2c3523acb34c87f14e18cbcd2d87db8c8584e # v1.2
         if: always()
         with:
           name: Publish SpotBugs


### PR DESCRIPTION
## What

Pins the third-party GitHub Actions used in `IO_Iceberg_Unit_Tests.yml` to their exact commit SHA instead of a mutable version tag:

- `actions/checkout@v7` → `@3d3c42e...` (`# v7`)
- `actions/upload-artifact@v7` (both usages) → `@043fb46...` (`# v7`)
- `EnricoMi/publish-unit-test-result-action@v2` → `@d0a4676...` (`# v2`)
- `jwgmeligmeyling/spotbugs-github-action@v1.2` → `@b8e2c35...` (`# v1.2`)

## Why

A tag like `@v7` can be moved to point at different code after the fact (by the action's own maintainer, or if their account/repo is compromised), so a workflow pinned only to a tag can silently start running different code than what was reviewed when the workflow was written. Pinning to a full commit SHA (keeping the version as a trailing comment for readability) is the mitigation GitHub's own Actions security hardening guide and OpenSSF Scorecard's `Pinned-Dependencies` check both recommend.

This only touches the one workflow file that had unpinned references; the local composite actions under `./.github/actions/...` are untouched since they aren't external and don't carry this risk.

## Testing

This is a CI-workflow-only change with no code path to unit test. I verified each SHA by resolving the exact commit each tag currently points to via the GitHub API (`git/refs/tags/...`, dereferencing the annotated tag object for `EnricoMi/publish-unit-test-result-action`), and confirmed the file is still valid YAML. The real verification is that the workflow keeps running identically on its next trigger, since each SHA is exactly the commit its tag currently resolves to.
