### PR TITLE
Fix flaky Playground local cache tests

### DIFF
--- a/playground/backend/internal/cache/local/local_cache_test.go
+++ b/playground/backend/internal/cache/local/local_cache_test.go
@@ -525,16 +525,13 @@ func TestLocalCache_startGC(t *testing.T) {
 	ignoreOpenCensus := goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start")
 	defer goleak.VerifyNone(t, ignoreOpenCensus)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	preparedId, _ := uuid.NewUUID()
 	preparedItemsMap := make(map[uuid.UUID]map[cache.SubKey]interface{})
 	preparedItemsMap[preparedId] = make(map[cache.SubKey]interface{})
 	preparedItemsMap[preparedId][cache.CompileOutput] = "TEST_VALUE1"
 	preparedItemsMap[preparedId][cache.RunOutput] = "TEST_VALUE2"
 	preparedExpMap := make(map[uuid.UUID]time.Time)
-	preparedExpMap[preparedId] = time.Now().Add(time.Microsecond)
+	preparedExpMap[preparedId] = time.Now().Add(-time.Millisecond)
 	type fields struct {
 		cleanupInterval     time.Duration
 		items               map[uuid.UUID]map[cache.SubKey]interface{}
@@ -559,21 +556,45 @@ func TestLocalCache_startGC(t *testing.T) {
 			fields: fields{
 				cleanupInterval:     time.Microsecond,
 				items:               nil,
-				pipelinesExpiration: preparedExpMap,
+				pipelinesExpiration: nil,
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
 			lc := &Cache{
 				cleanupInterval:     tt.fields.cleanupInterval,
 				items:               tt.fields.items,
 				pipelinesExpiration: tt.fields.pipelinesExpiration,
 			}
-			go lc.startGC(ctx)
-			time.Sleep(time.Millisecond)
-			if len(tt.fields.items) != 0 {
-				t.Errorf("Pipeline: %s not deleted in time.", preparedId)
+			done := make(chan struct{})
+			go func() {
+				lc.startGC(ctx)
+				close(done)
+			}()
+			if lc.items == nil {
+				select {
+				case <-done:
+				case <-time.After(time.Second):
+					t.Fatal("startGC did not stop for nil cache items")
+				}
+				return
+			}
+			deadline := time.Now().Add(time.Second)
+			for {
+				lc.mu.RLock()
+				itemsCount := len(lc.items)
+				lc.mu.RUnlock()
+				if itemsCount == 0 {
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatalf("Pipeline: %s not deleted in time.", preparedId)
+				}
+				time.Sleep(time.Millisecond)
 			}
 		})
 	}

--- a/playground/backend/internal/cache/local/local_cache_test.go
+++ b/playground/backend/internal/cache/local/local_cache_test.go
@@ -61,7 +61,7 @@ func TestLocalCache_GetValue(t *testing.T) {
 	preparedItemsMap[preparedId] = make(map[cache.SubKey]interface{})
 	preparedItemsMap[preparedId][preparedSubKey] = value
 	preparedExpMap := make(map[uuid.UUID]time.Time)
-	preparedExpMap[preparedId] = time.Now().Add(time.Millisecond)
+	preparedExpMap[preparedId] = time.Now().Add(time.Minute)
 	endedExpMap := make(map[uuid.UUID]time.Time)
 	endedExpMap[preparedId] = time.Now().Add(-time.Millisecond)
 	type fields struct {
@@ -147,7 +147,7 @@ func TestLocalCache_GetValue(t *testing.T) {
 func TestLocalCache_SetValue(t *testing.T) {
 	preparedId, _ := uuid.NewUUID()
 	preparedExpMap := make(map[uuid.UUID]time.Time)
-	preparedExpMap[preparedId] = time.Now().Add(time.Millisecond)
+	preparedExpMap[preparedId] = time.Now().Add(time.Minute)
 	type fields struct {
 		cleanupInterval     time.Duration
 		items               map[uuid.UUID]map[cache.SubKey]interface{}


### PR DESCRIPTION
## Summary

Two local-cache tests depended on runner timing or unsynchronized state:

- `TestLocalCache_GetValue` and `TestLocalCache_SetValue` expired fixtures one millisecond after setup. Slow runners could cross that deadline before assertions ran. Their non-expired fixtures now use a one-minute deadline.
- `TestLocalCache_startGC` slept for one millisecond, then read the cache map while the GC goroutine could delete from it. It now polls for cleanup within a bounded deadline while holding the cache mutex. Each subtest owns its context and expiration state, and the nil-cache case still verifies that GC stops.

Production cache behavior is unchanged.

## Reproduction

The scheduled Playground precommit failed in `TestLocalCache_SetValue/Set_value` because `GetValue` reported the newly stored value as missing:

https://github.com/apache/beam/actions/runs/33273173203

The GC race reproduced immediately with:

```text
go test -race ./internal/cache/local -run '^TestLocalCache_startGC$'
```

Race detector reported an unlocked test read at `local_cache_test.go:575` concurrent with deletion in `Cache.clearItems`.

## Testing

- `cd playground/backend && go test ./internal/cache/local`
- `cd playground/backend && go test ./internal/cache/local -run '^TestLocalCache_(GetValue|SetValue)$' -count=10000`
- `cd playground/backend && go test -race ./internal/cache/local -run '^TestLocalCache_(GetValue|SetValue)$' -count=100`
- `cd playground/backend && go test -race ./internal/cache/local -run '^TestLocalCache_startGC$' -count=1000`
- `cd playground/backend && go test -race ./internal/cache/local -count=1`

`./gradlew :playground:backend:test` also ran the changed cache package successfully, then stopped on unrelated local emulator and Scio setup failures.

------------------------

- [x] No tracking issue; failing CI run and race reproducer are included above.
- [x] `CHANGES.md` is unchanged because this is a test-only stabilization.
- [x] This contribution is not large.
