### PR TITLE
[Java] Preserve CoderTranslatorRegistrar binary compatibility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -87,6 +87,7 @@
 
 ## Bugfixes
 
+* (Java) Restored binary compatibility for `CoderTranslatorRegistrar` implementations compiled against Beam 2.76 and earlier ([#38714](https://github.com/apache/beam/issues/38714)).
 * (Java) Fixed the Spark runner firing processing-time timers in reverse timestamp order ([#39824](https://github.com/apache/beam/issues/39824)).
 * (Python) Fixed incorrect profiler options handling on portable runners ([#39613](https://github.com/apache/beam/issues/39613)).
 * (Java) KafkaIO dynamic reads no longer require the obsolete `beam_fn_api` experiment ([#29998](https://github.com/apache/beam/issues/29998)).

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/CoderTranslatorRegistrar.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/CoderTranslatorRegistrar.java
@@ -41,13 +41,23 @@ public interface CoderTranslatorRegistrar {
    * Returns whether the given Coder is known to this CoderTranslatorRegistrar. If the Coder is
    * known, then getCoderTranslator() will return a non-null CoderTranslator.
    */
-  boolean isKnownCoder(Coder<?> coder, PipelineOptions options);
+  default boolean isKnownCoder(Coder<?> coder, PipelineOptions options) {
+    return getCoderURNs().containsKey(coder.getClass());
+  }
 
   /** Returns the CoderTranslator to use for this Coder, or null if the Coder is not known. */
-  @Nullable
-  CoderTranslator<? extends Coder> getCoderTranslator(Class<? extends Coder> coderClass);
+  default @Nullable CoderTranslator<? extends Coder> getCoderTranslator(
+      Class<? extends Coder> coderClass) {
+    return getCoderTranslators().get(coderClass);
+  }
 
   /** Returns the Coder to use for the given Urn, or null if the Urn is for an unknown Coder. */
-  @Nullable
-  Class<? extends Coder> getCoderForUrn(String coderUrn);
+  default @Nullable Class<? extends Coder> getCoderForUrn(String coderUrn) {
+    for (Map.Entry<Class<? extends Coder>, String> coderUrnEntry : getCoderURNs().entrySet()) {
+      if (coderUrnEntry.getValue().equals(coderUrn)) {
+        return coderUrnEntry.getKey();
+      }
+    }
+    return null;
+  }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/construction/CoderTranslationTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/construction/CoderTranslationTest.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
@@ -46,6 +47,7 @@ import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.TimestampPrefixingWindowCoder;
 import org.apache.beam.sdk.coders.VarLongCoder;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.schemas.AutoValueSchema;
 import org.apache.beam.sdk.schemas.NoSuchSchemaException;
 import org.apache.beam.sdk.schemas.Schema;
@@ -63,6 +65,7 @@ import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.sdk.values.WindowedValues;
 import org.apache.beam.sdk.values.WindowedValues.FullWindowedValueCoder;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableSet;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -172,6 +175,43 @@ public class CoderTranslationTest {
           "All Model Coders should be registered",
           CoderTranslation.getKnownTranslators().keySet(),
           hasItems(new ModelCoderRegistrar().getCoderTranslators().keySet().toArray(new Class[0])));
+    }
+
+    @Test
+    public void legacyRegistrarUsesDefaultLookupMethods() {
+      CoderTranslatorRegistrar registrar = new LegacyCoderTranslatorRegistrar();
+
+      assertThat(
+          registrar.isKnownCoder(StringUtf8Coder.of(), PipelineOptionsFactory.create()),
+          equalTo(true));
+      assertThat(
+          registrar.getCoderTranslator(StringUtf8Coder.class),
+          equalTo(LegacyCoderTranslatorRegistrar.TRANSLATOR));
+      assertThat(
+          registrar.getCoderForUrn(LegacyCoderTranslatorRegistrar.URN),
+          equalTo(StringUtf8Coder.class));
+      assertThat(
+          registrar.isKnownCoder(VarLongCoder.of(), PipelineOptionsFactory.create()),
+          equalTo(false));
+      assertThat(registrar.getCoderTranslator(VarLongCoder.class), Matchers.nullValue());
+      assertThat(registrar.getCoderForUrn("unknown"), Matchers.nullValue());
+    }
+
+    /** Implements only the registrar methods available before Beam 2.77.0. */
+    private static class LegacyCoderTranslatorRegistrar implements CoderTranslatorRegistrar {
+      private static final String URN = "beam:coder:legacy_test:v1";
+      private static final CoderTranslator<StringUtf8Coder> TRANSLATOR =
+          CoderTranslators.atomic(StringUtf8Coder.class);
+
+      @Override
+      public Map<Class<? extends Coder>, String> getCoderURNs() {
+        return ImmutableMap.of(StringUtf8Coder.class, URN);
+      }
+
+      @Override
+      public Map<Class<? extends Coder>, CoderTranslator<? extends Coder>> getCoderTranslators() {
+        return ImmutableMap.of(StringUtf8Coder.class, TRANSLATOR);
+      }
     }
   }
 


### PR DESCRIPTION
Addresses #38714.

## Problem

The nightly snapshot workflow started failing consistently after #39594 merged. Both affected Dataflow jobs reach `SplitWithSizing`, then repeatedly lose their Java SDK harness.

#39594 added three abstract methods to the public `CoderTranslatorRegistrar` SPI. Development SDK jobs use the pinned `beam-master-20260731` Dataflow worker container, whose registrar implementations were compiled before those methods existed. Calling a new method on one of those implementations is binary-incompatible and throws `AbstractMethodError`, terminating the harness.

Public workflow logs contain the resulting harness disconnects, while worker diagnostics require access to the `apache-beam-testing` project. I verified the underlying failure directly by compiling a registrar against the parent of #39594 and running that unchanged bytecode with current `beam-sdks-java-core`. It fails with:

```text
java.lang.AbstractMethodError: Receiver class LegacyRegistrar does not define or inherit an implementation of the resolved method 'abstract boolean isKnownCoder(...)'
```

## Fix

Provide default implementations for the three new lookup methods using the two maps already required by the older SPI. Existing registrars remain loadable across the SDK/container version boundary. `ModelCoderRegistrar` keeps its option-aware overrides, including SchemaCoder update-compatibility behavior.

Regression coverage uses a registrar that implements only the pre-2.77 methods. The same separately compiled legacy bytecode also runs successfully after this change.

## Validation

```text
./gradlew :sdks:java:core:spotlessCheck
./gradlew :sdks:java:core:test
./gradlew :runners:google-cloud-dataflow-java:test --tests 'org.apache.beam.runners.dataflow.DataflowPipelineTranslatorTest'
./gradlew :sdks:java:harness:test --tests 'org.apache.beam.fn.harness.state.StateBackedIterableTest'
```

All passed locally.

------------------------

- [x] Mention the appropriate issue in the description.
- [x] Update `CHANGES.md` with the binary-compatibility fix.
- [x] This contribution is small and does not require an ICLA update.
