### PR TITLE
Deflake JmsIO authentication tests

### DIFF
--- a/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOTest.java
+++ b/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOTest.java
@@ -192,7 +192,8 @@ public class JmsIOTest {
 
   @Test
   public void testAuthenticationRequired() {
-    pipeline.apply(JmsIO.read().withConnectionFactory(connectionFactory).withQueue(QUEUE));
+    // A topic produces one source, avoiding races between concurrent authentication failures.
+    pipeline.apply(JmsIO.read().withConnectionFactory(connectionFactory).withTopic(TOPIC));
     String errorMessage =
         this.connectionFactoryClass == ActiveMQConnectionFactory.class
             ? "User name [null] or password is invalid."
@@ -205,7 +206,7 @@ public class JmsIOTest {
     pipeline.apply(
         JmsIO.read()
             .withConnectionFactory(connectionFactory)
-            .withQueue(QUEUE)
+            .withTopic(TOPIC)
             .withUsername(USERNAME)
             .withPassword("BAD"));
 


### PR DESCRIPTION
The `JmsIOTest` authentication assertions can fail even though the broker correctly rejects unauthenticated connections. This occurred in the [Java IOs precommit](https://github.com/apache/beam/actions/runs/33296279996/job/99216380971): ActiveMQ logged the expected authentication failure, but the test observed `peer (...) stopped`.

## Cause

Queue reads split into multiple concurrent sources. After one reader reports the expected authentication error, DirectRunner cancels the pipeline and the fixture stops the broker while other readers are still connecting. Depending on timing, the pipeline can surface a secondary transport shutdown instead of the original security error.

## Fix

Use a topic for the two authentication tests. Topics produce one `UnboundedJmsSource`, removing the concurrent-failure race while preserving end-to-end pipeline coverage for missing and invalid credentials with both ActiveMQ and Qpid. Existing tests continue to cover queue splitting and queue reads.

## Validation

```text
./gradlew :sdks:java:io:jms:spotlessCheck :sdks:java:io:jms:cleanTest :sdks:java:io:jms:test
```

The full 70-test JMS suite passed. Both authentication tests also passed in 20 consecutive clean executions.

------------------------

- [x] Linked the failing workflow run above; no issue is associated.
- [x] `CHANGES.md` is unchanged because this is a test-only fix.
- [x] This contribution is small and does not require an ICLA update.
