### PR TITLE
[Python] Speed up ApproximateUnique accumulator merging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,6 +71,7 @@
 ## New Features / Improvements
 
 * X feature added (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
+* (Python) Reduced the cost of merging `ApproximateUnique` accumulators by avoiding an unnecessary copy and heap rebuild ([#19459](https://github.com/apache/beam/issues/19459)).
 * (Java/Python) `Watch` can bound its deduplication state by event time, retiring an output key once the greatest emitted timestamp has moved more than the allowed lateness past it. Java adds `Watch.growthOf(...).withTimestampCursor()`. Python adds `allowed_lateness` for the existing `timestamp_cursor` option ([#18459](https://github.com/apache/beam/issues/18459)).
 * (Java) Spark Structured Streaming runner: stateful ParDo with state, timers, `@RequiresTimeSortedInput` and tagged outputs is now supported in batch mode ([#39779](https://github.com/apache/beam/issues/39779)).
 * (Python) Added support for Vertex AI Model Monitoring V2 in RunInference ([#39738](https://github.com/apache/beam/issues/39738)).

--- a/sdks/python/apache_beam/transforms/stats.py
+++ b/sdks/python/apache_beam/transforms/stats.py
@@ -262,11 +262,14 @@ class ApproximateUniqueCombineFn(CombineFn):
     except Exception as e:
       raise RuntimeError("Runtime exception: %s" % e)
 
-  # created an issue https://github.com/apache/beam/issues/19459 to speed up
-  # merge process.
   def merge_accumulators(self, accumulators, *args, **kwargs):
-    merged_accumulator = self.create_accumulator()
-    for accumulator in accumulators:
+    accumulator_iter = iter(accumulators)
+    try:
+      merged_accumulator = next(accumulator_iter)
+    except StopIteration:
+      return self.create_accumulator()
+
+    for accumulator in accumulator_iter:
       for i in accumulator._sample_heap:
         merged_accumulator.add(i)
 

--- a/sdks/python/apache_beam/transforms/stats_test.py
+++ b/sdks/python/apache_beam/transforms/stats_test.py
@@ -219,6 +219,40 @@ class ApproximateUniqueTest(unittest.TestCase):
 
     self.assertRegex(e.exception.args[0], 'Runtime exception')
 
+  def test_approximate_unique_merge_accumulators_reuses_first(self):
+    sample_size = 16
+    combine_fn = ApproximateUniqueCombineFn(sample_size, coders.VarIntCoder())
+    accumulators = [combine_fn.create_accumulator() for _ in range(3)]
+    for accumulator, values in zip(
+        accumulators, [range(16), range(8, 24), range(24, 40)]):
+      for value in values:
+        accumulator.add(value)
+
+    later_accumulator_states = [(
+        list(accumulator._sample_heap),
+        set(accumulator._sample_set),
+        accumulator._min_hash) for accumulator in accumulators[1:]]
+
+    merged_accumulator = combine_fn.merge_accumulators(iter(accumulators))
+
+    self.assertIs(merged_accumulator, accumulators[0])
+    self.assertEqual(set(range(24, 40)), merged_accumulator._sample_set)
+    self.assertEqual(24, merged_accumulator._min_hash)
+    self.assertEqual(
+        later_accumulator_states,
+        [(
+            list(accumulator._sample_heap),
+            set(accumulator._sample_set),
+            accumulator._min_hash) for accumulator in accumulators[1:]])
+
+  def test_approximate_unique_merge_accumulators_empty(self):
+    combine_fn = ApproximateUniqueCombineFn(16, coders.VarIntCoder())
+
+    merged_accumulator = combine_fn.merge_accumulators(iter(()))
+
+    self.assertEqual([], merged_accumulator._sample_heap)
+    self.assertEqual(set(), merged_accumulator._sample_set)
+
   def test_get_sample_size_from_est_error(self):
     # test if get correct sample size from input error.
     assert beam.ApproximateUnique._get_sample_size_from_est_error(0.5) == 16


### PR DESCRIPTION
## Summary

- reuse the first `ApproximateUnique` accumulator instead of allocating an empty heap and reinserting every sampled hash
- preserve the empty-iterable behavior and leave later accumulators unchanged
- add merge identity, result, non-mutation, and empty-input coverage
- document the improvement in `CHANGES.md`

This brings the Python merge path in line with the existing Java implementation and removes one accumulator's worth of heap insertions from every merge.

Fixes #19459.

## Validation

- `pytest apache_beam/transforms/stats_test.py`: 87 passed with the source implementation
- rebuilt the Python extensions, then reran the same suite: 87 passed
- focused new merge tests: 2 passed in both source and extension-backed runs
- Ruff, YAPF, and `git diff --check`: passed
- CPU microbenchmark, two identical full accumulators (median of 101 runs):
  - sample size 1,600: 0.6172 ms -> 0.2158 ms (2.86x)
  - sample size 10,000: 3.9099 ms -> 1.3734 ms (2.85x)

No GPU was used or required.

## AI disclosure

The implementation, tests, benchmark, and this description were generated with OpenAI Codex at the account owner's request. Codex re-checked the final diff against the repository code and ran the validations listed above. No separate human line-by-line code review was performed before submission.
