### PR TITLE
[Python] Configure object detection benchmark timeout

### DIFF
--- a/.github/workflows/load-tests-pipeline-options/beam_Inference_Python_Benchmarks_Dataflow_Pytorch_Image_Object_Detection.txt
+++ b/.github/workflows/load-tests-pipeline-options/beam_Inference_Python_Benchmarks_Dataflow_Pytorch_Image_Object_Detection.txt
@@ -31,6 +31,7 @@
 --resize_shorter_side=800
 --score_threshold=0.5
 --max_detections=50
+--timeout_ms=3600000
 --input=gs://apache-beam-ml/testing/inputs/openimage_50k_benchmark.txt
 --model_state_dict_path=gs://apache-beam-ml/models/torchvision.detection.fasterrcnn_resnet50_fpn.pth
 --runner=DataflowRunner

--- a/sdks/python/apache_beam/examples/inference/pytorch_image_object_detection.py
+++ b/sdks/python/apache_beam/examples/inference/pytorch_image_object_detection.py
@@ -268,6 +268,11 @@ def parse_known_args(argv):
           'and publishes them to Pub/Sub. This delay allows the main streaming '
           'pipeline workers to start and scale before data ingestion begins.'),
   )
+  parser.add_argument(
+      '--timeout_ms',
+      type=int,
+      default=1800000,
+      help='Maximum pipeline runtime before cleanup, in milliseconds.')
 
   # Model & inference
   parser.add_argument(
@@ -496,7 +501,7 @@ def run(
 
   result = pipeline.run()
   try:
-    result.wait_until_finish(duration=1800000)  # 30 min
+    result.wait_until_finish(duration=known_args.timeout_ms)
   finally:
     try:
       result.cancel()


### PR DESCRIPTION
Addresses #38782.

The object-detection example cancels its Dataflow job after a hard-coded 30-minute wait, even though the benchmark workflow allows 180 minutes per step. Recent benchmark runs reached that cancellation after about 1,803 seconds.

Add `--timeout_ms` to the example, retaining the 30-minute default, and set the shared object-detection benchmark options to 60 minutes. That override applies to all four CPU/GPU and batch/streaming combinations.

This PR remains draft pending an end-to-end Dataflow run. The fixed-batch configuration fix in #39953 is now upstream and may change runtime. The timeout increase should only merge if the corrected benchmark still needs more than 30 minutes.

The [September 2 benchmark](https://github.com/apache/beam/actions/runs/33588634892/job/100117894110) includes #39953 and still cancels CPU object detection after 1,804 seconds, but it reports repeated SDK harness disconnections well before that deadline, described in the log as likely process crashes. This does not establish how long a healthy run needs or show that 60 minutes would help. The [September 3 run](https://github.com/apache/beam/actions/runs/33717519346/job/100529723733) failed during setup and skipped the benchmarks. Worker-failure diagnosis and useful end-to-end timing evidence are still needed before merging.

Validation:

- Isolated parser and orchestration checks pass for the default, an override, streaming execution, and cleanup after a wait failure. These verify timeout forwarding and cancellation without running a model or Dataflow job.
- Python compilation, YAPF, Ruff, and `git diff --check` pass.

End-to-end validation requires the Dataflow benchmark infrastructure.
