### PR TITLE
[Java] Remove MS_EXPOSE_REP from the global SpotBugs filter

### DIFF
--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/metrics/MetricsAccumulator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/metrics/MetricsAccumulator.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.spark.metrics;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import org.apache.beam.runners.core.metrics.MetricsContainerStepMap;
 import org.apache.beam.runners.spark.SparkPipelineOptions;
@@ -82,6 +83,10 @@ public class MetricsAccumulator {
     }
   }
 
+  @SuppressFBWarnings(
+      value = "MS_EXPOSE_REP",
+      justification =
+          "Spark merges only the accumulator instance the driver registered. A copy would collect metrics that nothing reports.")
   public static MetricsContainerStepMapAccumulator getInstance() {
     if (instance == null) {
       throw new IllegalStateException("Metrics accumulator has not been instantiated");

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/metrics/MetricsAccumulator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/metrics/MetricsAccumulator.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.spark.structuredstreaming.metrics;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.beam.runners.core.metrics.MetricsContainerStepMap;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.spark.sql.SparkSession;
@@ -85,6 +86,10 @@ public class MetricsAccumulator
    * Get the {@link MetricsAccumulator} on this driver. If there's no such accumulator yet, it will
    * be created and registered using the provided {@link SparkSession}.
    */
+  @SuppressFBWarnings(
+      value = "MS_EXPOSE_REP",
+      justification =
+          "Spark merges only the accumulator instance the driver registered. A copy would collect metrics that nothing reports.")
   public static MetricsAccumulator getInstance(SparkSession session) {
     MetricsAccumulator current = instance;
     if (current != null) {

--- a/sdks/java/build-tools/src/main/resources/beam/spotbugs-filter.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/spotbugs-filter.xml
@@ -57,7 +57,6 @@
 
   <!-- TODO(https://github.com/apache/beam/issues/35312) resolve findings-->
   <Bug pattern="CT_CONSTRUCTOR_THROW"/>
-  <Bug pattern="MS_EXPOSE_REP"/>
 
   <!--
     Many test classes are captured by lambdas and marked `implements Serializable`. They are not

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/Lineage.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/Lineage.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.metrics;
 
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkNotNull;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -122,6 +123,10 @@ public class Lineage {
   }
 
   /** {@link Lineage} representing sources and optionally side inputs. */
+  @SuppressFBWarnings(
+      value = "MS_EXPOSE_REP",
+      justification =
+          "Every reporter writes into the same metric cell, so all callers need the one shared instance. A copy would drop the lineage it records.")
   public static Lineage getSources() {
     Lineage localSources = sources;
     if (localSources == null) {
@@ -131,6 +136,10 @@ public class Lineage {
   }
 
   /** {@link Lineage} representing sinks. */
+  @SuppressFBWarnings(
+      value = "MS_EXPOSE_REP",
+      justification =
+          "Every reporter writes into the same metric cell, so all callers need the one shared instance. A copy would drop the lineage it records.")
   public static Lineage getSinks() {
     Lineage localSinks = sinks;
     if (localSinks == null) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/SourceMetrics.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/SourceMetrics.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.metrics;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Joiner;
 
 /** Standard {@link org.apache.beam.sdk.io.Source} Metrics. */
@@ -69,6 +70,10 @@ public class SourceMetrics {
   }
 
   /** Gauge for source backlog in bytes. */
+  @SuppressFBWarnings(
+      value = "MS_EXPOSE_REP",
+      justification =
+          "A Gauge is a handle onto one metric cell, not a value. A copy would send the reading nowhere.")
   public static Gauge backlogBytes() {
     return BACKLOG_BYTES_GAUGE;
   }
@@ -84,6 +89,10 @@ public class SourceMetrics {
   }
 
   /** Gauge for source backlog in elements. */
+  @SuppressFBWarnings(
+      value = "MS_EXPOSE_REP",
+      justification =
+          "A Gauge is a handle onto one metric cell, not a value. A copy would send the reading nowhere.")
   public static Gauge backlogElements() {
     return BACKLOG_ELEMENTS_GAUGE;
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/ModelCoders.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/ModelCoders.java
@@ -22,6 +22,7 @@ import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Pr
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
 
 import com.google.auto.value.AutoValue;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Set;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Coder;
 import org.apache.beam.model.pipeline.v1.RunnerApi.FunctionSpec;
@@ -97,6 +98,12 @@ public class ModelCoders {
           SHARDED_KEY_CODER_URN,
           NULLABLE_CODER_URN);
 
+  @SuppressFBWarnings(
+      value = "MS_EXPOSE_REP",
+      justification =
+          "Returns a Guava ImmutableSet."
+              + " Spotbugs matches its known-immutable list by fully qualified name, so it cannot recognise collections relocated into org.apache.beam.vendor.guava."
+              + " See https://github.com/spotbugs/spotbugs/issues/1601.")
   public static Set<String> urns() {
     return MODEL_CODER_URNS;
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/PTransformTranslation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/PTransformTranslation.java
@@ -22,6 +22,7 @@ import static org.apache.beam.model.pipeline.v1.ExternalTransforms.ExpansionMeth
 import static org.apache.beam.sdk.util.construction.BeamUrns.getUrn;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -417,6 +418,12 @@ public class PTransformTranslation {
       knownPayloadTranslators;
 
   @Internal
+  @SuppressFBWarnings(
+      value = "MS_EXPOSE_REP",
+      justification =
+          "Returns a Guava ImmutableMap."
+              + " Spotbugs matches its known-immutable list by fully qualified name, so it cannot recognise collections relocated into org.apache.beam.vendor.guava."
+              + " See https://github.com/spotbugs/spotbugs/issues/1601.")
   public static Map<Class<? extends PTransform>, TransformPayloadTranslator>
       getKnownPayloadTranslators() {
     if (knownPayloadTranslators == null) {

--- a/sdks/java/io/thrift/src/main/java/org/apache/beam/sdk/io/thrift/ThriftSchema.java
+++ b/sdks/java/io/thrift/src/main/java/org/apache/beam/sdk/io/thrift/ThriftSchema.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.io.thrift;
 
 import static java.util.Collections.unmodifiableMap;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
@@ -121,6 +122,10 @@ public final class ThriftSchema extends GetterBasedSchemaProviderV2 {
    *
    * @see #custom() for how to manually pass the beam type for container typedefs
    */
+  @SuppressFBWarnings(
+      value = "MS_EXPOSE_REP",
+      justification =
+          "The default provider holds an empty typedef map that is never mutated. Callers needing typedefs go through custom(), which builds a separate instance.")
   public static @NonNull SchemaProvider provider() {
     return defaultProvider;
   }

--- a/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/NamedTestResult.java
+++ b/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/NamedTestResult.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.testutils;
 
 import com.google.cloud.bigquery.LegacySQLTypeName;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Map;
 import org.apache.beam.sdk.testutils.publishing.InfluxDBPublisher;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
@@ -83,6 +84,12 @@ public class NamedTestResult implements TestResult {
         .build();
   }
 
+  @SuppressFBWarnings(
+      value = "MS_EXPOSE_REP",
+      justification =
+          "Returns a Guava ImmutableMap."
+              + " Spotbugs matches its known-immutable list by fully qualified name, so it cannot recognise collections relocated into org.apache.beam.vendor.guava."
+              + " See https://github.com/spotbugs/spotbugs/issues/1601.")
   public static Map<String, String> getSchema() {
     return schema;
   }

--- a/sdks/java/testing/tpcds/src/main/java/org/apache/beam/sdk/tpcds/TpcdsSchemas.java
+++ b/sdks/java/testing/tpcds/src/main/java/org/apache/beam/sdk/tpcds/TpcdsSchemas.java
@@ -17,12 +17,18 @@
  */
 package org.apache.beam.sdk.tpcds;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 
+@SuppressFBWarnings(
+    value = "MS_EXPOSE_REP",
+    justification =
+        "Fixed TPC-DS table definitions, built once at class load."
+            + " Schema is mutable only through setUUID, which no caller here uses, and copying twenty-four schemas on every accessor call would cost real time in a benchmark harness.")
 public class TpcdsSchemas {
   /**
    * Get all tpcds table schemas automatically by reading json files. In this case all field will be


### PR DESCRIPTION
`sdks/java/build-tools/src/main/resources/beam/spotbugs-filter.xml` turns off `MS_EXPOSE_REP` for every module. That hides 34 findings today, and hides any new one automatically. This removes that line and marks the existing sites one by one.

Nothing changes at runtime and no finding is fixed. What changes is that the next accessor someone writes that returns a mutable static will fail `spotbugsMain` instead of passing quietly.

Addresses #35312. That issue covers two patterns. `CT_CONSTRUCTOR_THROW` has about 140 sites and is not touched here.

### The 34 findings

| Cause | Sites |
|---|---|
| Relocated Guava immutable collections | 3 |
| `TpcdsSchemas` fixed table definitions | 24 |
| Metric handles that have to be shared to work | 6 |
| One shared empty instance | 1 |

That is 11 `@SuppressFBWarnings` annotations across 9 files. `TpcdsSchemas` takes one annotation on the class for all 24 of its findings.

### Why these are suppressed instead of fixed

I tried fixing them first. In each case the fix makes the code worse.

**Relocated Guava**, 3 sites: `ModelCoders.urns()`, `PTransformTranslation.getKnownPayloadTranslators()`, `NamedTestResult.getSchema()`. These already return an `ImmutableSet` or `ImmutableMap`. Wrapping the return in `Collections.unmodifiableSet` does clear the finding, I checked, but it puts a second immutable wrapper around a collection that is already immutable, and the next reader has to work out why it is there.

**`TpcdsSchemas`**, 24 sites. Moving the 24 `Schema.builder()` chains into their getters means rebuilding fixed table definitions on every call, inside a benchmark.

**`Lineage`, both Spark `MetricsAccumulator` classes, and the two `SourceMetrics` gauges**, 6 sites. Returning the shared instance is the whole point. A copy would collect metrics that nothing reports.

**`ThriftSchema.provider()`**, 1 site. It returns a single shared instance holding an empty map. Removing it means allocating on every call, and `provider() == provider()` stops being true.

This is the same split as #35394, which fixed `DCN_NULLPOINTER_EXCEPTION`, `PA_PUBLIC_PRIMITIVE_ATTRIBUTE` and `DMI_RANDOM_USED_ONLY_ONCE`, where the findings were real bugs, and left `MS_EXPOSE_REP` in the filter.

### Why the Guava sites cannot be configured away

`MutableClasses.mutableSignature()` checks the fully qualified name against a hardcoded list. That list has `com.google.common.collect.ImmutableSet` but not `org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableSet`. When that check misses, it scans the class for public methods with setter-like names and walks up the superclass chain. The relocated `ImmutableCollection` declares `add`, `remove`, `addAll`, `removeAll`, `removeIf` and `clear`, so that check fails too.

The list is `static final` and 4.8.3 reads no property that would extend it. The only hook is a class annotation whose descriptor ends in `/Immutable;`, which would have to be added to Guava's own source.

Upstream, spotbugs/spotbugs#1601 is open with 44 comments. The pull request that would make the list configurable, spotbugs/spotbugs#1619, has been a draft since 2021 and a maintainer objected to it. Filing a new issue would just duplicate #1601.

`SourceMetrics` shows plainly that the check goes by name. `elementsRead()` and `bytesRead()` return static `Counter` fields and pass. `backlogBytes()` and `backlogElements()` return static `Gauge` fields and fail. The only difference is that `Gauge` has `set(long)` and `Counter` has `inc()`.

### Notes for reviewers

- `edu.umd.cs.findbugs.annotations.SuppressFBWarnings` is LGPL. `spotbugs-annotations` is already a `compileOnly` dependency and is not shipped, and `sdks/java/core` main source already imports it.
- `matchType = EXACT` is not available in spotbugs-annotations 4.8.3, which has only `value()` and `justification()`. Suppression matches by prefix, so `MS_EXPOSE_REP` also covers `MS_EXPOSE_BUF`. None of these sites return an array, so nothing extra gets suppressed.
- `TpcdsSchemas` is annotated on the class rather than on 24 getters, since all 24 have the same reason.
- `ExecutionStateSampler.java:55` already had `@SuppressFBWarnings("MS_EXPOSE_REP")` from #35313 and is unchanged.
- The Guava justifications are longer than the rest because they name the upstream issue, which nobody could guess from the call site. Long strings break at sentence ends only. `LineLength` is disabled in `checkstyle.xml`, and google-java-format does not split string literals, so `spotlessJavaCheck` is stable on them.

### Verified

`spotbugsMain` and `spotlessJavaCheck` pass on `:sdks:java:core`, `:sdks:java:io:thrift`, `:sdks:java:testing:tpcds`, `:sdks:java:testing:test-utils` and `:runners:spark:3`.

`sdks/java/io/components:spotbugsMain` already fails on master for an unrelated reason, two `SE_BAD_FIELD` findings in `EnvoyRateLimiterFactory`.
