### PR TITLE
[Python] Honor fixed object detection batch size

### DIFF
--- a/sdks/python/apache_beam/examples/inference/pytorch_image_object_detection.py
+++ b/sdks/python/apache_beam/examples/inference/pytorch_image_object_detection.py
@@ -431,7 +431,8 @@ def run(
       model_params={},
       state_dict_path=known_args.model_state_dict_path,
       device=device,
-      inference_batch_size=batch_size,
+      min_batch_size=batch_size,
+      max_batch_size=batch_size,
       inference_fn=_torchvision_detection_inference_fn,
   )
 


### PR DESCRIPTION
Related to #38782 and #39949.

## Why

The object-detection example describes its inference batch size as fixed, but passes `inference_batch_size` to `PytorchModelHandlerTensor`. That handler does not consume this keyword. It reaches `ModelHandler` through `**kwargs`, where it is ignored, leaving `RunInference` to use adaptive `BatchElements` defaults.

This means all four Faster R-CNN benchmark variants have been measuring an unintended batching policy since they were added.

## What changed

Pass the configured size through the supported `min_batch_size` and `max_batch_size` arguments. Setting both to the same value makes `BatchElements` use the requested fixed size, currently 8 in the benchmark configuration.

This is separate from #39949 because corrected batching may change runtime. The timeout change can remain draft until a Dataflow run shows whether 30 minutes is still insufficient.

## Validation

* `python -m py_compile sdks/python/apache_beam/examples/inference/pytorch_image_object_detection.py`
* `yapf==0.43.0 --diff` on the changed file
* `ruff==0.15.22 check --ignore I001,UP006` on the changed file
* `git diff --check`

The existing Python ML precommit covers `PytorchModelHandlerTensor` batching behavior.