### PR TITLE
[Kafka] Fix KafkaToPubsubE2ETest by bumping the purged cloud-sdk emulator image tag

### DIFF
--- a/examples/java/src/test/java/org/apache/beam/examples/complete/kafkatopubsub/KafkaToPubsubE2ETest.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/complete/kafkatopubsub/KafkaToPubsubE2ETest.java
@@ -53,7 +53,7 @@ import org.testcontainers.utility.DockerImageName;
 /** E2E test for {@link KafkaToPubsub} pipeline. */
 public class KafkaToPubsubE2ETest {
   private static final String PUBSUB_EMULATOR_IMAGE =
-      "gcr.io/google.com/cloudsdktool/cloud-sdk:316.0.0-emulators";
+      "gcr.io/google.com/cloudsdktool/cloud-sdk:583.0.0-emulators";
   private static final String KAFKA_IMAGE_NAME = "confluentinc/cp-kafka:5.4.3";
   private static final String PUBSUB_MESSAGE = "test pubsub message";
   private static final String KAFKA_TOPIC_NAME = "messages-topic";


### PR DESCRIPTION
Fixes #39955.

gcr.io purged the 316.0.0 tag family from cloudsdktool/cloud-sdk, the registry returns 404 manifest unknown and the tags list has no 316.0.0 entries left. 
KafkaToPubsubE2ETest pins that tag for its PubSub emulator container, so the class rule fails before any test runs and every beam_PreCommit_Java run has been red since 2026-09-01 roughly 02:30 UTC, on master (runs 33488230103 and 33478152767) and on every PR.

This bumps the pin to 583.0.0-emulators, the newest versioned emulator tag. Verified locally with Docker, the container pulls and starts on the new image and testKafkaToPubsubE2E passes.

If preferred we can use the rolling emulators tag, at the cost of a moving image.
Happy to switch 👯 

R: @Abacn
