### PR TITLE
Always resolve builtin types in dataclass field type inference

### DIFF
--- a/sdks/python/apache_beam/typehints/trivial_inference.py
+++ b/sdks/python/apache_beam/typehints/trivial_inference.py
@@ -776,6 +776,34 @@ def infer_return_type_func(f, input_types, debug=False, depth=0):
   return result
 
 
+_BUILTIN_TYPES = (
+    bool,
+    bytearray,
+    bytes,
+    complex,
+    float,
+    int,
+    str,
+    dict,
+    frozenset,
+    list,
+    set,
+    tuple,
+)
+_CONTAINER_CONSTRAINTS = (
+    typehints.ListConstraint,
+    typehints.DictConstraint,
+    typehints.SetTypeConstraint,
+    typehints.FrozenSetTypeConstraint,
+    typehints.TupleConstraint,
+    typehints.TupleSequenceConstraint,
+)
+
+
+def _is_builtin_type(t):
+  return t in _BUILTIN_TYPES or isinstance(t, _CONTAINER_CONSTRAINTS)
+
+
 def resolve_dataclass_field_type(x):
   """
   Resolve a type to Beam typehint under global pipeline option context.
@@ -785,7 +813,7 @@ def resolve_dataclass_field_type(x):
   incorrect typehints; non-deterministic or nullable types disallowed by
   consumer transform but check disabled by Any; tests rely on Any),
   --exclude_infer_dataclass_field_type option to instruct falling back to Any.
-  Fields of builtin primitives are always respected.
+  Fields of builtin types and their Optional are always respected.
   """
   from apache_beam.options.pipeline_options_context import get_pipeline_options
   options = get_pipeline_options()
@@ -795,8 +823,12 @@ def resolve_dataclass_field_type(x):
   else:
     disabled = False
 
+  norm_x = typehints.normalize(x)
   if not disabled:
-    return typehints.normalize(x)
-  if x in (bool, bytes, complex, float, int, str):
-    return x
+    return norm_x
+  if _is_builtin_type(norm_x):
+    return norm_x
+  if (typehints.is_nullable(norm_x) and
+      _is_builtin_type(typehints.get_concrete_type_from_nullable(norm_x))):
+    return norm_x
   return Any

--- a/sdks/python/apache_beam/typehints/trivial_inference_test.py
+++ b/sdks/python/apache_beam/typehints/trivial_inference_test.py
@@ -21,6 +21,7 @@
 
 import dataclasses
 import types
+import typing
 import unittest
 
 import apache_beam as beam
@@ -501,18 +502,44 @@ class TrivialInferenceTest(unittest.TestCase):
       name: str
       tags: list[str]
       custom: BaseClass
+      opt_id: typing.Optional[int]
+      opt_custom: typing.Optional[BaseClass]
+      mapping: dict[str, int]
+      coord: tuple[float, float]
+      categories: set[str]
+      immutable: frozenset[int]
 
     self.assertReturnType(
-        typehints.Tuple[int, str, typehints.List[str], BaseClass],
+        typehints.Tuple[int,
+                        str,
+                        typehints.List[str],
+                        BaseClass,
+                        typehints.Optional[int],
+                        typehints.Optional[BaseClass],
+                        typehints.Dict[str, int],
+                        typehints.Tuple[float, float],
+                        typehints.Set[str],
+                        typehints.FrozenSet[int]],
         python_callable.PythonCallableWithSource(
-            "lambda x: (x.id, x.name, x.tags, x.custom)"), [MyDataClass])
+            "lambda x: (x.id, x.name, x.tags, x.custom, x.opt_id, x.opt_custom, "
+            "x.mapping, x.coord, x.categories, x.immutable)"), [MyDataClass])
 
     options = PipelineOptions(['--exclude_infer_dataclass_field_type'])
     with scoped_pipeline_options(options):
       self.assertReturnType(
-          typehints.Tuple[int, str, typehints.Any, typehints.Any],
+          typehints.Tuple[int,
+                          str,
+                          typehints.List[str],
+                          typehints.Any,
+                          typehints.Optional[int],
+                          typehints.Any,
+                          typehints.Dict[str, int],
+                          typehints.Tuple[float, float],
+                          typehints.Set[str],
+                          typehints.FrozenSet[int]],
           python_callable.PythonCallableWithSource(
-              "lambda x: (x.id, x.name, x.tags, x.custom)"), [MyDataClass])
+              "lambda x: (x.id, x.name, x.tags, x.custom, x.opt_id, x.opt_custom, "
+              "x.mapping, x.coord, x.categories, x.immutable)"), [MyDataClass])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
exclude_infer_dataclass_field_type was introduced to temporarily keeping old behavior of typehint resolution of dataclass field type. We now aim to gradualy phase out this restriction. First, expand the types always enabled to all Python built-in types, not limited to primitive types, and Optional[...] hints as well

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
