### PR TITLE
Add test case verifying metric capture in Setup() lifecycle method

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/repro_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/repro_test.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package exec
 
 import (

--- a/sdks/go/pkg/beam/core/runtime/exec/repro_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/repro_test.go
@@ -1,0 +1,80 @@
+package exec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/window"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/metrics"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/typex"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/util/reflectx"
+)
+
+var setupCounterNoCtx = metrics.NewCounter("test", "setup_counter_no_ctx")
+
+type SetupMetricsDoFnNoCtx struct{}
+
+func (fn *SetupMetricsDoFnNoCtx) Setup() {
+	setupCounterNoCtx.Inc(context.Background(), 1)
+}
+
+func (fn *SetupMetricsDoFnNoCtx) ProcessElement(v int) int {
+	return v
+}
+
+func TestSetupMetricsNoCtx(t *testing.T) {
+	fn, err := graph.NewDoFn(&SetupMetricsDoFnNoCtx{})
+	if err != nil {
+		t.Fatalf("invalid DoFn: %v", err)
+	}
+
+	g := graph.New()
+	nN := g.NewNode(typex.New(reflectx.Int), window.DefaultWindowingStrategy(), true)
+
+	edge, err := graph.NewParDo(g, g.Root(), fn, []*graph.Node{nN}, nil, nil)
+	if err != nil {
+		t.Fatalf("invalid pardo: %v", err)
+	}
+
+	out := &CaptureNode{UID: 1}
+	pardo := &ParDo{UID: 2, Fn: edge.DoFn, Inbound: edge.Input, Out: []Node{out}}
+	root := &FixedRoot{UID: 3, Elements: makeInput(1, 2, 3), Out: pardo}
+
+	p, err := NewPlan("test-plan", []Unit{root, pardo, out})
+	if err != nil {
+		t.Fatalf("failed to construct plan: %v", err)
+	}
+
+	// In a real runner, SetBundleID is called before Execute.
+	ctx := metrics.SetBundleID(context.Background(), "bundle-1")
+
+	if err := p.Execute(ctx, "bundle-1", DataContext{}); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+
+	store := metrics.GetStore(ctx)
+	if store == nil {
+		t.Fatal("no metrics store found")
+	}
+
+	var found bool
+	extractor := metrics.Extractor{
+		SumInt64: func(labels metrics.Labels, v int64) {
+			if labels.Transform() == pardo.PID && labels.Namespace() == "test" && labels.Name() == "setup_counter_no_ctx" {
+				if v != 1 {
+					t.Errorf("expected counter value 1, got %v", v)
+				}
+				found = true
+			}
+		},
+	}
+
+	if err := extractor.ExtractFrom(store); err != nil {
+		t.Fatalf("extraction failed: %v", err)
+	}
+
+	if found {
+		t.Error("setup_counter_no_ctx metric should not be found in the bundle's metrics store when Setup() does not accept context")
+	}
+}

--- a/sdks/go/pkg/beam/core/runtime/exec/setup_metrics_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/setup_metrics_test.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package exec
 
 import (

--- a/sdks/go/pkg/beam/core/runtime/exec/setup_metrics_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/setup_metrics_test.go
@@ -1,0 +1,80 @@
+package exec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/window"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/metrics"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/typex"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/util/reflectx"
+)
+
+var setupCounter2 = metrics.NewCounter("test", "setup_counter_2")
+
+type SetupMetricsDoFn2 struct{}
+
+func (fn *SetupMetricsDoFn2) Setup(ctx context.Context) {
+	setupCounter2.Inc(ctx, 1)
+}
+
+func (fn *SetupMetricsDoFn2) ProcessElement(v int) int {
+	return v
+}
+
+func TestSetupMetricsWithCtx2(t *testing.T) {
+	fn, err := graph.NewDoFn(&SetupMetricsDoFn2{})
+	if err != nil {
+		t.Fatalf("invalid DoFn: %v", err)
+	}
+
+	g := graph.New()
+	nN := g.NewNode(typex.New(reflectx.Int), window.DefaultWindowingStrategy(), true)
+
+	edge, err := graph.NewParDo(g, g.Root(), fn, []*graph.Node{nN}, nil, nil)
+	if err != nil {
+		t.Fatalf("invalid pardo: %v", err)
+	}
+
+	out := &CaptureNode{UID: 1}
+	pardo := &ParDo{UID: 2, Fn: edge.DoFn, Inbound: edge.Input, Out: []Node{out}}
+	root := &FixedRoot{UID: 3, Elements: makeInput(1, 2, 3), Out: pardo}
+
+	p, err := NewPlan("test-plan", []Unit{root, pardo, out})
+	if err != nil {
+		t.Fatalf("failed to construct plan: %v", err)
+	}
+
+	// In a real runner, SetBundleID is called before Execute.
+	ctx := metrics.SetBundleID(context.Background(), "bundle-1")
+
+	if err := p.Execute(ctx, "bundle-1", DataContext{}); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+
+	store := metrics.GetStore(ctx)
+	if store == nil {
+		t.Fatal("no metrics store found")
+	}
+
+	var found bool
+	extractor := metrics.Extractor{
+		SumInt64: func(labels metrics.Labels, v int64) {
+			if labels.Transform() == pardo.PID && labels.Namespace() == "test" && labels.Name() == "setup_counter_2" {
+				if v != 1 {
+					t.Errorf("expected counter value 1, got %v", v)
+				}
+				found = true
+			}
+		},
+	}
+
+	if err := extractor.ExtractFrom(store); err != nil {
+		t.Fatalf("extraction failed: %v", err)
+	}
+
+	if !found {
+		t.Error("setup_counter_2 metric not found in the bundle's metrics store")
+	}
+}


### PR DESCRIPTION
Hi! 

This PR adds a test case to  to clarify how metrics can be captured during the  lifecycle method of a .

### Background
I investigated [BEAM-27038](https://github.com/apache/beam/issues/27038) and found that the behavior of metrics in  is tied to how the Go SDK handles context. 
- If the  method accepts a  argument, the framework correctly passes the bundle's context, and metrics are captured.
- If the  method does not accept context, any metrics incremented using  are correctly (but perhaps unexpectedly) dropped.

### Changes
- Added  to verify that metrics are captured when  accepts context.
- Added  to verify the expected behavior when  does not accept context.

This PR aims to serve as a documentation-by-test for this convention. 

Thanks!