### PR TITLE
Fix GCS glob matching for multi-byte characters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -95,6 +95,7 @@
 * (Java) KafkaIO dynamic reads no longer require the obsolete `beam_fn_api` experiment ([#29998](https://github.com/apache/beam/issues/29998)).
 * (Prism) Self-checkpointing splittable DoFns now resume after their requested delay instead of immediately, so polling SDFs no longer busy-spin ([#39848](https://github.com/apache/beam/issues/39848)).
 * (Java) MongoDbIO read splitting now preserves non-ObjectId `_id` types (e.g. string ids) instead of failing to parse the generated range filters ([#39900](https://github.com/apache/beam/issues/39900)).
+* (Go) Fixed GCS glob matching silently dropping objects when the glob pattern contains multi-byte characters ([#39969](https://github.com/apache/beam/issues/39969)).
 
 ## Security Fixes
 

--- a/sdks/go/pkg/beam/io/filesystem/gcs/gcs.go
+++ b/sdks/go/pkg/beam/io/filesystem/gcs/gcs.go
@@ -53,14 +53,16 @@ func globToRegex(pattern string) (*regexp.Regexp, error) {
 	var result strings.Builder
 	result.WriteString("^")
 
-	for i := 0; i < len(pattern); i++ {
-		c := pattern[i]
+	// Scan rune by rune so multi-byte characters are handled correctly.
+	runes := []rune(pattern)
+	for i := 0; i < len(runes); i++ {
+		c := runes[i]
 		switch c {
 		case '*':
 			// Check for ** (double asterisk)
-			if i+1 < len(pattern) && pattern[i+1] == '*' {
+			if i+1 < len(runes) && runes[i+1] == '*' {
 				// Check if followed by / (e.g., "**/" matches zero or more path segments)
-				if i+2 < len(pattern) && pattern[i+2] == '/' {
+				if i+2 < len(runes) && runes[i+2] == '/' {
 					// **/ matches "" or "something/" or "a/b/c/"
 					result.WriteString("(?:.*/)?")
 					i += 2 // Skip the second * and the /
@@ -77,26 +79,26 @@ func globToRegex(pattern string) (*regexp.Regexp, error) {
 		case '[':
 			// Character class - find the closing bracket
 			j := i + 1
-			if j < len(pattern) && pattern[j] == '!' {
+			if j < len(runes) && runes[j] == '!' {
 				j++
 			}
-			if j < len(pattern) && pattern[j] == ']' {
+			if j < len(runes) && runes[j] == ']' {
 				j++
 			}
-			for j < len(pattern) && pattern[j] != ']' {
+			for j < len(runes) && runes[j] != ']' {
 				j++
 			}
-			if j >= len(pattern) {
+			if j >= len(runes) {
 				return nil, fmt.Errorf("syntax error: unclosed '[' in pattern %q", pattern)
 			} else {
 				// Copy the character class, converting ! to ^ for negation
 				result.WriteByte('[')
-				content := pattern[i+1 : j]
+				content := runes[i+1 : j]
 				if len(content) > 0 && content[0] == '!' {
 					result.WriteByte('^')
 					content = content[1:]
 				}
-				result.WriteString(content)
+				result.WriteString(string(content))
 				result.WriteByte(']')
 				i = j
 			}

--- a/sdks/go/pkg/beam/io/filesystem/gcs/gcs_test.go
+++ b/sdks/go/pkg/beam/io/filesystem/gcs/gcs_test.go
@@ -322,6 +322,14 @@ func TestGlobToRegex(t *testing.T) {
 		{"file.txt", "file.txt", true},
 		{"file.txt", "fileXtxt", false},
 		{"file(1).txt", "file(1).txt", true},
+
+		// Multi-byte characters must be preserved
+		{"résumé.txt", "résumé.txt", true},
+		{"résumé.txt", "resume.txt", false},
+		{"résumé/*.txt", "résumé/file.txt", true},
+		{"*/résumé.txt", "dir/résumé.txt", true},
+		{"*.txt", "résumé.txt", true},
+		{"ïé.txt", "ïé.txt", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #39969

## summary

[`fileio.MatchAll`](https://github.com/apache/beam/blob/8b431c8ed2b7edb9ac481fbb000139fcc50789cd/sdks/go/pkg/beam/io/fileio/match.go#L106) fails to return existing GCS objects when the glob pattern contains multi-byte characters.

The root cause is in `globToRegex()` function called within `filesystem.List()` in `sdks/go/pkg/beam/io/filesystem/gcs/gcs.go`.
`globToRegex()` translates a glob pattern into a regular expression, but it scanned the pattern byte by byte in order to handle wildcards. 
As a result, when the pattern contained multibyte characters, the generated regular expression became corrupted and no longer matched any actual paths.

This behavior was introduced by #38099 in version 2.75.0; earlier versions used the rune-aware `filepath.Match`, so version 2.74.0 and earlier are unaffected.

This PR makes `globToRegex()` scan the pattern rune by rune, so glob patterns containing multi-byte characters can be used.

## simple string to regex example

<details>
<summary>byte-by-byte</summary>

```Go
package main

import (
	"fmt"
	"regexp"
	"strings"
)

func main() {
	pattern := "café.txt" // é is 0xC3 0xA9 in UTF-8

	// Build the regex by scanning the pattern byte by byte (the original bug).
	var b strings.Builder
	for i := 0; i < len(pattern); i++ {
		b.WriteString(regexp.QuoteMeta(string(pattern[i]))) // pattern[i] is a byte
	}
	re := b.String()

	fmt.Printf("pattern = %q  (bytes: % x)\n", pattern, []byte(pattern))
	fmt.Printf("regex   = %q\n", re)
	fmt.Printf("matches %q? %v\n", pattern, regexp.MustCompile(re).MatchString(pattern))
}
```

output:

```
pattern = "café.txt"
regex   = "cafÃ©\.txt" // built the corrupted regex
matches "café.txt"? false
```

</details>

<details>
<summary>rune-by-rune</summary>

```Go
package main

import (
	"fmt"
	"regexp"
	"strings"
)

func main() {
	pattern := "café.txt" // é is 0xC3 0xA9 in UTF-8

	// Build the regex by scanning the pattern rune by rune (the fix).
	var b strings.Builder
	for _, r := range pattern { // r is a rune (a full character)
		b.WriteString(regexp.QuoteMeta(string(r)))
	}
	re := b.String()

	fmt.Printf("pattern = %q  (bytes: % x)\n", pattern, []byte(pattern))
	fmt.Printf("regex   = %q\n", re)
	fmt.Printf("matches %q? %v\n", pattern, regexp.MustCompile(re).MatchString(pattern))
}
```

output:

```
pattern = "café.txt"
regex   = "café\.txt" // built include multibyte regex
matches "café.txt"? true
```

In this simple case, using `range` is sufficient, but since the actual `globToRegex` function requires looking ahead (`runes[i+1]`) and index jumps (`i = j`), it is implemented using `[]rune + index`.

</details>

## tests

Added multi-byte cases to `TestGlobToRegex` (e.g. résumé.txt, résumé/*.txt, */résumé.txt). They fail on master and pass with this change.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
