### PR TITLE
[CI] Re-pin gradle/actions/setup-gradle to an allowlisted SHA (v6.3.0)

### DIFF
--- a/.github/actions/setup-environment-action/action.yml
+++ b/.github/actions/setup-environment-action/action.yml
@@ -94,7 +94,7 @@ runs:
         distribution: 'temurin'
         java-version: ${{ inputs.java-version == 'default' && '21' || inputs.java-version }}
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
       with:
         cache-disabled: ${{ inputs.disable-cache }}
         validate-wrappers: false


### PR DESCRIPTION
Every GitHub Actions job on master and on PRs has failed since 2026-09-03 around 03:00 UTC in the `Setup environment` step, before checkout:

```
##[error]The action gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e is not allowed in apache/beam because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns: ...
```

Evidence: master run 33680323870 (2026-09-02T20:36Z) was green, scheduled master runs 33714725135 and 33715111662 (2026-09-03T04:2xZ) and PR runs 33723362071, 33723362072, 33723362078 (06:28Z) all fail with this error.

Cause: the ASF allowlist is an exact SHA list in [apache/infrastructure-actions/actions.yml](https://github.com/apache/infrastructure-actions/blob/main/actions.yml). Beam pinned the v6.1.0 SHA, which carried `expires_at: 2026-09-03` and was removed by [commit 63206b15a5 "Remove Expired Refs"](https://github.com/apache/infrastructure-actions/commit/63206b15a5) at 03:06Z. Dependabot does not bump this pin because it lives in a composite action under `.github/actions`.

Fix: re-pin to v6.3.0, SHA `9c971963bec38e04b3d30dcc455b5382be2fdbfb`, which is allowlisted without an expiry date and still supports the `cache-disabled` and `validate-wrappers` inputs. v6.3.0 bumps the cache protocol, so the first run after merge is a Gradle cache miss. The ASF allowlist check script passes locally on this branch, all 39 action refs are allowed and none expires within 60 days.

Note: PreCommit workflows run on `pull_request_target`, but `setup-action` checks out the PR merge ref and the composite action is loaded from that workspace, so the PreCommit runs on this PR already exercise the new pin. The RAT PreCommit here passed the `Setup environment` step.

Blocks #39971 and every other open PR. cc @Abacn
