### PR TITLE
Adds drain support to Spanner CDC source. 

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dao/PartitionMetadataAdminDao.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dao/PartitionMetadataAdminDao.java
@@ -259,10 +259,10 @@ public class PartitionMetadataAdminDao {
     List<String> ddl = new ArrayList<>();
     if (this.isPostgres()) {
       indexes.forEach(index -> ddl.add("DROP INDEX \"" + index + "\""));
-      ddl.add("DROP TABLE \"" + names.getTableName() + "\"");
+      ddl.add("DROP TABLE IF EXISTS \"" + names.getTableName() + "\"");
     } else {
       indexes.forEach(index -> ddl.add("DROP INDEX " + index));
-      ddl.add("DROP TABLE " + names.getTableName());
+      ddl.add("DROP TABLE IF EXISTS " + names.getTableName());
     }
     OperationFuture<Void, UpdateDatabaseDdlMetadata> op =
         databaseAdminClient.updateDatabaseDdl(instanceId, databaseId, ddl, null);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dao/PartitionMetadataAdminDao.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dao/PartitionMetadataAdminDao.java
@@ -258,10 +258,10 @@ public class PartitionMetadataAdminDao {
   public void deletePartitionMetadataTable(List<String> indexes) {
     List<String> ddl = new ArrayList<>();
     if (this.isPostgres()) {
-      indexes.forEach(index -> ddl.add("DROP INDEX \"" + index + "\""));
+      indexes.forEach(index -> ddl.add("DROP INDEX IF EXISTS \"" + index + "\""));
       ddl.add("DROP TABLE IF EXISTS \"" + names.getTableName() + "\"");
     } else {
-      indexes.forEach(index -> ddl.add("DROP INDEX " + index));
+      indexes.forEach(index -> ddl.add("DROP INDEX IF EXISTS " + index));
       ddl.add("DROP TABLE IF EXISTS " + names.getTableName());
     }
     OperationFuture<Void, UpdateDatabaseDdlMetadata> op =

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/DetectNewPartitionsDoFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/DetectNewPartitionsDoFn.java
@@ -37,7 +37,9 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.DoFn.UnboundedPerElement;
 import org.apache.beam.sdk.transforms.splittabledofn.ManualWatermarkEstimator;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
+import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.TruncateResult;
 import org.apache.beam.sdk.transforms.splittabledofn.WatermarkEstimators.Manual;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.slf4j.Logger;
@@ -119,6 +121,11 @@ public class DetectNewPartitionsDoFn extends DoFn<PartitionMetadata, PartitionMe
     final com.google.cloud.Timestamp createdAt = partition.getCreatedAt();
     return TimestampRange.of(
         TimestampUtils.previous(createdAt), com.google.cloud.Timestamp.MAX_VALUE);
+  }
+
+  @TruncateRestriction
+  public @Nullable TruncateResult<TimestampRange> truncateRestriction() {
+    return null;
   }
 
   @GetSize

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/ReadChangeStreamPartitionDoFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/ReadChangeStreamPartitionDoFn.java
@@ -48,7 +48,9 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.DoFn.UnboundedPerElement;
 import org.apache.beam.sdk.transforms.splittabledofn.ManualWatermarkEstimator;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
+import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.TruncateResult;
 import org.apache.beam.sdk.transforms.splittabledofn.WatermarkEstimators.Manual;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.slf4j.Logger;
@@ -167,6 +169,11 @@ public class ReadChangeStreamPartitionDoFn extends DoFn<PartitionMetadata, DataC
 
     metrics.incActivePartitionReadCounter();
     return TimestampRange.of(startTimestamp, endTimestamp);
+  }
+
+  @TruncateRestriction
+  public @Nullable TruncateResult<TimestampRange> truncateRestriction() {
+    return null;
   }
 
   @GetSize

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dao/PartitionMetadataAdminDaoTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dao/PartitionMetadataAdminDaoTest.java
@@ -145,9 +145,9 @@ public class PartitionMetadataAdminDaoTest {
         .updateDatabaseDdl(eq(INSTANCE_ID), eq(DATABASE_ID), statements.capture(), isNull());
     assertEquals(3, ((Collection<?>) statements.getValue()).size());
     Iterator<String> it = statements.getValue().iterator();
-    assertTrue(it.next().contains("DROP INDEX"));
-    assertTrue(it.next().contains("DROP INDEX"));
-    assertTrue(it.next().contains("DROP TABLE"));
+    assertTrue(it.next().contains("DROP INDEX IF EXISTS"));
+    assertTrue(it.next().contains("DROP INDEX IF EXISTS"));
+    assertTrue(it.next().contains("DROP TABLE IF EXISTS"));
   }
 
   @Test
@@ -158,7 +158,7 @@ public class PartitionMetadataAdminDaoTest {
         .updateDatabaseDdl(eq(INSTANCE_ID), eq(DATABASE_ID), statements.capture(), isNull());
     assertEquals(1, ((Collection<?>) statements.getValue()).size());
     Iterator<String> it = statements.getValue().iterator();
-    assertTrue(it.next().contains("DROP TABLE"));
+    assertTrue(it.next().contains("DROP TABLE IF EXISTS"));
   }
 
   @Test
@@ -170,9 +170,9 @@ public class PartitionMetadataAdminDaoTest {
         .updateDatabaseDdl(eq(INSTANCE_ID), eq(DATABASE_ID), statements.capture(), isNull());
     assertEquals(3, ((Collection<?>) statements.getValue()).size());
     Iterator<String> it = statements.getValue().iterator();
-    assertTrue(it.next().contains("DROP INDEX \""));
-    assertTrue(it.next().contains("DROP INDEX \""));
-    assertTrue(it.next().contains("DROP TABLE \""));
+    assertTrue(it.next().contains("DROP INDEX IF EXISTS \""));
+    assertTrue(it.next().contains("DROP INDEX IF EXISTS \""));
+    assertTrue(it.next().contains("DROP TABLE IF EXISTS \""));
   }
 
   @Test
@@ -183,7 +183,7 @@ public class PartitionMetadataAdminDaoTest {
         .updateDatabaseDdl(eq(INSTANCE_ID), eq(DATABASE_ID), statements.capture(), isNull());
     assertEquals(1, ((Collection<?>) statements.getValue()).size());
     Iterator<String> it = statements.getValue().iterator();
-    assertTrue(it.next().contains("DROP TABLE \""));
+    assertTrue(it.next().contains("DROP TABLE IF EXISTS \""));
   }
 
   @Test


### PR DESCRIPTION
Before this change, we were calling the default implementation of truncateRestriction on drain, which, for bounded restrictions tries to finish evaluating the entire restriction. Both SDF's in the Spanner CDC source use bounded restrictions that are effectively unbounded. Overriding truncateRestriction to return null on these SDFs allows terminating immediately.

In addition, we had to change the cleanup action from DROP TABLE to DROP TABLE IF EXISTS to make deletion idempotent. Otherwise, if that work item gets retried by the backend, it will start fail-looping, preventing drain from completing.

We don't have a great way to test drain here, but I ran a test pipeline on Dataflow and verified that it can now drain successfully.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
