### PR TITLE
[Python] Isolate async work by key and window

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -94,6 +94,7 @@
 
 * (Java) Fixed the Spark runner firing processing-time timers in reverse timestamp order ([#39824](https://github.com/apache/beam/issues/39824)).
 * (Python) Fixed incorrect profiler options handling on portable runners ([#39613](https://github.com/apache/beam/issues/39613)).
+* (Python) Fixed `AsyncWrapper` mixing results between keys or windows whose values or custom identifiers match, and cancelling work belonging to other windows.
 * (Java) KafkaIO dynamic reads no longer require the obsolete `beam_fn_api` experiment ([#29998](https://github.com/apache/beam/issues/29998)).
 * (Prism) Self-checkpointing splittable DoFns now resume after their requested delay instead of immediately, so polling SDFs no longer busy-spin ([#39848](https://github.com/apache/beam/issues/39848)).
 * (Java) MongoDbIO read splitting now preserves non-ObjectId `_id` types (e.g. string ids) instead of failing to parse the generated range filters ([#39900](https://github.com/apache/beam/issues/39900)).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -94,7 +94,7 @@
 
 * (Java) Fixed the Spark runner firing processing-time timers in reverse timestamp order ([#39824](https://github.com/apache/beam/issues/39824)).
 * (Python) Fixed incorrect profiler options handling on portable runners ([#39613](https://github.com/apache/beam/issues/39613)).
-* (Python) Fixed `AsyncWrapper` mixing results between keys or windows whose values or custom identifiers match, and cancelling work belonging to other windows.
+* (Python) Fixed `AsyncWrapper` mixing results between keys or windows whose values or custom identifiers match, and cancelling work belonging to other windows ([#39996](https://github.com/apache/beam/pull/39996)).
 * (Java) KafkaIO dynamic reads no longer require the obsolete `beam_fn_api` experiment ([#29998](https://github.com/apache/beam/issues/29998)).
 * (Prism) Self-checkpointing splittable DoFns now resume after their requested delay instead of immediately, so polling SDFs no longer busy-spin ([#39848](https://github.com/apache/beam/issues/39848)).
 * (Java) MongoDbIO read splitting now preserves non-ObjectId `_id` types (e.g. string ids) instead of failing to parse the generated range filters ([#39900](https://github.com/apache/beam/issues/39900)).

--- a/sdks/python/apache_beam/transforms/async_dofn.py
+++ b/sdks/python/apache_beam/transforms/async_dofn.py
@@ -291,7 +291,10 @@ class AsyncWrapper(beam.DoFn):
         AsyncWrapper._items_in_buffer[self._uuid] -= 1
 
   def _element_id(self, element, window=beam.DoFn.WindowParam):
-    return (element[0], window, self._id_fn(element[1]))
+    # Encoded keys survive state decoding and distinguish numeric keys that
+    # compare equal in Python, such as signed zero or bool and int values.
+    encoded_key = self.TO_PROCESS.coder.key_coder().encode(element[0])
+    return (encoded_key, window, self._id_fn(element[1]))
 
   def schedule_if_room(
       self,
@@ -486,6 +489,7 @@ class AsyncWrapper(beam.DoFn):
           ' been set.')
     if self._verbose_logging:
       logging.info('procesing timer for key: %s', key)
+    encoded_key = self.TO_PROCESS.coder.key_coder().encode(key)
     # Runner state is scoped to a key and window. Leave work belonging to
     # other state cells alone when synchronizing the shared local map.
     with AsyncWrapper._lock:
@@ -496,7 +500,7 @@ class AsyncWrapper(beam.DoFn):
       }
       to_remove_ids = []
       for element_id, (element, future) in processing_elements.items():
-        if (element_id[:2] == (key, window) and
+        if (element_id[:2] == (encoded_key, window) and
             element_id not in to_process_local_ids):
           items_cancelled += 1
           future.cancel()

--- a/sdks/python/apache_beam/transforms/async_dofn.py
+++ b/sdks/python/apache_beam/transforms/async_dofn.py
@@ -114,6 +114,7 @@ class AsyncWrapper(beam.DoFn):
         schedule an item.  Used in testing to ensure timeouts are met.
       id_fn: A function that returns a hashable object from an element. This
         will be used to track items instead of the element's default hash.
+        Identifiers are scoped to the input key and window.
       use_asyncio: If true, use asyncio and coroutines to process items. If
         false, use ThreadPoolExecutor. Use asyncio when the work being done
         is not CPU intensive and heavily waits on network or IO which can
@@ -289,7 +290,16 @@ class AsyncWrapper(beam.DoFn):
       if self._uuid in AsyncWrapper._items_in_buffer:
         AsyncWrapper._items_in_buffer[self._uuid] -= 1
 
-  def schedule_if_room(self, element, ignore_buffer=False, *args, **kwargs):
+  def _element_id(self, element, window=beam.DoFn.WindowParam):
+    return (element[0], window, self._id_fn(element[1]))
+
+  def schedule_if_room(
+      self,
+      element,
+      ignore_buffer=False,
+      *args,
+      window=beam.DoFn.WindowParam,
+      **kwargs):
     """Schedules an item to be processed asynchronously if there is room.
 
     Args:
@@ -297,6 +307,7 @@ class AsyncWrapper(beam.DoFn):
       ignore_buffer: If true will ignore the buffer limit and schedule the item
         regardless of the buffer size.  Used when an item needs to skip to the
         front such as retries.
+      window: The Beam window owning the item. Not passed to the wrapped dofn.
       *args: arguments that the wrapped dofn requires.
       **kwargs: keyword arguments that the wrapped dofn requires.
 
@@ -304,7 +315,7 @@ class AsyncWrapper(beam.DoFn):
       True if the item was scheduled False otherwise.
     """
     with AsyncWrapper._lock:
-      element_id = self._id_fn(element[1])
+      element_id = self._element_id(element, window)
       if element_id in AsyncWrapper._processing_elements[self._uuid]:
         logging.info('item %s already in processing elements', element)
         return True
@@ -329,7 +340,13 @@ class AsyncWrapper(beam.DoFn):
 
   # Add an item to the processing pool. Add the future returned by that item to
   # processing_elements_.
-  def schedule_item(self, element, ignore_buffer=False, *args, **kwargs):
+  def schedule_item(
+      self,
+      element,
+      ignore_buffer=False,
+      *args,
+      window=beam.DoFn.WindowParam,
+      **kwargs):
     """Schedules an item to be processed asynchronously.
 
     If the queue is full will block until room opens up.
@@ -342,6 +359,7 @@ class AsyncWrapper(beam.DoFn):
       ignore_buffer: If true will ignore the buffer limit and schedule the item
         regardless of the buffer size.  Used when an item needs to skip to the
         front such as retries.
+      window: The Beam window owning the item. Not passed to the wrapped dofn.
       *args: arguments that the wrapped dofn requires.
       **kwargs: keyword arguments that the wrapped dofn requires.
     """
@@ -349,7 +367,8 @@ class AsyncWrapper(beam.DoFn):
     sleep_time = 0.01
     total_sleep = 0
     while not done and total_sleep < self._timeout:
-      done = self.schedule_if_room(element, ignore_buffer, *args, **kwargs)
+      done = self.schedule_if_room(
+          element, ignore_buffer, *args, window=window, **kwargs)
       if not done:
         sleep_time = min(self.max_wait_time, sleep_time * 2)
         if self._verbose_logging or total_sleep > 10:
@@ -386,6 +405,7 @@ class AsyncWrapper(beam.DoFn):
       element,
       timer=beam.DoFn.TimerParam(TIMER),
       to_process=beam.DoFn.StateParam(TO_PROCESS),
+      window=beam.DoFn.WindowParam,
       *args,
       **kwargs):
     """Add the elements to the list of items to be processed asynchronously.
@@ -397,6 +417,7 @@ class AsyncWrapper(beam.DoFn):
       element: The element to process.
       timer: Callback timer that will commit elements.
       to_process: State that keeps track of queued items for exactly once.
+      window: The Beam window owning the item. Not passed to the wrapped dofn.
       *args: arguments that the wrapped dofn requires.
       **kwargs: keyword arguments that the wrapped dofn requires.
 
@@ -404,7 +425,7 @@ class AsyncWrapper(beam.DoFn):
       An empty list. The elements will be output asynchronously.
     """
 
-    self.schedule_item(element)
+    self.schedule_item(element, window=window)
 
     to_process.add(element)
 
@@ -424,16 +445,19 @@ class AsyncWrapper(beam.DoFn):
       self,
       to_process=beam.DoFn.StateParam(TO_PROCESS),
       timer=beam.DoFn.TimerParam(TIMER),
+      window=beam.DoFn.WindowParam,
   ):
     """Commits finished items and synchronizes local state with runner state.
 
-    Note timer firings are per key while local state contains messages for all
-    keys.  Only messages for the given key will be output/cleaned up.
+    Timer firings are per key and window while local state contains messages
+    for all keys and windows. Only messages for the given key and window will
+    be output/cleaned up.
 
     Args:
       to_process: State that keeps track of queued messagees for this key.
       timer: Timer that initiated this commit and can be reset if not all items
-        have finished..
+        have finished.
+      window: The Beam window owning the state and timer.
 
     Returns:
       A list of elements that have finished processing for this key.
@@ -455,22 +479,25 @@ class AsyncWrapper(beam.DoFn):
     key = None
     to_reschedule = []
     if to_process_local:
-      key = str(to_process_local[0][0])
+      key = to_process_local[0][0]
     else:
       logging.error(
           'no elements in state during timer callback. Timer should not have'
           ' been set.')
     if self._verbose_logging:
       logging.info('procesing timer for key: %s', key)
-    # processing state is per key so we expect this state to only contain a
-    # given key.  Skip items in processing_elements which are for a different
-    # key.
+    # Runner state is scoped to a key and window. Leave work belonging to
+    # other state cells alone when synchronizing the shared local map.
     with AsyncWrapper._lock:
       processing_elements = AsyncWrapper._processing_elements[self._uuid]
-      to_process_local_ids = {self._id_fn(e[1]) for e in to_process_local}
+      to_process_local_ids = {
+          self._element_id(e, window)
+          for e in to_process_local
+      }
       to_remove_ids = []
       for element_id, (element, future) in processing_elements.items():
-        if element[0] == key and element_id not in to_process_local_ids:
+        if (element_id[:2] == (key, window) and
+            element_id not in to_process_local_ids):
           items_cancelled += 1
           future.cancel()
           to_remove_ids.append(element_id)
@@ -485,7 +512,7 @@ class AsyncWrapper(beam.DoFn):
       finished_items = []
       for x in to_process_local:
         items_in_se_state += 1
-        x_id = self._id_fn(x[1])
+        x_id = self._element_id(x, window)
         if x_id in processing_elements:
           _, future = processing_elements[x_id]
           if future.done():
@@ -507,7 +534,7 @@ class AsyncWrapper(beam.DoFn):
 
     # Reschedule the items not under a lock
     for x in to_reschedule:
-      self.schedule_item(x, ignore_buffer=False)
+      self.schedule_item(x, ignore_buffer=False, window=window)
 
     # Update processing state to remove elements we've finished
     to_process.clear()
@@ -543,6 +570,7 @@ class AsyncWrapper(beam.DoFn):
       self,
       to_process=beam.DoFn.StateParam(TO_PROCESS),
       timer=beam.DoFn.TimerParam(TIMER),
+      window=beam.DoFn.WindowParam,
   ):
     """Helper method to commit finished items in response to timer firing.
 
@@ -550,8 +578,9 @@ class AsyncWrapper(beam.DoFn):
       to_process: State that keeps track of queued items for exactly once.
       timer: Timer that initiated this commit and can be reset if not all items
         have finished.
+      window: The Beam window owning the state and timer.
 
     Returns:
       A generator of elements that have finished processing for this key.
     """
-    return self.commit_finished_items(to_process, timer)
+    return self.commit_finished_items(to_process, timer, window)

--- a/sdks/python/apache_beam/transforms/async_dofn_test.py
+++ b/sdks/python/apache_beam/transforms/async_dofn_test.py
@@ -20,6 +20,7 @@ import multiprocessing
 import random
 import time
 import unittest
+from concurrent.futures import Future
 from concurrent.futures import ThreadPoolExecutor
 from threading import Lock
 
@@ -27,6 +28,7 @@ from parameterized import parameterized_class
 
 import apache_beam as beam
 import apache_beam.transforms.async_dofn as async_lib
+from apache_beam.transforms.window import IntervalWindow
 
 
 class BasicDofn(beam.DoFn):
@@ -219,6 +221,135 @@ class AsyncTest(unittest.TestCase):
     self.check_output(result, [msg1])
     self.assertEqual(fake_bag_state_key1.items, [])
     self.assertEqual(fake_bag_state_key2.items, [])
+
+  def test_equal_values_in_different_keys(self):
+    dofn = BasicDofn()
+    async_dofn = async_lib.AsyncWrapper(dofn, use_asyncio=self.use_asyncio)
+    async_dofn.setup()
+    first_state = FakeBagState([])
+    second_state = FakeBagState([])
+    timer = FakeTimer(0)
+    first = ('key1', 7)
+    second = ('key2', 7)
+    async_dofn.process(first, to_process=first_state, timer=timer)
+    async_dofn.process(second, to_process=second_state, timer=timer)
+    self.wait_for_empty(async_dofn)
+
+    self.check_output(
+        async_dofn.commit_finished_items(second_state, timer), [second])
+    self.assertEqual(second_state.items, [])
+    self.assertEqual(first_state.items, [first])
+    self.check_output(
+        async_dofn.commit_finished_items(first_state, timer), [first])
+    self.assertEqual(first_state.items, [])
+    self.assertEqual(dofn.getProcessed(), 2)
+
+  def test_custom_ids_are_scoped_to_key(self):
+    dofn = BasicDofn()
+    async_dofn = async_lib.AsyncWrapper(
+        dofn, id_fn=lambda value: value['id'], use_asyncio=self.use_asyncio)
+    async_dofn.setup()
+    first_state = FakeBagState([])
+    second_state = FakeBagState([])
+    timer = FakeTimer(0)
+    first = (1, {'id': 7, 'value': 'first'})
+    second = (2, {'id': 7, 'value': 'second'})
+    async_dofn.process(first, to_process=first_state, timer=timer)
+    async_dofn.process(second, to_process=second_state, timer=timer)
+    self.wait_for_empty(async_dofn)
+
+    self.check_output(
+        async_dofn.commit_finished_items(second_state, timer), [second])
+    self.check_output(
+        async_dofn.commit_finished_items(first_state, timer), [first])
+    self.assertEqual(first_state.items, [])
+    self.assertEqual(second_state.items, [])
+    self.assertEqual(dofn.getProcessed(), 2)
+
+  def _check_ids_across_windows(self, first, second, id_fn=None):
+    dofn = BasicDofn()
+    async_dofn = async_lib.AsyncWrapper(
+        dofn, id_fn=id_fn, use_asyncio=self.use_asyncio)
+    async_dofn.setup()
+    first_window = IntervalWindow(0, 10)
+    second_window = IntervalWindow(10, 20)
+    first_state = FakeBagState([])
+    second_state = FakeBagState([])
+    timer = FakeTimer(0)
+    async_dofn.process(
+        first, to_process=first_state, timer=timer, window=first_window)
+    async_dofn.process(
+        second, to_process=second_state, timer=timer, window=second_window)
+    self.wait_for_empty(async_dofn)
+
+    self.check_output(
+        async_dofn.timer_callback(second_state, timer, second_window), [second])
+    self.assertEqual(second_state.items, [])
+    self.assertEqual(first_state.items, [first])
+    self.check_output(
+        async_dofn.timer_callback(first_state, timer, first_window), [first])
+    self.assertEqual(first_state.items, [])
+    self.assertEqual(dofn.getProcessed(), 2)
+
+  def test_equal_values_in_different_windows(self):
+    self._check_ids_across_windows((1, 7), (1, 7))
+
+  def test_custom_ids_are_scoped_to_window(self):
+    first = (1, {'id': 7, 'value': 'first'})
+    second = (1, {'id': 7, 'value': 'second'})
+    self._check_ids_across_windows(
+        first, second, id_fn=lambda value: value['id'])
+
+  def test_cancellation_preserves_other_window_work(self):
+    for completed in (False, True):
+      with self.subTest(completed=completed):
+        async_dofn = async_lib.AsyncWrapper(
+            BasicDofn(), use_asyncio=self.use_asyncio)
+        first_window = IntervalWindow(0, 10)
+        second_window = IntervalWindow(10, 20)
+        first, orphan, second = (1, 'first'), (1, 'orphan'), (1, 'second')
+        first_future, orphan_future, second_future = Future(), Future(), Future()
+        first_future.set_result([first])
+        if completed:
+          second_future.set_result([second])
+        processing = async_lib.AsyncWrapper._processing_elements[
+            async_dofn._uuid]
+        for element, window, future in (
+            (first, first_window, first_future),
+            (orphan, first_window, orphan_future),
+            (second, second_window, second_future)):
+          element_id = async_dofn._element_id(element, window)
+          processing[element_id] = (element, future)
+        timer = FakeTimer(0)
+        first_state, second_state = FakeBagState([first]), FakeBagState([second])
+
+        self.check_output(
+            async_dofn.timer_callback(first_state, timer, first_window),
+            [first])
+        self.assertTrue(orphan_future.cancelled())
+        self.assertEqual(list(processing.values()), [(second, second_future)])
+        self.assertFalse(second_future.cancelled())
+        if not completed:
+          second_future.set_result([second])
+        self.check_output(
+            async_dofn.timer_callback(second_state, timer, second_window),
+            [second])
+        self.assertEqual(second_state.items, [])
+
+  def test_timer_reschedules_work_in_its_window(self):
+    dofn = BasicDofn()
+    async_dofn = async_lib.AsyncWrapper(dofn, use_asyncio=self.use_asyncio)
+    async_dofn.setup()
+    window = IntervalWindow(10, 20)
+    element = (1, 'retry')
+    state, timer = FakeBagState([element]), FakeTimer(0)
+
+    self.check_output(async_dofn.timer_callback(state, timer, window), [])
+    self.wait_for_empty(async_dofn)
+    self.check_output(
+        async_dofn.timer_callback(state, timer, window), [element])
+    self.assertEqual(state.items, [])
+    self.assertEqual(dofn.getProcessed(), 1)
 
   def test_long_item(self):
     # Test that everything still works with a long running time for the dofn.
@@ -565,7 +696,7 @@ class AsyncTest(unittest.TestCase):
     # Verify the failed future was popped from local processing_elements
     with async_lib.AsyncWrapper._lock:
       self.assertNotIn(
-          async_dofn._id_fn(msg[1]),
+          async_dofn._element_id(msg),
           async_lib.AsyncWrapper._processing_elements[async_dofn._uuid],
       )
 

--- a/sdks/python/apache_beam/transforms/async_dofn_test.py
+++ b/sdks/python/apache_beam/transforms/async_dofn_test.py
@@ -16,6 +16,7 @@
 #
 
 import logging
+import math
 import multiprocessing
 import random
 import time
@@ -89,6 +90,18 @@ class FakeTimer:
 
   def set(self, time):
     self.time = time
+
+
+class FakeEncodedBagState(FakeBagState):
+  def __init__(self, items, coder):
+    super().__init__([coder.encode(item) for item in items])
+    self.coder = coder
+
+  def add(self, item):
+    super().add(self.coder.encode(item))
+
+  def read(self):
+    return [self.coder.decode(item) for item in super().read()]
 
 
 @parameterized_class([
@@ -265,6 +278,81 @@ class AsyncTest(unittest.TestCase):
     self.assertEqual(first_state.items, [])
     self.assertEqual(second_state.items, [])
     self.assertEqual(dofn.getProcessed(), 2)
+
+  def test_nan_key_survives_state_roundtrip(self):
+    dofn = BasicDofn()
+    async_dofn = async_lib.AsyncWrapper(dofn, use_asyncio=self.use_asyncio)
+    async_dofn.setup()
+    state = FakeEncodedBagState([], async_dofn.TO_PROCESS.coder)
+    timer = FakeTimer(0)
+    async_dofn.process((float('nan'), 7), to_process=state, timer=timer)
+    self.wait_for_empty(async_dofn)
+
+    result = async_dofn.commit_finished_items(state, timer)
+    self.assertEqual(len(result), 1)
+    self.assertTrue(math.isnan(result[0][0]))
+    self.assertEqual(result[0][1], 7)
+    self.assertEqual(state.read(), [])
+    self.assertEqual(dofn.getProcessed(), 1)
+    self.assertEqual(
+        async_lib.AsyncWrapper._processing_elements[async_dofn._uuid], {})
+
+  def test_numeric_keys_remain_distinct_after_state_roundtrip(self):
+    dofn = BasicDofn()
+    async_dofn = async_lib.AsyncWrapper(dofn, use_asyncio=self.use_asyncio)
+    async_dofn.setup()
+    coder = async_dofn.TO_PROCESS.coder
+    elements = [(key, 7) for key in (-0.0, 0.0, 1, 1.0, True)]
+    states = [FakeEncodedBagState([], coder) for _ in elements]
+    timer = FakeTimer(0)
+    for element, state in zip(elements, states):
+      async_dofn.process(element, to_process=state, timer=timer)
+    self.wait_for_empty(async_dofn)
+
+    for element, state in reversed(list(zip(elements, states))):
+      result = async_dofn.commit_finished_items(state, timer)
+      self.assertEqual(len(result), 1)
+      # Python equality hides the distinctions between these encoded keys.
+      self.assertEqual(coder.encode(result[0]), coder.encode(element))
+      self.assertEqual(state.read(), [])
+    self.assertEqual(dofn.getProcessed(), len(elements))
+    self.assertEqual(
+        async_lib.AsyncWrapper._processing_elements[async_dofn._uuid], {})
+
+  def test_cancellation_uses_encoded_key_scope(self):
+    for key, other_key in ((float('nan'), 1.0), (-0.0, 0.0), (1, 1.0)):
+      with self.subTest(key=key, other_key=other_key):
+        async_dofn = async_lib.AsyncWrapper(
+            BasicDofn(), use_asyncio=self.use_asyncio)
+        async_dofn.setup()
+        first = (key, 'first')
+        orphan = (key, 'orphan')
+        other = (other_key, 'other')
+        first_future, orphan_future, other_future = Future(), Future(), Future()
+        first_future.set_result([first])
+        processing = async_lib.AsyncWrapper._processing_elements[
+            async_dofn._uuid]
+        for element, future in ((first, first_future), (orphan, orphan_future),
+                                (other, other_future)):
+          processing[async_dofn._element_id(element)] = (element, future)
+        coder = async_dofn.TO_PROCESS.coder
+        state = FakeEncodedBagState([first], coder)
+        timer = FakeTimer(0)
+
+        result = async_dofn.commit_finished_items(state, timer)
+        self.assertEqual([coder.encode(item) for item in result],
+                         [coder.encode(first)])
+        self.assertEqual(state.read(), [])
+        self.assertTrue(orphan_future.cancelled())
+        self.assertFalse(other_future.cancelled())
+        self.assertEqual(list(processing.values()), [(other, other_future)])
+
+        other_future.set_result([other])
+        other_state = FakeEncodedBagState([other], coder)
+        self.assertEqual(
+            async_dofn.commit_finished_items(other_state, timer), [other])
+        self.assertEqual(other_state.read(), [])
+        self.assertEqual(processing, {})
 
   def _check_ids_across_windows(self, first, second, id_fn=None):
     dofn = BasicDofn()


### PR DESCRIPTION
`AsyncWrapper` tracks local futures by value (or `id_fn` result), while runner state and timers are scoped to a key and window. For inputs `('key1', 7)` and `('key2', 7)`, the second key can consume the first key's result and clear its own state without running its input. Equal identifiers across windows have the same problem. Timer cleanup can also cancel work belonging to another window of the same key.

Track futures by `(encoded_key, window, identifier)` and pass the window through scheduling, timer callbacks, and retries. The key uses the existing bag-state key coder: its encoded identity survives state decoding, including NaN keys, and distinguishes numeric keys that compare equal in Python, such as `-0.0` and `0.0`. Cleanup only removes orphaned work from the current encoded key and window. The persisted bag-state format stays unchanged.

## Testing

From `sdks/python`, with the SDK and test dependencies installed:

```sh
python -m pytest apache_beam/transforms/async_dofn_test.py -q -n 2
```

All 48 tests and 10 subtests pass on Python 3.12.

The cases exercise both the thread-pool and asyncio implementations: equal values and custom IDs across keys/windows, cleanup preserving another window's pending and completed work, and timer-driven rescheduling. The four cross-key regression cases fail against the upstream implementation. Additional state-coder roundtrip cases cover NaN completion, signed-zero and mixed numeric-key separation, and cancellation preserving another encoded key's work. Those cases fail with raw Python keys in the tracking map.

YAPF 0.43.0, Ruff 0.15.22, and `git diff --check` pass for the changed files. Validation uses the actual wrapper with state/timer doubles, including the real bag-state coder for the numeric-key cases; no end-to-end runner test was added.

## Downsides

Each local tracking entry now includes encoded key bytes and its window. Inputs with matching identifiers in different keys or windows execute independently and can occupy separate buffer slots. The configured buffer limit is unchanged.

------------------------

- [x] Describe the bug and include reproducible regression tests.
- [x] Update `CHANGES.md` with the behavior change.
- [ ] Apache Individual Contributor License Agreement, if required for this contribution.
