### PR TITLE
[Java] Preserve BigQuery failed rows across retries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -92,6 +92,7 @@
 
 ## Bugfixes
 
+* (Java) Fixed BigQuery Storage Write API failure outputs returning the wrong original row after consecutive serialization errors ([#39999](https://github.com/apache/beam/pull/39999)).
 * (Java) Fixed the Spark runner firing processing-time timers in reverse timestamp order ([#39824](https://github.com/apache/beam/issues/39824)).
 * (Python) Fixed incorrect profiler options handling on portable runners ([#39613](https://github.com/apache/beam/issues/39613)).
 * (Java) KafkaIO dynamic reads no longer require the obsolete `beam_fn_api` experiment ([#29998](https://github.com/apache/beam/issues/29998)).

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
@@ -738,15 +738,18 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
                 // rows.
                 ProtoRows.Builder retryRows = ProtoRows.newBuilder();
                 List<org.joda.time.Instant> retryTimestamps = Lists.newArrayList();
+                List<@Nullable TableRow> retryFailsafeTableRows = Lists.newArrayList();
                 for (int i = 0; i < failedContext.protoRows.getSerializedRowsCount(); ++i) {
                   if (!failedRowIndices.contains(i)) {
                     ByteString rowBytes = failedContext.protoRows.getSerializedRows(i);
                     retryRows.addSerializedRows(rowBytes);
                     retryTimestamps.add(failedContext.timestamps.get(i));
+                    retryFailsafeTableRows.add(failedContext.failsafeTableRows.get(i));
                   }
                 }
                 failedContext.protoRows = retryRows.build();
                 failedContext.timestamps = retryTimestamps;
+                failedContext.failsafeTableRows = retryFailsafeTableRows;
                 int numRowsRetried = failedContext.protoRows.getSerializedRowsCount();
                 BigQuerySinkMetrics.appendRowsRowStatusCounter(
                         BigQuerySinkMetrics.RowStatus.RETRIED, errorCode, shortTableUrn)

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWritesShardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWritesShardedRecords.java
@@ -608,15 +608,18 @@ public class StorageApiWritesShardedRecords<DestinationT extends @NonNull Object
         // rows.
         ProtoRows.Builder retryRows = ProtoRows.newBuilder();
         @Nullable List<org.joda.time.Instant> timestamps = Lists.newArrayList();
+        List<@Nullable TableRow> failsafeTableRows = Lists.newArrayList();
         for (int i = 0; i < failedContext.protoRows.getSerializedRowsCount(); ++i) {
           if (!failedRowIndices.contains(i)) {
             ByteString rowBytes = failedContext.protoRows.getSerializedRows(i);
             retryRows.addSerializedRows(rowBytes);
             timestamps.add(failedContext.timestamps.get(i));
+            failsafeTableRows.add(failedContext.failsafeTableRows.get(i));
           }
         }
         failedContext.protoRows = retryRows.build();
         failedContext.timestamps = timestamps;
+        failedContext.failsafeTableRows = failsafeTableRows;
         int retriedRows = failedContext.protoRows.getSerializedRowsCount();
         BigQuerySinkMetrics.appendRowsRowStatusCounter(
                 BigQuerySinkMetrics.RowStatus.RETRIED, errorCode, shortTableId)

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteRetryTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteRetryTest.java
@@ -86,8 +86,9 @@ public class StorageApiWriteRetryTest {
   private static final List<Integer> APPEND_SIZES = Collections.synchronizedList(new ArrayList<>());
 
   @Before
-  public void setUp() {
+  public void setUp() throws Exception {
     FakeDatasetService.setUp();
+    BigQueryIO.clearStaticCaches();
     APPEND_SIZES.clear();
     pipeline.getOptions().as(BigQueryOptions.class).setProject("project-id");
     pipeline.getOptions().as(DirectOptions.class).setTargetParallelism(1);

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteRetryTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteRetryTest.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.bigquery;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItems;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.services.bigquery.model.Table;
+import com.google.api.services.bigquery.model.TableFieldSchema;
+import com.google.api.services.bigquery.model.TableReference;
+import com.google.api.services.bigquery.model.TableRow;
+import com.google.api.services.bigquery.model.TableSchema;
+import com.google.cloud.bigquery.storage.v1.AppendRowsRequest;
+import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
+import com.google.cloud.bigquery.storage.v1.Exceptions;
+import com.google.cloud.bigquery.storage.v1.ProtoRows;
+import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.DynamicMessage;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.beam.runners.direct.DirectOptions;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.CreateDisposition;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.Method;
+import org.apache.beam.sdk.io.gcp.testing.FakeBigQueryServices;
+import org.apache.beam.sdk.io.gcp.testing.FakeDatasetService;
+import org.apache.beam.sdk.io.gcp.testing.FakeJobService;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.TestStream;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.FlatMapElements;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.joda.time.Duration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+/** Regression tests for row bookkeeping across Storage Write API retries. */
+@RunWith(Parameterized.class)
+public class StorageApiWriteRetryTest {
+  @Parameters(name = "method={0}, streaming={1}")
+  public static Iterable<Object[]> parameters() {
+    return ImmutableList.of(
+        new Object[] {Method.STORAGE_WRITE_API, false},
+        new Object[] {Method.STORAGE_WRITE_API, true},
+        new Object[] {Method.STORAGE_API_AT_LEAST_ONCE, false});
+  }
+
+  @Parameter public Method method;
+
+  @Parameter(1)
+  public boolean streaming;
+
+  @Rule public final transient TestPipeline pipeline = TestPipeline.create();
+
+  private static final List<Integer> APPEND_SIZES = Collections.synchronizedList(new ArrayList<>());
+
+  @Before
+  public void setUp() {
+    FakeDatasetService.setUp();
+    APPEND_SIZES.clear();
+    pipeline.getOptions().as(BigQueryOptions.class).setProject("project-id");
+    pipeline.getOptions().as(DirectOptions.class).setTargetParallelism(1);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    BigQueryIO.clearStaticCaches();
+  }
+
+  @Test
+  public void testConsecutiveSerializationErrorsPreserveOriginalRows() throws Exception {
+    TableReference table =
+        new TableReference()
+            .setProjectId("project-id")
+            .setDatasetId("dataset-id")
+            .setTableId("table-id");
+    TableSchema schema =
+        new TableSchema()
+            .setFields(ImmutableList.of(new TableFieldSchema().setName("id").setType("STRING")));
+    FakeDatasetService dataset = new RejectOneRowPerAppend();
+    dataset.createDataset("project-id", "dataset-id", "", "", null);
+    dataset.createTable(new Table().setTableReference(table).setSchema(schema));
+
+    PCollection<TableRow> rows;
+    if (streaming) {
+      rows =
+          pipeline.apply(
+              TestStream.create(TableRowJsonCoder.of())
+                  .addElements(row("A"), row("B"), row("C"))
+                  .advanceProcessingTime(Duration.standardSeconds(2))
+                  .advanceWatermarkToInfinity());
+    } else {
+      // Emit all rows from one element so the unsharded writer receives one bundle.
+      rows =
+          pipeline
+              .apply(Create.of(0))
+              .apply(
+                  FlatMapElements.into(TypeDescriptor.of(TableRow.class))
+                      .via(ignored -> ImmutableList.of(row("A"), row("B"), row("C"))))
+              .setCoder(TableRowJsonCoder.of());
+    }
+
+    BigQueryIO.Write<TableRow> write =
+        BigQueryIO.writeTableRows()
+            .to(table)
+            .withMethod(method)
+            .withCreateDisposition(CreateDisposition.CREATE_NEVER)
+            .withFormatRecordOnFailureFunction(
+                input -> new TableRow().set("original_id", input.get("id")))
+            .withPropagateSuccessfulStorageApiWrites(true)
+            .withTestServices(
+                new FakeBigQueryServices()
+                    .withDatasetService(dataset)
+                    .withJobService(new FakeJobService()))
+            .withoutValidation();
+    if (streaming) {
+      write =
+          write
+              .withNumStorageWriteApiStreams(1)
+              .withTriggeringFrequency(Duration.standardSeconds(1));
+    } else {
+      write = write.withNumStorageWriteApiStreams(0);
+    }
+    WriteResult result = rows.apply(write);
+    PAssert.that(
+            result
+                .getFailedStorageApiInserts()
+                .apply(
+                    MapElements.into(TypeDescriptor.of(TableRow.class))
+                        .via(BigQueryStorageApiInsertError::getRow)))
+        .containsInAnyOrder(
+            new TableRow().set("original_id", "A"), new TableRow().set("original_id", "B"));
+    PAssert.that(result.getSuccessfulStorageApiInserts()).containsInAnyOrder(row("C"));
+
+    pipeline.run().waitUntilFinish();
+
+    assertThat(
+        dataset.getAllRows("project-id", "dataset-id", "table-id"), containsInAnyOrder(row("C")));
+    // Ensure this exercised successive retries of the same multirow batch, not singleton writes.
+    assertThat(APPEND_SIZES, hasItems(3, 2, 1));
+  }
+
+  private static TableRow row(String id) {
+    return new TableRow().set("id", id);
+  }
+
+  private static class RejectOneRowPerAppend extends FakeDatasetService {
+    @Override
+    public BigQueryServices.StreamAppendClient getStreamAppendClient(
+        String streamName,
+        DescriptorProtos.DescriptorProto descriptor,
+        boolean useConnectionPool,
+        AppendRowsRequest.MissingValueInterpretation missingValueInterpretation)
+        throws Exception {
+      BigQueryServices.StreamAppendClient delegate =
+          super.getStreamAppendClient(
+              streamName, descriptor, useConnectionPool, missingValueInterpretation);
+      Descriptor protoDescriptor = TableRowToStorageApiProto.wrapDescriptorProto(descriptor);
+      return new BigQueryServices.StreamAppendClient() {
+        @Override
+        public ApiFuture<AppendRowsResponse> appendRows(long offset, ProtoRows rows)
+            throws Exception {
+          APPEND_SIZES.add(rows.getSerializedRowsCount());
+          try {
+            for (int i = 0; i < rows.getSerializedRowsCount(); i++) {
+              String id =
+                  (String)
+                      DynamicMessage.parseFrom(protoDescriptor, rows.getSerializedRows(i))
+                          .getField(protoDescriptor.findFieldByName("id"));
+              if (!id.equals("C")) {
+                return ApiFutures.immediateFailedFuture(
+                    new Exceptions.AppendSerializationError(
+                        400, "Invalid row", streamName, ImmutableMap.of(i, "Invalid id: " + id)));
+              }
+            }
+          } catch (Exception e) {
+            return ApiFutures.immediateFailedFuture(e);
+          }
+          return delegate.appendRows(offset, rows);
+        }
+
+        @Override
+        public com.google.cloud.bigquery.storage.v1.@Nullable TableSchema getUpdatedSchema() {
+          return delegate.getUpdatedSchema();
+        }
+
+        @Override
+        public void pin() {
+          delegate.pin();
+        }
+
+        @Override
+        public void unpin() {
+          delegate.unpin();
+        }
+
+        @Override
+        public void close() throws Exception {
+          delegate.close();
+        }
+      };
+    }
+  }
+}


### PR DESCRIPTION
Consecutive BigQuery Storage Write API row errors can duplicate a previously rejected record in Beam's failure output and omit the newly rejected record. After a serialization error, both Java writers compact the retry payload and timestamps but retain the original `failsafeTableRows` list. A later error index is then applied to the wrong version of that list.

For a write using `withFormatRecordOnFailureFunction`:

| Append request | Simulated service response | Expected failed original row | Current Beam output |
| --- | --- | --- | --- |
| `[A, B, C]` | Reject index 0 | A | A |
| `[B, C]` | Reject index 0 | B | A |
| `[C]` | Success | — | — |

C is written successfully. B is neither written nor recoverable from the failure output. The [Storage Write API contract](https://docs.cloud.google.com/bigquery/docs/reference/storage/rpc/google.cloud.bigquery.storage.v1#rowerror) defines error indexes relative to the current request. This is a controlled reproduction with simulated responses, not a reproduced live BigQuery incident.

Filter failsafe rows alongside payloads and timestamps in both the sharded and unsharded writers. This preserves their positional correspondence through successive retries, including nullable entries used for the protobuf-to-TableRow fallback.

## Reproduction and testing

The new `StorageApiWriteRetryTest` runs public `BigQueryIO` pipelines with the DirectRunner and a fake append service. It uses a failure formatter that returns `original_id` records distinct from the serialized rows, rejects one row per append, then delegates the successful append to `FakeDatasetService`. Assertions cover the failed records, successful output, persisted rows, and the three shrinking append sizes.

```sh
./gradlew :sdks:java:io:google-cloud-platform:test \
  --tests org.apache.beam.sdk.io.gcp.bigquery.StorageApiWriteRetryTest
```

The same regression fails in all three modes against unchanged upstream writer classes and passes with this fix: batch `STORAGE_WRITE_API`, streaming `STORAGE_WRITE_API` with a fixed shard, and `STORAGE_API_AT_LEAST_ONCE`.

The branch passes the normal Gradle compiler checks and a combined test run with the two existing `BigQueryIOWriteTest` cases `testStorageWriteReturnsAppendSerializationError` and `testStorageWriteWithMultipleAppendsPerStream`: 8 passed, 5 inapplicable parameter combinations skipped. `spotlessJavaCheck`, `validateChanges`, and `git diff --check` also pass. The baseline comparison separately compiles the unchanged writer classes with the same regression against released Beam 2.76 dependencies.

## Downsides

Each serialization-error retry allocates one additional list of references to the surviving failsafe rows. The normal append path is unchanged; the error-path allocation is proportional to the batch being retried and does not copy the row objects.

------------------------

- [x] Describe the bug and include a reproducible regression test.
- [x] Update `CHANGES.md` with the behavior change.
- [ ] Apache Individual Contributor License Agreement, if required for this contribution.
