### PR TITLE
[Python] Finish async bundles after processing outputs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,7 @@
 
 ## Bugfixes
 
+* (Python) Fixed `AsyncWrapper` finalizing bundles before generator processing, which could drop buffered writes, and nesting iterable outputs ([#40000](https://github.com/apache/beam/pull/40000)).
 * Fixed X (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
 
 ## Security Fixes

--- a/sdks/python/apache_beam/transforms/async_dofn.py
+++ b/sdks/python/apache_beam/transforms/async_dofn.py
@@ -212,9 +212,9 @@ class AsyncWrapper(beam.DoFn):
     self._sync_fn.teardown()
 
   def sync_fn_process(self, element, *args, **kwargs):
-    """Makes the call to the wrapped dofn's start_bundle, process
+    """Calls the wrapped dofn's start_bundle, process and finish_bundle methods.
 
-    methods.  It will then combine the results into a single generator.
+    Collects process outputs before finishing the bundle.
 
     Args:
       element: The element to process.
@@ -225,31 +225,21 @@ class AsyncWrapper(beam.DoFn):
         called with.
 
     Returns:
-      A generator of elements produced by the input element.
+      A list of elements produced by the input element.
     """
+    def _collect(result):
+      if result is None:
+        return []
+      if isinstance(result, Iterable) and not isinstance(result, (str, bytes)):
+        return list(result)
+      return [result]
+
     self._sync_fn.start_bundle()
-    process_result = self._sync_fn.process(element, *args, **kwargs)
-    bundle_result = self._sync_fn.finish_bundle()
-
-    # both process and finish bundle may or may not return generators. We want
-    # to combine whatever results have been returned into a single generator. If
-    # they are single elements then wrap them in lists so that we can combine
-    # them.
-    if not process_result:
-      process_result = []
-    elif not isinstance(process_result, GeneratorType):
-      process_result = [process_result]
-    if not bundle_result:
-      bundle_result = []
-    elif not isinstance(bundle_result, GeneratorType):
-      bundle_result = [bundle_result]
-
-    to_return = []
-    for x in process_result:
-      to_return.append(x)
-    for x in bundle_result:
-      to_return.append(x)
-    return to_return
+    # Exhaust lazy process outputs before finish_bundle flushes or closes any
+    # resources used by the process iterator.
+    process_result = _collect(self._sync_fn.process(element, *args, **kwargs))
+    bundle_result = _collect(self._sync_fn.finish_bundle())
+    return process_result + bundle_result
 
   async def async_fn_process(self, element, *args, **kwargs):
     """Makes the call to the wrapped dofn's start_bundle, process

--- a/sdks/python/apache_beam/transforms/async_dofn_test.py
+++ b/sdks/python/apache_beam/transforms/async_dofn_test.py
@@ -27,6 +27,7 @@ from parameterized import parameterized_class
 
 import apache_beam as beam
 import apache_beam.transforms.async_dofn as async_lib
+from apache_beam.transforms.window import GlobalWindows
 
 
 class BasicDofn(beam.DoFn):
@@ -532,6 +533,84 @@ class AsyncTest(unittest.TestCase):
       )
     else:
       self.assertEqual(p.exitcode, 0)
+
+  def _schedule_lifecycle_item(self, dofn):
+    wrapper = async_lib.AsyncWrapper(
+        dofn, parallelism=1, use_asyncio=self.use_asyncio)
+    wrapper.setup()
+    state, timer = FakeBagState([]), FakeTimer(0)
+    wrapper.process(('key', 7), to_process=state, timer=timer)
+    self.wait_for_empty(wrapper)
+    return wrapper, state, timer
+
+  def test_finish_bundle_flushes_generator_process(self):
+    class BufferedWriter(beam.DoFn):
+      def __init__(self):
+        self.persisted = []
+
+      def start_bundle(self):
+        self.pending = []
+
+      def process(self, element):
+        self.pending.append(element)
+        yield from ()
+
+      def finish_bundle(self):
+        self.persisted.extend(self.pending)
+        self.pending.clear()
+
+    dofn = BufferedWriter()
+    wrapper, state, timer = self._schedule_lifecycle_item(dofn)
+    self.assertEqual([], wrapper.commit_finished_items(state, timer))
+    self.assertEqual([], state.items)
+    self.assertEqual([('key', 7)], dofn.persisted)
+    self.assertEqual([], dofn.pending)
+
+  def test_process_accepts_non_generator_iterables(self):
+    for iterable_type in (list, tuple, iter):
+      with self.subTest(iterable_type=iterable_type):
+
+        class IterableOutput(beam.DoFn):
+          def process(self, element):
+            return iterable_type([element, element])
+
+        wrapper, state, timer = self._schedule_lifecycle_item(IterableOutput())
+        self.assertEqual([('key', 7), ('key', 7)],
+                         wrapper.commit_finished_items(state, timer))
+        self.assertEqual([], state.items)
+
+  def test_finish_bundle_accepts_list_output(self):
+    output = GlobalWindows.windowed_value(('key', 'finished'))
+
+    class ListFinishOutput(beam.DoFn):
+      def process(self, element):
+        return None
+
+      def finish_bundle(self):
+        return [output]
+
+    wrapper, state, timer = self._schedule_lifecycle_item(ListFinishOutput())
+    self.assertEqual([output], wrapper.commit_finished_items(state, timer))
+    self.assertEqual([], state.items)
+
+  def test_generator_failure_does_not_finish_bundle(self):
+    class FailingProcess(beam.DoFn):
+      def __init__(self):
+        self.finished = False
+
+      def process(self, element):
+        yield element
+        raise RuntimeError('process iteration failed')
+
+      def finish_bundle(self):
+        self.finished = True
+
+    dofn = FailingProcess()
+    wrapper, state, timer = self._schedule_lifecycle_item(dofn)
+    with self.assertRaisesRegex(RuntimeError, 'process iteration failed'):
+      wrapper.commit_finished_items(state, timer)
+    self.assertEqual([('key', 7)], state.items)
+    self.assertFalse(dofn.finished)
 
   def test_transient_rpc_failure_retry(self):
     # Verify DoFn exceptions wipe local active state so retries reschedule work.


### PR DESCRIPTION
The default thread-pool path in `AsyncWrapper` calls `finish_bundle()` before iterating the wrapped `process()` result. Calling a generator function does not execute its body, so a buffered writer can flush an empty buffer and only then enqueue the input. The future completes successfully and the wrapper clears the input from runner state without persisting it.

For a generator-based `process()` that buffers one row and a non-generator `finish_bundle()` that flushes the buffer:

| Behavior | Lifecycle order | Persisted rows | Remaining runner state |
| --- | --- | --- | --- |
| Before | start, finish, process | Empty | Empty |
| After | start, process, finish | Input row | Empty |

Collect the process outputs before calling `finish_bundle()`. Handle iterable and `None` results consistently with the asyncio path, including list-valued finish outputs. A generator that raises during iteration now prevents bundle finalization. The existing scalar treatment of strings and bytes is retained.

## Reproduction and testing

From `sdks/python` with the SDK and test dependencies installed:

```sh
python -m pytest apache_beam/transforms/async_dofn_test.py -q -n 2
```

All 38 tests and 6 subtests pass on Python 3.12. New regressions exercise the actual scheduling, future, and commit path with the module's existing state/timer doubles: buffered flushing, list/tuple/iterator process results, list-valued finish output, and a generator exception after yielding. The regressions fail against the upstream thread-pool implementation; asyncio supplies a passing control. No external service is used.

YAPF 0.43.0, Ruff 0.15.22, and `git diff --check` pass.

## Downsides

Non-generator iterable returns now emit their individual elements, matching the DoFn contract and asyncio behavior. Code relying on the previous extra nesting of a returned list or tuple will observe different output shapes.

------------------------

- [x] Describe the bug and include reproducible regression tests.
- [x] Update `CHANGES.md` with the behavior change.
- [ ] Apache Individual Contributor License Agreement, if required for this contribution.
