### PR TITLE
[Python] Keep BigQuery load jobs distinct for table aliases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,7 @@
 
 ## Bugfixes
 
+* (Python) Fixed BigQuery `FILE_LOADS` silently omitting files when dynamic destinations use different spellings of the same table ([#40001](https://github.com/apache/beam/pull/40001)).
 * Fixed X (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
 
 ## Security Fixes

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -749,14 +749,11 @@ class TriggerLoadJobs(beam.DoFn):
     if table_reference.projectId is None:
       table_reference.projectId = vp.RuntimeValueProvider.get_value(
           'project', str, '') or self.project
-    # Load jobs for a single destination are always triggered from the same
-    # worker. This means that we can generate a deterministic numbered job id,
-    # and not need to worry.
+    # Use the same destination identity as file grouping. Equivalent table
+    # references can form separate groups with different files but identical
+    # partition numbers, so normalizing the reference would collide job IDs.
     destination_hash = _bq_uuid(
-        '%s:%s.%s' % (
-            table_reference.projectId,
-            table_reference.datasetId,
-            table_reference.tableId))
+        bigquery_tools.get_hashable_destination(destination))
     job_name = '%s_%s_pane%s_partition%s' % (
         load_job_name_prefix, destination_hash, pane_info.index, partition_key)
     _LOGGER.info('Load job has %s files. Job name is %s.', len(files), job_name)

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
@@ -407,6 +407,86 @@ class TestPartitionFiles(unittest.TestCase):
 
 
 class TestBigQueryFileLoads(_TestCaseWithTempDirCleanUp):
+  @parameterized.expand([
+      ('append', BigQueryDisposition.WRITE_APPEND),
+      ('truncate', BigQueryDisposition.WRITE_TRUNCATE),
+  ])
+  def test_equivalent_destinations_keep_distinct_load_jobs(
+      self, unused_name, write_disposition):
+    destinations = [
+        'project:dataset.table', 'dataset.table', 'project.dataset.table'
+    ]
+    files = ['gs://bucket/file%d' % i for i in range(len(destinations))]
+    jobs = {}
+
+    def insert_job(request, upload=None):
+      job = request.job
+      job_id = job.jobReference.jobId
+      if job_id in jobs:
+        raise HttpError({'status': '409'},
+                        ('Already Exists: Job project:US.' + job_id).encode(),
+                        '')
+      job.status = bigquery_api.JobStatus(state='DONE')
+      jobs[job_id] = job
+      return job
+
+    client = mock.Mock()
+    client.jobs.Insert.side_effect = insert_job
+    client.jobs.Get.side_effect = lambda request: jobs[request.jobId]
+    schema = mock.Mock(return_value=_ELEMENTS_SCHEMA)
+    parameters = mock.Mock(return_value={'timePartitioning': {'type': 'DAY'}})
+    loader = bqfl.TriggerLoadJobs(
+        project='project',
+        schema=schema,
+        temporary_tables=True,
+        additional_bq_parameters=parameters,
+        test_client=client)
+    loader.start_bundle()
+
+    # File grouping keeps these equivalent destination strings separate, so
+    # each group has a partition zero containing different source files.
+    partitions = [(destination, (0, [path]))
+                  for destination, path in zip(destinations, files)]
+    for partition in partitions:
+      list(loader.process(partition, 'load', pane_info=mock.Mock(index=0)))
+    loaded = [result.value for result in loader.finish_bundle()]
+    first_ids = [job.jobId for _, job in loaded]
+    self.assertEqual(
+        'load_29b51c1b5b03c4804123fd20083029da_pane0_partition0', first_ids[0])
+
+    # Replaying the same partitions must resolve to the same jobs, without
+    # treating a different destination group's files as an already-run job.
+    loader.start_bundle()
+    for partition in partitions:
+      list(loader.process(partition, 'load', pane_info=mock.Mock(index=0)))
+    replayed = [result.value for result in loader.finish_bundle()]
+    self.assertEqual(first_ids, [job.jobId for _, job in replayed])
+    self.assertEqual([call(dest) for dest in destinations] * 2,
+                     schema.call_args_list)
+    self.assertEqual([call(dest) for dest in destinations] * 2,
+                     parameters.call_args_list)
+
+    copier = bqfl.TriggerCopyJobs(
+        project='project',
+        write_disposition=write_disposition,
+        test_client=client)
+    copier.setup()
+    copier.start_bundle()
+    copier.process(replayed, 'copy')
+    list(copier.finish_bundle())
+
+    copy_jobs = [job for job in jobs.values() if job.configuration.copy]
+    copied_files = [
+        path for job in copy_jobs
+        for path in jobs[job.configuration.copy.sourceTable.tableId].
+        configuration.load.sourceUris
+    ]
+    self.assertCountEqual(files, copied_files)
+    self.assertEqual(3, len(set(first_ids)))
+    self.assertEqual(
+        [write_disposition, 'WRITE_APPEND', 'WRITE_APPEND'],
+        [job.configuration.copy.writeDisposition for job in copy_jobs])
+
   def test_trigger_load_jobs_with_empty_files(self):
     destination = "project:dataset.table"
     empty_files = []


### PR DESCRIPTION
Python BigQuery `FILE_LOADS` can silently omit rows when a dynamic destination returns different supported spellings of the same table. With `project='project'`, both `project:dataset.table` and `dataset.table` identify one destination table, but file grouping retains the original strings. Each group starts at partition zero, while load-job IDs previously hashed the resolved table reference. The resulting ID collision makes BigQuery treat the second group's files as an already-submitted job.

For two input rows routed to these two spellings, a public `WriteToBigQuery` pipeline finishes successfully with only one row written. Using the same spelling for both rows writes both. The colon/dot qualified aliases reproduce the same defect.

Hash the same destination identity used by file grouping. Separate groups now receive separate load jobs and temporary tables, while retries of a group retain their deterministic IDs. Original schema and additional-parameter callback arguments are preserved. Copy-job bookkeeping already resolves the physical table, so only the first copy uses `WRITE_TRUNCATE` when requested.

## Reproduction and testing

From `sdks/python`, with SDK and GCP test dependencies installed:

```sh
python -m pytest apache_beam/io/gcp/bigquery_file_loads_test.py -q \
  -k equivalent_destinations_keep_distinct_load_jobs
```

Both new cases fail against upstream and pass with the fix. They exercise actual load/copy DoFns and `BigQueryWrapper` with a Jobs endpoint that deduplicates job IDs, covering append/truncate modes, every source file reaching a copy job, replay stability, canonical-ID compatibility, and callback arguments.

The non-integration FILE_LOADS suite passes: 38 tests, with 6 integration tests deselected and credential discovery stubbed only in the test process. A separate public-transform reproduction using `BundleBasedDirectRunner`, local temporary files, and a fake Jobs endpoint passes all 3 cases; upstream loses a row in both alias cases while the identical-spelling control passes. No live BigQuery service was used.

YAPF 0.43.0, Ruff 0.15.22, and `git diff --check` pass.

The tox environments also set `GRPC_ENABLE_FORK_SUPPORT=0` before Python starts, applying the existing Beam CI workaround for [gRPC fork instability](https://github.com/grpc/grpc/issues/37710). The macOS Python 3.14 failure was a fatal gRPC poll-engine assertion while launching Java; changing the setting in test-class setup does not update gRPC's cached value.

Validation of this CI fix on Linux with Python 3.14.5 and grpcio 1.83.1: all 18 subprocess-server tests pass with gRPC initialized before test-class setup, all 38 FILE_LOADS unit tests pass (6 integration tests deselected; credential discovery stubbed in the test process), and 3 portable-runner subprocess tests pass. Tox confirms the macOS environment sets the variable at startup. macOS CI confirmation is pending.

## Downsides

Noncanonical destination spellings now receive different load-job IDs. Replaying unfinished loads across an in-place SDK update can therefore resubmit a previously completed load under a new ID. Canonical `project:dataset.table` destinations retain their existing IDs, and retries within either version remain stable.

------------------------

- [x] Describe the bug and include reproducible regression tests.
- [x] Update `CHANGES.md` with the behavior change.
- [ ] Apache Individual Contributor License Agreement, if required for this contribution.

