### PR TITLE
[Java] Remove CT_CONSTRUCTOR_THROW from the global SpotBugs filter

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/complete/datatokenization/utils/SchemasUtils.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/complete/datatokenization/utils/SchemasUtils.java
@@ -21,6 +21,7 @@ import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryUtils.fromTableSchema;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
 
 import com.google.api.services.bigquery.model.TableSchema;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
@@ -53,6 +54,11 @@ import org.slf4j.LoggerFactory;
   "argument",
   "return"
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class SchemasUtils {
 
   /* Logger for class.*/

--- a/examples/java/src/main/java/org/apache/beam/examples/subprocess/utils/CallingSubProcessUtils.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/subprocess/utils/CallingSubProcessUtils.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.examples.subprocess.utils;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -88,6 +89,11 @@ public class CallingSubProcessUtils {
   }
 
   /** Permit class for access to worker cpu resources. */
+  @SuppressFBWarnings(
+      value = "CT_CONSTRUCTOR_THROW",
+      justification =
+          "Public API, so it cannot be made final."
+              + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
   public static class Permit implements AutoCloseable {
 
     private String binaryName;

--- a/examples/java/src/main/java/org/apache/beam/examples/subprocess/utils/ExecutableFile.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/subprocess/utils/ExecutableFile.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.examples.subprocess.utils;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.beam.examples.subprocess.configuration.SubProcessConfiguration;
 import org.apache.beam.sdk.coders.DefaultCoder;
 import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
@@ -26,6 +27,11 @@ import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
 @SuppressWarnings({
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class ExecutableFile {
 
   String fileName;

--- a/it/clickhouse/src/main/java/org/apache/beam/it/clickhouse/ClickHouseResourceManager.java
+++ b/it/clickhouse/src/main/java/org/apache/beam/it/clickhouse/ClickHouseResourceManager.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.it.clickhouse;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -44,6 +45,11 @@ import org.testcontainers.utility.DockerImageName;
  *
  * <p>The class is thread-safe.
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class ClickHouseResourceManager extends TestContainerResourceManager<GenericContainer<?>>
     implements ResourceManager {
 

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/bigtable/BigtableResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/bigtable/BigtableResourceManager.java
@@ -49,6 +49,7 @@ import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -77,6 +78,11 @@ import org.threeten.bp.Duration;
  *
  * <p>The class is thread-safe.
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class BigtableResourceManager implements ResourceManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(BigtableResourceManager.class);

--- a/it/splunk/src/main/java/org/apache/beam/it/splunk/SplunkResourceManager.java
+++ b/it/splunk/src/main/java/org/apache/beam/it/splunk/SplunkResourceManager.java
@@ -25,6 +25,7 @@ import com.splunk.Job;
 import com.splunk.ResultsReader;
 import com.splunk.ResultsReaderXml;
 import com.splunk.ServiceArgs;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.time.Duration;
@@ -60,6 +61,11 @@ import org.testcontainers.utility.DockerImageName;
  * <p>Note: The Splunk TestContainer will only run on M1 Mac's if the Docker version is >= 4.16.0
  * and the "Use Rosetta for x86/amd64 emulation on Apple Silicon" setting is enabled.
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class SplunkResourceManager extends TestContainerResourceManager<SplunkContainer>
     implements ResourceManager {
 

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/StatefulDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/StatefulDoFnRunner.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.core;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -59,6 +60,11 @@ import org.joda.time.Instant;
   "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class StatefulDoFnRunner<InputT, OutputT, W extends BoundedWindow>
     implements DoFnRunner<InputT, OutputT> {
 

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/construction/SerializablePipelineOptions.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/construction/SerializablePipelineOptions.java
@@ -19,6 +19,7 @@ package org.apache.beam.runners.core.construction;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
@@ -32,6 +33,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * Holds a {@link PipelineOptions} in JSON serialized form and calls {@link
  * FileSystems#setDefaultPipelineOptions(PipelineOptions)} on construction or on deserialization.
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class SerializablePipelineOptions implements Serializable {
   private static final ObjectMapper MAPPER =
       new ObjectMapper()

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/BoundedTrieData.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/BoundedTrieData.java
@@ -57,8 +57,12 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Immuta
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
 @SuppressFBWarnings(
-    value = "IS2_INCONSISTENT_SYNC",
-    justification = "Some access on purpose are left unsynchronized")
+    value = {"IS2_INCONSISTENT_SYNC", "CT_CONSTRUCTOR_THROW"},
+    justification =
+        "Some access on purpose are left unsynchronized."
+            + " Public, so it cannot be made final despite @Internal."
+            + " Out-of-tree code such as a forked runner may already subclass it."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class BoundedTrieData implements Serializable {
 
   private static final int DEFAULT_BOUND = 100; // Default maximum size of the trie

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoEvaluator.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoEvaluator.java
@@ -53,7 +53,7 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Immuta
   "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
-class ParDoEvaluator<InputT> implements TransformEvaluator<InputT> {
+final class ParDoEvaluator<InputT> implements TransformEvaluator<InputT> {
 
   public interface DoFnRunnerFactory<InputT, OutputT> {
     PushbackSideInputDoFnRunner<InputT, OutputT> createRunner(

--- a/runners/flink/1.20/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/1.20/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -1500,7 +1500,7 @@ public class DoFnOperator<PreInputT, InputT, OutputT>
     }
   }
 
-  class FlinkTimerInternals implements TimerInternals {
+  final class FlinkTimerInternals implements TimerInternals {
 
     private static final String PENDING_TIMERS_STATE_NAME = "pending-timers";
 

--- a/runners/flink/2.0/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
+++ b/runners/flink/2.0/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
@@ -26,6 +26,7 @@ import static org.apache.beam.sdk.util.construction.ExecutableStageTranslation.g
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auto.service.AutoService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -130,6 +131,11 @@ import org.apache.flink.util.OutputTag;
   "keyfor",
   "nullness"
 }) // TODO(https://github.com/apache/beam/issues/20497)
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class FlinkStreamingPortablePipelineTranslator
     implements FlinkPortablePipelineTranslator<
         FlinkStreamingPortablePipelineTranslator.StreamingTranslationContext> {

--- a/runners/flink/2.0/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/2.0/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -1529,7 +1529,7 @@ public class DoFnOperator<PreInputT, InputT, OutputT>
     }
   }
 
-  class FlinkTimerInternals implements TimerInternals {
+  final class FlinkTimerInternals implements TimerInternals {
 
     private static final String PENDING_TIMERS_STATE_NAME = "pending-timers";
 

--- a/runners/flink/2.0/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
+++ b/runners/flink/2.0/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.flink.translation.wrappers.streaming.io;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -67,6 +68,11 @@ import org.slf4j.LoggerFactory;
   "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class UnboundedSourceWrapper<OutputT, CheckpointMarkT extends UnboundedSource.CheckpointMark>
     extends RichParallelSourceFunction<WindowedValue<ValueWithRecordId<OutputT>>>
     implements BeamStoppableFunction,

--- a/runners/flink/2.0/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
+++ b/runners/flink/2.0/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.flink.translation.wrappers.streaming.state;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
@@ -103,6 +104,11 @@ import org.joda.time.Instant;
   "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class FlinkStateInternals<K> implements StateInternals {
 
   private static final StateNamespace globalWindowNamespace =
@@ -1185,7 +1191,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     }
   }
 
-  private class FlinkWatermarkHoldState implements WatermarkHoldState {
+  private final class FlinkWatermarkHoldState implements WatermarkHoldState {
 
     private final TimestampCombiner timestampCombiner;
     private final String namespaceString;

--- a/runners/flink/2.2/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/2.2/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -1529,7 +1529,7 @@ public class DoFnOperator<PreInputT, InputT, OutputT>
     }
   }
 
-  class FlinkTimerInternals implements TimerInternals {
+  final class FlinkTimerInternals implements TimerInternals {
 
     private static final String PENDING_TIMERS_STATE_NAME = "pending-timers";
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
@@ -26,6 +26,7 @@ import static org.apache.beam.sdk.util.construction.ExecutableStageTranslation.g
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auto.service.AutoService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -130,6 +131,11 @@ import org.apache.flink.util.OutputTag;
   "keyfor",
   "nullness"
 }) // TODO(https://github.com/apache/beam/issues/20497)
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class FlinkStreamingPortablePipelineTranslator
     implements FlinkPortablePipelineTranslator<
         FlinkStreamingPortablePipelineTranslator.StreamingTranslationContext> {

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkAssignContext.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkAssignContext.java
@@ -26,7 +26,7 @@ import org.joda.time.Instant;
 
 /** {@link org.apache.beam.sdk.transforms.windowing.WindowFn.AssignContext} for Flink functions. */
 @SuppressWarnings({"keyfor", "nullness"}) // TODO(https://github.com/apache/beam/issues/20497)
-class FlinkAssignContext<InputT, W extends BoundedWindow>
+final class FlinkAssignContext<InputT, W extends BoundedWindow>
     extends WindowFn<InputT, W>.AssignContext {
   private final WindowedValue<InputT> value;
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -1503,7 +1503,7 @@ public class DoFnOperator<PreInputT, InputT, OutputT>
     }
   }
 
-  class FlinkTimerInternals implements TimerInternals {
+  final class FlinkTimerInternals implements TimerInternals {
 
     private static final String PENDING_TIMERS_STATE_NAME = "pending-timers";
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KeyedPushedBackElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KeyedPushedBackElementsHandler.java
@@ -34,7 +34,7 @@ import org.apache.flink.runtime.state.VoidNamespaceSerializer;
  * operation is keyed and pushed-back data needs to stay in the correct partition when they get
  * moved.
  */
-class KeyedPushedBackElementsHandler<K, T> implements PushedBackElementsHandler<T> {
+final class KeyedPushedBackElementsHandler<K, T> implements PushedBackElementsHandler<T> {
 
   static <K, T> KeyedPushedBackElementsHandler<K, T> create(
       KeySelector<T, K> keySelector,

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.flink.translation.wrappers.streaming.io;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -66,6 +67,11 @@ import org.slf4j.LoggerFactory;
   "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class UnboundedSourceWrapper<OutputT, CheckpointMarkT extends UnboundedSource.CheckpointMark>
     extends RichParallelSourceFunction<WindowedValue<ValueWithRecordId<OutputT>>>
     implements BeamStoppableFunction,

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/FlinkSourceSplitEnumerator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/FlinkSourceSplitEnumerator.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.flink.translation.wrappers.streaming.io.source;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -39,6 +40,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Splits a Beam source and assigns its splits to Flink source readers round-robin. */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class FlinkSourceSplitEnumerator<T>
     implements SplitEnumerator<FlinkSourceSplit<T>, FlinkSourceEnumeratorState<T>> {
   private static final Logger LOG = LoggerFactory.getLogger(FlinkSourceSplitEnumerator.class);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/LazyFlinkSourceSplitEnumerator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/LazyFlinkSourceSplitEnumerator.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.flink.translation.wrappers.streaming.io.source;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -34,6 +35,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Splits a bounded Beam source and assigns one split for each reader request. */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class LazyFlinkSourceSplitEnumerator<T>
     implements SplitEnumerator<FlinkSourceSplit<T>, FlinkSourceEnumeratorState<T>> {
   private static final Logger LOG = LoggerFactory.getLogger(LazyFlinkSourceSplitEnumerator.class);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/BufferingDoFnRunner.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/BufferingDoFnRunner.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.flink.translation.wrappers.streaming.stableinput;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -55,6 +56,11 @@ import org.joda.time.Instant;
   "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class BufferingDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, OutputT> {
 
   public static <InputT, OutputT> BufferingDoFnRunner<InputT, OutputT> create(

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/KeyedBufferingElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/KeyedBufferingElementsHandler.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.flink.translation.wrappers.streaming.stableinput;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -31,6 +32,11 @@ import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 @SuppressWarnings({
   "rawtypes" // TODO(https://github.com/apache/beam/issues/20447)
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class KeyedBufferingElementsHandler implements BufferingElementsHandler {
 
   static KeyedBufferingElementsHandler create(

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.flink.translation.wrappers.streaming.state;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
@@ -103,6 +104,11 @@ import org.joda.time.Instant;
   "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class FlinkStateInternals<K> implements StateInternals {
 
   private static final StateNamespace globalWindowNamespace =
@@ -1185,7 +1191,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     }
   }
 
-  private class FlinkWatermarkHoldState implements WatermarkHoldState {
+  private final class FlinkWatermarkHoldState implements WatermarkHoldState {
 
     private final TimestampCombiner timestampCombiner;
     private final String namespaceString;

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactory.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.fnexecution.control;
 
 import com.google.auto.value.AutoValue;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.IdentityHashMap;
 import java.util.Map;
@@ -96,6 +97,11 @@ import org.slf4j.LoggerFactory;
   "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class DefaultJobBundleFactory implements JobBundleFactory {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultJobBundleFactory.class);
   private static final IdGenerator factoryIdGenerator = IdGenerators.incrementingLongs();

--- a/runners/jet/src/main/java/org/apache/beam/runners/jet/JetRunner.java
+++ b/runners/jet/src/main/java/org/apache/beam/runners/jet/JetRunner.java
@@ -24,6 +24,7 @@ import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.map.IMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -47,6 +48,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Jet specific implementation of Beam's {@link PipelineRunner}. */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class JetRunner extends PipelineRunner<PipelineResult> {
 
   private static final Logger LOG = LoggerFactory.getLogger(JetRunner.class);

--- a/runners/jet/src/main/java/org/apache/beam/runners/jet/processors/AbstractParDoP.java
+++ b/runners/jet/src/main/java/org/apache/beam/runners/jet/processors/AbstractParDoP.java
@@ -325,7 +325,7 @@ abstract class AbstractParDoP<InputT, OutputT> implements Processor {
    * An output manager that stores the output in an ArrayList, one for each output ordinal, and a
    * way to drain to outbox ({@link #tryFlush()}).
    */
-  static class JetOutputManager implements WindowedValueMultiReceiver {
+  static final class JetOutputManager implements WindowedValueMultiReceiver {
 
     private final Outbox outbox;
     private final Map<TupleTag<?>, Coder<?>> outputCoders;

--- a/runners/jet/src/main/java/org/apache/beam/runners/jet/processors/AssignWindowP.java
+++ b/runners/jet/src/main/java/org/apache/beam/runners/jet/processors/AssignWindowP.java
@@ -21,6 +21,7 @@ import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.core.AbstractProcessor;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ResettableSingletonTraverser;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Collection;
 import javax.annotation.Nonnull;
 import org.apache.beam.runners.jet.Utils;
@@ -43,6 +44,11 @@ import org.joda.time.Instant;
   "nullness",
   "keyfor"
 }) // TODO(https://github.com/apache/beam/issues/20497)
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class AssignWindowP<T> extends AbstractProcessor {
 
   @SuppressWarnings({"FieldCanBeLocal", "unused"})

--- a/runners/jet/src/main/java/org/apache/beam/runners/jet/processors/WindowGroupP.java
+++ b/runners/jet/src/main/java/org/apache/beam/runners/jet/processors/WindowGroupP.java
@@ -207,7 +207,7 @@ public class WindowGroupP<K, V> extends AbstractProcessor {
     }
   }
 
-  private class KeyManager {
+  private final class KeyManager {
 
     private final InMemoryTimerInternals timerInternals;
     private final InMemoryStateInternalsImpl stateInternals;

--- a/runners/spark/4/src/main/java/org/apache/beam/runners/spark/structuredstreaming/io/BoundedDatasetFactory.java
+++ b/runners/spark/4/src/main/java/org/apache/beam/runners/spark/structuredstreaming/io/BoundedDatasetFactory.java
@@ -270,7 +270,7 @@ public class BoundedDatasetFactory {
   }
 
   /** A partition iterator on a partitioned Beam {@link BoundedSource}. */
-  private static class SourcePartitionIterator<T> extends AbstractIterator<WindowedValue<T>>
+  private static final class SourcePartitionIterator<T> extends AbstractIterator<WindowedValue<T>>
       implements Closeable {
     BoundedReader<T> reader;
     boolean started = false;

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/io/SourceDStream.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/io/SourceDStream.java
@@ -53,7 +53,7 @@ import scala.Tuple2;
 @SuppressWarnings({
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
-class SourceDStream<T, CheckpointMarkT extends UnboundedSource.CheckpointMark>
+final class SourceDStream<T, CheckpointMarkT extends UnboundedSource.CheckpointMark>
     extends InputDStream<Tuple2<Source<T>, CheckpointMarkT>> {
   private static final Logger LOG = LoggerFactory.getLogger(SourceDStream.class);
 

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/metrics/SparkBeamMetricSource.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/metrics/SparkBeamMetricSource.java
@@ -18,12 +18,18 @@
 package org.apache.beam.runners.spark.metrics;
 
 import com.codahale.metrics.MetricRegistry;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.spark.metrics.source.Source;
 
 /**
  * A Spark {@link Source} that is tailored to expose a {@link SparkBeamMetric}, wrapping an
  * underlying {@link org.apache.beam.sdk.metrics.MetricResults} instance.
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class SparkBeamMetricSource implements Source {
   private static final String METRIC_NAME = "Metrics";
 

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/metrics/sink/CsvSink.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/metrics/sink/CsvSink.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.spark.metrics.sink;
 
 import com.codahale.metrics.MetricRegistry;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Properties;
 import org.apache.beam.runners.spark.metrics.WithMetricsSupport;
 import org.apache.spark.SecurityManager;
@@ -36,6 +37,11 @@ import org.apache.spark.metrics.sink.Sink;
  * "spark.metrics.conf.*.sink.csv.unit"=seconds
  * }</pre>
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class CsvSink implements Sink {
 
   // Initialized reflectively as done by Spark's MetricsSystem

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/metrics/sink/GraphiteSink.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/metrics/sink/GraphiteSink.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.spark.metrics.sink;
 
 import com.codahale.metrics.MetricRegistry;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Properties;
 import org.apache.beam.runners.spark.metrics.WithMetricsSupport;
 import org.apache.spark.SecurityManager;
@@ -39,6 +40,11 @@ import org.apache.spark.metrics.sink.Sink;
  * "spark.metrics.conf.*.sink.graphite.regex"="<optional_regex_to_send_matching_metrics>"
  * }</pre>
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class GraphiteSink implements Sink {
 
   // Initialized reflectively as done by Spark's MetricsSystem

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/io/BoundedDatasetFactory.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/io/BoundedDatasetFactory.java
@@ -262,7 +262,7 @@ public class BoundedDatasetFactory {
   }
 
   /** A partition iterator on a partitioned Beam {@link BoundedSource}. */
-  private static class SourcePartitionIterator<T> extends AbstractIterator<WindowedValue<T>>
+  private static final class SourcePartitionIterator<T> extends AbstractIterator<WindowedValue<T>>
       implements Closeable {
     BoundedReader<T> reader;
     boolean started = false;

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/metrics/SparkBeamMetricSource.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/metrics/SparkBeamMetricSource.java
@@ -18,12 +18,18 @@
 package org.apache.beam.runners.spark.structuredstreaming.metrics;
 
 import com.codahale.metrics.MetricRegistry;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.spark.metrics.source.Source;
 
 /**
  * A Spark {@link Source} that is tailored to expose a {@link SparkBeamMetric}, wrapping an
  * underlying {@link org.apache.beam.sdk.metrics.MetricResults} instance.
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class SparkBeamMetricSource implements Source {
   private final String name;
 

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/metrics/sink/CodahaleCsvSink.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/metrics/sink/CodahaleCsvSink.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.spark.structuredstreaming.metrics.sink;
 
 import com.codahale.metrics.MetricRegistry;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Properties;
 import org.apache.beam.runners.spark.structuredstreaming.metrics.WithMetricsSupport;
 import org.apache.spark.SecurityManager;
@@ -36,6 +37,11 @@ import org.apache.spark.metrics.sink.Sink;
  * "spark.metrics.conf.*.sink.csv.unit"=seconds
  * }</pre>
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class CodahaleCsvSink implements Sink {
 
   // Initialized reflectively as done by Spark's MetricsSystem

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/metrics/sink/CodahaleGraphiteSink.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/metrics/sink/CodahaleGraphiteSink.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.spark.structuredstreaming.metrics.sink;
 
 import com.codahale.metrics.MetricRegistry;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Properties;
 import org.apache.beam.runners.spark.structuredstreaming.metrics.WithMetricsSupport;
 import org.apache.spark.SecurityManager;
@@ -39,6 +40,11 @@ import org.apache.spark.metrics.sink.Sink;
  * "spark.metrics.conf.*.sink.graphite.regex"="<optional_regex_to_send_matching_metrics>"
  * }</pre>
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class CodahaleGraphiteSink implements Sink {
 
   // Initialized reflectively as done by Spark's MetricsSystem

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkBatchPortablePipelineTranslator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkBatchPortablePipelineTranslator.java
@@ -26,6 +26,7 @@ import static org.apache.beam.runners.fnexecution.translation.PipelineTranslator
 import static org.apache.beam.runners.fnexecution.translation.PipelineTranslatorUtils.instantiateCoder;
 
 import com.google.auto.service.AutoService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -77,6 +78,11 @@ import scala.Tuple2;
   "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class SparkBatchPortablePipelineTranslator
     implements SparkPortablePipelineTranslator<SparkTranslationContext> {
 

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkStreamingPortablePipelineTranslator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkStreamingPortablePipelineTranslator.java
@@ -24,6 +24,7 @@ import static org.apache.beam.runners.fnexecution.translation.PipelineTranslator
 import static org.apache.beam.runners.fnexecution.translation.PipelineTranslatorUtils.getWindowedValueCoder;
 import static org.apache.beam.runners.fnexecution.translation.PipelineTranslatorUtils.getWindowingStrategy;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -72,6 +73,11 @@ import scala.collection.JavaConverters;
   "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class SparkStreamingPortablePipelineTranslator
     implements SparkPortablePipelineTranslator<SparkStreamingTranslationContext> {
 

--- a/sdks/java/build-tools/src/main/resources/beam/spotbugs-filter.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/spotbugs-filter.xml
@@ -55,9 +55,6 @@
   -->
   <Bug pattern="UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS"/>
 
-  <!-- TODO(https://github.com/apache/beam/issues/35312) resolve findings-->
-  <Bug pattern="CT_CONSTRUCTOR_THROW"/>
-
   <!--
     Many test classes are captured by lambdas and marked `implements Serializable`. They are not
     actually serializable, so the TestPipeline that they employ does not need to be transient or

--- a/sdks/java/core/jmh/src/main/java/org/apache/beam/sdk/jmh/schemas/RowBundle.java
+++ b/sdks/java/core/jmh/src/main/java/org/apache/beam/sdk/jmh/schemas/RowBundle.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.jmh.schemas;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.charset.StandardCharsets;
 import org.apache.beam.sdk.schemas.Factory;
 import org.apache.beam.sdk.schemas.GetterBasedSchemaProvider;
@@ -54,6 +55,11 @@ import org.openjdk.jmh.infra.Blackhole;
  * adequately timestamped without risking generating wrong results.
  */
 @State(Scope.Benchmark)
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Subclassed inside Beam, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class RowBundle<T> {
   public enum Action {
     /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/CoderProviders.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/CoderProviders.java
@@ -55,7 +55,7 @@ public final class CoderProviders {
    * See {@link #fromStaticMethods} for a detailed description of the characteristics of this {@link
    * CoderProvider}.
    */
-  private static class CoderProviderFromStaticMethods extends CoderProvider {
+  private static final class CoderProviderFromStaticMethods extends CoderProvider {
 
     @SuppressFBWarnings("DCN_NULLPOINTER_EXCEPTION") // TODO(#35312)
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/fn/data/BeamFnDataOutboundAggregator.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/fn/data/BeamFnDataOutboundAggregator.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.fn.data;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -61,6 +62,11 @@ import org.slf4j.LoggerFactory;
 // create another memory barrier. Also note that flush is always invoked when synchronizing on
 // flushLock when there is a periodic flushing thread.
 @NotThreadSafe
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Subclassed inside Beam, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class BeamFnDataOutboundAggregator {
 
   public static final String DATA_BUFFER_SIZE_LIMIT = "data_buffer_size_limit=";

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.io;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkNotNull;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
@@ -65,6 +66,11 @@ import org.joda.time.Instant;
 @SuppressWarnings({
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class CompressedSource<T> extends FileBasedSource<T> {
   /**
    * Factory interface for creating channels that decompress the content of an underlying channel.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Compression.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Compression.java
@@ -289,7 +289,7 @@ public enum Compression {
       throws IOException;
 
   /** Concatenates all {@link ZipInputStream}s contained within the zip file. */
-  private static class FullZipInputStream extends InputStream {
+  private static final class FullZipInputStream extends InputStream {
     private ZipInputStream zipInputStream;
     private ZipEntry currentEntry;
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/providers/JavaRowUdf.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/providers/JavaRowUdf.java
@@ -58,6 +58,11 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Strings;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.io.ByteStreams;
 
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class JavaRowUdf implements Serializable {
   private final Configuration config;
   private final Schema inputSchema;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ByteBuddyUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ByteBuddyUtils.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.schemas.utils;
 import static org.apache.beam.sdk.util.ByteBuddyUtils.getClassLoadingStrategy;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkNotNull;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -1540,7 +1541,7 @@ public class ByteBuddyUtils {
    * not be in the same order as the schema fields, reorders the parameters as necessary before
    * calling the constructor.
    */
-  static class StaticFactoryMethodInstruction extends InvokeUserCreateInstruction {
+  static final class StaticFactoryMethodInstruction extends InvokeUserCreateInstruction {
     private final Method creator;
 
     StaticFactoryMethodInstruction(
@@ -1567,6 +1568,11 @@ public class ByteBuddyUtils {
     }
   }
 
+  @SuppressFBWarnings(
+      value = "CT_CONSTRUCTOR_THROW",
+      justification =
+          "Extended by StaticFactoryMethodInstruction, so it cannot be made final."
+              + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
   static class InvokeUserCreateInstruction implements Implementation {
     protected final List<FieldValueTypeInformation> fields;
     protected final Class<?> targetClass;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ConvertHelpers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ConvertHelpers.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.schemas.utils;
 
 import static org.apache.beam.sdk.util.ByteBuddyUtils.getClassLoadingStrategy;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
@@ -69,6 +70,11 @@ public class ConvertHelpers {
   private static final Object lock = new Object();
 
   /** Return value after converting a schema. */
+  @SuppressFBWarnings(
+      value = "CT_CONSTRUCTOR_THROW",
+      justification =
+          "Public API, so it cannot be made final."
+              + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
   public static class ConvertedSchemaInformation<T> implements Serializable {
     // If the output type is a composite type, this is the schema coder.
     public final @Nullable SchemaCoder<T> outputSchemaCoder;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
@@ -1277,7 +1277,8 @@ public class PAssert {
    * A partially applied {@link AssertRelation}, where one value is provided along with a coder to
    * serialize/deserialize them.
    */
-  private static class CheckRelationAgainstExpected<T> implements SerializableFunction<T, Void> {
+  private static final class CheckRelationAgainstExpected<T>
+      implements SerializableFunction<T, Void> {
     private final AssertRelation<T, T> relation;
     private final byte[] encodedExpected;
     private final Coder<T> coder;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/SerializableMatchers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/SerializableMatchers.java
@@ -769,7 +769,7 @@ public class SerializableMatchers implements Serializable {
    * is not likely to be a good encoding, so should be used only for tests, where data volume is
    * small and minor costs are not critical.
    */
-  private static class SerializableViaCoder<T> implements SerializableSupplier<T> {
+  private static final class SerializableViaCoder<T> implements SerializableSupplier<T> {
     /** Cached value that is not serialized. */
     private transient @Nullable T value;
 
@@ -806,7 +806,7 @@ public class SerializableMatchers implements Serializable {
    * Serializable}. This is not likely to be a good encoding, so should be used only for tests,
    * where data volume is small and minor costs are not critical.
    */
-  private static class SerializableArrayViaCoder<T> implements SerializableSupplier<T[]> {
+  private static final class SerializableArrayViaCoder<T> implements SerializableSupplier<T[]> {
     /** Cached value that is not serialized. */
     @SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
     private transient T @Nullable [] value;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/AsyncWrapper.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/AsyncWrapper.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.transforms;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -67,6 +68,11 @@ import org.slf4j.LoggerFactory;
  * stateful. 2) Tagged output multi-outputs are unsupported. 3) StartBundle/finishBundle are invoked
  * per element so any batching or aggregation logic will not behave as expected.
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class AsyncWrapper<K, InputT, OutputT> extends DoFn<KV<K, InputT>, OutputT> {
 
   private static final Logger LOG = LoggerFactory.getLogger(AsyncWrapper.class);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/InferableFunction.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/InferableFunction.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.transforms;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.lang.reflect.Method;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.HasDisplayData;
@@ -34,6 +35,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 @SuppressWarnings({
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Exists to be subclassed by user code, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public abstract class InferableFunction<InputT, OutputT>
     implements ProcessFunction<InputT, OutputT>, HasDisplayData {
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Partition.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Partition.java
@@ -192,7 +192,7 @@ public class Partition<T> extends PTransform<PCollection<T>, PCollectionList<T>>
     this.partitionDoFn = partitionDoFn;
   }
 
-  private static class PartitionDoFn<X> extends DoFn<X, Void> {
+  private static final class PartitionDoFn<X> extends DoFn<X, Void> {
     private final int numPartitions;
     private final TupleTagList outputTags;
     private final Contextful<Contextful.Fn<X, Integer>> ctxFn;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Sample.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Sample.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.transforms;
 
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -293,6 +294,11 @@ public class Sample {
    *
    * @param <T> the type of the elements
    */
+  @SuppressFBWarnings(
+      value = "CT_CONSTRUCTOR_THROW",
+      justification =
+          "Public API, so it cannot be made final."
+              + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
   public static class FixedSizedSampleFn<T>
       extends CombineFn<
           T, Top.BoundedHeap<KV<Integer, T>, SerializableComparator<KV<Integer, T>>>, Iterable<T>> {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/SimpleFunction.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/SimpleFunction.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.transforms;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.lang.reflect.Method;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -29,6 +30,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 @SuppressWarnings({
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Exists to be subclassed by user code, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public abstract class SimpleFunction<InputT, OutputT> extends InferableFunction<InputT, OutputT>
     implements SerializableFunction<InputT, OutputT> {
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/View.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/View.java
@@ -511,7 +511,7 @@ public class View {
     }
   }
 
-  private static class SingletonCombineFn<T> extends Combine.BinaryCombineFn<T> {
+  private static final class SingletonCombineFn<T> extends Combine.BinaryCombineFn<T> {
     private final boolean hasDefault;
     private final @Nullable Coder<T> valueCoder;
     private final byte @Nullable [] defaultValue;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Watch.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Watch.java
@@ -881,7 +881,7 @@ public class Watch {
 
   @UnboundedPerElement
   @VisibleForTesting
-  protected static class WatchGrowthFn<InputT, OutputT, KeyT, TerminationStateT>
+  protected static final class WatchGrowthFn<InputT, OutputT, KeyT, TerminationStateT>
       extends DoFn<InputT, KV<InputT, List<TimestampedValue<OutputT>>>> {
     private final Watch.Growth<InputT, OutputT, KeyT> spec;
     private final Coder<OutputT> outputCoder;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/join/CoGbkResult.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/join/CoGbkResult.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.transforms.join;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -55,6 +56,11 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings({
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class CoGbkResult {
   /**
    * A map of integer union tags to a list of union objects. Note: the key and the embedded union

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
@@ -1419,7 +1419,7 @@ class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
     }
   }
 
-  private static class UserCodeMethodInvocation implements StackManipulation {
+  private static final class UserCodeMethodInvocation implements StackManipulation {
 
     private final @Nullable Integer returnVarIndex;
     private final MethodDescription targetMethod;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/FixedWindows.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/FixedWindows.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.transforms.windowing;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Objects;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.transforms.display.DisplayData;
@@ -35,6 +36,11 @@ import org.joda.time.Instant;
  *   Window.<Integer>into(FixedWindows.of(Duration.standardMinutes(10))));
  * }</pre>
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class FixedWindows extends PartitioningWindowFn<Object, IntervalWindow> {
 
   /** Size of this window. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/SlidingWindows.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/SlidingWindows.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.transforms.windowing;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -39,6 +40,11 @@ import org.joda.time.Instant;
  *   Window.<Integer>into(SlidingWindows.of(Duration.standardMinutes(10))));
  * }</pre>
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class SlidingWindows extends NonMergingWindowFn<Object, IntervalWindow> {
 
   /** Amount of time between generated windows. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ExplicitShardedFile.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ExplicitShardedFile.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.util;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.channels.Channels;
@@ -38,6 +39,12 @@ import org.slf4j.LoggerFactory;
 
 /** A sharded file where the file names are simply provided. */
 @Internal
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public, so it cannot be made final despite @Internal."
+            + " Out-of-tree code such as a forked runner may already subclass it."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class ExplicitShardedFile implements ShardedFile {
 
   private static final Logger LOG = LoggerFactory.getLogger(ExplicitShardedFile.class);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/MutationDetectors.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/MutationDetectors.java
@@ -75,7 +75,7 @@ public class MutationDetectors {
    *
    * @param <T> the type of values checked for mutation
    */
-  private static class CodedValueMutationDetector<T> implements MutationDetector {
+  private static final class CodedValueMutationDetector<T> implements MutationDetector {
 
     private final Coder<T> coder;
     private final T clonedOriginalValue;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/DefaultArtifactResolver.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/DefaultArtifactResolver.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.util.construction;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +38,11 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
 @SuppressWarnings({
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API for runner authors, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class DefaultArtifactResolver implements ArtifactResolver {
   public static final ArtifactResolver INSTANCE = new DefaultArtifactResolver();
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/WriteFilesTranslation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/WriteFilesTranslation.java
@@ -212,7 +212,7 @@ public class WriteFilesTranslation {
             .getPayload());
   }
 
-  static class RawWriteFiles extends PTransformTranslation.RawPTransform<PInput, POutput>
+  static final class RawWriteFiles extends PTransformTranslation.RawPTransform<PInput, POutput>
       implements WriteFilesLike {
 
     private final RunnerApi.PTransform protoTransform;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/graph/QueryablePipeline.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/graph/QueryablePipeline.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.util.construction.graph;
 
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Collections;
@@ -56,6 +57,11 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.graph.NetworkB
  * other.
  */
 @SuppressWarnings({"nullness", "keyfor"}) // TODO(https://github.com/apache/beam/issues/20497)
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API for runner authors, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class QueryablePipeline {
   // TODO: Is it better to have the signatures here require nodes in almost all contexts, or should
   // they all take strings? Nodes gives some degree of type signalling that names might not, but

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionViews.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionViews.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.values;
 
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -473,6 +474,12 @@ public class PCollectionViews {
    * <p>{@link SingletonViewFn} is meant to be removed in the future and replaced with this class.
    */
   @Internal
+  @SuppressFBWarnings(
+      value = "CT_CONSTRUCTOR_THROW",
+      justification =
+          "Public, so it cannot be made final despite @Internal."
+              + " Out-of-tree code such as a forked runner may already subclass it."
+              + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
   public static class SingletonViewFn2<T> extends ViewFn<IterableView<T>, T>
       implements HasDefaultValue<T>, IsSingletonView<T> {
     private byte @Nullable [] encodedDefaultValue;
@@ -574,6 +581,12 @@ public class PCollectionViews {
    * @deprecated See {@link SingletonViewFn2}.
    */
   @Deprecated
+  @SuppressFBWarnings(
+      value = "CT_CONSTRUCTOR_THROW",
+      justification =
+          "Public, so it cannot be made final despite @Internal."
+              + " Out-of-tree code such as a forked runner may already subclass it."
+              + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
   public static class SingletonViewFn<T> extends ViewFn<MultimapView<Void, T>, T>
       implements HasDefaultValue<T>, IsSingletonView<T> {
     private byte @Nullable [] encodedDefaultValue;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/TypeDescriptor.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/TypeDescriptor.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.values;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -46,6 +47,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * @param <T> the type represented by this {@link TypeDescriptor}
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Subclassed anonymously to capture a generic type, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public abstract class TypeDescriptor<T> implements Serializable {
 
   // This class is just a wrapper for TypeToken

--- a/sdks/java/expansion-service/src/main/java/org/apache/beam/sdk/expansion/service/ExpansionServer.java
+++ b/sdks/java/expansion-service/src/main/java/org/apache/beam/sdk/expansion/service/ExpansionServer.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.expansion.service;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
@@ -26,6 +27,11 @@ import org.apache.beam.vendor.grpc.v1p69p0.io.grpc.netty.NettyServerBuilder;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
 
 /** A {@link Server gRPC Server} for an ExpansionService. */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class ExpansionServer implements AutoCloseable {
   /**
    * Create a {@link ExpansionServer} for the provided ExpansionService running on an arbitrary

--- a/sdks/java/expansion-service/src/main/java/org/apache/beam/sdk/expansion/service/ExpansionServiceSchemaTransformProvider.java
+++ b/sdks/java/expansion-service/src/main/java/org/apache/beam/sdk/expansion/service/ExpansionServiceSchemaTransformProvider.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.expansion.service;
 
 import static org.apache.beam.sdk.util.construction.BeamUrns.getUrn;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -40,6 +41,11 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Immuta
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 @SuppressWarnings({"rawtypes"})
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class ExpansionServiceSchemaTransformProvider
     implements TransformProvider<PCollectionRowTuple, PCollectionRowTuple> {
 

--- a/sdks/java/expansion-service/src/main/java/org/apache/beam/sdk/expansion/service/JavaClassLookupTransformProvider.java
+++ b/sdks/java/expansion-service/src/main/java/org/apache/beam/sdk/expansion/service/JavaClassLookupTransformProvider.java
@@ -72,7 +72,7 @@ import org.yaml.snakeyaml.Yaml;
  * @param <OutputT> output {@link POutput} type of the transform
  */
 @SuppressFBWarnings("UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD")
-class JavaClassLookupTransformProvider<InputT extends PInput, OutputT extends POutput>
+final class JavaClassLookupTransformProvider<InputT extends PInput, OutputT extends POutput>
     implements TransformProvider<PInput, POutput> {
 
   public static final String ALLOW_LIST_VERSION = "v1";

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/GcsUtilV1.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/GcsUtilV1.java
@@ -105,6 +105,11 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings({
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Subclassed inside Beam, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 class GcsUtilV1 {
 
   @AutoValue
@@ -1009,7 +1014,7 @@ class GcsUtilV1 {
    * <p>Usage: create, enqueue(), and execute batch. Then, check getReadyToEnqueue() if another
    * round of enqueue() and execute is required. Repeat until getReadyToEnqueue() returns false.
    */
-  class RewriteOp extends JsonBatchCallback<RewriteResponse> {
+  final class RewriteOp extends JsonBatchCallback<RewriteResponse> {
     private final GcsPath from;
     private final GcsPath to;
     private final boolean deleteSource;

--- a/sdks/java/extensions/ml/src/main/java/org/apache/beam/sdk/extensions/ml/AnnotateImages.java
+++ b/sdks/java/extensions/ml/src/main/java/org/apache/beam/sdk/extensions/ml/AnnotateImages.java
@@ -23,6 +23,7 @@ import com.google.cloud.vision.v1.BatchAnnotateImagesResponse;
 import com.google.cloud.vision.v1.Feature;
 import com.google.cloud.vision.v1.ImageAnnotatorClient;
 import com.google.cloud.vision.v1.ImageContext;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -50,6 +51,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 @SuppressWarnings({
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Abstract, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 abstract class AnnotateImages<T>
     extends PTransform<PCollection<T>, PCollection<List<AnnotateImageResponse>>> {
 

--- a/sdks/java/extensions/sorter/src/main/java/org/apache/beam/sdk/extensions/sorter/HadoopExternalSorter.java
+++ b/sdks/java/extensions/sorter/src/main/java/org/apache/beam/sdk/extensions/sorter/HadoopExternalSorter.java
@@ -145,7 +145,7 @@ class HadoopExternalSorter extends ExternalSorter {
   }
 
   /** An {@link Iterator} producing the sorted data. */
-  private class SortedRecordsIterator implements Iterator<KV<byte[], byte[]>> {
+  private final class SortedRecordsIterator implements Iterator<KV<byte[], byte[]>> {
     private RawKeyValueIterator iterator;
 
     /** Next {@link KV} to return from {@link #next()}. */

--- a/sdks/java/extensions/sorter/src/main/java/org/apache/beam/sdk/extensions/sorter/NativeFileSorter.java
+++ b/sdks/java/extensions/sorter/src/main/java/org/apache/beam/sdk/extensions/sorter/NativeFileSorter.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
  * External Sorter based on <a
  * href="https://github.com/lemire/externalsortinginjava">lemire/externalsortinginjava</a>.
  */
-class NativeFileSorter {
+final class NativeFileSorter {
 
   private static final Logger LOG = LoggerFactory.getLogger(NativeFileSorter.class);
 

--- a/sdks/java/extensions/sql/iceberg/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/iceberg/IcebergTable.java
+++ b/sdks/java/extensions/sql/iceberg/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/iceberg/IcebergTable.java
@@ -52,7 +52,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class IcebergTable extends SchemaBaseBeamTable {
+final class IcebergTable extends SchemaBaseBeamTable {
   private static final Logger LOG = LoggerFactory.getLogger(IcebergTable.class);
   @VisibleForTesting static final String CATALOG_PROPERTIES_FIELD = "catalog_properties";
   @VisibleForTesting static final String HADOOP_CONFIG_PROPERTIES_FIELD = "config_properties";

--- a/sdks/java/harness/jmh/src/main/java/org/apache/beam/fn/harness/jmh/ProcessBundleBenchmark.java
+++ b/sdks/java/harness/jmh/src/main/java/org/apache/beam/fn/harness/jmh/ProcessBundleBenchmark.java
@@ -21,6 +21,7 @@ import static org.apache.beam.sdk.values.WindowedValues.valueInGlobalWindow;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
 import static org.junit.Assert.assertEquals;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -108,6 +109,11 @@ public class ProcessBundleBenchmark {
 
   /** Sets up the {@link ExecutionStateTracker} and an execution state. */
   @State(Scope.Benchmark)
+  @SuppressFBWarnings(
+      value = "CT_CONSTRUCTOR_THROW",
+      justification =
+          "Subclassed inside Beam, so it cannot be made final."
+              + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
   public static class SdkHarness {
     @Param({"true", "false"})
     public String elementsEmbedding = "false";
@@ -220,6 +226,11 @@ public class ProcessBundleBenchmark {
   }
 
   @State(Scope.Benchmark)
+  @SuppressFBWarnings(
+      value = "CT_CONSTRUCTOR_THROW",
+      justification =
+          "Subclassed inside Beam, so it cannot be made final."
+              + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
   public static class TrivialTransform extends SdkHarness {
     final BundleProcessor processor;
     final ExecutableProcessBundleDescriptor descriptor;
@@ -325,6 +336,11 @@ public class ProcessBundleBenchmark {
   }
 
   @State(Scope.Benchmark)
+  @SuppressFBWarnings(
+      value = "CT_CONSTRUCTOR_THROW",
+      justification =
+          "Subclassed inside Beam, so it cannot be made final."
+              + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
   public static class StatefulTransform extends SdkHarness {
     final BundleProcessor processor;
     final ExecutableProcessBundleDescriptor descriptor;

--- a/sdks/java/harness/jmh/src/main/java/org/apache/beam/fn/harness/jmh/logging/BeamFnLoggingClientBenchmark.java
+++ b/sdks/java/harness/jmh/src/main/java/org/apache/beam/fn/harness/jmh/logging/BeamFnLoggingClientBenchmark.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.fn.harness.jmh.logging;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.Closeable;
 import java.util.HashMap;
 import java.util.UUID;
@@ -81,6 +82,11 @@ public class BeamFnLoggingClientBenchmark {
 
   /** Setup a simple logging service and configure the {@link BeamFnLoggingClient}. */
   @State(Scope.Benchmark)
+  @SuppressFBWarnings(
+      value = "CT_CONSTRUCTOR_THROW",
+      justification =
+          "Subclassed inside Beam, so it cannot be made final."
+              + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
   public static class ManageLoggingClientAndService {
     public final LoggingClient loggingClient;
     public final CallCountLoggingService loggingService;

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/BeamFnDataReadRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/BeamFnDataReadRunner.java
@@ -22,6 +22,7 @@ import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Pr
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables.getOnlyElement;
 
 import com.google.auto.service.AutoService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -61,6 +62,11 @@ import org.slf4j.LoggerFactory;
  * Registers as a consumer for data over the Beam Fn API. Multiplexes any received data to all
  * receivers in a specified output map.
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class BeamFnDataReadRunner<OutputT> {
 
   private static final Logger LOG = LoggerFactory.getLogger(BeamFnDataReadRunner.class);

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -22,6 +22,7 @@ import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Pr
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
 
 import com.google.auto.service.AutoService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -138,6 +139,12 @@ import org.joda.time.format.PeriodFormat;
   "rawtypes" // TODO(https://github.com/apache/beam/issues/20447)
 })
 @Internal
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public, so it cannot be made final despite @Internal."
+            + " Out-of-tree code such as a forked runner may already subclass it."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimatorStateT, OutputT>
     implements FnApiStateAccessor.MutatingStateContext<Object, BoundedWindow> {
   /** A registrar which provides a factory to handle Java {@link DoFn}s. */
@@ -1339,7 +1346,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
     }
   }
 
-  private class FnApiTimer<K> implements org.apache.beam.sdk.state.Timer {
+  private final class FnApiTimer<K> implements org.apache.beam.sdk.state.Timer {
     private final String timerIdOrFamily;
     private final K userKey;
     private final String dynamicTimerTag;

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/SplittablePairWithRestrictionDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/SplittablePairWithRestrictionDoFnRunner.java
@@ -21,6 +21,7 @@ import static org.apache.beam.sdk.util.Preconditions.checkStateNotNull;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
 
 import com.google.auto.service.AutoService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.Map;
 import java.util.function.Function;
@@ -60,6 +61,11 @@ import org.joda.time.Instant;
  * WindowedValue<InputT>} to {@code WindowedValue<KV<InputT, KV<RestrictionT,
  * WatermarkEstimatorStateT>>>}
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class SplittablePairWithRestrictionDoFnRunner<
         InputT, RestrictionT, WatermarkEstimatorStateT, OutputT>
     implements FnApiStateAccessor.MutatingStateContext<Void, BoundedWindow> {

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/SplittableSplitAndSizeRestrictionsDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/SplittableSplitAndSizeRestrictionsDoFnRunner.java
@@ -21,6 +21,7 @@ import static org.apache.beam.sdk.util.Preconditions.checkStateNotNull;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
 
 import com.google.auto.service.AutoService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
@@ -78,6 +79,12 @@ import org.joda.time.Instant;
  * method.
  */
 @Internal
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public, so it cannot be made final despite @Internal."
+            + " Out-of-tree code such as a forked runner may already subclass it."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class SplittableSplitAndSizeRestrictionsDoFnRunner<
         InputT, RestrictionT extends @NonNull Object, PositionT, WatermarkEstimatorStateT, OutputT>
     implements FnApiStateAccessor.MutatingStateContext<Void, BoundedWindow> {

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/SplittableTruncateSizedRestrictionsDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/SplittableTruncateSizedRestrictionsDoFnRunner.java
@@ -21,6 +21,7 @@ import static org.apache.beam.sdk.util.Preconditions.checkStateNotNull;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
 
 import com.google.auto.service.AutoService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -82,6 +83,11 @@ import org.joda.time.Instant;
  * <p>The input and output types for this transform are
  * <li>{@code WindowedValue<KV<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>, Double>>}
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class SplittableTruncateSizedRestrictionsDoFnRunner<
         InputT, RestrictionT extends @NonNull Object, PositionT, WatermarkEstimatorStateT, OutputT>
     implements FnApiStateAccessor.MutatingStateContext<Void, BoundedWindow> {

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ExecutionStateSampler.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ExecutionStateSampler.java
@@ -18,6 +18,7 @@
 package org.apache.beam.fn.harness.control;
 
 import com.google.auto.value.AutoValue;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -63,6 +64,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Monitors the execution of one or more execution threads. */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Subclassed inside Beam, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class ExecutionStateSampler {
 
   private static final Logger LOG = LoggerFactory.getLogger(ExecutionStateSampler.class);

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/data/PTransformFunctionRegistry.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/data/PTransformFunctionRegistry.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.fn.harness.data;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.fn.harness.control.ExecutionStateSampler.ExecutionState;
@@ -53,6 +54,11 @@ import org.apache.beam.sdk.function.ThrowingRunnable;
  * // Note: this is used in ProcessBundleHandler.
  * </pre>
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class PTransformFunctionRegistry {
 
   private final ExecutionStateTracker stateTracker;

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/logging/BeamFnLoggingClient.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/logging/BeamFnLoggingClient.java
@@ -21,6 +21,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Throwables.getStackTraceAsString;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -68,6 +69,11 @@ import org.slf4j.MDC;
 /**
  * Configures {@link java.util.logging} to send all {@link LogRecord}s via the Beam Fn Logging API.
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class BeamFnLoggingClient implements LoggingClient {
   private static final String ROOT_LOGGER_NAME = "";
   private static final ImmutableMap<Level, BeamFnApi.LogEntry.Severity.Enum> LOG_LEVEL_MAP =

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/FnApiTimerBundleTracker.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/FnApiTimerBundleTracker.java
@@ -20,6 +20,7 @@ package org.apache.beam.fn.harness.state;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
 
 import com.google.auto.value.AutoValue;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.NavigableSet;
@@ -40,6 +41,11 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Sets;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Table;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Table.Cell;
 
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class FnApiTimerBundleTracker<K> {
   private final Supplier<ByteString> encodedCurrentKeySupplier;
   private final Supplier<ByteString> encodedCurrentWindowSupplier;

--- a/sdks/java/io/components/src/main/java/org/apache/beam/sdk/io/components/throttling/AdaptiveThrottler.java
+++ b/sdks/java/io/components/src/main/java/org/apache/beam/sdk/io/components/throttling/AdaptiveThrottler.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.io.components.throttling;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Random;
 import org.apache.beam.sdk.transforms.Sum;
 import org.apache.beam.sdk.util.MovingFunction;
@@ -28,6 +29,11 @@ import org.apache.beam.sdk.util.MovingFunction;
  * https://landing.google.com/sre/book/chapters/handling-overload.html#client-side-throttling-a7sYUg
  * for a full discussion of the use case and algorithm applied.
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Subclassed inside Beam, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class AdaptiveThrottler {
 
   // The target minimum number of requests per samplePeriodMs, even if no

--- a/sdks/java/io/components/src/main/java/org/apache/beam/sdk/io/components/throttling/ReactiveThrottler.java
+++ b/sdks/java/io/components/src/main/java/org/apache/beam/sdk/io/components/throttling/ReactiveThrottler.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.io.components.throttling;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +32,11 @@ import org.slf4j.LoggerFactory;
  * system recovery. capture the timestamp of the attempted request, then execute the request code.
  * On a success, call successfulRequest(timestamp) to report the success to the throttler.
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class ReactiveThrottler extends AdaptiveThrottler {
   private static final Logger LOG = LoggerFactory.getLogger(ReactiveThrottler.class);
   private static final long SECONDS_TO_MILLISECONDS = 1000L;

--- a/sdks/java/io/debezium/src/main/java/org/apache/beam/io/debezium/SourceRecordJson.java
+++ b/sdks/java/io/debezium/src/main/java/org/apache/beam/io/debezium/SourceRecordJson.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.io.debezium;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -60,6 +61,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * </pre>
  */
 @SuppressWarnings({"nullness"})
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class SourceRecordJson {
   private final @Nullable Struct value;
   private final @Nullable Event event;

--- a/sdks/java/io/delta/src/main/java/org/apache/beam/sdk/io/delta/SerializableRow.java
+++ b/sdks/java/io/delta/src/main/java/org/apache/beam/sdk/io/delta/SerializableRow.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.io.delta;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.MapValue;
@@ -50,6 +51,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * A serializable wrapper for Delta {@link Row} that implements the {@link Row} interface itself,
  * allowing worker nodes to access serialized Row objects using standard Delta Kernel APIs.
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class SerializableRow implements Row, Serializable {
   private static final long serialVersionUID = 1L;
 

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestUtils.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestUtils.java
@@ -567,7 +567,7 @@ class ElasticsearchIOTestUtils {
    * Small server that always returns a specified HTTP error code. This is useful to simulate server
    * errors in tests.
    */
-  static class AlwaysFailServer implements AutoCloseable {
+  static final class AlwaysFailServer implements AutoCloseable {
     private final HttpServer server;
     private final int port;
 

--- a/sdks/java/io/file-schema-transform/src/main/java/org/apache/beam/sdk/io/fileschematransform/FileWriteSchemaTransformProvider.java
+++ b/sdks/java/io/file-schema-transform/src/main/java/org/apache/beam/sdk/io/fileschematransform/FileWriteSchemaTransformProvider.java
@@ -99,7 +99,7 @@ public class FileWriteSchemaTransformProvider
    * #inputCollectionNames()} tagged {@link Row}s into a {@link PCollectionRowTuple} of {@link
    * #outputCollectionNames()} tagged {@link Row}s.
    */
-  static class FileWriteSchemaTransform extends SchemaTransform {
+  static final class FileWriteSchemaTransform extends SchemaTransform {
 
     final FileWriteSchemaTransformConfiguration configuration;
 

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/BeamRowWrapper.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/BeamRowWrapper.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.io.iceberg;
 
 import static org.apache.beam.sdk.util.Preconditions.checkStateNotNull;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -53,6 +54,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * <p><b>Note:</b> This implementation is <b>read-only</b>. Calls to {@link #set(int, Object)} will
  * throw an {@link UnsupportedOperationException}.
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class BeamRowWrapper implements StructLike {
 
   private final FieldType[] types;

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/BundleLifter.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/BundleLifter.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.io.iceberg;
 
 import static org.apache.beam.sdk.util.Preconditions.checkArgumentNotNull;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -42,6 +43,11 @@ import org.slf4j.LoggerFactory;
  *
  * @param <T> The type of elements in the input PCollection.
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class BundleLifter<T> extends PTransform<PCollection<T>, PCollectionTuple> {
 
   final TupleTag<T> smallBatchTag;

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/RecordWriter.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/RecordWriter.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.io.iceberg;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.Map;
 import org.apache.beam.sdk.metrics.Counter;
@@ -39,6 +40,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Subclassed inside Beam, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 class RecordWriter {
   private static final Logger LOG = LoggerFactory.getLogger(RecordWriter.class);
   private final Counter activeIcebergWriters =

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/RecordWriterManager.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/RecordWriterManager.java
@@ -93,7 +93,7 @@ class RecordWriterManager implements AutoCloseable {
    *
    * <p>On closing, each writer's output {@link DataFile} is collected.
    */
-  class DestinationState {
+  final class DestinationState {
     private final IcebergDestination icebergDestination;
     private final PartitionSpec spec;
     private final org.apache.iceberg.Schema schema;

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/cdc/DeleteReader.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/cdc/DeleteReader.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.io.iceberg.cdc;
 
 import static org.apache.beam.sdk.util.Preconditions.checkStateNotNull;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -58,6 +59,11 @@ import org.slf4j.LoggerFactory;
  * <p>This is mostly a copy of {@link org.apache.iceberg.data.DeleteFilter}, but flipping the logic
  * to output deleted records instead of filtering them out.
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Abstract, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public abstract class DeleteReader<T> {
   private static final Logger LOG = LoggerFactory.getLogger(DeleteReader.class);
 

--- a/sdks/java/io/influxdb/src/main/java/org/apache/beam/sdk/io/influxdb/ShardInformation.java
+++ b/sdks/java/io/influxdb/src/main/java/org/apache/beam/sdk/io/influxdb/ShardInformation.java
@@ -21,7 +21,7 @@ import java.io.Serializable;
 import java.util.List;
 
 /** POJO structure for shard information. */
-class ShardInformation implements Serializable {
+final class ShardInformation implements Serializable {
 
   private double id;
   private String retentionPolicy;

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/providers/ReadFromSqlServerSchemaTransformProvider.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/providers/ReadFromSqlServerSchemaTransformProvider.java
@@ -21,6 +21,7 @@ import static org.apache.beam.sdk.io.jdbc.JdbcUtil.MSSQL;
 import static org.apache.beam.sdk.util.construction.BeamUrns.getUrn;
 
 import com.google.auto.service.AutoService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Collections;
 import java.util.List;
 import org.apache.beam.model.pipeline.v1.ExternalTransforms;
@@ -78,6 +79,11 @@ public class ReadFromSqlServerSchemaTransformProvider extends JdbcReadSchemaTran
     return new SqlServerReadSchemaTransform(configuration);
   }
 
+  @SuppressFBWarnings(
+      value = "CT_CONSTRUCTOR_THROW",
+      justification =
+          "Public API, so it cannot be made final."
+              + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
   public static class SqlServerReadSchemaTransform extends JdbcReadSchemaTransform {
     public SqlServerReadSchemaTransform(JdbcReadSchemaTransformConfiguration config) {
       super(config, MSSQL);

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/providers/WriteToSqlServerSchemaTransformProvider.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/providers/WriteToSqlServerSchemaTransformProvider.java
@@ -21,6 +21,7 @@ import static org.apache.beam.sdk.io.jdbc.JdbcUtil.MSSQL;
 import static org.apache.beam.sdk.util.construction.BeamUrns.getUrn;
 
 import com.google.auto.service.AutoService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Collections;
 import java.util.List;
 import org.apache.beam.model.pipeline.v1.ExternalTransforms;
@@ -78,6 +79,11 @@ public class WriteToSqlServerSchemaTransformProvider extends JdbcWriteSchemaTran
     return new SqlServerWriteSchemaTransform(configuration);
   }
 
+  @SuppressFBWarnings(
+      value = "CT_CONSTRUCTOR_THROW",
+      justification =
+          "Public API, so it cannot be made final."
+              + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
   public static class SqlServerWriteSchemaTransform extends JdbcWriteSchemaTransform {
     public SqlServerWriteSchemaTransform(JdbcWriteSchemaTransformConfiguration config) {
       super(config, MSSQL);

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/ProducerSpEL.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/ProducerSpEL.java
@@ -34,7 +34,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 class ProducerSpEL {
 
-  private static class TransactionsImplementation {
+  private static final class TransactionsImplementation {
     private Method initTransactionsMethod;
     private Method beginTransactionMethod;
     private Method commitTransactionMethod;

--- a/sdks/java/io/kudu/src/main/java/org/apache/beam/sdk/io/kudu/KuduServiceImpl.java
+++ b/sdks/java/io/kudu/src/main/java/org/apache/beam/sdk/io/kudu/KuduServiceImpl.java
@@ -74,7 +74,7 @@ class KuduServiceImpl<T> implements KuduService<T> {
   }
 
   /** Writer storing an entity into Apache Kudu table. */
-  class WriterImpl implements Writer<T> {
+  final class WriterImpl implements Writer<T> {
     private final KuduIO.FormatFunction<T> formatFunction;
     private KuduClient client;
     private KuduSession session;

--- a/sdks/java/io/parquet/src/main/java/org/apache/beam/sdk/io/parquet/ParquetIO.java
+++ b/sdks/java/io/parquet/src/main/java/org/apache/beam/sdk/io/parquet/ParquetIO.java
@@ -709,7 +709,7 @@ public class ParquetIO {
     }
 
     @DoFn.BoundedPerElement
-    static class SplitReadFn<T> extends DoFn<ReadableFile, T> {
+    static final class SplitReadFn<T> extends DoFn<ReadableFile, T> {
       private final Class<? extends GenericData> modelClass;
       private final String requestSchemaString;
       // Default initial splitting the file into blocks of 64MB. Unit of SPLIT_LIMIT is byte.

--- a/sdks/java/io/pulsar/src/main/java/org/apache/beam/sdk/io/pulsar/NaiveReadFromPulsarDoFn.java
+++ b/sdks/java/io/pulsar/src/main/java/org/apache/beam/sdk/io/pulsar/NaiveReadFromPulsarDoFn.java
@@ -280,7 +280,7 @@ public class NaiveReadFromPulsarDoFn<T> extends DoFn<PulsarSourceDescriptor, T> 
     return new GrowableOffsetRangeTracker(restriction.getFrom(), offsetEstimator);
   }
 
-  private static class PulsarLatestOffsetEstimator
+  private static final class PulsarLatestOffsetEstimator
       implements GrowableOffsetRangeTracker.RangeEndEstimator {
 
     private final @Nullable Supplier<Message<byte[]>> memoizedBacklog;

--- a/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqIO.java
+++ b/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqIO.java
@@ -140,7 +140,7 @@ public class RabbitMqIO {
 
   private RabbitMqIO() {}
 
-  private static class ConnectionHandler {
+  private static final class ConnectionHandler {
 
     private final ConnectionFactory connectionFactory;
     private Connection connection;

--- a/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqMessage.java
+++ b/sdks/java/io/rabbitmq/src/main/java/org/apache/beam/sdk/io/rabbitmq/RabbitMqMessage.java
@@ -22,6 +22,7 @@ import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.Envelope;
 import com.rabbitmq.client.GetResponse;
 import com.rabbitmq.client.LongString;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -41,6 +42,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 @SuppressWarnings({
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class RabbitMqMessage implements Serializable {
 
   /**

--- a/sdks/java/io/rrio/src/main/java/org/apache/beam/io/requestresponse/Cache.java
+++ b/sdks/java/io/rrio/src/main/java/org/apache/beam/io/requestresponse/Cache.java
@@ -194,7 +194,7 @@ public final class Cache {
         KvCoder.of(requestTCoder, responseTCoder));
   }
 
-  private static class UsingRedis<RequestT, ResponseT> {
+  private static final class UsingRedis<RequestT, ResponseT> {
     private final Coder<RequestT> requestTCoder;
     private final Coder<@Nullable ResponseT> responseTCoder;
     private final RedisClient client;

--- a/sdks/java/io/snowflake/src/main/java/org/apache/beam/sdk/io/snowflake/data/text/SnowflakeBinary.java
+++ b/sdks/java/io/snowflake/src/main/java/org/apache/beam/sdk/io/snowflake/data/text/SnowflakeBinary.java
@@ -17,12 +17,18 @@
  */
 package org.apache.beam.sdk.io.snowflake.data.text;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.Serializable;
 import org.apache.beam.sdk.io.snowflake.data.SnowflakeDataType;
 
 @SuppressWarnings({
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Subclassed inside Beam, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class SnowflakeBinary implements SnowflakeDataType, Serializable {
 
   public static final Long MAX_SIZE = 8388608L;

--- a/sdks/java/io/snowflake/src/main/java/org/apache/beam/sdk/io/snowflake/data/text/SnowflakeVarchar.java
+++ b/sdks/java/io/snowflake/src/main/java/org/apache/beam/sdk/io/snowflake/data/text/SnowflakeVarchar.java
@@ -17,12 +17,18 @@
  */
 package org.apache.beam.sdk.io.snowflake.data.text;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.Serializable;
 import org.apache.beam.sdk.io.snowflake.data.SnowflakeDataType;
 
 @SuppressWarnings({
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Subclassed inside Beam, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class SnowflakeVarchar implements SnowflakeDataType, Serializable {
   public static final Long MAX_LENGTH = 16777216L;
   private Long length;

--- a/sdks/java/io/solace/src/main/java/org/apache/beam/sdk/io/solace/broker/BrokerResponse.java
+++ b/sdks/java/io/solace/src/main/java/org/apache/beam/sdk/io/solace/broker/BrokerResponse.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.io.solace.broker;
 
 import com.google.api.client.http.HttpResponse;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,6 +28,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class BrokerResponse {
   final int code;
   final String message;

--- a/sdks/java/io/splunk/src/main/java/org/apache/beam/sdk/io/splunk/CustomX509TrustManager.java
+++ b/sdks/java/io/splunk/src/main/java/org/apache/beam/sdk/io/splunk/CustomX509TrustManager.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.io.splunk;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -30,6 +31,11 @@ import org.checkerframework.checker.initialization.qual.UnknownInitialization;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** A Custom X509TrustManager that trusts a user provided CA and default CA's. */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class CustomX509TrustManager implements X509TrustManager {
 
   private final @Nullable X509TrustManager defaultTrustManager;

--- a/sdks/java/io/xml/src/main/java/org/apache/beam/sdk/io/xml/XmlSource.java
+++ b/sdks/java/io/xml/src/main/java/org/apache/beam/sdk/io/xml/XmlSource.java
@@ -99,7 +99,7 @@ public class XmlSource<T> extends FileBasedSource<T> {
    *
    * @param <T> Type of objects that will be read by the reader.
    */
-  private static class XMLReader<T> extends FileBasedReader<T> {
+  private static final class XMLReader<T> extends FileBasedReader<T> {
     // The amount of bytes read from the channel to memory when determining the starting offset of
     // the first record in a bundle. After matching to starting offset of the first record the
     // remaining bytes read to this buffer and the bytes still not read from the channel are used to

--- a/sdks/java/managed/src/main/java/org/apache/beam/sdk/managed/ManagedSchemaTransformProvider.java
+++ b/sdks/java/managed/src/main/java/org/apache/beam/sdk/managed/ManagedSchemaTransformProvider.java
@@ -152,7 +152,7 @@ public class ManagedSchemaTransformProvider
     return new ManagedSchemaTransform(managedConfig, schemaTransformProvider);
   }
 
-  static class ManagedSchemaTransform extends SchemaTransform {
+  static final class ManagedSchemaTransform extends SchemaTransform {
     private final ManagedConfig managedConfig;
     private final Row underlyingRowConfig;
     private final SchemaTransformProvider underlyingTransformProvider;

--- a/sdks/java/testing/load-tests/src/main/java/org/apache/beam/sdk/loadtests/LoadTest.java
+++ b/sdks/java/testing/load-tests/src/main/java/org/apache/beam/sdk/loadtests/LoadTest.java
@@ -21,6 +21,7 @@ import static org.apache.beam.sdk.io.synthetic.SyntheticOptions.fromJsonString;
 import static org.apache.beam.sdk.loadtests.JobFailure.handleFailure;
 
 import com.google.cloud.Timestamp;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -62,6 +63,11 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings({
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Abstract, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 abstract class LoadTest<OptionsT extends LoadTestOptions> {
 
   private static final Logger LOG = LoggerFactory.getLogger(LoadTest.class);

--- a/sdks/java/transform-service/launcher/src/main/java/org/apache/beam/sdk/transformservice/launcher/TransformServiceLauncher.java
+++ b/sdks/java/transform-service/launcher/src/main/java/org/apache/beam/sdk/transformservice/launcher/TransformServiceLauncher.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.transformservice.launcher;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -46,6 +47,11 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Can be either used programatically or as an executable jar.
  */
+@SuppressFBWarnings(
+    value = "CT_CONSTRUCTOR_THROW",
+    justification =
+        "Public API, so it cannot be made final."
+            + " A finalizer attack needs an attacker-supplied subclass on the classpath.")
 public class TransformServiceLauncher {
 
   private static final Logger LOG = LoggerFactory.getLogger(TransformServiceLauncher.class);


### PR DESCRIPTION
Part of #35312.

The global SpotBugs filter suppressed `CT_CONSTRUCTOR_THROW` in every module, so a constructor that throws after publishing `this` was never reported anywhere. This deletes those three filter lines and fixes everything the detector then found.

I used two fixes. Where the class is not public, I marked it `final`. SpotBugs' `ConstructorThrow` detector returns early on a final class, so the warning goes away because the problem is gone: a finalizer attack needs an attacker-supplied subclass, and a final class cannot have one. Every other class gets a `@SuppressFBWarnings` whose justification says why it has to stay extensible.

A class was made `final` only when it is neither abstract nor public. Code outside the repo can subclass a package-private class only by declaring itself inside a Beam package, which is unsupported and breaks under shaded jars, so sealing it cannot break a downstream user.

Public classes annotated `@Internal` get the suppression as well. `@Internal` withdraws the compatibility guarantee, but the class is still reachable, so a forked runner may already extend it and sealing it would break that fork at compile time. Six classes fall in this category: `BoundedTrieData`, `ExplicitShardedFile`, `PCollectionViews.SingletonViewFn`, `PCollectionViews.SingletonViewFn2`, `FnApiDoFnRunner`, and `SplittableSplitAndSizeRestrictionsDoFnRunner`.

I also checked that nothing in the repo extends any class I sealed. That check only proves the tree still compiles. It is not by itself a reason to seal a class, and it says nothing about out-of-tree code.

Verified locally with `./gradlew spotbugsMain spotlessJavaCheck --continue`: 140 modules pass `spotbugsMain`, 190 pass `spotlessJavaCheck`, and no report contains a `CT_CONSTRUCTOR_THROW` finding.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
