### PR TITLE
[KafkaIO] Fix off-by-one message backlog in SDF read

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/ReadFromKafkaDoFn.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/ReadFromKafkaDoFn.java
@@ -43,7 +43,6 @@ import org.apache.beam.sdk.transforms.splittabledofn.GrowableOffsetRangeTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.ManualWatermarkEstimator;
 import org.apache.beam.sdk.transforms.splittabledofn.OffsetRangeTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
-import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.HasProgress;
 import org.apache.beam.sdk.transforms.splittabledofn.UnsplittableRestrictionTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.WatermarkEstimator;
 import org.apache.beam.sdk.transforms.splittabledofn.WatermarkEstimators.MonotonicallyIncreasing;
@@ -552,7 +551,8 @@ abstract class ReadFromKafkaDoFn<K, V>
             return ProcessContinuation.stop();
           }
           if (timestampPolicy != null) {
-            updateWatermarkManually(timestampPolicy, watermarkEstimator, tracker);
+            updateWatermarkManually(
+                timestampPolicy, watermarkEstimator, expectedOffset, latestOffsetEstimator.get());
           }
           return ProcessContinuation.resume();
         }
@@ -595,7 +595,11 @@ abstract class ReadFromKafkaDoFn<K, V>
               // WatermarkEstimator should be a manual one.
               if (timestampPolicy != null) {
                 TimestampPolicyContext context =
-                    updateWatermarkManually(timestampPolicy, watermarkEstimator, tracker);
+                    updateWatermarkManually(
+                        timestampPolicy,
+                        watermarkEstimator,
+                        expectedOffset,
+                        latestOffsetEstimator.get());
                 outputTimestamp = timestampPolicy.getTimestampForRecord(context, kafkaRecord);
               } else {
                 Preconditions.checkStateNotNull(this.extractOutputTimestampFn);
@@ -614,7 +618,11 @@ abstract class ReadFromKafkaDoFn<K, V>
                   e,
                   "Failure deserializing Key or Value of Kakfa record reading from Kafka");
               if (timestampPolicy != null) {
-                updateWatermarkManually(timestampPolicy, watermarkEstimator, tracker);
+                updateWatermarkManually(
+                    timestampPolicy,
+                    watermarkEstimator,
+                    expectedOffset,
+                    latestOffsetEstimator.get());
               }
             }
           }
@@ -635,7 +643,8 @@ abstract class ReadFromKafkaDoFn<K, V>
             return ProcessContinuation.stop();
           }
           if (timestampPolicy != null) {
-            updateWatermarkManually(timestampPolicy, watermarkEstimator, tracker);
+            updateWatermarkManually(
+                timestampPolicy, watermarkEstimator, expectedOffset, latestOffsetEstimator.get());
           }
         }
 
@@ -653,7 +662,8 @@ abstract class ReadFromKafkaDoFn<K, V>
       }
 
       if (timestampPolicy != null) {
-        updateWatermarkManually(timestampPolicy, watermarkEstimator, tracker);
+        updateWatermarkManually(
+            timestampPolicy, watermarkEstimator, expectedOffset, latestOffsetEstimator.get());
       }
 
       return ProcessContinuation.resume();
@@ -672,11 +682,18 @@ abstract class ReadFromKafkaDoFn<K, V>
   private TimestampPolicyContext updateWatermarkManually(
       TimestampPolicy<K, V> timestampPolicy,
       WatermarkEstimator<Instant> watermarkEstimator,
-      RestrictionTracker<OffsetRange, Long> tracker) {
+      long nextOffset,
+      long estimatedEndOffset) {
     checkState(watermarkEstimator instanceof ManualWatermarkEstimator);
+    // Both offsets are exclusive: nextOffset is the offset that will be fetched next and
+    // estimatedEndOffset is the most recent estimate of the end offset of the partition. Their
+    // difference is the number of messages left to read, which reaches zero once the partition is
+    // fully consumed. Timestamp policies such as CustomTimestampPolicyWithLimitedDelay and
+    // TimestampPolicyFactory.LogAppendTimePolicy only advance the watermark of an idle partition
+    // when the backlog is exactly zero, so an inclusive offset here would pin their watermarks.
     TimestampPolicyContext context =
         new TimestampPolicyContext(
-            (long) ((HasProgress) tracker).getProgress().getWorkRemaining(), Instant.now());
+            Math.max(estimatedEndOffset, nextOffset) - nextOffset, Instant.now());
     ((ManualWatermarkEstimator<Instant>) watermarkEstimator)
         .setWatermark(ensureTimestampWithinBounds(timestampPolicy.getWatermark(context)));
     return context;

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/TimestampPolicy.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/TimestampPolicy.java
@@ -35,8 +35,8 @@ public abstract class TimestampPolicy<K, V> {
   public abstract static class PartitionContext {
     /**
      * Current backlog in messages (latest offset of the partition - offset of the next record to be
-     * processed). Both offsets are exclusive, so a backlog of zero means the reader has consumed the
-     * partition up to its latest known offset. Policies such as {@link
+     * processed). Both offsets are exclusive, so a backlog of zero means the reader has consumed
+     * the partition up to its latest known offset. Policies such as {@link
      * TimestampPolicyFactory.LogAppendTimePolicy} rely on that to advance the watermark of an idle
      * partition.
      */

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/TimestampPolicy.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/TimestampPolicy.java
@@ -34,7 +34,11 @@ public abstract class TimestampPolicy<K, V> {
    */
   public abstract static class PartitionContext {
     /**
-     * Current backlog in messages (latest offset of the partition - last processed record offset).
+     * Current backlog in messages (latest offset of the partition - offset of the next record to be
+     * processed). Both offsets are exclusive, so a backlog of zero means the reader has consumed the
+     * partition up to its latest known offset. Policies such as {@link
+     * TimestampPolicyFactory.LogAppendTimePolicy} rely on that to advance the watermark of an idle
+     * partition.
      */
     public abstract long getMessageBacklog();
 

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/ReadFromKafkaDoFnTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/ReadFromKafkaDoFnTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.beam.runners.core.metrics.DistributionCell;
@@ -57,6 +58,8 @@ import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.errorhandling.BadRecord;
 import org.apache.beam.sdk.transforms.errorhandling.ErrorHandler.DefaultErrorHandler;
 import org.apache.beam.sdk.transforms.splittabledofn.OffsetRangeTracker;
+import org.apache.beam.sdk.transforms.splittabledofn.WatermarkEstimators;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollection.IsBounded;
@@ -79,6 +82,7 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.checkerframework.checker.initialization.qual.Initialized;
@@ -97,6 +101,12 @@ public class ReadFromKafkaDoFnTest {
 
   private static final TupleTag<KV<KafkaSourceDescriptor, KafkaRecord<String, String>>> RECORDS =
       new TupleTag<>();
+
+  /** A fixed, positive record timestamp far enough in the past to let an idle watermark advance. */
+  private static final Instant IDLE_RECORD_TIMESTAMP = new Instant(1_600_000_000_000L);
+
+  private static final org.joda.time.Duration IDLE_MAX_DELAY =
+      org.joda.time.Duration.standardMinutes(1);
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 
@@ -336,6 +346,97 @@ public class ReadFromKafkaDoFnTest {
     public synchronized void seek(TopicPartition partition, long offset) {}
   }
 
+  /**
+   * A mock consumer which returns a single batch of {@code CREATE_TIME} records on its first poll
+   * and reports empty polls afterwards. Unlike {@link SimpleMockKafkaConsumer} it advances the
+   * consumer position as records are returned, so that {@link MockConsumer#currentLag} reports the
+   * lag implied by the end offset configured for the partition.
+   */
+  private static class IdlingMockKafkaConsumer extends MockConsumer<byte[], byte[]> {
+
+    private final TopicPartition topicPartition;
+    private final long numOfRecordsToReturn;
+    private final Instant recordTimestamp;
+    private long position = 0L;
+    private boolean polled = false;
+
+    IdlingMockKafkaConsumer(
+        TopicPartition topicPartition,
+        long numOfRecordsToReturn,
+        long remainingBacklog,
+        Instant recordTimestamp) {
+      super(OffsetResetStrategy.NONE);
+      this.topicPartition = topicPartition;
+      this.numOfRecordsToReturn = numOfRecordsToReturn;
+      this.recordTimestamp = recordTimestamp;
+      updateBeginningOffsets(ImmutableMap.of(topicPartition, 0L));
+      updateEndOffsets(ImmutableMap.of(topicPartition, numOfRecordsToReturn + remainingBacklog));
+    }
+
+    @Override
+    public synchronized List<PartitionInfo> partitionsFor(String topic) {
+      return ImmutableList.of(
+          new PartitionInfo(topicPartition.topic(), topicPartition.partition(), null, null, null));
+    }
+
+    @Override
+    public synchronized void seek(TopicPartition partition, long offset) {
+      this.position = offset;
+      super.seek(partition, offset);
+    }
+
+    @Override
+    public synchronized long position(TopicPartition partition) {
+      return this.position;
+    }
+
+    @Override
+    public synchronized ConsumerRecords<byte[], byte[]> poll(Duration timeout) {
+      if (polled) {
+        return ConsumerRecords.empty();
+      }
+      polled = true;
+      List<ConsumerRecord<byte[], byte[]>> records = new ArrayList<>();
+      for (long offset = position; offset < numOfRecordsToReturn; offset++) {
+        records.add(
+            new ConsumerRecord<>(
+                topicPartition.topic(),
+                topicPartition.partition(),
+                offset,
+                recordTimestamp.getMillis(),
+                TimestampType.CREATE_TIME,
+                ConsumerRecord.NULL_SIZE,
+                ConsumerRecord.NULL_SIZE,
+                "key".getBytes(StandardCharsets.UTF_8),
+                "value".getBytes(StandardCharsets.UTF_8),
+                new RecordHeaders(),
+                Optional.empty()));
+      }
+      if (records.isEmpty()) {
+        return ConsumerRecords.empty();
+      }
+      this.position = numOfRecordsToReturn;
+      return new ConsumerRecords<>(ImmutableMap.of(topicPartition, records));
+    }
+  }
+
+  private static class BacklogRecordingTimestampPolicy extends TimestampPolicy<String, String> {
+
+    private final List<Long> observedBacklogs = new ArrayList<>();
+
+    @Override
+    public Instant getTimestampForRecord(
+        PartitionContext context, KafkaRecord<String, String> record) {
+      return new Instant(record.getTimestamp());
+    }
+
+    @Override
+    public Instant getWatermark(PartitionContext context) {
+      observedBacklogs.add(context.getMessageBacklog());
+      return BoundedWindow.TIMESTAMP_MIN_VALUE;
+    }
+  }
+
   private static class MockMultiOutputReceiver implements MultiOutputReceiver {
 
     TestOutputReceiver<KV<KafkaSourceDescriptor, KafkaRecord<String, String>>> mockOutputReceiver =
@@ -551,6 +652,85 @@ public class ReadFromKafkaDoFnTest {
             receiver);
     assertEquals(ProcessContinuation.resume(), result);
     assertTrue(receiver.getGoodRecords().isEmpty());
+  }
+
+  @Test
+  public void testMessageBacklogReachesZeroWhenPartitionIsCaughtUp() throws Exception {
+    assertEquals(ImmutableList.of(2L, 1L, 0L, 0L), observeMessageBacklog(3L, 0L));
+  }
+
+  @Test
+  public void testMessageBacklogExcludesRecordsAlreadyRead() throws Exception {
+    assertEquals(ImmutableList.of(7L, 6L, 5L, 5L), observeMessageBacklog(3L, 5L));
+  }
+
+  private List<Long> observeMessageBacklog(long numOfRecords, long remainingBacklog)
+      throws Exception {
+    final BacklogRecordingTimestampPolicy timestampPolicy = new BacklogRecordingTimestampPolicy();
+    final ReadFromKafkaDoFn<String, String> dofn =
+        makeIdlingDoFn(
+            numOfRecords, remainingBacklog, (tp, previousWatermark) -> timestampPolicy);
+    final KafkaSourceDescriptor descriptor =
+        KafkaSourceDescriptor.of(topicPartition, null, null, null, null, null);
+
+    final ProcessContinuation result =
+        dofn.processElement(
+            descriptor,
+            dofn.restrictionTracker(descriptor, new OffsetRange(0L, Long.MAX_VALUE)),
+            new WatermarkEstimators.Manual(BoundedWindow.TIMESTAMP_MIN_VALUE),
+            new MockMultiOutputReceiver());
+
+    assertEquals(ProcessContinuation.resume(), result);
+    return timestampPolicy.observedBacklogs;
+  }
+
+  @Test
+  public void testWatermarkAdvancesForIdleCaughtUpPartition() throws Exception {
+    // The partition is fully consumed, so CustomTimestampPolicyWithLimitedDelay takes its idle
+    // branch and advances the watermark past the timestamp of the last record read.
+    assertTrue(observeIdleWatermark(0L).isAfter(IDLE_RECORD_TIMESTAMP));
+  }
+
+  @Test
+  public void testWatermarkDoesNotAdvanceForIdlePartitionWithBacklog() throws Exception {
+    // Records are still outstanding, so the watermark stays behind the last record read.
+    assertEquals(IDLE_RECORD_TIMESTAMP.minus(IDLE_MAX_DELAY), observeIdleWatermark(5L));
+  }
+
+  private Instant observeIdleWatermark(long remainingBacklog) throws Exception {
+    final ReadFromKafkaDoFn<String, String> dofn =
+        makeIdlingDoFn(
+            3L, remainingBacklog, TimestampPolicyFactory.withCreateTime(IDLE_MAX_DELAY));
+    final KafkaSourceDescriptor descriptor =
+        KafkaSourceDescriptor.of(topicPartition, null, null, null, null, null);
+    final WatermarkEstimators.Manual watermarkEstimator =
+        new WatermarkEstimators.Manual(BoundedWindow.TIMESTAMP_MIN_VALUE);
+
+    final ProcessContinuation result =
+        dofn.processElement(
+            descriptor,
+            dofn.restrictionTracker(descriptor, new OffsetRange(0L, Long.MAX_VALUE)),
+            watermarkEstimator,
+            new MockMultiOutputReceiver());
+
+    assertEquals(ProcessContinuation.resume(), result);
+    return watermarkEstimator.currentWatermark();
+  }
+
+  private ReadFromKafkaDoFn<String, String> makeIdlingDoFn(
+      long numOfRecords,
+      long remainingBacklog,
+      TimestampPolicyFactory<String, String> timestampPolicyFactory)
+      throws Exception {
+    final ReadFromKafkaDoFn<String, String> dofn =
+        ReadFromKafkaDoFn.create(
+            makeReadSourceDescriptor(
+                    new IdlingMockKafkaConsumer(
+                        topicPartition, numOfRecords, remainingBacklog, IDLE_RECORD_TIMESTAMP))
+                .withTimestampPolicyFactory(timestampPolicyFactory),
+            RECORDS);
+    dofn.setup();
+    return dofn;
   }
 
   @Test

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/ReadFromKafkaDoFnTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/ReadFromKafkaDoFnTest.java
@@ -668,8 +668,7 @@ public class ReadFromKafkaDoFnTest {
       throws Exception {
     final BacklogRecordingTimestampPolicy timestampPolicy = new BacklogRecordingTimestampPolicy();
     final ReadFromKafkaDoFn<String, String> dofn =
-        makeIdlingDoFn(
-            numOfRecords, remainingBacklog, (tp, previousWatermark) -> timestampPolicy);
+        makeIdlingDoFn(numOfRecords, remainingBacklog, (tp, previousWatermark) -> timestampPolicy);
     final KafkaSourceDescriptor descriptor =
         KafkaSourceDescriptor.of(topicPartition, null, null, null, null, null);
 
@@ -699,8 +698,7 @@ public class ReadFromKafkaDoFnTest {
 
   private Instant observeIdleWatermark(long remainingBacklog) throws Exception {
     final ReadFromKafkaDoFn<String, String> dofn =
-        makeIdlingDoFn(
-            3L, remainingBacklog, TimestampPolicyFactory.withCreateTime(IDLE_MAX_DELAY));
+        makeIdlingDoFn(3L, remainingBacklog, TimestampPolicyFactory.withCreateTime(IDLE_MAX_DELAY));
     final KafkaSourceDescriptor descriptor =
         KafkaSourceDescriptor.of(topicPartition, null, null, null, null, null);
     final WatermarkEstimators.Manual watermarkEstimator =


### PR DESCRIPTION

## Problem

`ReadFromKafkaDoFn` reports a fully caught-up partition as having a backlog of
**1, never 0**. The cause is a collision between two offset conventions.

### Kafka's offsets are exclusive; the tracker's claimed offset is not

`Consumer#position()` is documented as *"the offset of the **next record** that
will be fetched"* — it is exclusive by design, not off by one. `currentLag()` is
`logEndOffset - position()`. So the estimate KafkaIO installs in the tracker,

```java
final long position = consumer.position(topicPartition);
consumer.currentLag(topicPartition)
    .ifPresent(lag -> latestOffsetEstimator.lazySet(position + lag));
```

is exactly the log end offset — **exclusive**. That is precisely what the tracker
asks for; `GrowableOffsetRangeTracker.RangeEndEstimator` states *"The end offset
is exclusive for the range."* The estimator is correct.

`lastAttemptedOffset`, however, is the last **inclusive** offset claimed. And
`getProgress()` subtracts one from the other without converting:

```java
final long completedEnd = lastAttemptedOffset == null ? range.getFrom() : lastAttemptedOffset;
final long remainingEnd = Math.max(completedEnd, rangeEndEstimator.estimate());
return Progress.from(completedEnd - range.getFrom(), remainingEnd - completedEnd);
```

Once at least one record has been claimed, `workRemaining == realBacklog + 1`
(and `workCompleted` is one short). Worked through, for a partition holding
offsets 100–104 that the reader has fully drained:

| value | | |
|---|---|---|
| log end offset | 105 | exclusive |
| `position()` | 105 | exclusive — next record to fetch |
| `currentLag()` | 0 | reader is caught up |
| estimate (`position + lag`) | 105 | exclusive ✅ |
| `lastAttemptedOffset` | 104 | **inclusive** |
| `workRemaining` | `105 - 104` = **1** | ❌ should be 0 |

`ReadFromKafkaDoFn` then feeds that straight to the timestamp policy:

```java
new TimestampPolicyContext(
    (long) ((HasProgress) tracker).getProgress().getWorkRemaining(), Instant.now());
```

### Why it matters

Both `CustomTimestampPolicyWithLimitedDelay` and
`TimestampPolicyFactory.LogAppendTimePolicy` gate their idle-advance branch on
`ctx.getMessageBacklog() == 0`. Because that value can never reach zero, **the
branch is unreachable**, and an idle partition's watermark stays pinned at
`lastRecordTimestamp - maxDelay` for as long as the partition stays quiet.
Downstream event-time windows and triggers never fire.

Only the SDF path is affected. `KafkaUnboundedReader.backlogMessageCount()`
computes `latestOffset - nextOffset` — exclusive minus exclusive — and does reach
0. Dataflow always selects the SDF path (`KafkaIO.Read#runnerPrefersLegacyRead`
returns false for any `org.apache.beam.runners.dataflow.*` runner) unless the
`use_deprecated_read` experiment is set, so pipelines there are exposed by
default.

Observed in production on a Dataflow streaming job: a topic stopped producing and
the job reported data freshness growing 1:1 with wall clock for over eight hours,
while committed offsets showed the reader had been fully caught up the whole
time. It simply had no way to say so.

## Evidence this is an oversight rather than intent

Two places in the existing code handle the exclusive/inclusive distinction
correctly, one of them three lines from the defect:

1. **The claim path converts explicitly.** `ReadFromKafkaDoFn` subtracts one from
   `position()` to obtain a claimable inclusive offset:

   ```java
   if (expectedOffset < (expectedOffset = consumer.position(topicPartition))) {
     if (!tracker.tryClaim(expectedOffset - 1)) {
   ```

   The code knows the two conventions differ. `getProgress()` just never converts
   back.

2. **The `backlogBytes` gauge gets it right**, ~20 lines below
   `updateWatermarkManually` in the same method, using the exclusive
   `expectedOffset`:

   ```java
   BigDecimal.valueOf(Math.max(expectedOffset, latestOffsetEstimator.get()))
       .subtract(BigDecimal.valueOf(expectedOffset), MathContext.DECIMAL128)
   ```

   Same method, two conventions, and the metric uses the correct one.

Notably, *every* offset in `processElement` is already exclusive-next —
`tracker.currentRestriction().getFrom()`, `rawRecord.offset() + 1`, and
`consumer.position()`. `lastAttemptedOffset`, reachable only through the tracker,
is the sole inclusive value in the picture.

## Change

`updateWatermarkManually` now takes the exclusive next offset and the latest end
offset estimate directly, and computes
`max(estimatedEndOffset, nextOffset) - nextOffset` — exclusive minus exclusive,
matching both the gauge and the legacy reader. Every call site already had
`expectedOffset` in hand, so no new state is threaded through.

`TimestampPolicy.PartitionContext#getMessageBacklog`'s javadoc previously read
*"latest offset of the partition - last processed record offset"*, which
describes the buggy inclusive arithmetic and is plausibly how the slip survived
review. Reworded to state that both offsets are exclusive and that zero means
fully caught up.

`Long.MIN_VALUE` — the sentinel `latestOffsetEstimator` holds when the position is
undefined or out of range — still yields a backlog of 0 via the `max`, matching
today's behaviour on that path.

## Compacted topics

The value this method reports is a count of *offsets*, not of messages —
compaction deletes records while leaving the offset span intact, so on a
compacted topic the backlog overstates how many records actually remain. That is
pre-existing and unchanged here; `getSize` already notes it ("Compacted topics
may hold less records than the estimated offset range due to record deletion
within a partition"), and the legacy `KafkaUnboundedReader` has the same
characteristic since it also computes `latestOffset - nextOffset`. This change
removes a *systematic* off-by-one that affects every topic, compacted or not.

The idle-advance path does still reach zero on a compacted topic. The
"non-visible progress" branch claims up to `consumer.position() - 1` whenever the
position advances without any records being returned, which is exactly what a
fetch across a compacted region looks like, so `expectedOffset` follows the
consumer past the gaps. For a partition whose surviving records are at offsets
0, 2 and 4 with a log end offset of 5, the backlog after the final record is 0
with this change and 1 without it.

What this change does not address is a consumer position that stalls below the
log end offset with nothing left to fetch; the backlog would stay positive and
the watermark would not advance. That is a fetch-position concern rather than an
arithmetic one, is unaffected by this change, and behaves identically on the
legacy read path.

## Alternative considered: converting inside the tracker

The root cause is in `GrowableOffsetRangeTracker.getProgress()`, and
`completedEnd = lastAttemptedOffset + 1` would fix `workCompleted` too. I did not
do that here because:

- it changes progress values for **every** SDF using the tracker, and runners
  consume those for splitting and autoscaling decisions;
- it needs an overflow guard for the `lastAttemptedOffset == Long.MAX_VALUE`
  (range done) case, since `getProgress` feeds the subtraction through
  `UnsignedLong.fromLongBits`.

The two fixes are independent — this one derives the backlog without consulting
the tracker — so a later tracker fix will not double-correct. Happy to switch to
it, or file it as a follow-up, if reviewers prefer.

Scope note: `getSize()` is **not** affected. It builds a *fresh* tracker per
call, so `lastAttemptedOffset` is null, `completedEnd == range.getFrom()`, and
`workRemaining == estimate - from` — correct, because restriction starts are
exclusive-next offsets. The in-flight `getProgress()` the runner queries during
bundle processing does stay off by one until the tracker itself is fixed; that
affects splitting and progress reporting, not watermarks.

## Tests

Four tests in `ReadFromKafkaDoFnTest`, all driving the real
`GrowableOffsetRangeTracker` through `restrictionTracker()`:

- `testMessageBacklogReachesZeroWhenPartitionIsCaughtUp` — exact backlog sequence
  `[2, 1, 0, 0]` for three records on a partition with end offset 3.
- `testMessageBacklogExcludesRecordsAlreadyRead` — `[7, 6, 5, 5]` with five
  records left unread.
- `testWatermarkAdvancesForIdleCaughtUpPartition` — a real
  `CustomTimestampPolicyWithLimitedDelay` advances past the last record's
  timestamp once the partition drains.
- `testWatermarkDoesNotAdvanceForIdlePartitionWithBacklog` — the same policy
  stays at `lastRecordTimestamp - maxDelay` while records remain.

All four fail before the change and pass after. They use a new
`IdlingMockKafkaConsumer`, which returns one batch then empty polls and tracks
`position` so `currentLag` is meaningful; the existing `SimpleMockKafkaConsumer`
returns a fixed `position` and cannot express "caught up".

------------------------


Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
