### PR TITLE
Keep progress renewal heartbeats active through bundle teardown

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/BatchDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/BatchDataflowWorker.java
@@ -344,6 +344,8 @@ public class BatchDataflowWorker implements Closeable {
       worker.execute();
       // Ensure any pending dynamic split is reported before sending the final success status.
       progressUpdater.reportUnreportedSplit();
+      // Switch progress reporting to lightweight lease renewal pings now that compute is complete.
+      progressUpdater.setLeaseRenewalOnly(true);
       // Report success while progress reporting (and lease renewal) is still active.
       workItemStatusClient.reportSuccess();
     } finally {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/BatchDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/BatchDataflowWorker.java
@@ -288,8 +288,7 @@ public class BatchDataflowWorker implements Closeable {
 
       DataflowWorkProgressUpdater progressUpdater =
           new DataflowWorkProgressUpdater(workItemStatusClient, workItem, worker, options);
-      executeWork(worker, progressUpdater);
-      workItemStatusClient.reportSuccess();
+      executeWork(worker, progressUpdater, workItemStatusClient);
       return true;
     } catch (OutOfMemoryError oom) {
       throw oom;
@@ -311,6 +310,7 @@ public class BatchDataflowWorker implements Closeable {
   }
 
   /** Executes the work and report progress. For testing only. */
+  @VisibleForTesting
   void executeWork(DataflowWorkExecutor worker, DataflowWorkProgressUpdater progressUpdater)
       throws Exception {
     progressUpdater.startReportingProgress();
@@ -320,6 +320,34 @@ public class BatchDataflowWorker implements Closeable {
     } finally {
       // stopReportingProgress can throw an exception if the final progress
       // update fails. For correctness, the task must then be marked as failed.
+      progressUpdater.stopReportingProgress();
+    }
+  }
+
+  /**
+   * Executes the work, reports any unreported dynamic split, and reports final success while
+   * keeping progress reporting (and lease renewal) active.
+   *
+   * <p>By keeping the {@link DataflowWorkProgressUpdater} active until {@link
+   * WorkItemStatusClient#reportSuccess} completes, lease renewal heartbeats continue even if bundle
+   * completion or status reporting encounters delays, preventing lease expiration.
+   */
+  void executeWork(
+      DataflowWorkExecutor worker,
+      DataflowWorkProgressUpdater progressUpdater,
+      WorkItemStatusClient workItemStatusClient)
+      throws Exception {
+    progressUpdater.startReportingProgress();
+    try {
+      // Blocks while executing the work.
+      worker.execute();
+      // Ensure any pending dynamic split is reported before sending the final success status.
+      progressUpdater.reportUnreportedSplit();
+      // Report success while progress reporting (and lease renewal) is still active.
+      workItemStatusClient.reportSuccess();
+    } finally {
+      // Stop progress reporting only after work execution and reportSuccess have completed
+      // (or failed).
       progressUpdater.stopReportingProgress();
     }
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/BatchDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/BatchDataflowWorker.java
@@ -288,7 +288,7 @@ public class BatchDataflowWorker implements Closeable {
 
       DataflowWorkProgressUpdater progressUpdater =
           new DataflowWorkProgressUpdater(workItemStatusClient, workItem, worker, options);
-      executeWork(worker, progressUpdater, workItemStatusClient);
+      executeWorkAndReportSuccess(worker, progressUpdater, workItemStatusClient);
       return true;
     } catch (OutOfMemoryError oom) {
       throw oom;
@@ -332,7 +332,8 @@ public class BatchDataflowWorker implements Closeable {
    * WorkItemStatusClient#reportSuccess} completes, lease renewal heartbeats continue even if bundle
    * completion or status reporting encounters delays, preventing lease expiration.
    */
-  void executeWork(
+  @VisibleForTesting
+  void executeWorkAndReportSuccess(
       DataflowWorkExecutor worker,
       DataflowWorkProgressUpdater progressUpdater,
       WorkItemStatusClient workItemStatusClient)

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowWorkProgressUpdater.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowWorkProgressUpdater.java
@@ -27,7 +27,6 @@ import com.google.api.services.dataflow.model.HotKeyDetection;
 import com.google.api.services.dataflow.model.WorkItem;
 import com.google.api.services.dataflow.model.WorkItemServiceState;
 import java.util.concurrent.ScheduledExecutorService;
-import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
 import org.apache.beam.runners.dataflow.util.TimeUtil;
@@ -59,11 +58,9 @@ public class DataflowWorkProgressUpdater extends WorkProgressUpdater {
 
   private HotKeyLogger hotKeyLogger;
 
-  @GuardedBy("executor")
   private boolean wasAskedToAbort = false;
 
-  @GuardedBy("executor")
-  private boolean leaseRenewalOnly = false;
+  private volatile boolean leaseRenewalOnly = false;
 
   public DataflowWorkProgressUpdater(
       WorkItemStatusClient workItemStatusClient,
@@ -118,25 +115,19 @@ public class DataflowWorkProgressUpdater extends WorkProgressUpdater {
    * metrics, or progress.
    */
   public void setLeaseRenewalOnly(boolean leaseRenewalOnly) {
-    synchronized (executor) {
-      this.leaseRenewalOnly = leaseRenewalOnly;
-    }
+    this.leaseRenewalOnly = leaseRenewalOnly;
   }
 
   @VisibleForTesting
   public boolean isLeaseRenewalOnly() {
-    synchronized (executor) {
-      return leaseRenewalOnly;
-    }
+    return leaseRenewalOnly;
   }
 
   @Override
   protected void reportProgressHelper() throws Exception {
-    synchronized (executor) {
-      if (wasAskedToAbort) {
-        LOG.info("Service already asked to abort work item, not reporting ignored progress.");
-        return;
-      }
+    if (wasAskedToAbort) {
+      LOG.info("Service already asked to abort work item, not reporting ignored progress.");
+      return;
     }
     if (workItemStatusClient.isFinalStateSent()) {
       LOG.debug(
@@ -144,24 +135,14 @@ public class DataflowWorkProgressUpdater extends WorkProgressUpdater {
       return;
     }
 
-    boolean pingOnly;
-    synchronized (executor) {
-      pingOnly = leaseRenewalOnly;
-    }
-
-    if (pingOnly) {
+    if (leaseRenewalOnly && dynamicSplitResultToReport == null) {
       reportLeasePing();
       return;
     }
 
-    long leaseDurationMs;
-    synchronized (executor) {
-      leaseDurationMs = requestedLeaseDurationMs;
-    }
-
     WorkItemServiceState result =
         workItemStatusClient.reportUpdate(
-            dynamicSplitResultToReport, Duration.millis(leaseDurationMs));
+            dynamicSplitResultToReport, Duration.millis(requestedLeaseDurationMs));
 
     if (result != null) {
       handleServiceState(result);
@@ -172,21 +153,13 @@ public class DataflowWorkProgressUpdater extends WorkProgressUpdater {
    * Reports a lightweight lease renewal heartbeat to the worker service without extracting counters
    * or progress.
    */
-  public void reportLeasePing() throws Exception {
-    synchronized (executor) {
-      if (wasAskedToAbort) {
-        return;
-      }
-    }
-    if (workItemStatusClient.isFinalStateSent()) {
+  @VisibleForTesting
+  void reportLeasePing() throws Exception {
+    if (wasAskedToAbort || workItemStatusClient.isFinalStateSent()) {
       return;
     }
-    long leaseDurationMs;
-    synchronized (executor) {
-      leaseDurationMs = requestedLeaseDurationMs;
-    }
     WorkItemServiceState result =
-        workItemStatusClient.reportLeasePing(Duration.millis(leaseDurationMs));
+        workItemStatusClient.reportLeasePing(Duration.millis(requestedLeaseDurationMs));
     if (result != null) {
       handleServiceState(result);
     }
@@ -196,9 +169,7 @@ public class DataflowWorkProgressUpdater extends WorkProgressUpdater {
     if (result.getCompleteWorkStatus() != null
         && result.getCompleteWorkStatus().getCode() != com.google.rpc.Code.OK.getNumber()) {
       LOG.info("Service asked worker to abort with status: {}", result.getCompleteWorkStatus());
-      synchronized (executor) {
-        wasAskedToAbort = true;
-      }
+      wasAskedToAbort = true;
       worker.abort();
       return;
     }
@@ -224,12 +195,10 @@ public class DataflowWorkProgressUpdater extends WorkProgressUpdater {
     // Resets state after a successful progress report.
     dynamicSplitResultToReport = null;
 
-    synchronized (executor) {
-      progressReportIntervalMs =
-          nextProgressReportInterval(
-              fromCloudDuration(result.getReportStatusInterval()).getMillis(),
-              leaseRemainingTime(getLeaseExpirationTimestamp(result)));
-    }
+    progressReportIntervalMs =
+        nextProgressReportInterval(
+            fromCloudDuration(result.getReportStatusInterval()).getMillis(),
+            leaseRemainingTime(getLeaseExpirationTimestamp(result)));
 
     ApproximateSplitRequest suggestedStopPoint = result.getSplitRequest();
     if (suggestedStopPoint != null) {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowWorkProgressUpdater.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowWorkProgressUpdater.java
@@ -27,6 +27,7 @@ import com.google.api.services.dataflow.model.HotKeyDetection;
 import com.google.api.services.dataflow.model.WorkItem;
 import com.google.api.services.dataflow.model.WorkItemServiceState;
 import java.util.concurrent.ScheduledExecutorService;
+import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
 import org.apache.beam.runners.dataflow.util.TimeUtil;
@@ -58,7 +59,11 @@ public class DataflowWorkProgressUpdater extends WorkProgressUpdater {
 
   private HotKeyLogger hotKeyLogger;
 
+  @GuardedBy("executor")
   private boolean wasAskedToAbort = false;
+
+  @GuardedBy("executor")
+  private boolean leaseRenewalOnly = false;
 
   public DataflowWorkProgressUpdater(
       WorkItemStatusClient workItemStatusClient,
@@ -108,63 +113,58 @@ public class DataflowWorkProgressUpdater extends WorkProgressUpdater {
     return fromCloudDuration(workItem.getReportStatusInterval()).getMillis();
   }
 
+  /**
+   * Switches progress reporting to lightweight lease renewal pings without extracting counters,
+   * metrics, or progress.
+   */
+  public void setLeaseRenewalOnly(boolean leaseRenewalOnly) {
+    synchronized (executor) {
+      this.leaseRenewalOnly = leaseRenewalOnly;
+    }
+  }
+
+  @VisibleForTesting
+  public boolean isLeaseRenewalOnly() {
+    synchronized (executor) {
+      return leaseRenewalOnly;
+    }
+  }
+
   @Override
   protected void reportProgressHelper() throws Exception {
-    if (wasAskedToAbort) {
-      LOG.info("Service already asked to abort work item, not reporting ignored progress.");
-      return;
+    synchronized (executor) {
+      if (wasAskedToAbort) {
+        LOG.info("Service already asked to abort work item, not reporting ignored progress.");
+        return;
+      }
     }
     if (workItemStatusClient.isFinalStateSent()) {
       LOG.debug(
           "Final state already sent for work item {}, skipping progress report.", workString());
       return;
     }
+
+    boolean pingOnly;
+    synchronized (executor) {
+      pingOnly = leaseRenewalOnly;
+    }
+
+    if (pingOnly) {
+      reportLeasePing();
+      return;
+    }
+
+    long leaseDurationMs;
+    synchronized (executor) {
+      leaseDurationMs = requestedLeaseDurationMs;
+    }
+
     WorkItemServiceState result =
         workItemStatusClient.reportUpdate(
-            dynamicSplitResultToReport, Duration.millis(requestedLeaseDurationMs));
+            dynamicSplitResultToReport, Duration.millis(leaseDurationMs));
 
     if (result != null) {
-      if (result.getCompleteWorkStatus() != null
-          && result.getCompleteWorkStatus().getCode() != com.google.rpc.Code.OK.getNumber()) {
-        LOG.info("Service asked worker to abort with status: {}", result.getCompleteWorkStatus());
-        wasAskedToAbort = true;
-        worker.abort();
-        return;
-      }
-
-      if (result.getHotKeyDetection() != null
-          && result.getHotKeyDetection().getUserStepName() != null) {
-        HotKeyDetection hotKeyDetection = result.getHotKeyDetection();
-
-        // The key set the in BatchModeExecutionContext is only set in the GroupingShuffleReader
-        // which is the correct key. The key is also translated into a Java object in the reader.
-        if (options.isHotKeyLoggingEnabled() || hasExperiment(options, "enable_hot_key_logging")) {
-          hotKeyLogger.logHotKeyDetection(
-              hotKeyDetection.getUserStepName(),
-              TimeUtil.fromCloudDuration(hotKeyDetection.getHotKeyAge()),
-              workItemStatusClient.getExecutionContext().getKey());
-        } else {
-          hotKeyLogger.logHotKeyDetection(
-              hotKeyDetection.getUserStepName(),
-              TimeUtil.fromCloudDuration(hotKeyDetection.getHotKeyAge()));
-        }
-      }
-
-      // Resets state after a successful progress report.
-      dynamicSplitResultToReport = null;
-
-      progressReportIntervalMs =
-          nextProgressReportInterval(
-              fromCloudDuration(result.getReportStatusInterval()).getMillis(),
-              leaseRemainingTime(getLeaseExpirationTimestamp(result)));
-
-      ApproximateSplitRequest suggestedStopPoint = result.getSplitRequest();
-      if (suggestedStopPoint != null) {
-        LOG.info("Proposing dynamic split of work unit {} at {}", workString(), suggestedStopPoint);
-        dynamicSplitResultToReport =
-            worker.requestDynamicSplit(
-                SourceTranslationUtils.toDynamicSplitRequest(suggestedStopPoint));
-      }
+      handleServiceState(result);
     }
   }
 
@@ -173,10 +173,71 @@ public class DataflowWorkProgressUpdater extends WorkProgressUpdater {
    * or progress.
    */
   public void reportLeasePing() throws Exception {
-    if (wasAskedToAbort || workItemStatusClient.isFinalStateSent()) {
+    synchronized (executor) {
+      if (wasAskedToAbort) {
+        return;
+      }
+    }
+    if (workItemStatusClient.isFinalStateSent()) {
       return;
     }
-    workItemStatusClient.reportLeasePing(Duration.millis(requestedLeaseDurationMs));
+    long leaseDurationMs;
+    synchronized (executor) {
+      leaseDurationMs = requestedLeaseDurationMs;
+    }
+    WorkItemServiceState result =
+        workItemStatusClient.reportLeasePing(Duration.millis(leaseDurationMs));
+    if (result != null) {
+      handleServiceState(result);
+    }
+  }
+
+  private void handleServiceState(WorkItemServiceState result) throws Exception {
+    if (result.getCompleteWorkStatus() != null
+        && result.getCompleteWorkStatus().getCode() != com.google.rpc.Code.OK.getNumber()) {
+      LOG.info("Service asked worker to abort with status: {}", result.getCompleteWorkStatus());
+      synchronized (executor) {
+        wasAskedToAbort = true;
+      }
+      worker.abort();
+      return;
+    }
+
+    if (result.getHotKeyDetection() != null
+        && result.getHotKeyDetection().getUserStepName() != null) {
+      HotKeyDetection hotKeyDetection = result.getHotKeyDetection();
+
+      // The key set in BatchModeExecutionContext is only set in the GroupingShuffleReader
+      // which is the correct key. The key is also translated into a Java object in the reader.
+      if (options.isHotKeyLoggingEnabled() || hasExperiment(options, "enable_hot_key_logging")) {
+        hotKeyLogger.logHotKeyDetection(
+            hotKeyDetection.getUserStepName(),
+            TimeUtil.fromCloudDuration(hotKeyDetection.getHotKeyAge()),
+            workItemStatusClient.getExecutionContext().getKey());
+      } else {
+        hotKeyLogger.logHotKeyDetection(
+            hotKeyDetection.getUserStepName(),
+            TimeUtil.fromCloudDuration(hotKeyDetection.getHotKeyAge()));
+      }
+    }
+
+    // Resets state after a successful progress report.
+    dynamicSplitResultToReport = null;
+
+    synchronized (executor) {
+      progressReportIntervalMs =
+          nextProgressReportInterval(
+              fromCloudDuration(result.getReportStatusInterval()).getMillis(),
+              leaseRemainingTime(getLeaseExpirationTimestamp(result)));
+    }
+
+    ApproximateSplitRequest suggestedStopPoint = result.getSplitRequest();
+    if (suggestedStopPoint != null) {
+      LOG.info("Proposing dynamic split of work unit {} at {}", workString(), suggestedStopPoint);
+      dynamicSplitResultToReport =
+          worker.requestDynamicSplit(
+              SourceTranslationUtils.toDynamicSplitRequest(suggestedStopPoint));
+    }
   }
 
   /** Returns the given work unit's lease expiration timestamp. */

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowWorkProgressUpdater.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowWorkProgressUpdater.java
@@ -114,6 +114,11 @@ public class DataflowWorkProgressUpdater extends WorkProgressUpdater {
       LOG.info("Service already asked to abort work item, not reporting ignored progress.");
       return;
     }
+    if (workItemStatusClient.isFinalStateSent()) {
+      LOG.debug(
+          "Final state already sent for work item {}, skipping progress report.", workString());
+      return;
+    }
     WorkItemServiceState result =
         workItemStatusClient.reportUpdate(
             dynamicSplitResultToReport, Duration.millis(requestedLeaseDurationMs));
@@ -161,6 +166,17 @@ public class DataflowWorkProgressUpdater extends WorkProgressUpdater {
                 SourceTranslationUtils.toDynamicSplitRequest(suggestedStopPoint));
       }
     }
+  }
+
+  /**
+   * Reports a lightweight lease renewal heartbeat to the worker service without extracting counters
+   * or progress.
+   */
+  public void reportLeasePing() throws Exception {
+    if (wasAskedToAbort || workItemStatusClient.isFinalStateSent()) {
+      return;
+    }
+    workItemStatusClient.reportLeasePing(Duration.millis(requestedLeaseDurationMs));
   }
 
   /** Returns the given work unit's lease expiration timestamp. */

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkItemStatusClient.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkItemStatusClient.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.runners.dataflow.worker;
 
+import static org.apache.beam.sdk.util.Preconditions.checkArgumentNotNull;
+import static org.apache.beam.sdk.util.Preconditions.checkStateNotNull;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
@@ -224,11 +226,11 @@ public class WorkItemStatusClient {
    */
   public @Nullable WorkItemServiceState reportLeasePing(Duration requestedLeaseDuration)
       throws Exception {
-    checkState(worker != null, "setWorker should be called before reportLeasePing");
+    checkStateNotNull(worker, "setWorker should be called before reportLeasePing");
     if (finalStateSent) {
       return null;
     }
-    checkArgument(requestedLeaseDuration != null, "requestLeaseDuration must be non-null");
+    checkArgumentNotNull(requestedLeaseDuration, "requestLeaseDuration must be non-null");
     if (wasAskedToAbort) {
       LOG.info("Service already asked to abort work item, not reporting ignored progress.");
       return null;
@@ -261,7 +263,7 @@ public class WorkItemStatusClient {
 
   private synchronized @Nullable WorkItemServiceState execute(WorkItemStatus status)
       throws IOException {
-    if (finalStateSent && !Boolean.TRUE.equals(status.getCompleted())) {
+    if (finalStateSent && !status.getCompleted()) {
       LOG.info(
           "Final state already sent for work item {}, skipping non-final status update.",
           uniqueWorkId());
@@ -279,13 +281,13 @@ public class WorkItemStatusClient {
         return result;
       }
       nextReportIndex = result.getNextReportIndex();
-      if (nextReportIndex == null && !Boolean.TRUE.equals(status.getCompleted())) {
+      if (nextReportIndex == null && !status.getCompleted()) {
         LOG.error("Missing next work index in {} when reporting {}.", result, status);
       }
       commitMetrics();
     }
 
-    if (Boolean.TRUE.equals(status.getCompleted())) {
+    if (status.getCompleted()) {
       checkState(!finalStateSent, "cannot reportUpdates after sending a final state");
       finalStateSent = true;
     }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkItemStatusClient.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkItemStatusClient.java
@@ -74,10 +74,18 @@ public class WorkItemStatusClient {
   private Long nextReportIndex;
 
   private transient String uniqueWorkId = null;
-  private boolean finalStateSent = false;
-  private boolean wasAskedToAbort = false;
+  private volatile boolean finalStateSent = false;
+  private volatile boolean wasAskedToAbort = false;
 
   private @Nullable BatchModeExecutionContext executionContext;
+
+  /** Lock guarding metric and counter extraction and commit. */
+  private final Object metricsLock = new Object();
+
+  /** Returns whether a final completion status (success or error) has already been sent. */
+  public boolean isFinalStateSent() {
+    return finalStateSent;
+  }
 
   /**
    * Construct a partly-initialized {@link WorkItemStatusClient}. Once the {@link
@@ -152,7 +160,7 @@ public class WorkItemStatusClient {
   }
 
   /** Return the {@link WorkItemServiceState} resulting from sending a success completion status. */
-  public synchronized @Nullable WorkItemServiceState reportSuccess() throws IOException {
+  public @Nullable WorkItemServiceState reportSuccess() throws IOException {
     checkState(!finalStateSent, "cannot reportSuccess after sending a final state");
     checkState(worker != null, "setWorker should be called before reportSuccess");
     if (wasAskedToAbort) {
@@ -177,8 +185,20 @@ public class WorkItemStatusClient {
   }
 
   /** Return the {@link WorkItemServiceState} resulting from sending a progress update. */
-  public synchronized @Nullable WorkItemServiceState reportUpdate(
+  public @Nullable WorkItemServiceState reportUpdate(
       @Nullable DynamicSplitResult dynamicSplitResult, Duration requestedLeaseDuration)
+      throws Exception {
+    return reportUpdate(dynamicSplitResult, requestedLeaseDuration, true);
+  }
+
+  /**
+   * Return the {@link WorkItemServiceState} resulting from sending a progress update, optionally
+   * including counters and metrics.
+   */
+  public @Nullable WorkItemServiceState reportUpdate(
+      @Nullable DynamicSplitResult dynamicSplitResult,
+      Duration requestedLeaseDuration,
+      boolean includeCounters)
       throws Exception {
     checkState(worker != null, "setWorker should be called before reportUpdate");
     checkState(!finalStateSent, "cannot reportUpdates after sending a final state");
@@ -188,11 +208,34 @@ public class WorkItemStatusClient {
       return null;
     }
 
-    WorkItemStatus status = createStatusUpdate(false);
+    WorkItemStatus status = createStatusUpdate(false, includeCounters);
     status.setRequestedLeaseDuration(TimeUtil.toCloudDuration(requestedLeaseDuration));
     populateProgress(status);
     populateSplitResult(status, dynamicSplitResult);
 
+    return execute(status);
+  }
+
+  /**
+   * Sends a lightweight lease renewal heartbeat without counter extraction or progress sampling.
+   *
+   * <p>This can be used during bundle finalization, teardown, or when the worker is otherwise busy,
+   * to keep the lease active on the Dataflow service without incurring serialization overhead.
+   */
+  public @Nullable WorkItemServiceState reportLeasePing(Duration requestedLeaseDuration)
+      throws Exception {
+    checkState(worker != null, "setWorker should be called before reportLeasePing");
+    if (finalStateSent) {
+      return null;
+    }
+    checkArgument(requestedLeaseDuration != null, "requestLeaseDuration must be non-null");
+    if (wasAskedToAbort) {
+      LOG.info("Service already asked to abort work item, not reporting ignored progress.");
+      return null;
+    }
+
+    WorkItemStatus status = createStatusUpdate(false, false);
+    status.setRequestedLeaseDuration(TimeUtil.toCloudDuration(requestedLeaseDuration));
     return execute(status);
   }
 
@@ -218,6 +261,15 @@ public class WorkItemStatusClient {
 
   private synchronized @Nullable WorkItemServiceState execute(WorkItemStatus status)
       throws IOException {
+    if (finalStateSent && !Boolean.TRUE.equals(status.getCompleted())) {
+      LOG.info(
+          "Final state already sent for work item {}, skipping non-final status update.",
+          uniqueWorkId());
+      return null;
+    }
+    status.setReportIndex(
+        checkNotNull(nextReportIndex, "nextReportIndex should be non-null when sending an update"));
+
     WorkItemServiceState result = workUnitClient.reportWorkItemStatus(status);
     if (result != null) {
       if (result.getCompleteWorkStatus() != null
@@ -227,13 +279,13 @@ public class WorkItemStatusClient {
         return result;
       }
       nextReportIndex = result.getNextReportIndex();
-      if (nextReportIndex == null && !status.getCompleted()) {
+      if (nextReportIndex == null && !Boolean.TRUE.equals(status.getCompleted())) {
         LOG.error("Missing next work index in {} when reporting {}.", result, status);
       }
       commitMetrics();
     }
 
-    if (status.getCompleted()) {
+    if (Boolean.TRUE.equals(status.getCompleted())) {
       checkState(!finalStateSent, "cannot reportUpdates after sending a final state");
       finalStateSent = true;
     }
@@ -242,8 +294,7 @@ public class WorkItemStatusClient {
   }
 
   @VisibleForTesting
-  synchronized void populateSplitResult(
-      WorkItemStatus status, DynamicSplitResult dynamicSplitResult) {
+  void populateSplitResult(WorkItemStatus status, DynamicSplitResult dynamicSplitResult) {
     if (dynamicSplitResult instanceof NativeReader.DynamicSplitResultWithPosition) {
       NativeReader.DynamicSplitResultWithPosition asPosition =
           (NativeReader.DynamicSplitResultWithPosition) dynamicSplitResult;
@@ -260,7 +311,7 @@ public class WorkItemStatusClient {
   }
 
   @VisibleForTesting
-  synchronized void populateProgress(WorkItemStatus status) throws Exception {
+  void populateProgress(WorkItemStatus status) throws Exception {
     Progress progress = worker.getWorkerProgress();
     if (progress != null) {
       status.setReportedProgress(SourceTranslationUtils.readerProgressToCloudProgress(progress));
@@ -268,7 +319,7 @@ public class WorkItemStatusClient {
   }
 
   @VisibleForTesting
-  synchronized void populateMetricUpdates(WorkItemStatus status) {
+  void populateMetricUpdates(WorkItemStatus status) {
     List<MetricUpdate> updates = new ArrayList<>();
     if (executionContext != null && executionContext.getExecutionStateTracker() != null) {
       ExecutionStateTracker tracker = executionContext.getExecutionStateTracker();
@@ -291,14 +342,16 @@ public class WorkItemStatusClient {
     status.setMetricUpdates(updates);
   }
 
-  private synchronized WorkItemStatus createStatusUpdate(boolean isFinal) {
+  private WorkItemStatus createStatusUpdate(boolean isFinal) {
+    return createStatusUpdate(isFinal, true);
+  }
+
+  private WorkItemStatus createStatusUpdate(boolean isFinal, boolean includeCounters) {
     WorkItemStatus status = new WorkItemStatus();
     status.setWorkItemId(Long.toString(workItem.getId()));
     status.setCompleted(isFinal);
-    status.setReportIndex(
-        checkNotNull(nextReportIndex, "nextReportIndex should be non-null when sending an update"));
 
-    if (worker != null) {
+    if (worker != null && includeCounters) {
       populateMetricUpdates(status);
       populateCounterUpdates(status);
     }
@@ -309,7 +362,7 @@ public class WorkItemStatusClient {
   }
 
   @VisibleForTesting
-  synchronized void populateCounterUpdates(WorkItemStatus status) {
+  void populateCounterUpdates(WorkItemStatus status) {
     if (worker == null) {
       return;
     }
@@ -345,7 +398,7 @@ public class WorkItemStatusClient {
     status.setCounterUpdates(ImmutableList.copyOf(counterUpdatesMap.values()));
   }
 
-  private synchronized Iterable<CounterUpdate> extractCounters(@Nullable CounterSet counters) {
+  private Iterable<CounterUpdate> extractCounters(@Nullable CounterSet counters) {
     if (counters == null) {
       return Collections.emptyList();
     }
@@ -361,14 +414,16 @@ public class WorkItemStatusClient {
   }
 
   /**
-   * This and {@link #commitMetrics} need to be synchronized since we should not call {@link
-   * MetricsContainerImpl#getUpdates} on any object within an operation while also calling {@link
-   * MetricsContainerImpl#commitUpdates}.
+   * This and {@link #commitMetrics} synchronize on {@link #metricsLock} since we should not call
+   * {@link MetricsContainerImpl#getUpdates} on any object within an operation while also calling
+   * {@link MetricsContainerImpl#commitUpdates}.
    */
-  private synchronized Iterable<CounterUpdate> extractMetrics(boolean isFinalUpdate) {
-    return executionContext == null
-        ? Collections.emptyList()
-        : executionContext.extractMetricUpdates(isFinalUpdate);
+  private Iterable<CounterUpdate> extractMetrics(boolean isFinalUpdate) {
+    synchronized (metricsLock) {
+      return executionContext == null
+          ? Collections.emptyList()
+          : executionContext.extractMetricUpdates(isFinalUpdate);
+    }
   }
 
   public Iterable<CounterUpdate> extractMsecCounters(boolean isFinalUpdate) {
@@ -382,17 +437,19 @@ public class WorkItemStatusClient {
   }
 
   /**
-   * This and {@link #extractMetrics} need to be synchronized since we should not call {@link
-   * MetricsContainerImpl#getUpdates} on any object within an operation while also calling {@link
-   * MetricsContainerImpl#commitUpdates}.
+   * This and {@link #extractMetrics} synchronize on {@link #metricsLock} since we should not call
+   * {@link MetricsContainerImpl#getUpdates} on any object within an operation while also calling
+   * {@link MetricsContainerImpl#commitUpdates}.
    */
   @VisibleForTesting
-  synchronized void commitMetrics() {
-    if (executionContext == null) {
-      return;
-    }
+  void commitMetrics() {
+    synchronized (metricsLock) {
+      if (executionContext == null) {
+        return;
+      }
 
-    executionContext.commitMetricUpdates();
+      executionContext.commitMetricUpdates();
+    }
   }
 
   public BatchModeExecutionContext getExecutionContext() {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkItemStatusClient.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkItemStatusClient.java
@@ -81,9 +81,6 @@ public class WorkItemStatusClient {
 
   private @Nullable BatchModeExecutionContext executionContext;
 
-  /** Lock guarding metric and counter extraction and commit. */
-  private final Object metricsLock = new Object();
-
   /** Returns whether a final completion status (success or error) has already been sent. */
   public boolean isFinalStateSent() {
     return finalStateSent;
@@ -162,7 +159,7 @@ public class WorkItemStatusClient {
   }
 
   /** Return the {@link WorkItemServiceState} resulting from sending a success completion status. */
-  public @Nullable WorkItemServiceState reportSuccess() throws IOException {
+  public synchronized @Nullable WorkItemServiceState reportSuccess() throws IOException {
     checkState(!finalStateSent, "cannot reportSuccess after sending a final state");
     checkState(worker != null, "setWorker should be called before reportSuccess");
     if (wasAskedToAbort) {
@@ -187,7 +184,7 @@ public class WorkItemStatusClient {
   }
 
   /** Return the {@link WorkItemServiceState} resulting from sending a progress update. */
-  public @Nullable WorkItemServiceState reportUpdate(
+  public synchronized @Nullable WorkItemServiceState reportUpdate(
       @Nullable DynamicSplitResult dynamicSplitResult, Duration requestedLeaseDuration)
       throws Exception {
     return reportUpdate(dynamicSplitResult, requestedLeaseDuration, true);
@@ -197,14 +194,18 @@ public class WorkItemStatusClient {
    * Return the {@link WorkItemServiceState} resulting from sending a progress update, optionally
    * including counters and metrics.
    */
-  public @Nullable WorkItemServiceState reportUpdate(
+  public synchronized @Nullable WorkItemServiceState reportUpdate(
       @Nullable DynamicSplitResult dynamicSplitResult,
       Duration requestedLeaseDuration,
       boolean includeCounters)
       throws Exception {
     checkState(worker != null, "setWorker should be called before reportUpdate");
-    checkState(!finalStateSent, "cannot reportUpdates after sending a final state");
     checkArgument(requestedLeaseDuration != null, "requestLeaseDuration must be non-null");
+    if (finalStateSent) {
+      LOG.debug(
+          "Final state already sent for work item {}, skipping progress update.", uniqueWorkId());
+      return null;
+    }
     if (wasAskedToAbort) {
       LOG.info("Service already asked to abort work item, not reporting ignored progress.");
       return null;
@@ -224,13 +225,14 @@ public class WorkItemStatusClient {
    * <p>This can be used during bundle finalization, teardown, or when the worker is otherwise busy,
    * to keep the lease active on the Dataflow service without incurring serialization overhead.
    */
-  public @Nullable WorkItemServiceState reportLeasePing(Duration requestedLeaseDuration)
-      throws Exception {
+  public synchronized @Nullable WorkItemServiceState reportLeasePing(
+      Duration requestedLeaseDuration) throws Exception {
     checkStateNotNull(worker, "setWorker should be called before reportLeasePing");
+    checkArgumentNotNull(requestedLeaseDuration, "requestLeaseDuration must be non-null");
     if (finalStateSent) {
+      LOG.debug("Final state already sent for work item {}, skipping lease ping.", uniqueWorkId());
       return null;
     }
-    checkArgumentNotNull(requestedLeaseDuration, "requestLeaseDuration must be non-null");
     if (wasAskedToAbort) {
       LOG.info("Service already asked to abort work item, not reporting ignored progress.");
       return null;
@@ -264,7 +266,7 @@ public class WorkItemStatusClient {
   private synchronized @Nullable WorkItemServiceState execute(WorkItemStatus status)
       throws IOException {
     if (finalStateSent && !status.getCompleted()) {
-      LOG.info(
+      LOG.debug(
           "Final state already sent for work item {}, skipping non-final status update.",
           uniqueWorkId());
       return null;
@@ -284,7 +286,9 @@ public class WorkItemStatusClient {
       if (nextReportIndex == null && !status.getCompleted()) {
         LOG.error("Missing next work index in {} when reporting {}.", result, status);
       }
-      commitMetrics();
+      if (status.getMetricUpdates() != null || status.getCounterUpdates() != null) {
+        commitMetrics();
+      }
     }
 
     if (status.getCompleted()) {
@@ -296,7 +300,8 @@ public class WorkItemStatusClient {
   }
 
   @VisibleForTesting
-  void populateSplitResult(WorkItemStatus status, DynamicSplitResult dynamicSplitResult) {
+  synchronized void populateSplitResult(
+      WorkItemStatus status, DynamicSplitResult dynamicSplitResult) {
     if (dynamicSplitResult instanceof NativeReader.DynamicSplitResultWithPosition) {
       NativeReader.DynamicSplitResultWithPosition asPosition =
           (NativeReader.DynamicSplitResultWithPosition) dynamicSplitResult;
@@ -313,7 +318,7 @@ public class WorkItemStatusClient {
   }
 
   @VisibleForTesting
-  void populateProgress(WorkItemStatus status) throws Exception {
+  synchronized void populateProgress(WorkItemStatus status) throws Exception {
     Progress progress = worker.getWorkerProgress();
     if (progress != null) {
       status.setReportedProgress(SourceTranslationUtils.readerProgressToCloudProgress(progress));
@@ -321,7 +326,7 @@ public class WorkItemStatusClient {
   }
 
   @VisibleForTesting
-  void populateMetricUpdates(WorkItemStatus status) {
+  synchronized void populateMetricUpdates(WorkItemStatus status) {
     List<MetricUpdate> updates = new ArrayList<>();
     if (executionContext != null && executionContext.getExecutionStateTracker() != null) {
       ExecutionStateTracker tracker = executionContext.getExecutionStateTracker();
@@ -344,11 +349,11 @@ public class WorkItemStatusClient {
     status.setMetricUpdates(updates);
   }
 
-  private WorkItemStatus createStatusUpdate(boolean isFinal) {
+  private synchronized WorkItemStatus createStatusUpdate(boolean isFinal) {
     return createStatusUpdate(isFinal, true);
   }
 
-  private WorkItemStatus createStatusUpdate(boolean isFinal, boolean includeCounters) {
+  private synchronized WorkItemStatus createStatusUpdate(boolean isFinal, boolean includeCounters) {
     WorkItemStatus status = new WorkItemStatus();
     status.setWorkItemId(Long.toString(workItem.getId()));
     status.setCompleted(isFinal);
@@ -364,7 +369,7 @@ public class WorkItemStatusClient {
   }
 
   @VisibleForTesting
-  void populateCounterUpdates(WorkItemStatus status) {
+  synchronized void populateCounterUpdates(WorkItemStatus status) {
     if (worker == null) {
       return;
     }
@@ -400,7 +405,7 @@ public class WorkItemStatusClient {
     status.setCounterUpdates(ImmutableList.copyOf(counterUpdatesMap.values()));
   }
 
-  private Iterable<CounterUpdate> extractCounters(@Nullable CounterSet counters) {
+  private synchronized Iterable<CounterUpdate> extractCounters(@Nullable CounterSet counters) {
     if (counters == null) {
       return Collections.emptyList();
     }
@@ -416,16 +421,14 @@ public class WorkItemStatusClient {
   }
 
   /**
-   * This and {@link #commitMetrics} synchronize on {@link #metricsLock} since we should not call
-   * {@link MetricsContainerImpl#getUpdates} on any object within an operation while also calling
-   * {@link MetricsContainerImpl#commitUpdates}.
+   * This and {@link #commitMetrics} need to be synchronized since we should not call {@link
+   * MetricsContainerImpl#getUpdates} on any object within an operation while also calling {@link
+   * MetricsContainerImpl#commitUpdates}.
    */
-  private Iterable<CounterUpdate> extractMetrics(boolean isFinalUpdate) {
-    synchronized (metricsLock) {
-      return executionContext == null
-          ? Collections.emptyList()
-          : executionContext.extractMetricUpdates(isFinalUpdate);
-    }
+  private synchronized Iterable<CounterUpdate> extractMetrics(boolean isFinalUpdate) {
+    return executionContext == null
+        ? Collections.emptyList()
+        : executionContext.extractMetricUpdates(isFinalUpdate);
   }
 
   public Iterable<CounterUpdate> extractMsecCounters(boolean isFinalUpdate) {
@@ -439,19 +442,17 @@ public class WorkItemStatusClient {
   }
 
   /**
-   * This and {@link #extractMetrics} synchronize on {@link #metricsLock} since we should not call
-   * {@link MetricsContainerImpl#getUpdates} on any object within an operation while also calling
-   * {@link MetricsContainerImpl#commitUpdates}.
+   * This and {@link #extractMetrics} need to be synchronized since we should not call {@link
+   * MetricsContainerImpl#getUpdates} on any object within an operation while also calling {@link
+   * MetricsContainerImpl#commitUpdates}.
    */
   @VisibleForTesting
-  void commitMetrics() {
-    synchronized (metricsLock) {
-      if (executionContext == null) {
-        return;
-      }
-
-      executionContext.commitMetricUpdates();
+  synchronized void commitMetrics() {
+    if (executionContext == null) {
+      return;
     }
+
+    executionContext.commitMetricUpdates();
   }
 
   public BatchModeExecutionContext getExecutionContext() {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/WorkProgressUpdater.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/WorkProgressUpdater.java
@@ -82,7 +82,7 @@ public abstract class WorkProgressUpdater {
   private long nextPeriodicCheckpointTimeMs;
 
   /** Executor used to schedule work progress updates. */
-  private final ScheduledExecutorService executor;
+  protected final ScheduledExecutorService executor;
 
   /** Clock used to either provide real system time or mocked to virtualize time for testing. */
   protected final Clock clock;

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/WorkProgressUpdater.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/WorkProgressUpdater.java
@@ -185,6 +185,27 @@ public abstract class WorkProgressUpdater {
   }
 
   /**
+   * Reports any pending dynamic split if one has not yet been reported.
+   *
+   * <p>This should be invoked when the worker finishes processing elements, before reporting final
+   * success, so that any dynamic split is sent to the backend while progress reporting is still
+   * active.
+   *
+   * @throws Exception if reporting the dynamic split fails
+   */
+  public void reportUnreportedSplit() throws Exception {
+    synchronized (executor) {
+      if (dynamicSplitResultToReport != null) {
+        LOG.debug(
+            "Sending progress update with unreported split: {} for work item: {}",
+            dynamicSplitResultToReport,
+            workString());
+        reportProgressHelper();
+      }
+    }
+  }
+
+  /**
    * Stops sending work progress updates to the worker service. It may throw an exception if the
    * final progress report fails to be sent for some reason.
    */
@@ -196,7 +217,7 @@ public abstract class WorkProgressUpdater {
       // We send a final progress report in case there was an unreported dynamic split.
       if (dynamicSplitResultToReport != null) {
         LOG.debug(
-            "Sending final progress update with unreported split: {} " + "for work item: {}",
+            "Sending final progress update with unreported split: {} for work item: {}",
             dynamicSplitResultToReport,
             workString());
         reportProgressHelper(); // This call can fail with an exception

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/WorkProgressUpdater.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/WorkProgressUpdater.java
@@ -82,7 +82,7 @@ public abstract class WorkProgressUpdater {
   private long nextPeriodicCheckpointTimeMs;
 
   /** Executor used to schedule work progress updates. */
-  protected final ScheduledExecutorService executor;
+  private final ScheduledExecutorService executor;
 
   /** Clock used to either provide real system time or mocked to virtualize time for testing. */
   protected final Clock clock;

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/BatchDataflowWorkerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/BatchDataflowWorkerTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -54,6 +55,7 @@ import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.hamcrest.MockitoHamcrest;
@@ -166,6 +168,65 @@ public class BatchDataflowWorkerTest {
     SourceSplitResponse splitResponse = new SourceSplitResponse();
     splitResponse.setShards(ImmutableList.of(new SourceSplitShard(), new SourceSplitShard()));
     assertThat(DataflowApiUtils.computeSerializedSizeBytes(splitResponse), greaterThan(0L));
+  }
+
+  @Test
+  public void testExecuteWorkKeepsProgressUpdaterActiveUntilReportSuccess() throws Exception {
+    BatchDataflowWorker worker =
+        new BatchDataflowWorker(
+            mockWorkUnitClient, IntrinsicMapTaskExecutorFactory.defaultFactory(), options);
+    WorkItemStatusClient mockStatusClient = mock(WorkItemStatusClient.class);
+
+    worker.executeWork(mockWorkExecutor, mockProgressUpdater, mockStatusClient);
+
+    InOrder inOrder = inOrder(mockProgressUpdater, mockWorkExecutor, mockStatusClient);
+    inOrder.verify(mockProgressUpdater).startReportingProgress();
+    inOrder.verify(mockWorkExecutor).execute();
+    inOrder.verify(mockProgressUpdater).reportUnreportedSplit();
+    inOrder.verify(mockStatusClient).reportSuccess();
+    inOrder.verify(mockProgressUpdater).stopReportingProgress();
+  }
+
+  @Test
+  public void testExecuteWorkStopsProgressUpdaterWhenWorkerFails() throws Exception {
+    doThrow(new WorkerException()).when(mockWorkExecutor).execute();
+    BatchDataflowWorker worker =
+        new BatchDataflowWorker(
+            mockWorkUnitClient, IntrinsicMapTaskExecutorFactory.defaultFactory(), options);
+    WorkItemStatusClient mockStatusClient = mock(WorkItemStatusClient.class);
+
+    try {
+      worker.executeWork(mockWorkExecutor, mockProgressUpdater, mockStatusClient);
+    } catch (WorkerException e) {
+      /* Expected - ignore. */
+    }
+
+    verify(mockProgressUpdater, times(1)).startReportingProgress();
+    verify(mockWorkExecutor, times(1)).execute();
+    verify(mockProgressUpdater, times(0)).reportUnreportedSplit();
+    verify(mockStatusClient, times(0)).reportSuccess();
+    verify(mockProgressUpdater, times(1)).stopReportingProgress();
+  }
+
+  @Test
+  public void testExecuteWorkStopsProgressUpdaterWhenReportSuccessFails() throws Exception {
+    WorkItemStatusClient mockStatusClient = mock(WorkItemStatusClient.class);
+    doThrow(new IOException("RPC failure")).when(mockStatusClient).reportSuccess();
+    BatchDataflowWorker worker =
+        new BatchDataflowWorker(
+            mockWorkUnitClient, IntrinsicMapTaskExecutorFactory.defaultFactory(), options);
+
+    try {
+      worker.executeWork(mockWorkExecutor, mockProgressUpdater, mockStatusClient);
+    } catch (IOException e) {
+      /* Expected - ignore. */
+    }
+
+    verify(mockProgressUpdater, times(1)).startReportingProgress();
+    verify(mockWorkExecutor, times(1)).execute();
+    verify(mockProgressUpdater, times(1)).reportUnreportedSplit();
+    verify(mockStatusClient, times(1)).reportSuccess();
+    verify(mockProgressUpdater, times(1)).stopReportingProgress();
   }
 
   private static class WorkerException extends Exception {}

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/BatchDataflowWorkerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/BatchDataflowWorkerTest.java
@@ -171,13 +171,14 @@ public class BatchDataflowWorkerTest {
   }
 
   @Test
-  public void testExecuteWorkKeepsProgressUpdaterActiveUntilReportSuccess() throws Exception {
+  public void testExecuteWorkAndReportSuccessKeepsProgressUpdaterActiveUntilReportSuccess()
+      throws Exception {
     BatchDataflowWorker worker =
         new BatchDataflowWorker(
             mockWorkUnitClient, IntrinsicMapTaskExecutorFactory.defaultFactory(), options);
     WorkItemStatusClient mockStatusClient = mock(WorkItemStatusClient.class);
 
-    worker.executeWork(mockWorkExecutor, mockProgressUpdater, mockStatusClient);
+    worker.executeWorkAndReportSuccess(mockWorkExecutor, mockProgressUpdater, mockStatusClient);
 
     InOrder inOrder = inOrder(mockProgressUpdater, mockWorkExecutor, mockStatusClient);
     inOrder.verify(mockProgressUpdater).startReportingProgress();
@@ -188,7 +189,8 @@ public class BatchDataflowWorkerTest {
   }
 
   @Test
-  public void testExecuteWorkStopsProgressUpdaterWhenWorkerFails() throws Exception {
+  public void testExecuteWorkAndReportSuccessStopsProgressUpdaterWhenWorkerFails()
+      throws Exception {
     doThrow(new WorkerException()).when(mockWorkExecutor).execute();
     BatchDataflowWorker worker =
         new BatchDataflowWorker(
@@ -196,7 +198,7 @@ public class BatchDataflowWorkerTest {
     WorkItemStatusClient mockStatusClient = mock(WorkItemStatusClient.class);
 
     try {
-      worker.executeWork(mockWorkExecutor, mockProgressUpdater, mockStatusClient);
+      worker.executeWorkAndReportSuccess(mockWorkExecutor, mockProgressUpdater, mockStatusClient);
     } catch (WorkerException e) {
       /* Expected - ignore. */
     }
@@ -209,7 +211,8 @@ public class BatchDataflowWorkerTest {
   }
 
   @Test
-  public void testExecuteWorkStopsProgressUpdaterWhenReportSuccessFails() throws Exception {
+  public void testExecuteWorkAndReportSuccessStopsProgressUpdaterWhenReportSuccessFails()
+      throws Exception {
     WorkItemStatusClient mockStatusClient = mock(WorkItemStatusClient.class);
     doThrow(new IOException("RPC failure")).when(mockStatusClient).reportSuccess();
     BatchDataflowWorker worker =
@@ -217,7 +220,7 @@ public class BatchDataflowWorkerTest {
             mockWorkUnitClient, IntrinsicMapTaskExecutorFactory.defaultFactory(), options);
 
     try {
-      worker.executeWork(mockWorkExecutor, mockProgressUpdater, mockStatusClient);
+      worker.executeWorkAndReportSuccess(mockWorkExecutor, mockProgressUpdater, mockStatusClient);
     } catch (IOException e) {
       /* Expected - ignore. */
     }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/BatchDataflowWorkerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/BatchDataflowWorkerTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -184,6 +185,7 @@ public class BatchDataflowWorkerTest {
     inOrder.verify(mockProgressUpdater).startReportingProgress();
     inOrder.verify(mockWorkExecutor).execute();
     inOrder.verify(mockProgressUpdater).reportUnreportedSplit();
+    inOrder.verify(mockProgressUpdater).setLeaseRenewalOnly(true);
     inOrder.verify(mockStatusClient).reportSuccess();
     inOrder.verify(mockProgressUpdater).stopReportingProgress();
   }
@@ -206,6 +208,7 @@ public class BatchDataflowWorkerTest {
     verify(mockProgressUpdater, times(1)).startReportingProgress();
     verify(mockWorkExecutor, times(1)).execute();
     verify(mockProgressUpdater, times(0)).reportUnreportedSplit();
+    verify(mockProgressUpdater, times(0)).setLeaseRenewalOnly(anyBoolean());
     verify(mockStatusClient, times(0)).reportSuccess();
     verify(mockProgressUpdater, times(1)).stopReportingProgress();
   }
@@ -228,6 +231,7 @@ public class BatchDataflowWorkerTest {
     verify(mockProgressUpdater, times(1)).startReportingProgress();
     verify(mockWorkExecutor, times(1)).execute();
     verify(mockProgressUpdater, times(1)).reportUnreportedSplit();
+    verify(mockProgressUpdater, times(1)).setLeaseRenewalOnly(true);
     verify(mockStatusClient, times(1)).reportSuccess();
     verify(mockProgressUpdater, times(1)).stopReportingProgress();
   }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/DataflowWorkProgressUpdaterTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/DataflowWorkProgressUpdaterTest.java
@@ -291,6 +291,7 @@ public class DataflowWorkProgressUpdaterTest {
     // And nothing happened after that.
     verify(workItemStatusClient, Mockito.atLeastOnce()).uniqueWorkId();
     verify(workItemStatusClient, Mockito.atLeastOnce()).getExecutionContext();
+    verify(workItemStatusClient, Mockito.atLeastOnce()).isFinalStateSent();
     verifyNoMoreInteractions(workItemStatusClient);
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/DataflowWorkProgressUpdaterTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/DataflowWorkProgressUpdaterTest.java
@@ -23,9 +23,12 @@ import static org.apache.beam.runners.dataflow.worker.SourceTranslationUtils.clo
 import static org.apache.beam.runners.dataflow.worker.SourceTranslationUtils.cloudProgressToReaderProgress;
 import static org.apache.beam.runners.dataflow.worker.SourceTranslationUtils.toDynamicSplitRequest;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -293,6 +296,20 @@ public class DataflowWorkProgressUpdaterTest {
     verify(workItemStatusClient, Mockito.atLeastOnce()).getExecutionContext();
     verify(workItemStatusClient, Mockito.atLeastOnce()).isFinalStateSent();
     verifyNoMoreInteractions(workItemStatusClient);
+  }
+
+  @Test
+  public void workProgressUpdaterSendsLeasePingWhenLeaseRenewalOnly() throws Exception {
+    when(workItemStatusClient.reportLeasePing(isA(Duration.class)))
+        .thenReturn(generateServiceState(null, 1000));
+    progressUpdater.startReportingProgress();
+    progressUpdater.setLeaseRenewalOnly(true);
+    assertTrue(progressUpdater.isLeaseRenewalOnly());
+
+    executor.runNextRunnable();
+    verify(workItemStatusClient).reportLeasePing(isA(Duration.class));
+    verify(workItemStatusClient, never()).reportUpdate(any(), any());
+    progressUpdater.stopReportingProgress();
   }
 
   private WorkItemServiceState generateServiceState(

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/LeaseRenewalRaceTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/LeaseRenewalRaceTest.java
@@ -120,9 +120,8 @@ public class LeaseRenewalRaceTest {
    * An in-flight update cannot have its drained metrics dropped by a racing completion.
    */
   @Test
-  public void drainedMetricUpdatesAreLostWhenProgressUpdateRacesReportSuccess() throws Exception {
+  public void drainedMetricUpdatesSurviveConcurrentReportSuccess() throws Exception {
     CountDownLatch drained = new CountDownLatch(1);
-    CountDownLatch finalSent = new CountDownLatch(1);
     AtomicReference<Throwable> progressFailure = new AtomicReference<>();
     List<CounterUpdate> pending = new ArrayList<>();
     pending.add(namedCounter("user-metric", 1L));
@@ -135,7 +134,6 @@ public class LeaseRenewalRaceTest {
                 pending.clear();
                 if (!copy.isEmpty()) {
                   drained.countDown();
-                  finalSent.await(1, TimeUnit.SECONDS);
                 }
                 return copy;
               }
@@ -158,7 +156,6 @@ public class LeaseRenewalRaceTest {
     assertTrue("progress thread should have drained", drained.await(5, TimeUnit.SECONDS));
 
     statusClient.reportSuccess();
-    finalSent.countDown();
     progressThread.join(5000);
 
     boolean anyStatusCarriesTheMetric =

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/LeaseRenewalRaceTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/LeaseRenewalRaceTest.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.api.services.dataflow.model.CounterUpdate;
+import com.google.api.services.dataflow.model.NameAndKind;
+import com.google.api.services.dataflow.model.SplitInt64;
+import com.google.api.services.dataflow.model.WorkItem;
+import com.google.api.services.dataflow.model.WorkItemServiceState;
+import com.google.api.services.dataflow.model.WorkItemStatus;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.joda.time.Duration;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Multi-threaded concurrency tests verifying race conditions and invariants between progress
+ * reporting, lightweight lease renewal, and final completion in {@link WorkItemStatusClient}.
+ */
+@RunWith(JUnit4.class)
+public class LeaseRenewalRaceTest {
+
+  private static final Duration LEASE = Duration.standardSeconds(10L);
+
+  private WorkUnitClient workUnitClient;
+  private DataflowWorkExecutor worker;
+  private BatchModeExecutionContext executionContext;
+  private WorkItemStatusClient statusClient;
+  private List<WorkItemStatus> sent;
+
+  @Before
+  public void setUp() throws Exception {
+    workUnitClient = mock(WorkUnitClient.class);
+    worker = mock(DataflowWorkExecutor.class);
+    DataflowPipelineOptions options = PipelineOptionsFactory.as(DataflowPipelineOptions.class);
+    executionContext = BatchModeExecutionContext.forTesting(options, "testStage");
+
+    WorkItem workItem =
+        new WorkItem().setProjectId("p").setJobId("j").setId(1L).setInitialReportIndex(5L);
+
+    statusClient = new WorkItemStatusClient(workUnitClient, workItem);
+    sent = new ArrayList<>();
+
+    when(workUnitClient.reportWorkItemStatus(any(WorkItemStatus.class)))
+        .thenAnswer(
+            invocation -> {
+              WorkItemStatus status = invocation.getArgument(0);
+              sent.add(status);
+              return new WorkItemServiceState().setNextReportIndex(status.getReportIndex() + 1);
+            });
+  }
+
+  private static CounterUpdate namedCounter(String name, long value) {
+    return new CounterUpdate()
+        .setNameAndKind(new NameAndKind().setName(name).setKind("SUM"))
+        .setInteger(new SplitInt64().setLowBits(value));
+  }
+
+  /**
+   * Verifies that when a progress update is called after or racing with {@code reportSuccess()}, it
+   * takes the graceful skip path and returns {@code null} instead of throwing {@link
+   * IllegalStateException}.
+   */
+  @Test
+  public void inFlightProgressUpdateThrowsAfterFinalState() throws Exception {
+    when(worker.extractMetricUpdates()).thenReturn(Collections.emptyList());
+    statusClient.setWorker(worker, executionContext);
+    statusClient.reportSuccess();
+    assertTrue(statusClient.isFinalStateSent());
+
+    WorkItemServiceState state = null;
+    Throwable thrown = null;
+    try {
+      state = statusClient.reportUpdate(null, LEASE);
+    } catch (Throwable t) {
+      thrown = t;
+    }
+
+    assertNull("reportUpdate should take the graceful skip path, not throw", thrown);
+    assertNull("reportUpdate should return null after final state", state);
+  }
+
+  /**
+   * Verifies that metric updates extracted by a concurrent progress update thread are never
+   * silently discarded when racing with {@code reportSuccess()}.
+   *
+   * <p>Because {@code reportUpdate()} and {@code reportSuccess()} synchronize on {@link
+   * WorkItemStatusClient}, metric extraction, status RPC execution, and metric commits are atomic.
+   * An in-flight update cannot have its drained metrics dropped by a racing completion.
+   */
+  @Test
+  public void drainedMetricUpdatesAreLostWhenProgressUpdateRacesReportSuccess() throws Exception {
+    CountDownLatch drained = new CountDownLatch(1);
+    CountDownLatch finalSent = new CountDownLatch(1);
+    AtomicReference<Throwable> progressFailure = new AtomicReference<>();
+    List<CounterUpdate> pending = new ArrayList<>();
+    pending.add(namedCounter("user-metric", 1L));
+
+    when(worker.extractMetricUpdates())
+        .thenAnswer(
+            invocation -> {
+              synchronized (pending) {
+                List<CounterUpdate> copy = new ArrayList<>(pending);
+                pending.clear();
+                if (!copy.isEmpty()) {
+                  drained.countDown();
+                  finalSent.await(1, TimeUnit.SECONDS);
+                }
+                return copy;
+              }
+            });
+
+    statusClient.setWorker(worker, executionContext);
+
+    Thread progressThread =
+        new Thread(
+            () -> {
+              try {
+                statusClient.reportUpdate(null, LEASE);
+              } catch (Throwable t) {
+                progressFailure.set(t);
+              }
+            },
+            "progress-updater");
+    progressThread.start();
+
+    assertTrue("progress thread should have drained", drained.await(5, TimeUnit.SECONDS));
+
+    statusClient.reportSuccess();
+    finalSent.countDown();
+    progressThread.join(5000);
+
+    boolean anyStatusCarriesTheMetric =
+        sent.stream()
+            .filter(s -> s.getCounterUpdates() != null)
+            .flatMap(s -> s.getCounterUpdates().stream())
+            .anyMatch(
+                c ->
+                    c.getNameAndKind() != null
+                        && "user-metric".equals(c.getNameAndKind().getName()));
+
+    assertTrue(
+        "drained metric update was silently dropped -- never reached the service",
+        anyStatusCarriesTheMetric);
+  }
+
+  /** Verifies that lightweight lease pings succeed and do not extract or commit metric updates. */
+  @Test
+  public void reportLeasePingDoesNotExtractOrDropMetrics() throws Exception {
+    when(worker.extractMetricUpdates())
+        .thenReturn(Collections.singletonList(namedCounter("pending-metric", 42L)));
+    statusClient.setWorker(worker, executionContext);
+
+    WorkItemServiceState pingState = statusClient.reportLeasePing(LEASE);
+    assertTrue(pingState != null);
+
+    // Verify ping status had no metric or counter updates
+    assertEquals(1, sent.size());
+    WorkItemStatus pingStatus = sent.get(0);
+    assertNull("Lease ping must not include counter updates", pingStatus.getCounterUpdates());
+    assertNull("Lease ping must not include metric updates", pingStatus.getMetricUpdates());
+
+    // Verify pending metrics are still present and sent by reportSuccess
+    statusClient.reportSuccess();
+    assertEquals(2, sent.size());
+    WorkItemStatus successStatus = sent.get(1);
+    boolean successCarriesMetric =
+        successStatus.getCounterUpdates() != null
+            && successStatus.getCounterUpdates().stream()
+                .anyMatch(
+                    c ->
+                        c.getNameAndKind() != null
+                            && "pending-metric".equals(c.getNameAndKind().getName()));
+    assertTrue("reportSuccess must report the pending metric", successCarriesMetric);
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkItemStatusClientTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkItemStatusClientTest.java
@@ -248,9 +248,8 @@ public class WorkItemStatusClientTest {
     statusClient.setWorker(worker, executionContext);
     statusClient.reportSuccess();
 
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("reportUpdate");
-    statusClient.reportUpdate(null, LEASE_DURATION);
+    WorkItemServiceState result = statusClient.reportUpdate(null, LEASE_DURATION);
+    assertThat(result, nullValue());
   }
 
   @Test

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkItemStatusClientTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkItemStatusClientTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.isA;
@@ -53,6 +54,7 @@ import org.apache.beam.runners.core.metrics.ExecutionStateTracker;
 import org.apache.beam.runners.core.metrics.ExecutionStateTracker.ExecutionState;
 import org.apache.beam.runners.core.metrics.MetricsContainerImpl;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
+import org.apache.beam.runners.dataflow.util.TimeUtil;
 import org.apache.beam.runners.dataflow.worker.MetricsToCounterUpdateConverter.Kind;
 import org.apache.beam.runners.dataflow.worker.SourceTranslationUtils.DataflowReaderPosition;
 import org.apache.beam.runners.dataflow.worker.WorkerCustomSources.BoundedSourceSplit;
@@ -523,6 +525,81 @@ public class WorkItemStatusClientTest {
     thrown.expectMessage("setWorker");
     thrown.expectMessage("reportUpdate");
     statusClient.reportUpdate(null, null);
+  }
+
+  @Test
+  public void reportLeasePing() throws Exception {
+    statusClient.setWorker(worker, executionContext);
+    statusClient.reportLeasePing(LEASE_DURATION);
+
+    verify(workUnitClient).reportWorkItemStatus(statusCaptor.capture());
+    WorkItemStatus workStatus = statusCaptor.getValue();
+    assertThat(workStatus.getWorkItemId(), equalTo(Long.toString(WORK_ID)));
+    assertThat(workStatus.getCompleted(), equalTo(false));
+    assertThat(workStatus.getReportIndex(), equalTo(INITIAL_REPORT_INDEX));
+    assertThat(
+        workStatus.getRequestedLeaseDuration(), equalTo(TimeUtil.toCloudDuration(LEASE_DURATION)));
+    assertThat(workStatus.getCounterUpdates(), nullValue());
+    assertThat(workStatus.getMetricUpdates(), nullValue());
+  }
+
+  @Test
+  public void reportLeasePingAfterSuccessReturnsNull() throws Exception {
+    when(worker.extractMetricUpdates()).thenReturn(Collections.emptyList());
+    statusClient.setWorker(worker, executionContext);
+    statusClient.reportSuccess();
+
+    WorkItemServiceState result = statusClient.reportLeasePing(LEASE_DURATION);
+    assertThat(result, nullValue());
+  }
+
+  @Test
+  public void reportUpdateWithoutCounters() throws Exception {
+    when(worker.extractMetricUpdates()).thenReturn(Collections.emptyList());
+    statusClient.setWorker(worker, executionContext);
+
+    statusClient.reportUpdate(null, LEASE_DURATION, false);
+    verify(workUnitClient).reportWorkItemStatus(statusCaptor.capture());
+    WorkItemStatus workStatus = statusCaptor.getValue();
+    assertThat(workStatus.getCompleted(), equalTo(false));
+    assertThat(workStatus.getCounterUpdates(), nullValue());
+    assertThat(workStatus.getMetricUpdates(), nullValue());
+  }
+
+  @Test
+  public void isFinalStateSentStatus() throws Exception {
+    statusClient.setWorker(worker, executionContext);
+    assertThat(statusClient.isFinalStateSent(), equalTo(false));
+
+    when(worker.extractMetricUpdates()).thenReturn(Collections.emptyList());
+    statusClient.reportSuccess();
+    assertThat(statusClient.isFinalStateSent(), equalTo(true));
+  }
+
+  @Test
+  public void reportLeasePingDuringSuccessExecution() throws Exception {
+    when(worker.extractMetricUpdates()).thenReturn(Collections.emptyList());
+    statusClient.setWorker(worker, executionContext);
+
+    when(workUnitClient.reportWorkItemStatus(isA(WorkItemStatus.class)))
+        .thenAnswer(
+            invocation -> {
+              WorkItemStatus status = invocation.getArgument(0);
+              return new WorkItemServiceState().setNextReportIndex(status.getReportIndex() + 1);
+            });
+
+    WorkItemServiceState pingState = statusClient.reportLeasePing(LEASE_DURATION);
+    assertThat(pingState, notNullValue());
+
+    WorkItemServiceState successState = statusClient.reportSuccess();
+    assertThat(successState, notNullValue());
+
+    verify(workUnitClient, times(2)).reportWorkItemStatus(statusCaptor.capture());
+    List<WorkItemStatus> allStatuses = statusCaptor.getAllValues();
+    assertThat(allStatuses.get(0).getCompleted(), equalTo(false));
+    assertThat(allStatuses.get(0).getReportIndex(), equalTo(INITIAL_REPORT_INDEX));
+    assertThat(allStatuses.get(1).getCompleted(), equalTo(true));
+    assertThat(allStatuses.get(1).getReportIndex(), equalTo(INITIAL_REPORT_INDEX + 1));
   }
 
   private static class DummyBoundedSource extends BoundedSource<Integer> {

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkItemStatusClientTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkItemStatusClientTest.java
@@ -528,6 +528,21 @@ public class WorkItemStatusClientTest {
   }
 
   @Test
+  public void reportLeasePingBeforeSetWorker() throws Exception {
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("setWorker should be called before reportLeasePing");
+    statusClient.reportLeasePing(LEASE_DURATION);
+  }
+
+  @Test
+  public void reportLeasePingNullDuration() throws Exception {
+    statusClient.setWorker(worker, executionContext);
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("requestLeaseDuration must be non-null");
+    statusClient.reportLeasePing(null);
+  }
+
+  @Test
   public void reportLeasePing() throws Exception {
     statusClient.setWorker(worker, executionContext);
     statusClient.reportLeasePing(LEASE_DURATION);


### PR DESCRIPTION
BatchDataflowWorker shut down WorkProgressUpdater in the finally block of executeWork() before calling workItemStatusClient.reportSuccess(). If the worker thread was delayed in closing connections, flushing shuffle state, or serializing counters and metrics, no lease renewals could be sent, allowing the 180s work item lease to expire on the Dataflow service.

Furthermore, reportSuccess() and reportUpdate() in WorkItemStatusClient both synchronized on the same monitor lock, blocking any concurrent lease renewals while the worker thread was assembling final metrics.

To fix this:
1. Extend progress reporting in BatchDataflowWorker so progressUpdater stays active until reportSuccess() completes, while reporting any unreported dynamic split before success.
2. Decouple monitor locking in WorkItemStatusClient so counter and metric extraction run outside the RPC lock, using a dedicated metricsLock to serialize metric extraction and commits.
3. Support lightweight lease renewal pings without heavyweight metric serialization to keep leases alive under high CPU/memory utilization.
4. Gracefully handle in-flight non-final status updates in execute() if a final completion state was already sent.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
