### PR TITLE
Fix Bigtable Tests for google-cloud-bigtable >= 2.44.0

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigtableio.py
+++ b/sdks/python/apache_beam/io/gcp/bigtableio.py
@@ -283,7 +283,13 @@ class WriteToBigTable(beam.PTransform):
     def process(self, direct_row):
       args = {"key": direct_row.row_key, "mutations": []}
       # start accumulating mutations in a list
-      for mutation in direct_row._get_mutations():
+      # In google-cloud-bigtable >= 2.44.0, _get_mutations() returns Python
+      # dataclass objects (RowMutationEntry) instead of protobuf messages.
+      # Use _get_mutation_pbs() to retrieve Mutation protobuf objects.
+      mutations = (
+          direct_row._get_mutation_pbs() if hasattr(
+              direct_row, '_get_mutation_pbs') else direct_row._get_mutations())
+      for mutation in mutations:
         if mutation.__contains__("set_cell"):
           mutation_dict = {
               "type": b'SetCell',

--- a/sdks/python/apache_beam/io/gcp/bigtableio_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigtableio_test.py
@@ -119,6 +119,15 @@ class TestBeamRowToPartialRowData(unittest.TestCase):
 class TestBigtableDirectRowToBeamRow(unittest.TestCase):
   doFn = bigtableio.WriteToBigTable._DirectRowMutationsToBeamRow()
 
+  @staticmethod
+  def _get_mutation_pbs(direct_row):
+    # In google-cloud-bigtable >= 2.44.0, _get_mutations() returns Python
+    # dataclass objects instead of protobuf messages; use _get_mutation_pbs()
+    # to retrieve Mutation protobuf messages.
+    if hasattr(direct_row, '_get_mutation_pbs'):
+      return direct_row._get_mutation_pbs()
+    return direct_row._get_mutations()
+
   def test_set_cell(self):
     # create some set cell mutations
     direct_row: DirectRow = DirectRow('key-1')
@@ -144,7 +153,7 @@ class TestBigtableDirectRowToBeamRow(unittest.TestCase):
     # sort both lists of mutations for convenience
     beam_row_mutations = sorted(beam_row.mutations, key=lambda m: m['value'])
     bt_row_mutations = sorted(
-        direct_row._get_mutations(), key=lambda m: m.set_cell.value)
+        self._get_mutation_pbs(direct_row), key=lambda m: m.set_cell.value)
     self.assertEqual(beam_row.key, direct_row.row_key)
     self.assertEqual(len(beam_row_mutations), len(bt_row_mutations))
 
@@ -186,7 +195,7 @@ class TestBigtableDirectRowToBeamRow(unittest.TestCase):
     beam_row_mutations = sorted(
         beam_row.mutations, key=lambda m: m['column_qualifier'])
     bt_row_mutations = sorted(
-        direct_row._get_mutations(),
+        self._get_mutation_pbs(direct_row),
         key=lambda m: m.delete_from_column.column_qualifier)
     self.assertEqual(beam_row.key, direct_row.row_key)
     self.assertEqual(len(beam_row_mutations), len(bt_row_mutations))
@@ -232,8 +241,8 @@ class TestBigtableDirectRowToBeamRow(unittest.TestCase):
     beam_row_mutations = sorted(
         beam_row.mutations, key=lambda m: m['family_name'])
     bt_row_mutations = sorted(
-        direct_row._get_mutations(),
-        key=lambda m: m.delete_from_column.family_name)
+        self._get_mutation_pbs(direct_row),
+        key=lambda m: m.delete_from_family.family_name)
     self.assertEqual(beam_row.key, direct_row.row_key)
     self.assertEqual(len(beam_row_mutations), len(bt_row_mutations))
 


### PR DESCRIPTION
## Description
Fixes unit test and runtime failures in `apache_beam/io/gcp/bigtableio.py` with `google-cloud-bigtable >= 2.44.0`.
In `google-cloud-bigtable >= 2.44.0`, `DirectRow._get_mutations()` returns Python `RowMutationEntry` dataclass objects (`SetCell`, `DeleteRangeFromColumn`, `DeleteAllFromFamily`, `DeleteAllFromRow`) instead of raw `google.cloud.bigtable_v2.types.data.Mutation` protobuf messages. (https://github.com/googleapis/google-cloud-python/commit/990f86e45df15c594e82d19d6fe482f12d128430#diff-7f9a11d9f6bc7583fcd21212c25030948b23bcd4ba7c93caa0db6f6b7d886c8bR290) 

Because these dataclasses do not implement `__contains__`, checking oneof fields in `_DirectRowMutationsToBeamRow.process` raised `AttributeError: '...' object has no attribute '__contains__'`.

This PR updates `_DirectRowMutationsToBeamRow.process` and `TestBigtableDirectRowToBeamRow` to call `DirectRow._get_mutation_pbs()` when available to retrieve `Mutation` protobuf messages, falling back to `DirectRow._get_mutations()` for older `google-cloud-bigtable` versions.

fixes #34739