### PR TITLE
Remove nullness suppression in TaggedPValue

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/TaggedPValue.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/TaggedPValue.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.values;
 
 import com.google.auto.value.AutoValue;
 import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.sdk.util.Preconditions;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
 
 /**
@@ -33,9 +34,10 @@ public abstract class TaggedPValue {
     return new AutoValue_TaggedPValue(tag, value);
   }
 
-  @SuppressWarnings({"keyfor", "nullness"})
   public static TaggedPValue ofExpandedValue(PCollection<?> value) {
-    return of(Iterables.getOnlyElement(value.expand().keySet()), value);
+    return of(
+        Preconditions.checkArgumentNotNull(Iterables.getOnlyElement(value.expand().keySet())),
+        value);
   }
 
   /** Returns the local tag associated with the {@link PValue}. */


### PR DESCRIPTION
  Progress on #20507 (sub-task of umbrella #20497).
  
  `Iterables.getOnlyElement` returns `@Nullable T` under the Checker
  Framework stubs. This replaces the `@SuppressWarnings({"keyfor", "nullness"})`
  on `TaggedPValue.ofExpandedValue` with an explicit
  `Preconditions.checkArgumentNotNull` at the call site.
  
  Verified locally against `sdks:java:core`:
  
  - `spotlessJavaCheck`, `checkstyleMain`
  - `compileJava -PenableCheckerFramework`
  - The four test classes that exercise `ofExpandedValue`:
    `DeduplicatedFlattenFactoryTest`, `EmptyFlattenAsCreateFactoryTest`,
    `SingleInputOutputOverrideFactoryTest`, `TransformHierarchyTest`

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
