### PR TITLE
Remove nullness suppression in PTransformReplacements

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/PTransformReplacements.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/PTransformReplacements.java
@@ -23,12 +23,13 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.beam.sdk.runners.AppliedPTransform;
 import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.util.Preconditions;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** Utilty class for PTransform replacements. */
-@SuppressWarnings({"nullness", "keyfor"}) // TODO(https://github.com/apache/beam/issues/20497)
 public class PTransformReplacements {
   /**
    * Gets the singleton input of an {@link AppliedPTransform}, ignoring any additional inputs
@@ -42,7 +43,7 @@ public class PTransformReplacements {
 
   private static <T> PCollection<T> getSingletonMainInput(
       Map<TupleTag<?>, PCollection<?>> inputs, Set<TupleTag<?>> ignoredTags) {
-    PCollection<T> mainInput = null;
+    @Nullable PCollection<T> mainInput = null;
     for (Map.Entry<TupleTag<?>, PCollection<?>> input : inputs.entrySet()) {
       if (!ignoredTags.contains(input.getKey())) {
         checkArgument(
@@ -58,16 +59,17 @@ public class PTransformReplacements {
         mainInput = (PCollection<T>) input.getValue();
       }
     }
-    checkArgument(
-        mainInput != null,
+    return Preconditions.checkArgumentNotNull(
+        mainInput,
         "No main input found in inputs: Inputs %s, Side Input tags %s",
         inputs,
         ignoredTags);
-    return mainInput;
   }
 
   public static <T> PCollection<T> getSingletonMainOutput(
       AppliedPTransform<?, PCollection<T>, ? extends PTransform<?, PCollection<T>>> transform) {
-    return (PCollection<T>) Iterables.getOnlyElement(transform.getOutputs().values());
+    return (PCollection<T>)
+        Preconditions.checkArgumentNotNull(
+            Iterables.getOnlyElement(transform.getOutputs().values()));
   }
 }


### PR DESCRIPTION
Progress on #20507 (sub-task of umbrella #20497).
  
  Drop the class-level `@SuppressWarnings({"nullness", "keyfor"})` on
  `PTransformReplacements`. The `mainInput` local is now typed `@Nullable`,
  and the two return sites use `Preconditions.checkArgumentNotNull` (which
  has `@EnsuresNonNull`) so the Checker Framework accepts the returned
  value as non-null. The `"keyfor"` suppression was unused.
  
  Verified locally against `sdks:java:core`:
  
  - `spotlessJavaCheck`, `checkstyleMain`
  - `compileJava -PenableCheckerFramework` (clean rebuild)
  - `PTransformReplacementsTest`, `SingleInputOutputOverrideFactoryTest`,
    `MorePipelineTest`


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
