### PR TITLE
Docs: document accepted encoder/decoder signatures on coder.RegisterCoder

### DIFF
--- a/sdks/go/pkg/beam/core/graph/coder/coder.go
+++ b/sdks/go/pkg/beam/core/graph/coder/coder.go
@@ -142,6 +142,10 @@ func validateDecoder(t reflect.Type, decode any) error {
 
 // NewCustomCoder creates a coder for the supplied parameters defining a
 // particular encoding strategy.
+//
+// encode and decode must be functions matching one of the signatures documented
+// on RegisterCoder. NewCustomCoder returns an error if either function fails
+// signature validation.
 func NewCustomCoder(id string, t reflect.Type, encode, decode any) (*CustomCoder, error) {
 	if err := validateEncoder(t, encode); err != nil {
 		return nil, errors.WithContext(err, "NewCustomCoder")

--- a/sdks/go/pkg/beam/core/graph/coder/registry.go
+++ b/sdks/go/pkg/beam/core/graph/coder/registry.go
@@ -44,6 +44,31 @@ var (
 // over to check if element types implement them.
 //
 // Repeated registrations of the same type overrides prior ones.
+//
+// The enc and dec arguments must be functions matching one of the following
+// signatures, where T is the user type registered (the concrete type
+// represented by t, or an interface implemented by encoded values):
+//
+// Supported encoder signatures:
+//
+//	func(T) []byte
+//	func(reflect.Type, T) []byte
+//	func(T) ([]byte, error)
+//	func(reflect.Type, T) ([]byte, error)
+//
+// Supported decoder signatures:
+//
+//	func([]byte) T
+//	func(reflect.Type, []byte) T
+//	func([]byte) (T, error)
+//	func(reflect.Type, []byte) (T, error)
+//
+// The optional leading reflect.Type parameter is set to the concrete element
+// type at coder construction time; it lets a single (enc, dec) pair serve
+// multiple types (for example, when t is an interface).
+//
+// Passing a function that does not match one of these signatures will cause
+// RegisterCoder to panic.
 func RegisterCoder(t reflect.Type, enc, dec any) {
 	if _, err := NewCustomCoder(t.String(), t, enc, dec); err != nil {
 		panic(errors.Wrapf(err, "RegisterCoder failed for type %v", t))


### PR DESCRIPTION
Addresses #21930

Adds explicit encoder/decoder function signature documentation to
`coder.RegisterCoder`, matching the four signatures already documented on
the top-level `beam.RegisterCoder` wrapper in `forward.go`. Also adds a
short note on `NewCustomCoder` pointing at the same signature spec, since
it accepts the same functions.

Docs-only change — no behavior modification. `go vet` and `go build`
on `pkg/beam/core/graph/coder/...` both clean.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
