### PR TITLE
[Go] Fix pubsubio import of removed genproto package

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,6 +98,7 @@
 * (Prism) Self-checkpointing splittable DoFns now resume after their requested delay instead of immediately, so polling SDFs no longer busy-spin ([#39848](https://github.com/apache/beam/issues/39848)).
 * (Java) MongoDbIO read splitting now preserves non-ObjectId `_id` types (e.g. string ids) instead of failing to parse the generated range filters ([#39900](https://github.com/apache/beam/issues/39900)).
 * (Go) Fixed GCS glob matching silently dropping objects when the glob pattern contains multi-byte characters ([#39969](https://github.com/apache/beam/issues/39969)).
+* (Go) Fixed pubsubio importing a `google.golang.org/genproto` package removed in recent releases, which broke builds of Go modules depending on a current `genproto` version ([#40018](https://github.com/apache/beam/issues/40018)).
 
 ## Security Fixes
 

--- a/sdks/go.mod
+++ b/sdks/go.mod
@@ -61,7 +61,7 @@ require (
 	golang.org/x/sys v0.47.0
 	golang.org/x/text v0.41.0
 	google.golang.org/api v0.297.0
-	google.golang.org/genproto v0.0.0-20260715232425-e75dac1f907d
+	google.golang.org/genproto v0.0.0-20260715232425-e75dac1f907d // indirect
 	google.golang.org/grpc v1.83.2
 	google.golang.org/protobuf v1.36.12
 	gopkg.in/yaml.v2 v2.4.0
@@ -82,7 +82,7 @@ require (
 	cloud.google.com/go/auth v0.23.2 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/monitoring v1.30.0 // indirect
-	cloud.google.com/go/pubsub/v2 v2.6.2 // indirect
+	cloud.google.com/go/pubsub/v2 v2.6.2
 	dario.cat/mergo v1.0.2 // indirect
 	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.6.0 // indirect

--- a/sdks/go/pkg/beam/io/pubsubio/pubsubio.go
+++ b/sdks/go/pkg/beam/io/pubsubio/pubsubio.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"reflect"
 
+	pb "cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/typex"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/util/protox"
@@ -32,7 +33,6 @@ import (
 	pipepb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/pipeline_v1"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/register"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/util/pubsubx"
-	pb "google.golang.org/genproto/googleapis/pubsub/v1"
 	"google.golang.org/protobuf/proto"
 )
 


### PR DESCRIPTION
`pubsubio` imported `google.golang.org/genproto/googleapis/pubsub/v1` just to use
`PubsubMessage` as a plain proto struct. Recent `genproto` releases dropped that
package, breaking builds for any module needing a newer `genproto`. The actual
read/write logic never used a gRPC client from it — it delegates to Dataflow's
native `pubsub_read/write` external transform.

This swaps the import for `cloud.google.com/go/pubsub/v2/apiv1/pubsubpb`, which is
wire-compatible (same field numbers) — no behavior change.

- [x] fixes #40018
- [x] Updated `CHANGES.md`.
