### PR TITLE
Kafka Streams runner: add a flush marker payload variant

### DIFF
--- a/runners/kafka-streams/proto/src/main/proto/kafka_streams_payload.proto
+++ b/runners/kafka-streams/proto/src/main/proto/kafka_streams_payload.proto
@@ -50,9 +50,32 @@ message KafkaStreamsPayload {
     bytes value = 1;
   }
 
-  // Exactly one variant is set; the oneof case discriminates data vs watermark.
+  // A request to close the open bundle and flush its output.
+  //
+  // A bundle has to be bounded in time as well as in size, or on a sparse stream the elements
+  // already fed to it wait for the next watermark. Closing it from a wall-clock punctuator does
+  // not work: transactions are committed by the Kafka Streams runtime in the background, are
+  // agnostic to punctuations, and are deliberately not exposed, so a bundle cannot be aligned with
+  // one. Instead a source emits this marker on its own punctuator and it travels the topology as
+  // an ordinary record, so a stage closes its bundle from process() rather than beside it.
+  //
+  // The partition fields are what let the marker be targeted rather than broadcast. Broadcasting
+  // would deliver one flush per upstream partition, so a downstream partition would see N times
+  // more flushes than the configured interval. Instead the producing partition addresses a slice
+  // of the downstream partitions, and the slices tile the whole range, so each downstream
+  // partition receives exactly one flush per interval.
+  message FlushPayload {
+    // Which partition (physical instance) of the producing transform emitted this marker, in
+    // [0, total_partitions).
+    uint32 source_partition = 1;
+    // How many partitions (physical instances) the producing transform has in total.
+    uint32 total_partitions = 2;
+  }
+
+  // Exactly one variant is set; the oneof case discriminates data vs watermark vs flush.
   oneof payload {
     WatermarkPayload watermark = 1;
     DataPayload data = 2;
+    FlushPayload flush = 3;
   }
 }

--- a/runners/kafka-streams/proto/src/main/proto/kafka_streams_payload.proto
+++ b/runners/kafka-streams/proto/src/main/proto/kafka_streams_payload.proto
@@ -50,26 +50,13 @@ message KafkaStreamsPayload {
     bytes value = 1;
   }
 
-  // A request to close the open bundle and flush its output.
-  //
-  // A bundle has to be bounded in time as well as in size, or on a sparse stream the elements
-  // already fed to it wait for the next watermark. Closing it from a wall-clock punctuator does
-  // not work: transactions are committed by the Kafka Streams runtime in the background, are
-  // agnostic to punctuations, and are deliberately not exposed, so a bundle cannot be aligned with
-  // one. Instead a source emits this marker on its own punctuator and it travels the topology as
-  // an ordinary record, so a stage closes its bundle from process() rather than beside it.
-  //
-  // The partition fields are what let the marker be targeted rather than broadcast. Broadcasting
-  // would deliver one flush per upstream partition, so a downstream partition would see N times
-  // more flushes than the configured interval. Instead the producing partition addresses a slice
-  // of the downstream partitions, and the slices tile the whole range, so each downstream
-  // partition receives exactly one flush per interval.
+  // A request to close the open bundle and flush its output. See
+  // https://github.com/apache/beam/issues/39633.
   message FlushPayload {
-    // Which partition (physical instance) of the producing transform emitted this marker, in
-    // [0, total_partitions).
-    uint32 source_partition = 1;
-    // How many partitions (physical instances) the producing transform has in total.
-    uint32 total_partitions = 2;
+    // Which partitions of the repartition topic this marker is for. The producer picks them so
+    // that each downstream partition gets exactly one flush per interval; broadcasting would give
+    // it one per upstream partition instead.
+    repeated uint32 target_partitions = 1;
   }
 
   // Exactly one variant is set; the oneof case discriminates data vs watermark vs flush.

--- a/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/FlushPayload.java
+++ b/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/FlushPayload.java
@@ -17,30 +17,21 @@
  */
 package org.apache.beam.runners.kafka.streams.translation;
 
+import java.util.Set;
+
 /**
  * The flush-only view of a {@link KStreamsPayload}, obtained via {@link KStreamsPayload#asFlush()}.
- * As with {@link WatermarkPayload}, the accessors live here so they are only reachable once the
- * caller has checked the kind and narrowed the payload.
  *
- * <p>A flush marker asks the stage that receives it to close its open bundle and flush the output,
- * which is how a bundle is bounded in time. It arrives as an ordinary record, so the bundle is
- * closed from {@code process()} rather than from a punctuator: transactions are committed by the
- * Kafka Streams runtime in the background and are not exposed, so a bundle cannot be aligned with
- * one, and trying to do it from a punctuator duplicated output against a real broker
- * (https://github.com/apache/beam/issues/39633).
- *
- * <p>The partition fields exist so the marker can be targeted rather than broadcast. Broadcasting
- * would give a downstream partition one flush per upstream partition, so N times more flushes than
- * the interval asks for. Instead the producing partition addresses a slice of the downstream
- * partitions and the slices tile the range, so each downstream partition gets exactly one flush per
- * interval. Unlike a watermark, a flush needs no aggregation on arrival: there is nothing to hold
- * and nothing to combine, because only one arrives.
+ * <p>A flush marker asks the stage that receives it to close its bundle, which is how a bundle is
+ * bounded in time. It arrives as a record so the bundle is closed from {@code process()} rather
+ * than from a punctuator; see https://github.com/apache/beam/issues/39633.
  */
 public interface FlushPayload {
 
-  /** Which partition of the producing transform emitted this marker. */
-  int getSourcePartition();
-
-  /** How many partitions the producing transform has in total. */
-  int getTotalSourcePartitions();
+  /**
+   * The repartition-topic partitions this marker is addressed to. Never empty: a producer with
+   * nothing to address emits no marker. The receiving stage ignores this; only the partitioner
+   * reads it.
+   */
+  Set<Integer> getTargetPartitions();
 }

--- a/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/FlushPayload.java
+++ b/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/FlushPayload.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.kafka.streams.translation;
+
+/**
+ * The flush-only view of a {@link KStreamsPayload}, obtained via {@link KStreamsPayload#asFlush()}.
+ * As with {@link WatermarkPayload}, the accessors live here so they are only reachable once the
+ * caller has checked the kind and narrowed the payload.
+ *
+ * <p>A flush marker asks the stage that receives it to close its open bundle and flush the output,
+ * which is how a bundle is bounded in time. It arrives as an ordinary record, so the bundle is
+ * closed from {@code process()} rather than from a punctuator: transactions are committed by the
+ * Kafka Streams runtime in the background and are not exposed, so a bundle cannot be aligned with
+ * one, and trying to do it from a punctuator duplicated output against a real broker
+ * (https://github.com/apache/beam/issues/39633).
+ *
+ * <p>The partition fields exist so the marker can be targeted rather than broadcast. Broadcasting
+ * would give a downstream partition one flush per upstream partition, so N times more flushes than
+ * the interval asks for. Instead the producing partition addresses a slice of the downstream
+ * partitions and the slices tile the range, so each downstream partition gets exactly one flush per
+ * interval. Unlike a watermark, a flush needs no aggregation on arrival: there is nothing to hold
+ * and nothing to combine, because only one arrives.
+ */
+public interface FlushPayload {
+
+  /** Which partition of the producing transform emitted this marker. */
+  int getSourcePartition();
+
+  /** How many partitions the producing transform has in total. */
+  int getTotalSourcePartitions();
+}

--- a/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/KStreamsPayload.java
+++ b/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/KStreamsPayload.java
@@ -18,9 +18,11 @@
 package org.apache.beam.runners.kafka.streams.translation;
 
 import java.util.Objects;
+import java.util.Set;
 import org.apache.beam.sdk.values.WindowedValue;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.MoreObjects;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableSet;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -48,6 +50,7 @@ public final class KStreamsPayload<T> {
   private final String transformId;
   private final int sourcePartition;
   private final int totalSourcePartitions;
+  private final Set<Integer> targetPartitions;
 
   private KStreamsPayload(
       Kind kind,
@@ -55,18 +58,20 @@ public final class KStreamsPayload<T> {
       long watermarkMillis,
       String transformId,
       int sourcePartition,
-      int totalSourcePartitions) {
+      int totalSourcePartitions,
+      Set<Integer> targetPartitions) {
     this.kind = kind;
     this.data = data;
     this.watermarkMillis = watermarkMillis;
     this.transformId = transformId;
     this.sourcePartition = sourcePartition;
     this.totalSourcePartitions = totalSourcePartitions;
+    this.targetPartitions = targetPartitions;
   }
 
   /** Returns a data payload wrapping the given {@link WindowedValue}. */
   public static <T> KStreamsPayload<T> data(WindowedValue<T> value) {
-    return new KStreamsPayload<>(Kind.DATA, value, 0L, "", 0, 0);
+    return new KStreamsPayload<>(Kind.DATA, value, 0L, "", 0, 0, ImmutableSet.of());
   }
 
   /**
@@ -90,26 +95,24 @@ public final class KStreamsPayload<T> {
         sourcePartition,
         totalSourcePartitions);
     return new KStreamsPayload<>(
-        Kind.WATERMARK, null, watermarkMillis, transformId, sourcePartition, totalSourcePartitions);
+        Kind.WATERMARK,
+        null,
+        watermarkMillis,
+        transformId,
+        sourcePartition,
+        totalSourcePartitions,
+        ImmutableSet.of());
   }
 
   /**
-   * Returns a flush marker: a request to close the open bundle and flush its output, carrying the
-   * partition of the producing transform that emitted it and how many partitions that transform
-   * has. Those two fields are what let the marker be addressed to a slice of the downstream
-   * partitions rather than broadcast to all of them; see {@link FlushPayload}.
+   * Returns a flush marker addressed to the given repartition-topic partitions. A producer with no
+   * partitions to address emits no marker, so the set must not be empty.
    */
-  public static <T> KStreamsPayload<T> flush(int sourcePartition, int totalSourcePartitions) {
+  public static <T> KStreamsPayload<T> flush(Set<Integer> targetPartitions) {
     Preconditions.checkArgument(
-        totalSourcePartitions > 0,
-        "totalSourcePartitions must be positive: %s",
-        totalSourcePartitions);
-    Preconditions.checkArgument(
-        sourcePartition >= 0 && sourcePartition < totalSourcePartitions,
-        "sourcePartition %s out of range for totalSourcePartitions %s",
-        sourcePartition,
-        totalSourcePartitions);
-    return new KStreamsPayload<>(Kind.FLUSH, null, 0L, "", sourcePartition, totalSourcePartitions);
+        !targetPartitions.isEmpty(), "flush marker must target at least one partition");
+    return new KStreamsPayload<>(
+        Kind.FLUSH, null, 0L, "", 0, 0, ImmutableSet.copyOf(targetPartitions));
   }
 
   public boolean isData() {
@@ -157,13 +160,8 @@ public final class KStreamsPayload<T> {
   /** {@link FlushPayload} view backed by this payload's fields. */
   private final class FlushView implements FlushPayload {
     @Override
-    public int getSourcePartition() {
-      return sourcePartition;
-    }
-
-    @Override
-    public int getTotalSourcePartitions() {
-      return totalSourcePartitions;
+    public Set<Integer> getTargetPartitions() {
+      return targetPartitions;
     }
   }
 
@@ -204,13 +202,20 @@ public final class KStreamsPayload<T> {
         && transformId.equals(that.transformId)
         && sourcePartition == that.sourcePartition
         && totalSourcePartitions == that.totalSourcePartitions
+        && targetPartitions.equals(that.targetPartitions)
         && Objects.equals(data, that.data);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        kind, data, watermarkMillis, transformId, sourcePartition, totalSourcePartitions);
+        kind,
+        data,
+        watermarkMillis,
+        transformId,
+        sourcePartition,
+        totalSourcePartitions,
+        targetPartitions);
   }
 
   @Override

--- a/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/KStreamsPayload.java
+++ b/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/KStreamsPayload.java
@@ -24,10 +24,10 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Precondit
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * Envelope for every record value passed between the runner's processors. It is either a {@link
- * #isData() data} element wrapping a {@link WindowedValue}, or a {@link #isWatermark() watermark}
- * report carrying an event time plus the partition fields the downstream {@link WatermarkManager}
- * needs.
+ * Envelope for every record value passed between the runner's processors. It is a {@link #isData()
+ * data} element wrapping a {@link WindowedValue}, a {@link #isWatermark() watermark} report
+ * carrying an event time plus the partition fields the downstream {@link WatermarkManager} needs,
+ * or a {@link #isFlush() flush} marker asking the receiving stage to close its bundle.
  *
  * <p>One channel therefore carries both Beam data and the watermark coordination Kafka Streams has
  * no notion of. Across topic boundaries it is encoded by {@link KStreamsPayloadSerde}.
@@ -38,7 +38,8 @@ public final class KStreamsPayload<T> {
 
   private enum Kind {
     DATA,
-    WATERMARK
+    WATERMARK,
+    FLUSH
   }
 
   private final Kind kind;
@@ -92,12 +93,35 @@ public final class KStreamsPayload<T> {
         Kind.WATERMARK, null, watermarkMillis, transformId, sourcePartition, totalSourcePartitions);
   }
 
+  /**
+   * Returns a flush marker: a request to close the open bundle and flush its output, carrying the
+   * partition of the producing transform that emitted it and how many partitions that transform
+   * has. Those two fields are what let the marker be addressed to a slice of the downstream
+   * partitions rather than broadcast to all of them; see {@link FlushPayload}.
+   */
+  public static <T> KStreamsPayload<T> flush(int sourcePartition, int totalSourcePartitions) {
+    Preconditions.checkArgument(
+        totalSourcePartitions > 0,
+        "totalSourcePartitions must be positive: %s",
+        totalSourcePartitions);
+    Preconditions.checkArgument(
+        sourcePartition >= 0 && sourcePartition < totalSourcePartitions,
+        "sourcePartition %s out of range for totalSourcePartitions %s",
+        sourcePartition,
+        totalSourcePartitions);
+    return new KStreamsPayload<>(Kind.FLUSH, null, 0L, "", sourcePartition, totalSourcePartitions);
+  }
+
   public boolean isData() {
     return kind == Kind.DATA;
   }
 
   public boolean isWatermark() {
     return kind == Kind.WATERMARK;
+  }
+
+  public boolean isFlush() {
+    return kind == Kind.FLUSH;
   }
 
   /**
@@ -119,6 +143,28 @@ public final class KStreamsPayload<T> {
   public WatermarkPayload asWatermark() {
     Preconditions.checkState(isWatermark(), "Payload is not a watermark: kind=%s", kind);
     return new WatermarkView();
+  }
+
+  /**
+   * Narrows this payload to its {@link FlushPayload} view. Caller must check {@link #isFlush()}
+   * first; calling this on any other payload throws.
+   */
+  public FlushPayload asFlush() {
+    Preconditions.checkState(isFlush(), "Payload is not a flush marker: kind=%s", kind);
+    return new FlushView();
+  }
+
+  /** {@link FlushPayload} view backed by this payload's fields. */
+  private final class FlushView implements FlushPayload {
+    @Override
+    public int getSourcePartition() {
+      return sourcePartition;
+    }
+
+    @Override
+    public int getTotalSourcePartitions() {
+      return totalSourcePartitions;
+    }
   }
 
   /** {@link WatermarkPayload} view backed by this payload's fields. */
@@ -172,6 +218,10 @@ public final class KStreamsPayload<T> {
     MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this).add("kind", kind);
     if (kind == Kind.DATA) {
       helper.add("data", data);
+    } else if (kind == Kind.FLUSH) {
+      helper
+          .add("sourcePartition", sourcePartition)
+          .add("totalSourcePartitions", totalSourcePartitions);
     } else {
       helper
           .add("watermarkMillis", watermarkMillis)

--- a/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/KStreamsPayloadSerde.java
+++ b/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/KStreamsPayloadSerde.java
@@ -36,9 +36,9 @@ import org.apache.kafka.common.serialization.Serializer;
  *
  * <p>The wire form is the {@link KafkaStreamsPayload} protobuf message — protobuf gives compatible
  * schema evolution and compact varint encoding. The data variant carries the {@link WindowedValue}
- * encoded with the {@link Coder} supplied for the topic's PCollection; the watermark variant
- * carries the coder-independent watermark report. A {@link KStreamsPayloadSerde} is therefore
- * parameterized by the data {@link Coder} (different topics carry different element types).
+ * encoded with the {@link Coder} supplied for the topic's PCollection; the watermark and flush
+ * variants are coder-independent. A {@link KStreamsPayloadSerde} is therefore parameterized by the
+ * data {@link Coder} (different topics carry different element types).
  *
  * <p>The serde assumes non-null payloads: the topics it is used on (repartition and watermark
  * fan-out) are not log-compacted, so no tombstone (null-valued) records occur.
@@ -77,6 +77,12 @@ public final class KStreamsPayloadSerde<T> implements Serde<KStreamsPayload<T>> 
         proto.setData(
             KafkaStreamsPayload.DataPayload.newBuilder()
                 .setValue(ByteString.copyFrom(encoded.toByteArray())));
+      } else if (payload.isFlush()) {
+        FlushPayload flush = payload.asFlush();
+        proto.setFlush(
+            KafkaStreamsPayload.FlushPayload.newBuilder()
+                .setSourcePartition(flush.getSourcePartition())
+                .setTotalPartitions(flush.getTotalSourcePartitions()));
       } else {
         WatermarkPayload watermark = payload.asWatermark();
         proto.setWatermark(
@@ -113,6 +119,9 @@ public final class KStreamsPayloadSerde<T> implements Serde<KStreamsPayload<T>> 
               watermark.getTransformId(),
               watermark.getSourcePartition(),
               watermark.getTotalPartitions());
+        case FLUSH:
+          KafkaStreamsPayload.FlushPayload flush = proto.getFlush();
+          return KStreamsPayload.flush(flush.getSourcePartition(), flush.getTotalPartitions());
         case PAYLOAD_NOT_SET:
         default:
           throw new SerializationException(

--- a/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/KStreamsPayloadSerde.java
+++ b/runners/kafka-streams/src/main/java/org/apache/beam/runners/kafka/streams/translation/KStreamsPayloadSerde.java
@@ -24,6 +24,7 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.values.WindowedValue;
 import org.apache.beam.vendor.grpc.v1p69p0.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.grpc.v1p69p0.com.google.protobuf.InvalidProtocolBufferException;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableSet;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
@@ -78,11 +79,9 @@ public final class KStreamsPayloadSerde<T> implements Serde<KStreamsPayload<T>> 
             KafkaStreamsPayload.DataPayload.newBuilder()
                 .setValue(ByteString.copyFrom(encoded.toByteArray())));
       } else if (payload.isFlush()) {
-        FlushPayload flush = payload.asFlush();
         proto.setFlush(
             KafkaStreamsPayload.FlushPayload.newBuilder()
-                .setSourcePartition(flush.getSourcePartition())
-                .setTotalPartitions(flush.getTotalSourcePartitions()));
+                .addAllTargetPartitions(payload.asFlush().getTargetPartitions()));
       } else {
         WatermarkPayload watermark = payload.asWatermark();
         proto.setWatermark(
@@ -120,8 +119,8 @@ public final class KStreamsPayloadSerde<T> implements Serde<KStreamsPayload<T>> 
               watermark.getSourcePartition(),
               watermark.getTotalPartitions());
         case FLUSH:
-          KafkaStreamsPayload.FlushPayload flush = proto.getFlush();
-          return KStreamsPayload.flush(flush.getSourcePartition(), flush.getTotalPartitions());
+          return KStreamsPayload.flush(
+              ImmutableSet.copyOf(proto.getFlush().getTargetPartitionsList()));
         case PAYLOAD_NOT_SET:
         default:
           throw new SerializationException(

--- a/runners/kafka-streams/src/test/java/org/apache/beam/runners/kafka/streams/translation/KStreamsPayloadSerdeTest.java
+++ b/runners/kafka-streams/src/test/java/org/apache/beam/runners/kafka/streams/translation/KStreamsPayloadSerdeTest.java
@@ -48,6 +48,44 @@ public class KStreamsPayloadSerdeTest {
   }
 
   @Test
+  public void roundTripsFlushPayload() {
+    KStreamsPayload<Integer> payload = KStreamsPayload.flush(3, 8);
+    KStreamsPayload<Integer> out = roundTrip(payload);
+    assertThat(out.isFlush(), is(true));
+    assertThat(out.isData(), is(false));
+    assertThat(out.isWatermark(), is(false));
+    assertThat(out.asFlush().getSourcePartition(), is(3));
+    assertThat(out.asFlush().getTotalSourcePartitions(), is(8));
+    assertThat(out, is(payload));
+  }
+
+  @Test
+  public void aFlushPayloadSurvivesTheFirstAndLastPartition() {
+    // Partition 0 and the last partition are the boundary cases of the range check, and the last
+    // one also happens to be the only partition that emits a flush when fanning in.
+    assertThat(roundTrip(KStreamsPayload.flush(0, 1)).asFlush().getSourcePartition(), is(0));
+    KStreamsPayload<Integer> last = roundTrip(KStreamsPayload.flush(7, 8));
+    assertThat(last.asFlush().getSourcePartition(), is(7));
+    assertThat(last.asFlush().getTotalSourcePartitions(), is(8));
+  }
+
+  @Test
+  public void aFlushPayloadRejectsAPartitionOutsideItsRange() {
+    assertThrows(IllegalArgumentException.class, () -> KStreamsPayload.flush(8, 8));
+    assertThrows(IllegalArgumentException.class, () -> KStreamsPayload.flush(-1, 8));
+    assertThrows(IllegalArgumentException.class, () -> KStreamsPayload.flush(0, 0));
+  }
+
+  @Test
+  public void aFlushPayloadIsNotAWatermarkOrData() {
+    KStreamsPayload<Integer> flush = KStreamsPayload.flush(0, 1);
+    assertThrows(IllegalStateException.class, flush::asWatermark);
+    assertThrows(IllegalStateException.class, flush::getData);
+    KStreamsPayload<Integer> data = KStreamsPayload.data(WindowedValues.valueInGlobalWindow(1));
+    assertThrows(IllegalStateException.class, data::asFlush);
+  }
+
+  @Test
   public void roundTripsDataPayload() {
     KStreamsPayload<Integer> payload = KStreamsPayload.data(WindowedValues.valueInGlobalWindow(42));
     KStreamsPayload<Integer> out = roundTrip(payload);

--- a/runners/kafka-streams/src/test/java/org/apache/beam/runners/kafka/streams/translation/KStreamsPayloadSerdeTest.java
+++ b/runners/kafka-streams/src/test/java/org/apache/beam/runners/kafka/streams/translation/KStreamsPayloadSerdeTest.java
@@ -27,6 +27,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.values.WindowedValue;
 import org.apache.beam.sdk.values.WindowedValues;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableSet;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
@@ -49,36 +50,25 @@ public class KStreamsPayloadSerdeTest {
 
   @Test
   public void roundTripsFlushPayload() {
-    KStreamsPayload<Integer> payload = KStreamsPayload.flush(3, 8);
+    KStreamsPayload<Integer> payload = KStreamsPayload.flush(ImmutableSet.of(0, 3, 7));
     KStreamsPayload<Integer> out = roundTrip(payload);
     assertThat(out.isFlush(), is(true));
     assertThat(out.isData(), is(false));
     assertThat(out.isWatermark(), is(false));
-    assertThat(out.asFlush().getSourcePartition(), is(3));
-    assertThat(out.asFlush().getTotalSourcePartitions(), is(8));
+    assertThat(out.asFlush().getTargetPartitions(), is(ImmutableSet.of(0, 3, 7)));
     assertThat(out, is(payload));
   }
 
   @Test
-  public void aFlushPayloadSurvivesTheFirstAndLastPartition() {
-    // Partition 0 and the last partition are the boundary cases of the range check, and the last
-    // one also happens to be the only partition that emits a flush when fanning in.
-    assertThat(roundTrip(KStreamsPayload.flush(0, 1)).asFlush().getSourcePartition(), is(0));
-    KStreamsPayload<Integer> last = roundTrip(KStreamsPayload.flush(7, 8));
-    assertThat(last.asFlush().getSourcePartition(), is(7));
-    assertThat(last.asFlush().getTotalSourcePartitions(), is(8));
-  }
-
-  @Test
-  public void aFlushPayloadRejectsAPartitionOutsideItsRange() {
-    assertThrows(IllegalArgumentException.class, () -> KStreamsPayload.flush(8, 8));
-    assertThrows(IllegalArgumentException.class, () -> KStreamsPayload.flush(-1, 8));
-    assertThrows(IllegalArgumentException.class, () -> KStreamsPayload.flush(0, 0));
+  public void aFlushPayloadMustTargetSomething() {
+    // A producer with nothing to address emits no marker at all, so an empty set is a bug rather
+    // than a case to encode.
+    assertThrows(IllegalArgumentException.class, () -> KStreamsPayload.flush(ImmutableSet.of()));
   }
 
   @Test
   public void aFlushPayloadIsNotAWatermarkOrData() {
-    KStreamsPayload<Integer> flush = KStreamsPayload.flush(0, 1);
+    KStreamsPayload<Integer> flush = KStreamsPayload.flush(ImmutableSet.of(0));
     assertThrows(IllegalStateException.class, flush::asWatermark);
     assertThrows(IllegalStateException.class, flush::getData);
     KStreamsPayload<Integer> data = KStreamsPayload.data(WindowedValues.valueInGlobalWindow(1));


### PR DESCRIPTION
## Summary

First of four PRs toward bundles bounded by time (#39633). This one adds the flush marker to the payload envelope and nothing else: nothing emits a marker and nothing consumes one yet, so there is no behaviour change.

## Why a marker rather than a timer

`--maxBundleTimeMs` is accepted today and has no effect. A bundle must be closed before its output is flushed, so it needs a time bound as well as a size one, otherwise on a sparse stream the elements already fed to it wait for the next watermark.

The natural implementation, closing the bundle from a wall-clock punctuator, produces duplicate output against a real broker: a test with two chained GroupByKeys across four partitions emits its single group six times, reproducibly, and the count keeps climbing after input stops.

Asking about this on the Kafka dev list settled why. Matthias J. Sax's answer was that punctuations do not fit the exactly-once pattern of "read records, produce output, atomically commit the output plus the input offsets", that there is no supported way to run work just before a commit, and that transactions are an internal Kafka Streams concept deliberately not exposed at the API level. So the design was wrong rather than the implementation: bundles have to work without being coupled to transaction boundaries the runner does not control and cannot see.

He also corrected a mistaken note in #39633 — there is no `commitOffsetNeeded` flag, it is `commitNeeded`, and it is set after a punctuation runs, so punctuator output is not outside the commit accounting as we had written. The issue has been corrected.

The way forward is to make the flush data-driven, the way watermarks already are. A source emits a marker on the punctuator it already runs, the marker travels the topology as an ordinary record, and each stage closes its bundle when it **receives** one, inside `process()`. Bundle boundaries then never touch transaction boundaries.

## What is here

A third variant alongside data and watermark:

- `FlushPayload`, the narrowed view, mirroring the existing `WatermarkPayload`.
- `KStreamsPayload.flush(sourcePartition, totalSourcePartitions)`, with the same range validation the watermark factory has.
- The proto variant and serde support in both directions.

The marker carries the producing partition and that transform's partition count. Those exist so it can be **targeted rather than broadcast**. Broadcasting would deliver one flush per upstream partition, so a downstream partition would see N times more flushes than the configured interval asks for. Instead each producing partition will address a slice of the downstream partitions, and the slices tile the whole range, so every downstream partition receives exactly one flush per interval. The rule is `[floor(i*D/U), floor((i+1)*D/U))` for upstream partition `i`, with `U` upstream partitions and `D` downstream, and it holds for fan-out, fan-in, equal counts and a single partition on either side. That logic lands in the next PR, in the partitioner.

Unlike a watermark, a flush needs no aggregation when it arrives. There is nothing to hold and nothing to combine, because exactly one arrives.

## The remaining three

2. Rename `GroupByKeyBroadcastPartitioner` to something that covers targeting a possibly empty subset, and add the targeting rule.
3. Sources emit the marker on their existing punctuator, at `maxBundleTimeMs`.
4. `ExecutableStageProcessor` closes and flushes its bundle when a marker arrives, then forwards it on.

## Testing

```
./gradlew -Pwith-kafka-streams-runner :runners:kafka-streams:build
./gradlew -Pwith-kafka-streams-runner :runners:kafka-streams:validatesRunner
```

Both pass. Four new tests cover the serde round trip, the first and last partition as the boundaries of the range check, rejection of a partition outside its range, and that a flush cannot be read as a watermark or as data. Changing one field in the serde fails two of them, so they are testing something.
