### PR TITLE
[Java] Extract common timestamp output DoFn

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Create.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Create.java
@@ -754,10 +754,16 @@ public class Create<T> {
       this.typeDescriptor = typeDescriptor;
     }
 
-    private static class ConvertTimestamps<T> extends DoFn<TimestampedValue<T>, T> {
-      @ProcessElement
-      public void processElement(@Element TimestampedValue<T> element, OutputReceiver<T> r) {
-        r.outputWithTimestamp(element.getValue(), element.getTimestamp());
+    private static class ConvertTimestamps<T>
+        extends OutputWithTimestampDoFn<TimestampedValue<T>, T> {
+      @Override
+      T getOutput(TimestampedValue<T> element) {
+        return element.getValue();
+      }
+
+      @Override
+      Instant getTimestamp(TimestampedValue<T> element) {
+        return element.getTimestamp();
       }
     }
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/OutputWithTimestampDoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/OutputWithTimestampDoFn.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.transforms;
+
+import org.joda.time.Instant;
+
+/** A {@link DoFn} that extracts an output value and timestamp from each input element. */
+abstract class OutputWithTimestampDoFn<InputT, OutputT> extends DoFn<InputT, OutputT> {
+
+  @ProcessElement
+  public void processElement(@Element InputT element, OutputReceiver<OutputT> receiver) {
+    receiver.outputWithTimestamp(getOutput(element), getTimestamp(element));
+  }
+
+  abstract OutputT getOutput(InputT element);
+
+  abstract Instant getTimestamp(InputT element);
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithTimestamps.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithTimestamps.java
@@ -119,7 +119,7 @@ public class WithTimestamps<T> extends PTransform<PCollection<T>, PCollection<T>
         "AddTimestamps", ParDo.of(new AddTimestampsDoFn<>(fn, allowedTimestampSkew)));
   }
 
-  private static class AddTimestampsDoFn<T> extends DoFn<T, T> {
+  private static class AddTimestampsDoFn<T> extends OutputWithTimestampDoFn<T, T> {
     private final SerializableFunction<T, Instant> fn;
     private final Duration allowedTimestampSkew;
 
@@ -128,12 +128,17 @@ public class WithTimestamps<T> extends PTransform<PCollection<T>, PCollection<T>
       this.allowedTimestampSkew = allowedTimestampSkew;
     }
 
-    @ProcessElement
-    public void processElement(@Element T element, OutputReceiver<T> r) {
+    @Override
+    T getOutput(T element) {
+      return element;
+    }
+
+    @Override
+    Instant getTimestamp(T element) {
       Instant timestamp = fn.apply(element);
       checkNotNull(
           timestamp, "Timestamps for WithTimestamps cannot be null. Timestamp provided by %s.", fn);
-      r.outputWithTimestamp(element, timestamp);
+      return timestamp;
     }
 
     @Override


### PR DESCRIPTION
Extract a package-private `OutputWithTimestampDoFn` shared by
`WithTimestamps.AddTimestampsDoFn` and
`Create.TimestampedValues.ConvertTimestamps`.

The existing transform structure is intentionally preserved. In particular,
`Create.TimestampedValues` still creates an intermediate
`PCollection<TimestampedValue<T>>`, uses `TimestampedValueCoder`, restores the
output coder, and retains the `ConvertTimestamps` transform name. This avoids
the runner matching issue that previously occurred when
`TimestampedValues` inherited from `Create.Values`.

`WithTimestamps` continues to preserve its null timestamp validation and
allowed timestamp skew behavior.

Tests:
- `:sdks:java:core:test` for `WithTimestampsTest` and `CreateTest`
- `:runners:direct-java:needsRunnerTest` for `WithTimestampsTest` and `CreateTest`
- Pipeline renderer tests
- `:sdks:java:core:spotlessJavaCheck`
- `:sdks:java:core:javadoc`

Fixes #18350