### PR TITLE
[CI] Restore Java 17 in the Spark Versions PreCommit so the Spark 4 module runs

### DIFF
--- a/.github/workflows/beam_PreCommit_Java_Spark_Versions.yml
+++ b/.github/workflows/beam_PreCommit_Java_Spark_Versions.yml
@@ -90,7 +90,9 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment-action
         with:
-          java-version: 11
+          java-version: |
+            17
+            11
       - name: run sparkVersionsTest script
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:


### PR DESCRIPTION
`beam_PreCommit_Java_Spark_Versions` runs `:runners:spark:3:sparkVersionsTest :runners:spark:4:build -Pjava17Home=$JAVA_HOME_17_X64`. #39205 changed its Java setup from `17` plus `11` to `11` only, so `JAVA_HOME_17_X64` is empty, `java17Home` resolves to nothing, and `BeamModulePlugin` disables every task of `runners/spark/4` because its required JDK is missing. Every run since then prints

```
> Task :runners:spark:4:compileJava SKIPPED
> Task :runners:spark:4:test SKIPPED
> Task :runners:spark:4:build SKIPPED
BUILD SUCCESSFUL
```

and reports green. The Spark 4 unit tests, including the streaming source tests from #39971 and the translator tests in #40090, have not executed in CI in that period. `beam_PreCommit_Java` compiles the module on its native JDK but does not run its tests.

This restores the two version setup that #38453 introduced, same pattern as `beam_PreCommit_SQL_Java17`. Java 11 stays the default JDK for the Spark 3 part of the job, Java 17 is handed to the Spark 4 module through `java17Home`.

Verification after merge: the next master run of the workflow must show `:runners:spark:4:test` executed. Local equivalent, `./gradlew :runners:spark:4:build -Pjava17Home=/path/to/jdk17` runs 234 tests.

R: @Abacn
