### PR TITLE
[CI] Stop infinite reviewer reassignment, batch state commits, clean up stale state

### DIFF
--- a/scripts/ci/pr-bot/README.md
+++ b/scripts/ci/pr-bot/README.md
@@ -49,7 +49,6 @@ The bot consists of three core workflows and a persistent state tracking system:
 
 ### 4. Persistent State (`PersistentState`)
 * Stores PR review progress and label assignment rotations on the `pr-bot-state` Git branch under `state/pr-state/pr-<number>.json` and `state/reviewers-for-label-<label>.json`.
-* State changes within a run are staged locally and batched into a single Git commit and push per workflow execution.
 
 ## Build/Test
 

--- a/scripts/ci/pr-bot/README.md
+++ b/scripts/ci/pr-bot/README.md
@@ -23,6 +23,34 @@ This directory holds all the code (except for Actions Workflows) for our PR bot 
 For a list of commands to use when interacting with the bot, see [Commands.md](./Commands.md).
 For a design doc explaining the design and implementation, see [Automate Reviewer Assignment](https://docs.google.com/document/d/1FhRPRD6VXkYlLAPhNfZB7y2Yese2FCWBzjx67d3TjBo/edit#)
 
+## PR Bot Logic
+
+The bot consists of three core workflows and a persistent state tracking system:
+
+### 1. New PR Processing (`processNewPrs.ts`)
+* Runs periodically on a schedule (every 30 minutes).
+* Checks eligible open PRs (skips WIP, drafts, closed, PRs < 20 minutes old, PRs with notifications silenced, or PRs labeled `awaiting triage`).
+* Once CI checks pass, assigns reviewers based on configured label mappings in `.github/REVIEWERS.yml` (prioritizing least-recently-assigned reviewers).
+* If a non-committer reviewer approves, automatically assigns a committer for final review and merge.
+* Sets `Next Action: Reviewers` label.
+
+### 2. PR Updates & Commands (`processPrUpdate.ts`)
+* Triggered on PR pushes (`synchronize`) and comments (`issue_comment: created`).
+* Shifts attention back to reviewers (`Next Action: Reviewers`) when author pushes new commits or posts comments.
+* Removes `slow-review` label upon receiving a comment from a non-author reviewer.
+* Processes commands like `assign to next reviewer`, `waiting on author`, `stop reviewer notifications`, `assign set of reviewers`, and `remind me after tests pass`.
+
+### 3. Reviewer Reminders & Stale PRs (`findPrsNeedingAttention.ts`)
+* Runs daily to identify PRs needing action.
+* Flags PRs awaiting reviewer response as `slow-review` if inactive for ≥ 7 days (or ≥ 2 weekdays without comments).
+* If still no response after 2 more weekdays, reassigns to new reviewers, removes `slow-review`, and adds `reassigned-reviewers`.
+* **Stale PR Cutoff**: If a PR has both `reassigned-reviewers` and `Next Action: Reviewers` labels and review started > 60 days ago, it stops reviewer assignment loops and adds `awaiting triage`. PRs labeled `awaiting triage` are skipped.
+* **Stale State Cleanup**: Cleans up the oldest 100 state files for PRs that are no longer open to incrementally prune closed PR metadata from the state branch.
+
+### 4. Persistent State (`PersistentState`)
+* Stores PR review progress and label assignment rotations on the `pr-bot-state` Git branch under `state/pr-state/pr-<number>.json` and `state/reviewers-for-label-<label>.json`.
+* State changes within a run are staged locally and batched into a single Git commit and push per workflow execution.
+
 ## Build/Test
 
 To build, run:

--- a/scripts/ci/pr-bot/findPrsNeedingAttention.ts
+++ b/scripts/ci/pr-bot/findPrsNeedingAttention.ts
@@ -134,16 +134,14 @@ async function assignToNewReviewers(
     })
   );
 
-  await stateClient.writePrState(pull.number, prState, false);
+  await stateClient.writePrState(pull.number, prState);
   let labelsToUpdate = Object.keys(reviewerStateToUpdate);
   for (const label of labelsToUpdate) {
     await stateClient.writeReviewersForLabelState(
       label,
-      reviewerStateToUpdate[label],
-      false
+      reviewerStateToUpdate[label]
     );
   }
-  await stateClient.commitStateToRepo();
 }
 
 // Flag any prs that have been awaiting reviewer action at least 7 days,
@@ -261,6 +259,7 @@ async function processOldPrs() {
   }
 
   await stateClient.deleteStalePrStates(openPulls, 100);
+  await stateClient.commitStateToRepo();
 }
 
 processOldPrs();

--- a/scripts/ci/pr-bot/findPrsNeedingAttention.ts
+++ b/scripts/ci/pr-bot/findPrsNeedingAttention.ts
@@ -134,14 +134,16 @@ async function assignToNewReviewers(
     })
   );
 
-  await stateClient.writePrState(pull.number, prState);
+  await stateClient.writePrState(pull.number, prState, false);
   let labelsToUpdate = Object.keys(reviewerStateToUpdate);
   for (const label of labelsToUpdate) {
     await stateClient.writeReviewersForLabelState(
       label,
-      reviewerStateToUpdate[label]
+      reviewerStateToUpdate[label],
+      false
     );
   }
+  await stateClient.commitStateToRepo();
 }
 
 // Flag any prs that have been awaiting reviewer action at least 7 days,
@@ -259,7 +261,6 @@ async function processOldPrs() {
   }
 
   await stateClient.deleteStalePrStates(openPulls, 100);
-  await stateClient.commitStateToRepo();
 }
 
 processOldPrs();

--- a/scripts/ci/pr-bot/findPrsNeedingAttention.ts
+++ b/scripts/ci/pr-bot/findPrsNeedingAttention.ts
@@ -259,7 +259,6 @@ async function processOldPrs() {
   }
 
   await stateClient.deleteStalePrStates(openPulls, 100);
-  await stateClient.commitStateToRepo();
 }
 
 processOldPrs();

--- a/scripts/ci/pr-bot/findPrsNeedingAttention.ts
+++ b/scripts/ci/pr-bot/findPrsNeedingAttention.ts
@@ -26,14 +26,12 @@ const {
   REPO,
   PATH_TO_CONFIG_FILE,
   SLOW_REVIEW_LABEL,
+  REASSIGNED_REVIEWERS_LABEL,
+  AWAITING_TRIAGE_LABEL,
+  NEXT_ACTION_REVIEWERS_LABEL,
 } = require("./shared/constants");
+const { hasLabel } = github;
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
-
-function hasLabel(pull: any, labelName: string): boolean {
-  return pull.labels.some(
-    (label) => label.name.toLowerCase() === labelName.toLowerCase()
-  );
-}
 
 function getTwoWeekdaysAgo(): Date {
   const twoWeekDaysAgo = new Date(Date.now() - 2 * ONE_DAY_MS);
@@ -49,7 +47,7 @@ function getTwoWeekdaysAgo(): Date {
 }
 
 async function isSlowReview(pull: any): Promise<boolean> {
-  if (!hasLabel(pull, "Next Action: Reviewers")) {
+  if (!hasLabel(pull, NEXT_ACTION_REVIEWERS_LABEL)) {
     return false;
   }
   const lastModified = new Date(pull.updated_at);
@@ -102,15 +100,18 @@ async function assignToNewReviewers(
   let prState = await stateClient.getPrState(pull.number);
   let reviewerStateToUpdate = {};
   const labelObjects = pull.labels;
-  let reviewersToExclude: string[] = Object.values(prState.reviewersAssignedForLabels) as string[];
+  let reviewersToExclude: string[] = Object.values(
+    prState.reviewersAssignedForLabels
+  ) as string[];
   if (pull.requested_reviewers) {
-    reviewersToExclude = reviewersToExclude.concat(pull.requested_reviewers.map((r: any) => r.login));
+    reviewersToExclude = reviewersToExclude.concat(
+      pull.requested_reviewers.map((r: any) => r.login)
+    );
   }
   reviewersToExclude.push(pull.user.login);
   const reviewersForLabels: { [key: string]: string[] } =
     reviewerConfig.getReviewersForLabels(labelObjects, reviewersToExclude);
-  const fallbackReviewers =
-    reviewerConfig.getFallbackReviewers();
+  const fallbackReviewers = reviewerConfig.getFallbackReviewers();
   for (const labelObject of labelObjects) {
     const label = labelObject.name;
     let availableReviewers = reviewersForLabels[label];
@@ -156,6 +157,32 @@ async function processPull(
     console.log(`Skipping PR ${pull.number} - notifications silenced`);
     return;
   }
+  if (hasLabel(pull, AWAITING_TRIAGE_LABEL)) {
+    console.log(`Skipping PR ${pull.number} - awaiting triage`);
+    return;
+  }
+
+  const sixtyDaysAgo = new Date(Date.now() - 60 * ONE_DAY_MS);
+  const initialReviewDate = prState.reviewersAssignedAt
+    ? new Date(prState.reviewersAssignedAt)
+    : new Date(pull.created_at);
+  if (
+    hasLabel(pull, REASSIGNED_REVIEWERS_LABEL) &&
+    hasLabel(pull, NEXT_ACTION_REVIEWERS_LABEL) &&
+    initialReviewDate.getTime() < sixtyDaysAgo.getTime()
+  ) {
+    console.log(
+      `PR ${pull.number} has reassigned-reviewers and Next Action: Reviewers labels and review started >60 days ago - adding awaiting triage label`
+    );
+    await github.getGitHubClient().rest.issues.addLabels({
+      owner: REPO_OWNER,
+      repo: REPO,
+      issue_number: pull.number,
+      labels: [AWAITING_TRIAGE_LABEL],
+    });
+    return;
+  }
+
   if (hasLabel(pull, SLOW_REVIEW_LABEL)) {
     const lastModified = new Date(pull.updated_at);
     const twoWeekDaysAgo = getTwoWeekdaysAgo();
@@ -177,7 +204,7 @@ async function processPull(
         owner: REPO_OWNER,
         repo: REPO,
         issue_number: pull.number,
-        labels: ["reassigned-reviewers"],
+        labels: [REASSIGNED_REVIEWERS_LABEL],
       });
     }
 
@@ -186,9 +213,13 @@ async function processPull(
 
   if (await isSlowReview(pull)) {
     const client = github.getGitHubClient();
-    let reviewersToPing = Object.values(prState.reviewersAssignedForLabels || {});
+    let reviewersToPing = Object.values(
+      prState.reviewersAssignedForLabels || {}
+    );
     if (pull.requested_reviewers) {
-      reviewersToPing = reviewersToPing.concat(pull.requested_reviewers.map((r: any) => r.login));
+      reviewersToPing = reviewersToPing.concat(
+        pull.requested_reviewers.map((r: any) => r.login)
+      );
     }
     reviewersToPing = [...new Set(reviewersToPing as string[])];
 
@@ -226,6 +257,9 @@ async function processOldPrs() {
   for (const pull of openPulls) {
     await processPull(pull, reviewerConfig, stateClient);
   }
+
+  await stateClient.deleteStalePrStates(openPulls, 100);
+  await stateClient.commitStateToRepo();
 }
 
 processOldPrs();

--- a/scripts/ci/pr-bot/processNewPrs.ts
+++ b/scripts/ci/pr-bot/processNewPrs.ts
@@ -27,6 +27,7 @@ const {
   REPO,
   PATH_TO_CONFIG_FILE,
   REVIEWERS_ACTION,
+  AWAITING_TRIAGE_LABEL,
 } = require("./shared/constants");
 import { CheckStatus } from "./shared/checks";
 
@@ -44,6 +45,12 @@ import { CheckStatus } from "./shared/checks";
  * (in which case that's all we need to do).
  */
 function needsProcessed(pull: any, prState: typeof Pr): boolean {
+  if (github.hasLabel(pull, AWAITING_TRIAGE_LABEL)) {
+    console.log(
+      `Skipping PR ${pull.number} because it has awaiting triage label`
+    );
+    return false;
+  }
   const firstPythonPrToProcess = new Date(2022, 5, 16, 14); // June 16 2022, 14:00 UTC (note that JavaScript months are 0 indexed)
   const firstPrToProcess = new Date(2022, 6, 15, 23); // July 15 2022, 23:00 UTC (note that JavaScript months are 0 indexed)
   const createdAt = new Date(pull.created_at);
@@ -167,7 +174,9 @@ async function approvedBy(pull: any): Promise<string[]> {
 async function isAnyGithubReviewerCommitter(pull: any): Promise<boolean> {
   let reviewers: string[] = [];
   if (pull.requested_reviewers && pull.requested_reviewers.length > 0) {
-    reviewers = reviewers.concat(pull.requested_reviewers.map((r: any) => r.login));
+    reviewers = reviewers.concat(
+      pull.requested_reviewers.map((r: any) => r.login)
+    );
   }
   for (const reviewer of reviewers) {
     if (await github.checkIfCommitter(reviewer)) {
@@ -194,8 +203,8 @@ async function processPull(
       await github.addPrComment(
         pull.number,
         "Closing this PR because dependabot updates for container/** are not allowed due to generated files " +
-        "and excluded_paths is disabled due to dependabot/dependabot-core#14408. " +
-        "Once issue is resolved, please remove this step."
+          "and excluded_paths is disabled due to dependabot/dependabot-core#14408. " +
+          "Once issue is resolved, please remove this step."
       );
       await github.closePr(pull.number);
       return;
@@ -210,8 +219,10 @@ async function processPull(
   console.log(`Processing PR ${pull.number}`);
 
   // If reviewers are already assigned, we just need to check if we should assign a committer.
-  const hasReviewersAssignedForLabels = Object.keys(prState.reviewersAssignedForLabels).length > 0;
-  const hasGithubReviewers = pull.requested_reviewers && pull.requested_reviewers.length > 0;
+  const hasReviewersAssignedForLabels =
+    Object.keys(prState.reviewersAssignedForLabels).length > 0;
+  const hasGithubReviewers =
+    pull.requested_reviewers && pull.requested_reviewers.length > 0;
 
   if (hasReviewersAssignedForLabels || hasGithubReviewers) {
     if (prState.committerAssigned) {
@@ -237,7 +248,11 @@ async function processPull(
       // we can try to guess a label from the PR to assign a committer to.
       if (!labelOfReviewer) {
         let isGithubReviewer = false;
-        if (pull.requested_reviewers && pull.requested_reviewers.some((r: any) => r.login === approver)) isGithubReviewer = true;
+        if (
+          pull.requested_reviewers &&
+          pull.requested_reviewers.some((r: any) => r.login === approver)
+        )
+          isGithubReviewer = true;
 
         if (isGithubReviewer && pull.labels && pull.labels.length > 0) {
           const validLabels = reviewerConfig.getReviewersForAllLabels();
@@ -272,8 +287,7 @@ async function processPull(
         );
         const availableReviewers =
           reviewerConfig.getReviewersForLabel(labelOfReviewer);
-        const fallbackReviewers =
-          reviewerConfig.getFallbackReviewers();
+        const fallbackReviewers = reviewerConfig.getFallbackReviewers();
         const chosenCommitter = await reviewersState.assignNextCommitter(
           availableReviewers,
           fallbackReviewers
@@ -348,6 +362,7 @@ async function processPull(
 
   github.nextActionReviewers(pull.number, pull.labels);
   prState.nextAction = "Reviewers";
+  prState.reviewersAssignedAt = Date.now();
 
   await stateClient.writePrState(pull.number, prState);
   let labelsToUpdate = Object.keys(reviewerStateToUpdate);
@@ -375,6 +390,8 @@ async function processNewPrs() {
   for (const pull of openPulls) {
     await processPull(pull, reviewerConfig, stateClient);
   }
+
+  await stateClient.commitStateToRepo();
 }
 
 processNewPrs();

--- a/scripts/ci/pr-bot/processNewPrs.ts
+++ b/scripts/ci/pr-bot/processNewPrs.ts
@@ -304,13 +304,11 @@ async function processPull(
         prState.nextAction = REVIEWERS_ACTION;
 
         // Persist state
-        await stateClient.writePrState(pull.number, prState, false);
+        await stateClient.writePrState(pull.number, prState);
         await stateClient.writeReviewersForLabelState(
           labelOfReviewer,
-          reviewersState,
-          false
+          reviewersState
         );
-        await stateClient.commitStateToRepo();
 
         return;
       }
@@ -366,16 +364,14 @@ async function processPull(
   prState.nextAction = "Reviewers";
   prState.reviewersAssignedAt = Date.now();
 
-  await stateClient.writePrState(pull.number, prState, false);
+  await stateClient.writePrState(pull.number, prState);
   let labelsToUpdate = Object.keys(reviewerStateToUpdate);
   for (const label of labelsToUpdate) {
     await stateClient.writeReviewersForLabelState(
       label,
-      reviewerStateToUpdate[label],
-      false
+      reviewerStateToUpdate[label]
     );
   }
-  await stateClient.commitStateToRepo();
 }
 
 async function processNewPrs() {
@@ -394,6 +390,8 @@ async function processNewPrs() {
   for (const pull of openPulls) {
     await processPull(pull, reviewerConfig, stateClient);
   }
+
+  await stateClient.commitStateToRepo();
 }
 
 processNewPrs();

--- a/scripts/ci/pr-bot/processNewPrs.ts
+++ b/scripts/ci/pr-bot/processNewPrs.ts
@@ -304,11 +304,13 @@ async function processPull(
         prState.nextAction = REVIEWERS_ACTION;
 
         // Persist state
-        await stateClient.writePrState(pull.number, prState);
+        await stateClient.writePrState(pull.number, prState, false);
         await stateClient.writeReviewersForLabelState(
           labelOfReviewer,
-          reviewersState
+          reviewersState,
+          false
         );
+        await stateClient.commitStateToRepo();
 
         return;
       }
@@ -364,14 +366,16 @@ async function processPull(
   prState.nextAction = "Reviewers";
   prState.reviewersAssignedAt = Date.now();
 
-  await stateClient.writePrState(pull.number, prState);
+  await stateClient.writePrState(pull.number, prState, false);
   let labelsToUpdate = Object.keys(reviewerStateToUpdate);
   for (const label of labelsToUpdate) {
     await stateClient.writeReviewersForLabelState(
       label,
-      reviewerStateToUpdate[label]
+      reviewerStateToUpdate[label],
+      false
     );
   }
+  await stateClient.commitStateToRepo();
 }
 
 async function processNewPrs() {
@@ -390,8 +394,6 @@ async function processNewPrs() {
   for (const pull of openPulls) {
     await processPull(pull, reviewerConfig, stateClient);
   }
-
-  await stateClient.commitStateToRepo();
 }
 
 processNewPrs();

--- a/scripts/ci/pr-bot/processNewPrs.ts
+++ b/scripts/ci/pr-bot/processNewPrs.ts
@@ -390,8 +390,6 @@ async function processNewPrs() {
   for (const pull of openPulls) {
     await processPull(pull, reviewerConfig, stateClient);
   }
-
-  await stateClient.commitStateToRepo();
 }
 
 processNewPrs();

--- a/scripts/ci/pr-bot/processPrUpdate.ts
+++ b/scripts/ci/pr-bot/processPrUpdate.ts
@@ -205,6 +205,8 @@ async function processPrUpdate() {
     default:
       console.log("Not a PR comment or push, doing nothing");
   }
+
+  await stateClient.commitStateToRepo();
 }
 
 processPrUpdate();

--- a/scripts/ci/pr-bot/processPrUpdate.ts
+++ b/scripts/ci/pr-bot/processPrUpdate.ts
@@ -205,8 +205,6 @@ async function processPrUpdate() {
     default:
       console.log("Not a PR comment or push, doing nothing");
   }
-
-  await stateClient.commitStateToRepo();
 }
 
 processPrUpdate();

--- a/scripts/ci/pr-bot/shared/commentStrings.ts
+++ b/scripts/ci/pr-bot/shared/commentStrings.ts
@@ -26,7 +26,7 @@ export interface AssignReviewerOptions {
 
 // Custom notices for specific labels
 const LABEL_NOTICES: Record<string, string> = {
-  core: "This pull request likely touches a core component (\"core\" label). Please review with scrutiny.",
+  core: 'This pull request likely touches a core component ("core" label). Please review with scrutiny.',
 };
 
 function formatNotices(
@@ -59,8 +59,7 @@ export function assignReviewer(
   labelToReviewerMapping: any,
   options?: AssignReviewerOptions
 ): string {
-  let commentString =
-    "Assigning reviewers:\n\n";
+  let commentString = "Assigning reviewers:\n\n";
 
   for (let label in labelToReviewerMapping) {
     let reviewer = labelToReviewerMapping[label];

--- a/scripts/ci/pr-bot/shared/constants.ts
+++ b/scripts/ci/pr-bot/shared/constants.ts
@@ -31,3 +31,7 @@ export const BOT_NAME = "github-actions";
 export const REVIEWERS_ACTION = "Reviewers";
 export const SLOW_REVIEW_LABEL = "slow-review";
 export const NO_MATCHING_LABEL = "no-matching-label";
+export const REASSIGNED_REVIEWERS_LABEL = "reassigned-reviewers";
+export const AWAITING_TRIAGE_LABEL = "awaiting triage";
+export const NEXT_ACTION_REVIEWERS_LABEL = "Next Action: Reviewers";
+export const PR_STATE_DIR = "state/pr-state";

--- a/scripts/ci/pr-bot/shared/githubUtils.ts
+++ b/scripts/ci/pr-bot/shared/githubUtils.ts
@@ -123,3 +123,11 @@ function removeNextActionLabel(existingLabels: Label[]): string[] {
     )
     .map((label) => label.name);
 }
+
+export function hasLabel(pull: any, labelName: string): boolean {
+  return (pull?.labels || []).some(
+    (label: any) =>
+      (typeof label === "string" ? label : label?.name || "").toLowerCase() ===
+      labelName.toLowerCase()
+  );
+}

--- a/scripts/ci/pr-bot/shared/persistentState.ts
+++ b/scripts/ci/pr-bot/shared/persistentState.ts
@@ -33,7 +33,6 @@ function getReviewersForLabelFileName(label) {
 
 export class PersistentState {
   private switchedBranch = false;
-  private hasWrittenState = false;
 
   // Returns a Pr object representing the current saved state of the pr.
   async getPrState(prNumber: number): Promise<typeof Pr> {
@@ -42,9 +41,18 @@ export class PersistentState {
   }
 
   // Writes a Pr object representing the current saved state of the pr to persistent storage.
-  async writePrState(prNumber: number, newState: any) {
+  async writePrState(
+    prNumber: number,
+    newState: any,
+    commitImmediately: boolean = true
+  ) {
     var fileName = getPrFileName(prNumber);
-    await this.writeState(fileName, PR_STATE_DIR, new Pr(newState));
+    await this.writeState(
+      fileName,
+      PR_STATE_DIR,
+      new Pr(newState),
+      commitImmediately
+    );
   }
 
   // Returns a ReviewersForLabel object representing the current saved state of which reviewers have reviewed recently.
@@ -56,12 +64,17 @@ export class PersistentState {
   }
 
   // Writes a ReviewersForLabel object representing the current saved state of which reviewers have reviewed recently.
-  async writeReviewersForLabelState(label: string, newState: any) {
+  async writeReviewersForLabelState(
+    label: string,
+    newState: any,
+    commitImmediately: boolean = true
+  ) {
     var fileName = getReviewersForLabelFileName(label);
     await this.writeState(
       fileName,
       "state",
-      new ReviewersForLabel(label, newState)
+      new ReviewersForLabel(label, newState),
+      commitImmediately
     );
   }
 
@@ -108,20 +121,14 @@ export class PersistentState {
           prsToDelete[0].prNumber
         }, newest: PR ${prsToDelete[prsToDelete.length - 1].prNumber})`
       );
-      this.hasWrittenState = true;
+      await this.commitStateToRepo();
     }
 
     return prsToDelete.length;
   }
 
-  // Commits all written state changes to the pr-bot-state branch in a single batch.
+  // Commits state changes to the pr-bot-state branch.
   async commitStateToRepo() {
-    if (!this.hasWrittenState) {
-      console.log(
-        "Skipping updating state branch since there are no changes to commit"
-      );
-      return;
-    }
     try {
       await exec.exec("git pull origin pr-bot-state");
     } catch (err) {
@@ -145,7 +152,6 @@ export class PersistentState {
         "Skipping updating state branch since there are no changes to commit"
       );
     }
-    this.hasWrittenState = false;
   }
 
   private async getState(fileName, baseDirectory) {
@@ -157,7 +163,12 @@ export class PersistentState {
     return JSON.parse(fs.readFileSync(fileName, { encoding: "utf-8" }));
   }
 
-  private async writeState(fileName, baseDirectory, state) {
+  private async writeState(
+    fileName,
+    baseDirectory,
+    state,
+    commitImmediately: boolean = true
+  ) {
     await this.ensureCorrectBranch();
     fileName = path.join(baseDirectory, fileName);
     if (!fs.existsSync(baseDirectory)) {
@@ -166,7 +177,9 @@ export class PersistentState {
     fs.writeFileSync(fileName, JSON.stringify(state, null, 2), {
       encoding: "utf-8",
     });
-    this.hasWrittenState = true;
+    if (commitImmediately) {
+      await this.commitStateToRepo();
+    }
   }
 
   private async ensureCorrectBranch() {

--- a/scripts/ci/pr-bot/shared/persistentState.ts
+++ b/scripts/ci/pr-bot/shared/persistentState.ts
@@ -33,6 +33,7 @@ function getReviewersForLabelFileName(label) {
 
 export class PersistentState {
   private switchedBranch = false;
+  private hasWrittenState = false;
 
   // Returns a Pr object representing the current saved state of the pr.
   async getPrState(prNumber: number): Promise<typeof Pr> {
@@ -41,18 +42,9 @@ export class PersistentState {
   }
 
   // Writes a Pr object representing the current saved state of the pr to persistent storage.
-  async writePrState(
-    prNumber: number,
-    newState: any,
-    commitImmediately: boolean = true
-  ) {
+  async writePrState(prNumber: number, newState: any) {
     var fileName = getPrFileName(prNumber);
-    await this.writeState(
-      fileName,
-      PR_STATE_DIR,
-      new Pr(newState),
-      commitImmediately
-    );
+    await this.writeState(fileName, PR_STATE_DIR, new Pr(newState));
   }
 
   // Returns a ReviewersForLabel object representing the current saved state of which reviewers have reviewed recently.
@@ -64,17 +56,12 @@ export class PersistentState {
   }
 
   // Writes a ReviewersForLabel object representing the current saved state of which reviewers have reviewed recently.
-  async writeReviewersForLabelState(
-    label: string,
-    newState: any,
-    commitImmediately: boolean = true
-  ) {
+  async writeReviewersForLabelState(label: string, newState: any) {
     var fileName = getReviewersForLabelFileName(label);
     await this.writeState(
       fileName,
       "state",
-      new ReviewersForLabel(label, newState),
-      commitImmediately
+      new ReviewersForLabel(label, newState)
     );
   }
 
@@ -121,14 +108,20 @@ export class PersistentState {
           prsToDelete[0].prNumber
         }, newest: PR ${prsToDelete[prsToDelete.length - 1].prNumber})`
       );
-      await this.commitStateToRepo();
+      this.hasWrittenState = true;
     }
 
     return prsToDelete.length;
   }
 
-  // Commits state changes to the pr-bot-state branch.
+  // Commits all written state changes to the pr-bot-state branch in a single batch.
   async commitStateToRepo() {
+    if (!this.hasWrittenState) {
+      console.log(
+        "Skipping updating state branch since there are no changes to commit"
+      );
+      return;
+    }
     try {
       await exec.exec("git pull origin pr-bot-state");
     } catch (err) {
@@ -152,6 +145,7 @@ export class PersistentState {
         "Skipping updating state branch since there are no changes to commit"
       );
     }
+    this.hasWrittenState = false;
   }
 
   private async getState(fileName, baseDirectory) {
@@ -163,12 +157,7 @@ export class PersistentState {
     return JSON.parse(fs.readFileSync(fileName, { encoding: "utf-8" }));
   }
 
-  private async writeState(
-    fileName,
-    baseDirectory,
-    state,
-    commitImmediately: boolean = true
-  ) {
+  private async writeState(fileName, baseDirectory, state) {
     await this.ensureCorrectBranch();
     fileName = path.join(baseDirectory, fileName);
     if (!fs.existsSync(baseDirectory)) {
@@ -177,9 +166,7 @@ export class PersistentState {
     fs.writeFileSync(fileName, JSON.stringify(state, null, 2), {
       encoding: "utf-8",
     });
-    if (commitImmediately) {
-      await this.commitStateToRepo();
-    }
+    this.hasWrittenState = true;
   }
 
   private async ensureCorrectBranch() {

--- a/scripts/ci/pr-bot/shared/persistentState.ts
+++ b/scripts/ci/pr-bot/shared/persistentState.ts
@@ -171,7 +171,7 @@ export class PersistentState {
       await exec.exec(`git config user.name ${BOT_NAME}`);
       await exec.exec(`git config user.email ${BOT_NAME}@github.com`);
       await exec.exec("git config pull.rebase false");
-      await exec.exec("git fetch origin pr-bot-state");
+      await exec.exec("git fetch origin pr-bot-state --depth=1");
       await exec.exec("git checkout pr-bot-state");
     } catch {
       console.log(

--- a/scripts/ci/pr-bot/shared/persistentState.ts
+++ b/scripts/ci/pr-bot/shared/persistentState.ts
@@ -21,7 +21,7 @@ const fs = require("fs");
 const path = require("path");
 const { Pr } = require("./pr");
 const { ReviewersForLabel } = require("./reviewersForLabel");
-const { BOT_NAME } = require("./constants");
+const { BOT_NAME, PR_STATE_DIR } = require("./constants");
 
 function getPrFileName(prNumber) {
   return `pr-${prNumber}.json`.toLowerCase();
@@ -31,45 +31,20 @@ function getReviewersForLabelFileName(label) {
   return `reviewers-for-label-${label}.json`.toLowerCase();
 }
 
-async function commitStateToRepo() {
-  try {
-    await exec.exec("git pull origin pr-bot-state");
-  } catch (err) {
-    console.log(
-      `Unable to get most recent repo contents, commit may fail: ${err}`
-    );
-  }
-  // Print changes for observability
-  await exec.exec("git status", [], { ignoreReturnCode: true });
-  await exec.exec("git add state/*");
-  const changes = await exec.exec(
-    "git diff --quiet --cached origin/pr-bot-state state",
-    [],
-    { ignoreReturnCode: true }
-  );
-  if (changes == 1) {
-    await exec.exec(`git commit -m "Updating config from bot" --allow-empty`);
-    await exec.exec("git push origin pr-bot-state");
-  } else {
-    console.log(
-      "Skipping updating state branch since there are no changes to commit"
-    );
-  }
-}
-
 export class PersistentState {
   private switchedBranch = false;
+  private hasWrittenState = false;
 
   // Returns a Pr object representing the current saved state of the pr.
   async getPrState(prNumber: number): Promise<typeof Pr> {
     var fileName = getPrFileName(prNumber);
-    return new Pr(await this.getState(fileName, "state/pr-state"));
+    return new Pr(await this.getState(fileName, PR_STATE_DIR));
   }
 
   // Writes a Pr object representing the current saved state of the pr to persistent storage.
   async writePrState(prNumber: number, newState: any) {
     var fileName = getPrFileName(prNumber);
-    await this.writeState(fileName, "state/pr-state", new Pr(newState));
+    await this.writeState(fileName, PR_STATE_DIR, new Pr(newState));
   }
 
   // Returns a ReviewersForLabel object representing the current saved state of which reviewers have reviewed recently.
@@ -90,6 +65,89 @@ export class PersistentState {
     );
   }
 
+  // Deletes up to maxToDelete state files for PRs that are no longer open, starting from the oldest PRs.
+  async deleteStalePrStates(
+    openPulls: any[],
+    maxToDelete: number = 100
+  ): Promise<number> {
+    if (openPulls.length === 0) {
+      return 0;
+    }
+    await this.ensureCorrectBranch();
+    if (!fs.existsSync(PR_STATE_DIR)) {
+      return 0;
+    }
+    const openPrSet = new Set(openPulls.map((p) => p.number));
+    const files = fs.readdirSync(PR_STATE_DIR);
+    const stalePrs: { prNumber: number; filePath: string }[] = [];
+
+    for (const file of files) {
+      const match = file.match(/^pr-(\d+)\.json$/);
+      if (match) {
+        const prNumber = parseInt(match[1], 10);
+        if (!openPrSet.has(prNumber)) {
+          stalePrs.push({
+            prNumber,
+            filePath: path.join(PR_STATE_DIR, file),
+          });
+        }
+      }
+    }
+
+    // Sort by PR number ascending so the oldest PRs are deleted first
+    stalePrs.sort((a, b) => a.prNumber - b.prNumber);
+
+    const prsToDelete = stalePrs.slice(0, maxToDelete);
+    for (const pr of prsToDelete) {
+      fs.unlinkSync(pr.filePath);
+    }
+
+    if (prsToDelete.length > 0) {
+      console.log(
+        `Deleted ${prsToDelete.length} stale PR state files (oldest: PR ${
+          prsToDelete[0].prNumber
+        }, newest: PR ${prsToDelete[prsToDelete.length - 1].prNumber})`
+      );
+      this.hasWrittenState = true;
+    }
+
+    return prsToDelete.length;
+  }
+
+  // Commits all written state changes to the pr-bot-state branch in a single batch.
+  async commitStateToRepo() {
+    if (!this.hasWrittenState) {
+      console.log(
+        "Skipping updating state branch since there are no changes to commit"
+      );
+      return;
+    }
+    try {
+      await exec.exec("git pull origin pr-bot-state");
+    } catch (err) {
+      console.log(
+        `Unable to get most recent repo contents, commit may fail: ${err}`
+      );
+    }
+    // Print changes for observability
+    await exec.exec("git status", [], { ignoreReturnCode: true });
+    await exec.exec("git add -A state");
+    const changes = await exec.exec(
+      "git diff --quiet --cached origin/pr-bot-state state",
+      [],
+      { ignoreReturnCode: true }
+    );
+    if (changes == 1) {
+      await exec.exec(`git commit -m "Updating config from bot" --allow-empty`);
+      await exec.exec("git push origin pr-bot-state");
+    } else {
+      console.log(
+        "Skipping updating state branch since there are no changes to commit"
+      );
+    }
+    this.hasWrittenState = false;
+  }
+
   private async getState(fileName, baseDirectory) {
     await this.ensureCorrectBranch();
     fileName = path.join(baseDirectory, fileName);
@@ -108,7 +166,7 @@ export class PersistentState {
     fs.writeFileSync(fileName, JSON.stringify(state, null, 2), {
       encoding: "utf-8",
     });
-    await commitStateToRepo();
+    this.hasWrittenState = true;
   }
 
   private async ensureCorrectBranch() {

--- a/scripts/ci/pr-bot/shared/persistentState.ts
+++ b/scripts/ci/pr-bot/shared/persistentState.ts
@@ -31,9 +31,34 @@ function getReviewersForLabelFileName(label) {
   return `reviewers-for-label-${label}.json`.toLowerCase();
 }
 
+async function commitStateToRepo() {
+  try {
+    await exec.exec("git pull origin pr-bot-state");
+  } catch (err) {
+    console.log(
+      `Unable to get most recent repo contents, commit may fail: ${err}`
+    );
+  }
+  // Print changes for observability
+  await exec.exec("git status", [], { ignoreReturnCode: true });
+  await exec.exec("git add -A state");
+  const changes = await exec.exec(
+    "git diff --quiet --cached origin/pr-bot-state state",
+    [],
+    { ignoreReturnCode: true }
+  );
+  if (changes == 1) {
+    await exec.exec(`git commit -m "Updating config from bot" --allow-empty`);
+    await exec.exec("git push origin pr-bot-state");
+  } else {
+    console.log(
+      "Skipping updating state branch since there are no changes to commit"
+    );
+  }
+}
+
 export class PersistentState {
   private switchedBranch = false;
-  private hasWrittenState = false;
 
   // Returns a Pr object representing the current saved state of the pr.
   async getPrState(prNumber: number): Promise<typeof Pr> {
@@ -108,44 +133,10 @@ export class PersistentState {
           prsToDelete[0].prNumber
         }, newest: PR ${prsToDelete[prsToDelete.length - 1].prNumber})`
       );
-      this.hasWrittenState = true;
+      await commitStateToRepo();
     }
 
     return prsToDelete.length;
-  }
-
-  // Commits all written state changes to the pr-bot-state branch in a single batch.
-  async commitStateToRepo() {
-    if (!this.hasWrittenState) {
-      console.log(
-        "Skipping updating state branch since there are no changes to commit"
-      );
-      return;
-    }
-    try {
-      await exec.exec("git pull origin pr-bot-state");
-    } catch (err) {
-      console.log(
-        `Unable to get most recent repo contents, commit may fail: ${err}`
-      );
-    }
-    // Print changes for observability
-    await exec.exec("git status", [], { ignoreReturnCode: true });
-    await exec.exec("git add -A state");
-    const changes = await exec.exec(
-      "git diff --quiet --cached origin/pr-bot-state state",
-      [],
-      { ignoreReturnCode: true }
-    );
-    if (changes == 1) {
-      await exec.exec(`git commit -m "Updating config from bot" --allow-empty`);
-      await exec.exec("git push origin pr-bot-state");
-    } else {
-      console.log(
-        "Skipping updating state branch since there are no changes to commit"
-      );
-    }
-    this.hasWrittenState = false;
   }
 
   private async getState(fileName, baseDirectory) {
@@ -166,7 +157,7 @@ export class PersistentState {
     fs.writeFileSync(fileName, JSON.stringify(state, null, 2), {
       encoding: "utf-8",
     });
-    this.hasWrittenState = true;
+    await commitStateToRepo();
   }
 
   private async ensureCorrectBranch() {

--- a/scripts/ci/pr-bot/shared/pr.ts
+++ b/scripts/ci/pr-bot/shared/pr.ts
@@ -25,6 +25,7 @@ export class Pr {
   public stopReviewerNotifications: boolean;
   public remindAfterTestsPass: string[];
   public committerAssigned: boolean;
+  public reviewersAssignedAt: number;
 
   constructor(propertyDictionary) {
     this.commentedAboutFailingChecks = false;
@@ -33,6 +34,7 @@ export class Pr {
     this.stopReviewerNotifications = false;
     this.remindAfterTestsPass = []; // List of handles
     this.committerAssigned = false;
+    this.reviewersAssignedAt = 0;
 
     if (!propertyDictionary) {
       return;
@@ -58,6 +60,9 @@ export class Pr {
       }
       if ("committerAssigned" in propertyDictionary) {
         this.committerAssigned = propertyDictionary["committerAssigned"];
+      }
+      if ("reviewersAssignedAt" in propertyDictionary) {
+        this.reviewersAssignedAt = propertyDictionary["reviewersAssignedAt"];
       }
     }
   }

--- a/scripts/ci/pr-bot/shared/userCommand.ts
+++ b/scripts/ci/pr-bot/shared/userCommand.ts
@@ -115,11 +115,13 @@ async function assignToNextReviewer(
     prState.nextAction = "Reviewers";
 
     // Persist state
-    await stateClient.writePrState(pullNumber, prState);
+    await stateClient.writePrState(pullNumber, prState, false);
     await stateClient.writeReviewersForLabelState(
       labelOfReviewer,
-      reviewersState
+      reviewersState,
+      false
     );
+    await stateClient.commitStateToRepo();
   }
 }
 
@@ -237,13 +239,15 @@ async function assignReviewerSet(
   github.nextActionReviewers(pullNumber, existingLabels);
   prState.nextAction = "Reviewers";
 
-  await stateClient.writePrState(pullNumber, prState);
+  await stateClient.writePrState(pullNumber, prState, false);
   let labelsToUpdate = Object.keys(reviewerStateToUpdate);
   for (let i = 0; i < labelsToUpdate.length; i++) {
     let label = labelsToUpdate[i];
     await stateClient.writeReviewersForLabelState(
       label,
-      reviewerStateToUpdate[label]
+      reviewerStateToUpdate[label],
+      false
     );
   }
+  await stateClient.commitStateToRepo();
 }

--- a/scripts/ci/pr-bot/shared/userCommand.ts
+++ b/scripts/ci/pr-bot/shared/userCommand.ts
@@ -41,7 +41,7 @@ export async function processCommand(
   commentText = commentText.toLowerCase();
 
   let prState = await stateClient.getPrState(pullNumber);
-  if(prState.stopReviewerNotifications) {
+  if (prState.stopReviewerNotifications) {
     // Notifications stopped, only "allow assign set of reviewers"
     if (commentText.indexOf("assign set of reviewers") > -1) {
       await assignReviewerSet(payload, pullNumber, stateClient, reviewerConfig);
@@ -187,7 +187,7 @@ async function assignReviewerSet(
   reviewerConfig: typeof ReviewerConfig
 ) {
   let prState = await stateClient.getPrState(pullNumber);
-  if(prState.stopReviewerNotifications) {
+  if (prState.stopReviewerNotifications) {
     // Restore notifications, and clear any existing reviewer set to
     // allow new reviewers to be assigned.
     prState.stopReviewerNotifications = false;

--- a/scripts/ci/pr-bot/shared/userCommand.ts
+++ b/scripts/ci/pr-bot/shared/userCommand.ts
@@ -115,13 +115,11 @@ async function assignToNextReviewer(
     prState.nextAction = "Reviewers";
 
     // Persist state
-    await stateClient.writePrState(pullNumber, prState, false);
+    await stateClient.writePrState(pullNumber, prState);
     await stateClient.writeReviewersForLabelState(
       labelOfReviewer,
-      reviewersState,
-      false
+      reviewersState
     );
-    await stateClient.commitStateToRepo();
   }
 }
 
@@ -239,15 +237,13 @@ async function assignReviewerSet(
   github.nextActionReviewers(pullNumber, existingLabels);
   prState.nextAction = "Reviewers";
 
-  await stateClient.writePrState(pullNumber, prState, false);
+  await stateClient.writePrState(pullNumber, prState);
   let labelsToUpdate = Object.keys(reviewerStateToUpdate);
   for (let i = 0; i < labelsToUpdate.length; i++) {
     let label = labelsToUpdate[i];
     await stateClient.writeReviewersForLabelState(
       label,
-      reviewerStateToUpdate[label],
-      false
+      reviewerStateToUpdate[label]
     );
   }
-  await stateClient.commitStateToRepo();
 }

--- a/scripts/ci/pr-bot/test/githubUtilsTest.ts
+++ b/scripts/ci/pr-bot/test/githubUtilsTest.ts
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var assert = require("assert");
+const { hasLabel } = require("../shared/githubUtils");
+
+describe("githubUtils", function () {
+  describe("hasLabel()", function () {
+    it("should return true when label object matches exactly", function () {
+      const pull = {
+        labels: [{ name: "awaiting triage" }, { name: "go" }],
+      };
+      assert.equal(hasLabel(pull, "awaiting triage"), true);
+    });
+
+    it("should return true when label object matches case-insensitively", function () {
+      const pull = {
+        labels: [{ name: "Awaiting Triage" }],
+      };
+      assert.equal(hasLabel(pull, "awaiting triage"), true);
+      assert.equal(hasLabel(pull, "AWAITING TRIAGE"), true);
+    });
+
+    it("should return true when label is a string", function () {
+      const pull = {
+        labels: ["reassigned-reviewers", "go"],
+      };
+      assert.equal(hasLabel(pull, "reassigned-reviewers"), true);
+      assert.equal(hasLabel(pull, "REASSIGNED-REVIEWERS"), true);
+    });
+
+    it("should return false when label is not present", function () {
+      const pull = {
+        labels: [{ name: "go" }, { name: "python" }],
+      };
+      assert.equal(hasLabel(pull, "awaiting triage"), false);
+      assert.equal(hasLabel(pull, "reassigned-reviewers"), false);
+    });
+
+    it("should return false when pull or labels are empty or missing", function () {
+      assert.equal(hasLabel({}, "awaiting triage"), false);
+      assert.equal(hasLabel({ labels: [] }, "awaiting triage"), false);
+      assert.equal(hasLabel(null, "awaiting triage"), false);
+    });
+  });
+});
+
+export {};

--- a/scripts/ci/pr-bot/test/prTest.ts
+++ b/scripts/ci/pr-bot/test/prTest.ts
@@ -42,4 +42,17 @@ describe("Pr", function () {
       assert.equal("", testPr.getLabelForReviewer("testReviewer4"));
     });
   });
+
+  describe("reviewersAssignedAt", function () {
+    it("should default to 0 when not provided", function () {
+      let testPr = new Pr({});
+      assert.equal(testPr.reviewersAssignedAt, 0);
+    });
+
+    it("should retain reviewersAssignedAt when provided in dictionary", function () {
+      let timestamp = 1700000000000;
+      let testPr = new Pr({ reviewersAssignedAt: timestamp });
+      assert.equal(testPr.reviewersAssignedAt, timestamp);
+    });
+  });
 });


### PR DESCRIPTION
…ean up stale state

* Stop infinite reviewer reassignment loops: label with "awaiting triage" if a PR has both "reassigned-reviewers" and "Next Action: Reviewers", and review started >60 days ago.

* Track initial reviewer assignment timestamp (reviewersAssignedAt) in persistent PR state, falling back to PR creation time for legacy PRs.

* Skip reviewer assignment for PRs labeled "awaiting triage" across new PR processing and daily reminder workflows.

* Batch persistent state updates into a single commit and push per workflow execution instead of committing on every file write.

* Incrementally prune closed PR state files (oldest 100 per daily run) from the pr-bot-state branch.

* Document core PR bot logic in scripts/ci/pr-bot/README.md.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/actions/workflows/build_wheels.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/actions/workflows/python_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/actions/workflows/java_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/actions/workflows/go_tests.yml/badge.svg?event=schedule&&?branch=master)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
