### PR TITLE
Fix BigtableIO RESUME_OR_NEW duplicate InitializeDoFn execution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,6 +98,7 @@
 * (Prism) Self-checkpointing splittable DoFns now resume after their requested delay instead of immediately, so polling SDFs no longer busy-spin ([#39848](https://github.com/apache/beam/issues/39848)).
 * (Java) MongoDbIO read splitting now preserves non-ObjectId `_id` types (e.g. string ids) instead of failing to parse the generated range filters ([#39900](https://github.com/apache/beam/issues/39900)).
 * (Go) Fixed GCS glob matching silently dropping objects when the glob pattern contains multi-byte characters ([#39969](https://github.com/apache/beam/issues/39969)).
+* (Java) BigtableIO.readChangeStream() with RESUME_OR_NEW no longer starts duplicate consumers when InitializeDoFn is re-executed within the same pipeline run ([#39970](https://github.com/apache/beam/issues/39970)).
 
 ## Security Fixes
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -2553,8 +2553,9 @@ public class BigtableIO {
         daoFactory.close();
       }
 
+      String pipelineRunId = UniqueIdGenerator.generateRowKeyPrefix();
       InitializeDoFn initializeDoFn =
-          new InitializeDoFn(daoFactory, startTime, existingPipelineOptions);
+          new InitializeDoFn(daoFactory, startTime, existingPipelineOptions, pipelineRunId);
       DetectNewPartitionsDoFn detectNewPartitionsDoFn =
           new DetectNewPartitionsDoFn(getEndTime(), actionFactory, daoFactory, metrics);
       ReadChangeStreamPartitionDoFn readChangeStreamPartitionDoFn =

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dao/MetadataTableAdminDao.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dao/MetadataTableAdminDao.java
@@ -52,6 +52,7 @@ public class MetadataTableAdminDao {
   public static final String CF_VERSION = "version";
   public static final String CF_SHOULD_DELETE = "should_delete";
   public static final String QUALIFIER_DEFAULT = "latest";
+  public static final String QUALIFIER_PIPELINE_RUN_ID = "pipeline_run_id";
   public static final ImmutableList<String> COLUMN_FAMILIES =
       ImmutableList.of(
           CF_INITIAL_TOKEN,

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dao/MetadataTableDao.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dao/MetadataTableDao.java
@@ -208,6 +208,45 @@ public class MetadataTableDao {
   }
 
   /**
+   * Read the pipeline run id recorded when {@link
+   * org.apache.beam.sdk.io.gcp.bigtable.changestreams.dofn.InitializeDoFn} last completed for an
+   * active change stream pipeline.
+   */
+  public @Nullable String readPipelineRunId() {
+    Filter pipelineRunIdFilter =
+        FILTERS
+            .chain()
+            .filter(FILTERS.family().exactMatch(MetadataTableAdminDao.CF_VERSION))
+            .filter(FILTERS.qualifier().exactMatch(MetadataTableAdminDao.QUALIFIER_PIPELINE_RUN_ID))
+            .filter(FILTERS.limit().cellsPerColumn(1));
+    Row row = dataClient.readRow(tableId, getFullDetectNewPartition(), pipelineRunIdFilter);
+    if (row == null
+        || row.getCells(
+                MetadataTableAdminDao.CF_VERSION, MetadataTableAdminDao.QUALIFIER_PIPELINE_RUN_ID)
+            .isEmpty()) {
+      return null;
+    }
+    return row.getCells(
+            MetadataTableAdminDao.CF_VERSION, MetadataTableAdminDao.QUALIFIER_PIPELINE_RUN_ID)
+        .get(0)
+        .getValue()
+        .toStringUtf8();
+  }
+
+  /** Record the pipeline run id for the current change stream pipeline execution. */
+  public void writePipelineRunId(String pipelineRunId) {
+    long nowMicros = Instant.now().getMillis() * 1000L;
+    RowMutation rowMutation =
+        RowMutation.create(tableId, getFullDetectNewPartition())
+            .setCell(
+                MetadataTableAdminDao.CF_VERSION,
+                MetadataTableAdminDao.QUALIFIER_PIPELINE_RUN_ID,
+                nowMicros,
+                pipelineRunId);
+    mutateRowWithHardTimeout(rowMutation);
+  }
+
+  /**
    * Returns all the new partitions resulting from splits and merges waiting to be streamed
    * including ones marked for deletion.
    */

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dofn/InitializeDoFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dofn/InitializeDoFn.java
@@ -40,12 +40,17 @@ public class InitializeDoFn extends DoFn<byte[], InitialPipelineState> implement
   private final DaoFactory daoFactory;
   private Instant startTime;
   private final ExistingPipelineOptions existingPipelineOptions;
+  private final String pipelineRunId;
 
   public InitializeDoFn(
-      DaoFactory daoFactory, Instant startTime, ExistingPipelineOptions existingPipelineOptions) {
+      DaoFactory daoFactory,
+      Instant startTime,
+      ExistingPipelineOptions existingPipelineOptions,
+      String pipelineRunId) {
     this.daoFactory = daoFactory;
     this.startTime = startTime;
     this.existingPipelineOptions = existingPipelineOptions;
+    this.pipelineRunId = pipelineRunId;
   }
 
   @ProcessElement
@@ -53,6 +58,14 @@ public class InitializeDoFn extends DoFn<byte[], InitialPipelineState> implement
     LOG.info("{}", daoFactory.getStreamTableDebugString());
     LOG.info("{}", daoFactory.getMetadataTableDebugString());
     LOG.info("ChangeStreamName: {}", daoFactory.getChangeStreamName());
+
+    String storedPipelineRunId = daoFactory.getMetadataTableDao().readPipelineRunId();
+    if (storedPipelineRunId != null && storedPipelineRunId.equals(pipelineRunId)) {
+      LOG.info(
+          "Initialize already completed for pipeline run {}, skipping duplicate initialization",
+          pipelineRunId);
+      return;
+    }
 
     boolean resume = false;
     DetectNewPartitionsState detectNewPartitionsState =
@@ -101,6 +114,7 @@ public class InitializeDoFn extends DoFn<byte[], InitialPipelineState> implement
         // terminate pipeline
         return;
     }
+    daoFactory.getMetadataTableDao().writePipelineRunId(pipelineRunId);
     daoFactory.getMetadataTableDao().writeDetectNewPartitionVersion();
     receiver.output(new InitialPipelineState(startTime, resume));
   }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dofn/InitializeDoFnTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dofn/InitializeDoFnTest.java
@@ -61,6 +61,7 @@ public class InitializeDoFnTest {
   private transient MetadataTableDao metadataTableDao;
   @Mock private DoFn.OutputReceiver<InitialPipelineState> outputReceiver;
   private final String tableId = "table";
+  private static final String PIPELINE_RUN_ID = "test-pipeline-run";
 
   private static BigtableDataClient dataClient;
   private static BigtableTableAdminClient adminClient;
@@ -99,7 +100,10 @@ public class InitializeDoFnTest {
     Instant startTime = Instant.now();
     InitializeDoFn initializeDoFn =
         new InitializeDoFn(
-            daoFactory, startTime, BigtableIO.ExistingPipelineOptions.FAIL_IF_EXISTS);
+            daoFactory,
+            startTime,
+            BigtableIO.ExistingPipelineOptions.FAIL_IF_EXISTS,
+            PIPELINE_RUN_ID);
     initializeDoFn.processElement(outputReceiver);
     verify(outputReceiver, times(1)).output(new InitialPipelineState(startTime, false));
   }
@@ -110,7 +114,10 @@ public class InitializeDoFnTest {
     Instant startTime = Instant.now();
     InitializeDoFn initializeDoFn =
         new InitializeDoFn(
-            daoFactory, startTime, BigtableIO.ExistingPipelineOptions.FAIL_IF_EXISTS);
+            daoFactory,
+            startTime,
+            BigtableIO.ExistingPipelineOptions.FAIL_IF_EXISTS,
+            PIPELINE_RUN_ID);
     initializeDoFn.processElement(outputReceiver);
     verify(outputReceiver, never()).output(any());
   }
@@ -134,7 +141,10 @@ public class InitializeDoFnTest {
     Instant startTime = Instant.now();
     InitializeDoFn initializeDoFn =
         new InitializeDoFn(
-            daoFactory, startTime, BigtableIO.ExistingPipelineOptions.FAIL_IF_EXISTS);
+            daoFactory,
+            startTime,
+            BigtableIO.ExistingPipelineOptions.FAIL_IF_EXISTS,
+            PIPELINE_RUN_ID);
     initializeDoFn.processElement(outputReceiver);
     verify(outputReceiver, times(1)).output(new InitialPipelineState(startTime, false));
     assertNull(dataClient.readRow(tableId, metadataTableAdminDao.getChangeStreamNamePrefix()));
@@ -156,7 +166,11 @@ public class InitializeDoFnTest {
                 123L));
     Instant startTime = Instant.now();
     InitializeDoFn initializeDoFn =
-        new InitializeDoFn(daoFactory, startTime, BigtableIO.ExistingPipelineOptions.RESUME_OR_NEW);
+        new InitializeDoFn(
+            daoFactory,
+            startTime,
+            BigtableIO.ExistingPipelineOptions.RESUME_OR_NEW,
+            PIPELINE_RUN_ID);
     initializeDoFn.processElement(outputReceiver);
     // We want to resume but there's no DNP row, so we resume from the startTime provided.
     verify(outputReceiver, times(1)).output(new InitialPipelineState(startTime, false));
@@ -180,7 +194,11 @@ public class InitializeDoFnTest {
                 123L));
     Instant startTime = Instant.now();
     InitializeDoFn initializeDoFn =
-        new InitializeDoFn(daoFactory, startTime, BigtableIO.ExistingPipelineOptions.RESUME_OR_NEW);
+        new InitializeDoFn(
+            daoFactory,
+            startTime,
+            BigtableIO.ExistingPipelineOptions.RESUME_OR_NEW,
+            PIPELINE_RUN_ID);
     initializeDoFn.processElement(outputReceiver);
     verify(outputReceiver, times(1)).output(new InitialPipelineState(resumeTime, true));
     assertNull(dataClient.readRow(tableId, metadataTableAdminDao.getChangeStreamNamePrefix()));
@@ -202,7 +220,8 @@ public class InitializeDoFnTest {
                 123L));
     Instant startTime = Instant.now();
     InitializeDoFn initializeDoFn =
-        new InitializeDoFn(daoFactory, startTime, ExistingPipelineOptions.SKIP_CLEANUP);
+        new InitializeDoFn(
+            daoFactory, startTime, ExistingPipelineOptions.SKIP_CLEANUP, PIPELINE_RUN_ID);
     initializeDoFn.processElement(outputReceiver);
     // Skip cleanup will always resume from startTime
     verify(outputReceiver, times(1)).output(new InitialPipelineState(startTime, false));
@@ -228,11 +247,28 @@ public class InitializeDoFnTest {
                 123L));
     Instant startTime = Instant.now();
     InitializeDoFn initializeDoFn =
-        new InitializeDoFn(daoFactory, startTime, ExistingPipelineOptions.SKIP_CLEANUP);
+        new InitializeDoFn(
+            daoFactory, startTime, ExistingPipelineOptions.SKIP_CLEANUP, PIPELINE_RUN_ID);
     initializeDoFn.processElement(outputReceiver);
     // We don't want the pipeline to resume to avoid duplicates
     verify(outputReceiver, never()).output(any());
     // Existing metadata shouldn't be cleaned up
     assertNotNull(dataClient.readRow(tableId, metadataRowKey));
+  }
+
+  @Test
+  public void testInitializeSkipsDuplicatePipelineRun() throws IOException {
+    Instant resumeTime = Instant.now().minus(Duration.standardSeconds(10000));
+    metadataTableDao.updateDetectNewPartitionWatermark(resumeTime);
+    metadataTableDao.writePipelineRunId(PIPELINE_RUN_ID);
+    Instant startTime = Instant.now();
+    InitializeDoFn initializeDoFn =
+        new InitializeDoFn(
+            daoFactory,
+            startTime,
+            BigtableIO.ExistingPipelineOptions.RESUME_OR_NEW,
+            PIPELINE_RUN_ID);
+    initializeDoFn.processElement(outputReceiver);
+    verify(outputReceiver, never()).output(any());
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dofn/InitializeDoFnTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dofn/InitializeDoFnTest.java
@@ -34,6 +34,7 @@ import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import com.google.cloud.bigtable.emulator.v2.BigtableEmulatorRule;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
+import java.util.UUID;
 import org.apache.beam.sdk.io.gcp.bigtable.BigtableIO;
 import org.apache.beam.sdk.io.gcp.bigtable.BigtableIO.ExistingPipelineOptions;
 import org.apache.beam.sdk.io.gcp.bigtable.changestreams.dao.DaoFactory;
@@ -84,7 +85,7 @@ public class InitializeDoFnTest {
 
   @Before
   public void setUp() throws IOException {
-    String changeStreamName = "changeStreamName";
+    String changeStreamName = "changeStreamName-" + UUID.randomUUID();
     metadataTableAdminDao =
         spy(new MetadataTableAdminDao(adminClient, null, changeStreamName, tableId));
     metadataTableAdminDao.createMetadataTable();
@@ -180,6 +181,7 @@ public class InitializeDoFnTest {
   public void testInitializeResumeWithDNP() throws IOException {
     Instant resumeTime = Instant.now().minus(Duration.standardSeconds(10000));
     metadataTableDao.updateDetectNewPartitionWatermark(resumeTime);
+    metadataTableDao.writePipelineRunId("previous-pipeline-run");
     long nowMicros = Instant.now().getMillis() * 1000L;
     dataClient.mutateRow(
         RowMutation.create(


### PR DESCRIPTION
## Summary

- When `BigtableIO.readChangeStream()` uses `ExistingPipelineOptions.RESUME_OR_NEW`, a re-executed `InitializeDoFn` (e.g. Dataflow bundle retry) could see Detect New Partition metadata written by the same job and take the resume path, emitting a second `InitialPipelineState` and starting duplicate change-stream consumers.
- Assign a stable per-pipeline-run id at graph construction time, persist it in the metadata table on successful initialization, and skip `InitializeDoFn` output when the stored id matches the current run. A genuinely new job still resumes when the stored id differs.

Fixes #39970

## Test plan

- [x] Added `InitializeDoFnTest.testInitializeSkipsDuplicatePipelineRun` (emulator)
- [ ] `./gradlew :sdks:java:io:google-cloud-platform:test --tests org.apache.beam.sdk.io.gcp.bigtable.changestreams.dofn.InitializeDoFnTest` (local run hit disk pressure on cold clone; CI expected to run)